### PR TITLE
Add tests and docs for module synergy grapher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1682,6 +1682,22 @@ python self_improvement_engine.py fit-truth-adapter live.npz shadow.npz
 See [docs/truth_adapter.md](docs/truth_adapter.md) for details and additional
 configuration options.
 
+
+## Module Synergy Grapher
+
+Builds a weighted graph of module relationships and queries related modules.
+
+```bash
+python module_synergy_grapher.py build .
+python module_synergy_grapher.py cluster <module> --threshold 0.8
+```
+
+Use `--out` to choose an output file when building, `--path` to point at an
+existing graph when querying and `--threshold` to control cluster expansion.
+The `ModuleSynergyGrapher` constructor accepts a `coefficients` mapping to tune
+how `import`, `structure`, `workflow` and `semantic` signals contribute to edge
+weights.
+
 ## Vector Analytics
 
 `vector_metrics_analytics` surfaces stored vector metrics for quick

--- a/docs/module_synergy_grapher.md
+++ b/docs/module_synergy_grapher.md
@@ -1,0 +1,37 @@
+# Module Synergy Grapher
+
+`module_synergy_grapher` builds a weighted graph that links modules based on imports,
+structural similarity, workflow co-occurrence and semantic overlap. The resulting
+graph is saved to `sandbox_data/module_synergy_graph.json` for later queries.
+
+## Building
+
+```bash
+python module_synergy_grapher.py build <root>
+```
+
+Use `--out` to choose a custom output path.
+
+## Querying
+
+```bash
+python module_synergy_grapher.py cluster <module> --threshold 0.8 --path sandbox_data/module_synergy_graph.json
+```
+
+The `--threshold` flag filters edges by weight when expanding the cluster, and
+`--path` points to an alternate graph file.
+
+## Configuration
+
+The `ModuleSynergyGrapher` constructor accepts a `coefficients` mapping to adjust
+how each signal contributes to an edge:
+
+```python
+from module_synergy_grapher import ModuleSynergyGrapher
+
+grapher = ModuleSynergyGrapher(coefficients={"import": 1.0, "structure": 0.5, "workflow": 1.0, "semantic": 0.0})
+```
+
+Pass a custom `vector_service` if semantic similarity should use a different
+embedding backend.
+

--- a/tests/test_module_synergy_grapher.py
+++ b/tests/test_module_synergy_grapher.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from module_synergy_grapher import ModuleSynergyGrapher, get_synergy_cluster
+
+
+def _build_sample_graph(tmp_path: Path):
+    (tmp_path / "a.py").write_text(
+        "import b\n\n\ndef a_func():\n    return 1\n"
+    )
+    (tmp_path / "b.py").write_text(
+        "def b_func():\n    return 2\n"
+    )
+    grapher = ModuleSynergyGrapher()
+    graph = grapher.build_graph(tmp_path)
+    path = tmp_path / "sandbox_data" / "module_synergy_graph.json"
+    return graph, path
+
+
+def test_build_graph_basic(tmp_path: Path):
+    graph, path = _build_sample_graph(tmp_path)
+    assert set(graph.nodes) == {"a", "b"}
+    assert set(graph.edges) == {("a", "b")}
+    assert graph["a"]["b"]["weight"] == 1.0
+    assert path.exists()
+
+
+def test_get_synergy_cluster_thresholds(tmp_path: Path):
+    _, path = _build_sample_graph(tmp_path)
+    assert get_synergy_cluster("a", threshold=0.5, path=path) == {"a", "b"}
+    assert get_synergy_cluster("a", threshold=1.1, path=path) == {"a"}
+    assert get_synergy_cluster("b", threshold=0.5, path=path) == {"b"}


### PR DESCRIPTION
## Summary
- add unit tests for `ModuleSynergyGrapher` graph construction and `get_synergy_cluster`
- document building and querying the module synergy graph
- update README with module synergy grapher usage and configuration flags

## Testing
- `pytest tests/test_module_synergy_grapher.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab21c7dcd4832eb15a62eb8eb13e52