### PR TITLE
feat: integrate module synergy clusters

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -101,6 +101,11 @@ class SandboxSettings(BaseSettings):
         env="SANDBOX_USE_MEMORY",
         description="Enable GPT memory integration during sandbox runs.",
     )
+    use_module_synergy: bool = Field(
+        False,
+        env="SANDBOX_USE_MODULE_SYNERGY",
+        description="Enable module synergy suggestions during workflow simulation and replacement.",
+    )
     enable_truth_calibration: bool = Field(
         True,
         env="ENABLE_TRUTH_CALIBRATION",


### PR DESCRIPTION
## Summary
- use synergy cluster data when proposing module replacements
- surface complementary module suggestions during workflow simulation
- add SANDBOX_USE_MODULE_SYNERGY flag to toggle module synergy behavior

## Testing
- `python -m pre_commit run --files self_improvement_engine.py sandbox_runner/environment.py sandbox_settings.py` *(fails: sandbox_runner/environment.py:5625:14: F821 undefined name 'ROITracker', and other lint errors)*
- `pytest` *(fails: Missing system packages: ffmpeg, tesseract, qemu-system-x86_64. Install them using your package manager.)*


------
https://chatgpt.com/codex/tasks/task_e_68ab208af7cc832eab919edb9b9b89fc