### PR TITLE
Use insert_if_unique for bot records

### DIFF
--- a/bot_database.py
+++ b/bot_database.py
@@ -405,15 +405,17 @@ class BotDB(EmbeddableDBMixin):
             "name",
             "type",
             "tasks",
-            "dependencies",
             "purpose",
             "tags",
             "toolchain",
-            "version",
         ]
-        with self.router.get_connection("bots", "write") as conn:
-            rec.bid, inserted = insert_if_unique(
-                conn, "bots", values, hash_fields, menace_id
+        rec.bid, inserted = insert_if_unique(
+            self.conn, "bots", values, hash_fields, menace_id
+        )
+        self.conn.commit()
+        if not inserted:
+            logger.warning(
+                "bot '%s' already exists; using existing id %s", rec.name, rec.bid
             )
         if inserted:
             self._embed_record_on_write(rec.bid, rec)


### PR DESCRIPTION
## Summary
- deduplicate bot creation by using `insert_if_unique` and hashing core fields
- reuse existing bot when duplicate content found

## Testing
- `pre-commit run --files bot_database.py`
- `pytest tests/test_botdb_vector_search.py tests/test_db_router_get_connection.py tests/test_db_router_table_sharing.py tests/test_db_router_threaded_isolation.py tests/test_ipo_bot.py -q` *(fails: Duplicate insert ignored for bots (menace_id=743267b66c624082891bba540cc58b37))*
- `pytest tests/test_db_dedup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aba5cf2890832ea99de6db5f16e22d