### PR TITLE
feat: scope support for eval metrics

### DIFF
--- a/tests/test_data_bot.py
+++ b/tests/test_data_bot.py
@@ -83,3 +83,15 @@ def test_collect_additional_fields(tmp_path):
         "flexibility",
         "projected_lucrativity",
     }.issubset(df.columns)
+
+
+def test_fetch_eval_scope(tmp_path):
+    mdb = db.MetricsDB(tmp_path / "m.db")
+    mdb.log_eval("c", "m", 1.0)
+    mdb.log_eval("c", "m", 2.0, source_menace_id="other")
+    local = mdb.fetch_eval("c")
+    assert len(local) == 1 and local[0][2] == 1.0
+    remote = mdb.fetch_eval("c", scope="global")
+    assert len(remote) == 1 and remote[0][2] == 2.0
+    all_rows = mdb.fetch_eval("c", scope="all")
+    assert len(all_rows) == 2


### PR DESCRIPTION
## Summary
- extend eval metric storage with source_menace_id for scope-aware queries
- add scope-aware fetch_eval and propagate params through cross_query helpers
- test eval_metrics retrieval filtering by menace scope

## Testing
- `pytest tests/test_data_bot.py::test_fetch_eval_scope -q`
- `pytest tests/test_system_evolution_manager.py tests/test_workflow_benchmark.py tests/test_anomaly_detection.py tests/test_cross_query.py -q` *(fails: FileNotFoundError, TypeError)*


------
https://chatgpt.com/codex/tasks/task_e_68ab25d09a3c832e937bdfcbc6d9c107