### PR TITLE
docs: expand module synergy grapher guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1687,7 +1687,8 @@ configuration options.
 
 Builds a weighted graph of module relationships and queries related modules.
 See [docs/module_synergy_grapher.md](docs/module_synergy_grapher.md) for graph
-metrics, CLI options and sample cluster output.
+components, scoring, CLI options and workflow examples using
+`get_synergy_cluster`.
 
 ```bash
 python module_synergy_grapher.py --build [--config cfg.toml]


### PR DESCRIPTION
## Summary
- document module synergy graph components and scoring
- clarify CLI usage and `get_synergy_cluster` API with workflow example
- link synergy grapher docs from README

## Testing
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9b385e60832ea8bb91bb1bdd1131