### PR TITLE
Add module synergy caching

### DIFF
--- a/docs/module_synergy_grapher.md
+++ b/docs/module_synergy_grapher.md
@@ -14,6 +14,16 @@ python module_synergy_grapher.py --build [--config config.toml]
 The graph is persisted to `sandbox_data/module_synergy_graph.json` and can be
 rebuilt via `make synergy-graph` in automation contexts.
 
+## Caching
+
+To speed up subsequent runs, AST-derived identifiers and docstring embeddings
+for each module are cached in `sandbox_data/synergy_cache.json`.  Each cache
+entry stores the source file's modification time and a SHA256 hash.  During
+`build_graph` these values are compared against the current file; modules with
+unchanged metadata reuse cached details while others are recomputed.  Deleting
+or touching the source file invalidates its cache entry, and passing
+`--no-cache` rebuilds all entries from scratch.
+
 ## Querying
 
 ```bash


### PR DESCRIPTION
## Summary
- cache module AST details and embeddings in `sandbox_data/synergy_cache.json`
- recompute graph data only for modules whose sources changed
- document cache location and invalidation strategy

## Testing
- `pre-commit run --files module_synergy_grapher.py docs/module_synergy_grapher.md`
- `pytest tests/test_module_synergy_grapher.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab8abefeec832ea44fbf6c283e4565