### PR TITLE
Add scope filtering to metrics fetch

### DIFF
--- a/tests/test_data_bot.py
+++ b/tests/test_data_bot.py
@@ -95,3 +95,36 @@ def test_fetch_eval_scope(tmp_path):
     assert len(remote) == 1 and remote[0][2] == 2.0
     all_rows = mdb.fetch_eval("c", scope="all")
     assert len(all_rows) == 2
+
+
+def test_fetch_scope(tmp_path):
+    mdb = db.MetricsDB(tmp_path / "m.db")
+    mdb.add(
+        db.MetricRecord(
+            bot="a",
+            cpu=0.0,
+            memory=0.0,
+            response_time=0.0,
+            disk_io=0.0,
+            net_io=0.0,
+            errors=0,
+        )
+    )
+    mdb.add(
+        db.MetricRecord(
+            bot="b",
+            cpu=0.0,
+            memory=0.0,
+            response_time=0.0,
+            disk_io=0.0,
+            net_io=0.0,
+            errors=0,
+        ),
+        source_menace_id="other",
+    )
+    local = mdb.fetch(limit=None)
+    assert len(local) == 1 and local.iloc[0]["bot"] == "a"
+    remote = mdb.fetch(limit=None, scope="global")
+    assert len(remote) == 1 and remote.iloc[0]["bot"] == "b"
+    all_rows = mdb.fetch(limit=None, scope="all")
+    assert len(all_rows) == 2


### PR DESCRIPTION
## Summary
- track `source_menace_id` for metrics and index it
- support scope-aware filtering in `MetricsDB.fetch`
- add tests covering local, global and all metric retrieval

## Testing
- `pytest tests/test_data_bot.py::test_db_roundtrip tests/test_data_bot.py::test_collect_additional_fields tests/test_data_bot.py::test_fetch_eval_scope tests/test_data_bot.py::test_fetch_scope tests/test_weekly_metrics_bot.py::test_compile_message -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab278b2248832ea2611a9571d87de7