### PR TITLE
Implement module synergy graph builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1695,7 +1695,7 @@ python module_synergy_grapher.py cluster <module> --threshold 0.8
 Use `--out` to choose an output file when building, `--path` to point at an
 existing graph when querying and `--threshold` to control cluster expansion.
 The `ModuleSynergyGrapher` constructor accepts a `coefficients` mapping to tune
-how `import`, `structure`, `workflow` and `semantic` signals contribute to edge
+how `import`, `structure` and `cooccurrence` signals contribute to edge
 weights.
 
 ## Vector Analytics

--- a/docs/module_synergy_grapher.md
+++ b/docs/module_synergy_grapher.md
@@ -1,8 +1,9 @@
 # Module Synergy Grapher
 
-`module_synergy_grapher` builds a weighted graph that links modules based on imports,
-structural similarity, workflow co-occurrence and semantic overlap. The resulting
-graph is saved to `sandbox_data/module_synergy_graph.json` for later queries.
+`module_synergy_grapher` builds a weighted graph that links modules based on direct
+imports and shared dependencies, structural similarity and co-occurrence data from
+workflows and historical synergy records.  The resulting graph is saved to
+`sandbox_data/module_synergy_graph.json` for later queries.
 
 ## Building
 
@@ -29,9 +30,16 @@ how each signal contributes to an edge:
 ```python
 from module_synergy_grapher import ModuleSynergyGrapher
 
-grapher = ModuleSynergyGrapher(coefficients={"import": 1.0, "structure": 0.5, "workflow": 1.0, "semantic": 0.0})
+grapher = ModuleSynergyGrapher(
+    coefficients={"import": 1.0, "structure": 0.5, "cooccurrence": 1.0}
+)
 ```
 
-Pass a custom `vector_service` if semantic similarity should use a different
-embedding backend.
+Use the :meth:`save` method to serialise the graph in JSON or pickle format:
+
+```python
+graph = grapher.build_graph(".")
+grapher.save(graph, format="pickle")
+```
+
 


### PR DESCRIPTION
## Summary
- add ModuleSynergyGrapher to build a weighted networkx graph across modules
- integrate imports, AST overlap, workflow and synergy history co-occurrence
- document usage and saving in README and docs

## Testing
- `pytest tests/test_module_synergy_grapher.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab22d0c87c832e8a488e2734c5e5ac