### PR TITLE
Parallelize module embedding retrieval

### DIFF
--- a/docs/module_synergy_grapher.md
+++ b/docs/module_synergy_grapher.md
@@ -59,6 +59,7 @@ get_synergy_cluster("a", threshold=0.5)
 * `--threshold FLOAT` – minimum cumulative synergy required for inclusion (default `0.7`).
 * `--config PATH` – JSON/TOML file providing coefficient overrides.
 * `--no-cache` – recompute AST info and embeddings ignoring cached results.
+* `--embed-workers N` – number of threads used when fetching embeddings.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- compute missing module embeddings concurrently using a thread pool in `ModuleSynergyGrapher`
- expose `embed_workers` option and CLI flag to configure worker count
- document the new `--embed-workers` command-line option

## Testing
- `pytest tests/test_module_synergy_grapher.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab8bd2fffc832e984103d53af5c9e4