### PR TITLE
Refine workflow deduplication in add

### DIFF
--- a/task_handoff_bot.py
+++ b/task_handoff_bot.py
@@ -294,7 +294,7 @@ class WorkflowDB(EmbeddableDBMixin):
     # --------------------------------------------------------------
     # insert/fetch
     def add(self, wf: WorkflowRecord, source_menace_id: str = "") -> int:
-        values = {
+        core_fields = {
             "workflow": ",".join(wf.workflow),
             "action_chains": ",".join(wf.action_chains),
             "argument_strings": ",".join(wf.argument_strings),
@@ -302,6 +302,9 @@ class WorkflowDB(EmbeddableDBMixin):
             "enhancements": ",".join(wf.enhancements),
             "title": wf.title,
             "description": wf.description,
+        }
+        values = {
+            **core_fields,
             "task_sequence": ",".join(wf.task_sequence),
             "tags": ",".join(wf.tags),
             "category": wf.category,
@@ -313,14 +316,7 @@ class WorkflowDB(EmbeddableDBMixin):
             "estimated_profit_per_bot": wf.estimated_profit_per_bot,
             "timestamp": wf.timestamp,
         }
-        hash_fields = [
-            "workflow",
-            "action_chains",
-            "argument_strings",
-            "title",
-            "description",
-            "task_sequence",
-        ]
+        hash_fields = list(core_fields.keys())
         with self.router.get_connection("workflows", "write") as conn:
             wf.wid, inserted = insert_if_unique(
                 conn, "workflows", values, hash_fields, source_menace_id


### PR DESCRIPTION
## Summary
- Build core field dictionary for workflows and deduplicate via `insert_if_unique`
- Avoid embedding and event publication when duplicate workflows detected

## Testing
- `pre-commit run --files task_handoff_bot.py`
- `pytest` *(fails: Missing system packages: ffmpeg, tesseract, qemu-system-x86_64. Install them using your package manager.)*


------
https://chatgpt.com/codex/tasks/task_e_68aba7e1936c832ea79e4765fd0e728f