### PR TITLE
feat: capture intent comments

### DIFF
--- a/tests/test_intent_clusterer.py
+++ b/tests/test_intent_clusterer.py
@@ -5,8 +5,8 @@ import pytest
 
 sys.modules['hdbscan'] = None
 
-import intent_clusterer as ic
-from vector_utils import cosine_similarity
+import intent_clusterer as ic  # noqa: E402
+from vector_utils import cosine_similarity  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
@@ -61,3 +61,32 @@ def test_cluster_search(tmp_path):
     assert "A doc" in text and "B doc" in text
     res = clusterer.find_modules_related_to("cluster A", top_k=1)
     assert res and res[0]["cluster_id"] == cid
+
+
+def test_collect_intent_no_docstring(tmp_path):
+    path = tmp_path / "mod.py"
+    path.write_text("# comment about func\n\ndef fn():\n    pass\n")
+    clusterer = ic.IntentClusterer(DummyRetriever())
+    text, meta = clusterer._collect_intent(path)
+    assert meta["names"] == ["fn"]
+    assert "docstrings" not in meta
+    assert meta["comments"] == ["comment about func"]
+
+
+def test_collect_intent_only_comments_module(tmp_path):
+    path = tmp_path / "cmod.py"
+    path.write_text("# just a comment\n")
+    clusterer = ic.IntentClusterer(DummyRetriever())
+    text, meta = clusterer._collect_intent(path)
+    assert text == ""
+    assert meta["names"] == []
+
+
+def test_collect_intent_mixed_encoding(tmp_path):
+    path = tmp_path / "latin.py"
+    content = "# -*- coding: latin-1 -*-\n# espa\xf1ol\n\nclass X:\n    pass\n"
+    path.write_bytes(content.encode("latin-1"))
+    clusterer = ic.IntentClusterer(DummyRetriever())
+    text, meta = clusterer._collect_intent(path)
+    assert meta["names"] == ["X"]
+    assert "espa\xf1ol" in meta["comments"][0]


### PR DESCRIPTION
## Summary
- handle encoding and parse errors when collecting intents
- gather preceding comments for functions and classes
- test intent extraction with comments and mixed encodings

## Testing
- `pre-commit run --files intent_clusterer.py tests/test_intent_clusterer.py`
- `pytest tests/test_intent_clusterer.py`


------
https://chatgpt.com/codex/tasks/task_e_68aba2942f88832e94ca05dddb969bac