### PR TITLE
Support external config for ModuleSynergyGrapher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1688,14 +1688,15 @@ configuration options.
 Builds a weighted graph of module relationships and queries related modules.
 
 ```bash
-python module_synergy_grapher.py --build
+python module_synergy_grapher.py --build [--config cfg.toml]
 python module_synergy_grapher.py --cluster <module> --threshold 0.8
 ```
 
-The `--threshold` flag controls cluster expansion.  The
-`ModuleSynergyGrapher` constructor accepts a `coefficients` mapping to tune
-how `import`, `structure` and `cooccurrence` signals contribute to edge
-weights.  `make synergy-graph` can be used in automation to refresh the graph.
+The `--threshold` flag controls cluster expansion.  `--config` points to a
+JSON/TOML file whose `coefficients` section overrides the default weighting.
+The `ModuleSynergyGrapher` constructor accepts the same via its `config`
+parameter or a raw `coefficients` mapping.  `make synergy-graph` can be used in
+automation to refresh the graph.
 
 ## Vector Analytics
 

--- a/docs/module_synergy_grapher.md
+++ b/docs/module_synergy_grapher.md
@@ -8,7 +8,7 @@ workflows and historical synergy records.  The resulting graph is saved to
 ## Building
 
 ```bash
-python module_synergy_grapher.py --build
+python module_synergy_grapher.py --build [--config config.toml]
 ```
 
 The graph is persisted to `sandbox_data/module_synergy_graph.json` and can be
@@ -24,16 +24,17 @@ The `--threshold` flag filters edges by weight when expanding the cluster.
 
 ## Configuration
 
-The `ModuleSynergyGrapher` constructor accepts a `coefficients` mapping to adjust
-how each signal contributes to an edge:
+The `ModuleSynergyGrapher` constructor accepts either a `coefficients` mapping
+or a JSON/TOML `config` file to adjust how each signal contributes to an edge:
 
 ```python
 from module_synergy_grapher import ModuleSynergyGrapher
 
-grapher = ModuleSynergyGrapher(
-    coefficients={"import": 1.0, "structure": 0.5, "cooccurrence": 1.0}
-)
+grapher = ModuleSynergyGrapher(config="weights.json")
 ```
+
+The CLI also accepts `--config` to load the same style of configuration file
+when building the graph.
 
 The optional `embedding_threshold` parameter controls the minimum cosine
 similarity between module docstrings required before an embedding edge is

--- a/tests/test_module_synergy_grapher.py
+++ b/tests/test_module_synergy_grapher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import json
 
 import networkx as nx
 import pytest
@@ -100,6 +101,26 @@ def test_build_save_load_cluster(tmp_path: Path):
     assert set(loaded.edges) == {("a", "b")}
     assert loaded["a"]["b"]["weight"] == pytest.approx(1.0)
     assert loader.get_synergy_cluster("a", threshold=0.5) == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# Configuration handling
+
+
+def test_config_overrides(tmp_path: Path):
+    cfg = {"coefficients": {"import": 0.2}}
+    grapher = ModuleSynergyGrapher(config=cfg)
+    assert grapher.coefficients["import"] == 0.2
+
+    json_path = tmp_path / "cfg.json"
+    json_path.write_text(json.dumps({"coefficients": {"structure": 0.3}}))
+    grapher = ModuleSynergyGrapher(config=json_path)
+    assert grapher.coefficients["structure"] == 0.3
+
+    toml_path = tmp_path / "cfg.toml"
+    toml_path.write_text('coefficients = {cooccurrence = 0.4}')
+    grapher = ModuleSynergyGrapher(config=toml_path)
+    assert grapher.coefficients["cooccurrence"] == 0.4
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- allow `ModuleSynergyGrapher` to load coefficient overrides from a dict or JSON/TOML file
- expose `--config` flag in CLI
- document configuration and cover with tests

## Testing
- `pytest tests/test_module_synergy_grapher.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab83c6ade4832e97a2048297350160