### PR TITLE
Document content hash duplicate suppression

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@
     # sql == "SELECT * FROM bots WHERE bots.source_menace_id <> ?"
     # params == ["alpha"]
     ```
+  - Shared tables include a `content_hash` column storing a SHA256 hash of JSON-encoded core fields.
+    The `insert_if_unique` helper computes this hash and skips inserts when the value already exists,
+    preventing cross-instance duplicates.
 - Change Data Capture events published to `UnifiedEventBus`
 - Vector embedding search via `EmbeddableDBMixin` for bots, workflows,
   errors, enhancements and research items. Each database stores its own


### PR DESCRIPTION
## Summary
- note `content_hash` SHA256 dedup field for shared tables
- mention `insert_if_unique` helper to skip cross-instance duplicates

## Testing
- `pytest tests/test_db_dedup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab9fa21fe0832e8a8f635544973ea2