### PR TITLE
Add automatic coefficient tuning for module synergy grapher

### DIFF
--- a/docs/module_synergy_grapher.md
+++ b/docs/module_synergy_grapher.md
@@ -8,7 +8,7 @@ workflows and historical synergy records.  The resulting graph is saved to
 ## Building
 
 ```bash
-python module_synergy_grapher.py --build [--config config.toml]
+python module_synergy_grapher.py --build [--auto-tune] [--config config.toml]
 ```
 
 The graph is persisted to `sandbox_data/module_synergy_graph.json` and can be
@@ -60,6 +60,7 @@ get_synergy_cluster("a", threshold=0.5)
 * `--config PATH` – JSON/TOML file providing coefficient overrides.
 * `--no-cache` – recompute AST info and embeddings ignoring cached results.
 * `--embed-workers N` – number of threads used when fetching embeddings.
+* `--auto-tune` – learn coefficient weights from `synergy_history.db` before rebuilding.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- learn synergy coefficients from `synergy_history.db` via linear regression and persist as weights
- add `--auto-tune` CLI flag to recompute coefficients before rebuilding the synergy graph
- document auto-tuning and cover with regression test

## Testing
- `pytest tests/test_module_synergy_grapher.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab91c27ca0832e979caa866aa6268e