### PR TITLE
Add intent clusterer indexing and query tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@
   embedding fields and can use either a FAISS or Annoy backend for
   similarity queries. See [docs/embedding_system.md](docs/embedding_system.md)
   for configuration details and backfilling instructions.
+- Lightweight intent clustering for modules with semantic query support
+  ([docs/intent_clusterer.md](docs/intent_clusterer.md))
 - `EmbeddingBackfill` and `EmbeddingScheduler` now handle `bots`, `workflows`,
   `enhancements` and `errors` tables directly.  Operators can schedule
   periodic backfills by setting `EMBEDDING_SCHEDULER_SOURCES` to a comma

--- a/docs/intent_clusterer.md
+++ b/docs/intent_clusterer.md
@@ -1,0 +1,28 @@
+# Intent Clusterer
+
+The `IntentClusterer` indexes Python modules by capturing docstrings,
+comments and symbol names, storing embeddings via a retriever backend.
+It can then answer semantic queries and surface related modules or
+clusters.
+
+## Indexing a repository
+
+```python
+from intent_clusterer import IntentClusterer
+from universal_retriever import UniversalRetriever
+
+retriever = UniversalRetriever(...)
+clusterer = IntentClusterer(retriever)
+clusterer.index_repository("/path/to/repo")
+```
+
+## Querying intents
+
+```python
+matches = clusterer.query("update configuration", top_k=5)
+for match in matches:
+    print(match.path, match.cluster_ids, match.similarity)
+```
+
+`query` returns `IntentMatch` objects with module paths, similarity
+scores and any related cluster identifiers.


### PR DESCRIPTION
## Summary
- add fixtures and deterministic indexing/query tests for IntentClusterer
- document IntentClusterer usage and link from README

## Testing
- `pytest tests/test_intent_clusterer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aba7d958a0832eba479d85f19553cc