### PR TITLE
Add content hash indices for core bot databases

### DIFF
--- a/bot_database.py
+++ b/bot_database.py
@@ -167,11 +167,23 @@ class BotDB(EmbeddableDBMixin):
             self.conn.execute(
                 "ALTER TABLE bots ADD COLUMN source_menace_id TEXT NOT NULL DEFAULT ''"
             )
+        if "content_hash" not in cols:
+            try:
+                self.conn.execute(
+                    "ALTER TABLE bots ADD COLUMN content_hash TEXT UNIQUE"
+                )
+            except sqlite3.OperationalError:
+                self.conn.execute(
+                    "ALTER TABLE bots ADD COLUMN content_hash TEXT"
+                )
         idxs = [r[1] for r in self.conn.execute("PRAGMA index_list('bots')").fetchall()]
         if "ix_bots_source_menace_id" in idxs:
             self.conn.execute("DROP INDEX IF EXISTS ix_bots_source_menace_id")
         self.conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_bots_source_menace_id ON bots(source_menace_id)"
+        )
+        self.conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_bots_content_hash ON bots(content_hash)"
         )
         self.conn.execute(
             "CREATE TABLE IF NOT EXISTS bot_model(bot_id INTEGER, model_id INTEGER)"

--- a/chatgpt_enhancement_bot.py
+++ b/chatgpt_enhancement_bot.py
@@ -193,6 +193,15 @@ class EnhancementDB(EmbeddableDBMixin):
                             "TEXT NOT NULL DEFAULT ''"
                         )
                     )
+                if "content_hash" not in cols:
+                    try:
+                        conn.execute(
+                            "ALTER TABLE enhancements ADD COLUMN content_hash TEXT UNIQUE"
+                        )
+                    except sqlite3.OperationalError:
+                        conn.execute(
+                            "ALTER TABLE enhancements ADD COLUMN content_hash TEXT"
+                        )
                 idxs = [
                     r[1]
                     for r in conn.execute(
@@ -210,6 +219,12 @@ class EnhancementDB(EmbeddableDBMixin):
                             "ON enhancements(source_menace_id)"
                         )
                     )
+                conn.execute(
+                    (
+                        "CREATE UNIQUE INDEX IF NOT EXISTS "
+                        "idx_enhancements_content_hash ON enhancements(content_hash)"
+                    )
+                )
                 conn.execute(
                     """
                     CREATE TABLE IF NOT EXISTS enhancement_models (

--- a/error_bot.py
+++ b/error_bot.py
@@ -147,6 +147,18 @@ class ErrorDB(EmbeddableDBMixin):
             self.conn.execute(
                 "ALTER TABLE errors ADD COLUMN source_menace_id TEXT NOT NULL DEFAULT ''"
             )
+        if "content_hash" not in cols:
+            try:
+                self.conn.execute(
+                    "ALTER TABLE errors ADD COLUMN content_hash TEXT UNIQUE"
+                )
+            except sqlite3.OperationalError:
+                self.conn.execute(
+                    "ALTER TABLE errors ADD COLUMN content_hash TEXT"
+                )
+        self.conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_errors_content_hash ON errors(content_hash)"
+        )
         self.conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_errors_source_menace_id ON errors(source_menace_id)"
         )

--- a/task_handoff_bot.py
+++ b/task_handoff_bot.py
@@ -132,6 +132,18 @@ class WorkflowDB(EmbeddableDBMixin):
             self.conn.execute("ALTER TABLE workflows ADD COLUMN action_chains TEXT")
         if "argument_strings" not in cols:
             self.conn.execute("ALTER TABLE workflows ADD COLUMN argument_strings TEXT")
+        if "content_hash" not in cols:
+            try:
+                self.conn.execute(
+                    "ALTER TABLE workflows ADD COLUMN content_hash TEXT UNIQUE"
+                )
+            except sqlite3.OperationalError:
+                self.conn.execute(
+                    "ALTER TABLE workflows ADD COLUMN content_hash TEXT"
+                )
+        self.conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_workflows_content_hash ON workflows(content_hash)"
+        )
         self.conn.commit()
         EmbeddableDBMixin.__init__(
             self,


### PR DESCRIPTION
## Summary
- add `content_hash` column to enhancements, errors, bots, and workflows tables
- ensure unique index `idx_*_content_hash` exists for each table
- initialize schema changes before any inserts

## Testing
- `pytest -q` *(fails: import errors and missing modules)*
- `pytest tests/test_synergy_exporter_integration.py::test_exporter_updates_after_training -q` *(fails: assert None == 0.1)*

------
https://chatgpt.com/codex/tasks/task_e_68ab94673c5c832eb171bb27d94872fe