### PR TITLE
Add intent vectorization and database support

### DIFF
--- a/intent_db.py
+++ b/intent_db.py
@@ -1,0 +1,129 @@
+"""SQLite-backed storage for module intent embeddings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Tuple
+import sqlite3
+
+from vector_service import EmbeddableDBMixin
+try:  # pragma: no cover - import available when running inside package
+    from .db_router import DBRouter, GLOBAL_ROUTER, init_db_router
+except Exception:  # pragma: no cover - top level import fallback
+    from db_router import DBRouter, GLOBAL_ROUTER, init_db_router  # type: ignore
+
+from intent_vectorizer import IntentVectorizer
+
+
+@dataclass
+class IntentRecord:
+    """Representation of a module tracked for intent embedding."""
+
+    path: str
+    added: str = datetime.utcnow().isoformat()
+    id: int = 0
+
+
+class IntentDB(EmbeddableDBMixin):
+    """Persist intent embeddings for repository modules."""
+
+    def __init__(
+        self,
+        path: str | Path = "intent.db",
+        *,
+        router: DBRouter | None = None,
+        vector_index_path: str | Path | None = None,
+        embedding_version: int = 1,
+        vector_backend: str = "annoy",
+    ) -> None:
+        self.router = router or GLOBAL_ROUTER or init_db_router("intent", str(path), str(path))
+        self.conn = self.router.get_connection("intent")
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS intent_modules(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                path TEXT UNIQUE,
+                added TEXT,
+                source_menace_id TEXT NOT NULL
+            )
+            """
+        )
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_intent_path ON intent_modules(path)"
+        )
+        self.conn.commit()
+        index_path = (
+            Path(vector_index_path)
+            if vector_index_path is not None
+            else Path(path).with_suffix(".index")
+        )
+        meta_path = index_path.with_suffix(".json")
+        EmbeddableDBMixin.__init__(
+            self,
+            index_path=index_path,
+            metadata_path=meta_path,
+            embedding_version=embedding_version,
+            backend=vector_backend,
+        )
+        self._vectorizer = IntentVectorizer()
+
+    # ------------------------------------------------------------------
+    def add(self, path: str) -> int:
+        """Insert ``path`` into the database if not present."""
+
+        cur = self.conn.execute(
+            "INSERT OR IGNORE INTO intent_modules(path, added, source_menace_id) VALUES (?,?,?)",
+            (path, datetime.utcnow().isoformat(), self.router.menace_id),
+        )
+        self.conn.commit()
+        if cur.lastrowid:
+            return int(cur.lastrowid)
+        row = self.conn.execute("SELECT id FROM intent_modules WHERE path=?", (path,)).fetchone()
+        return int(row["id"]) if row else 0
+
+    # ------------------------------------------------------------------
+    def iter_records(self) -> Iterator[Tuple[int, Dict[str, Any], str]]:
+        """Yield records for embedding backfills."""
+
+        for row in self.conn.execute("SELECT id, path FROM intent_modules"):
+            yield int(row["id"]), {"path": row["path"]}, "module"
+
+    # ------------------------------------------------------------------
+    def _bundle(self, path: str) -> str:
+        return self._vectorizer.bundle(path)
+
+    def license_text(self, rec: Any) -> str | None:  # pragma: no cover - simple wrapper
+        path = None
+        if isinstance(rec, dict):
+            path = rec.get("path")
+        elif isinstance(rec, (str, Path)):
+            path = str(rec)
+        elif isinstance(rec, int):
+            row = self.conn.execute("SELECT path FROM intent_modules WHERE id=?", (rec,)).fetchone()
+            path = row["path"] if row else None
+        if not path:
+            return None
+        return self._bundle(path)
+
+    # ------------------------------------------------------------------
+    def vector(self, rec: Any) -> List[float]:
+        path = None
+        if isinstance(rec, dict):
+            path = rec.get("path")
+        elif isinstance(rec, (str, Path)):
+            path = str(rec)
+        elif isinstance(rec, int):
+            row = self.conn.execute("SELECT path FROM intent_modules WHERE id=?", (rec,)).fetchone()
+            path = row["path"] if row else None
+        if not path:
+            return []
+        text = self._bundle(path)
+        if not text:
+            return []
+        return self.encode_text(text)
+
+
+__all__ = ["IntentRecord", "IntentDB"]

--- a/intent_vectorizer.py
+++ b/intent_vectorizer.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+"""Utilities for extracting high level intent from Python modules.
+
+The :class:`IntentVectorizer` reads a module file and collects natural language
+signals such as docstrings, function or class names and leading comments.  The
+resulting text bundle can be embedded via ``SentenceTransformer`` or the
+lightweight local model bundled with :mod:`vector_service`.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Any, List
+import ast
+import io
+import tokenize
+
+from governed_embeddings import governed_embed
+try:  # pragma: no cover - optional heavy dependency
+    from sentence_transformers import SentenceTransformer  # type: ignore
+except Exception:  # pragma: no cover - allow running without dependency
+    SentenceTransformer = None  # type: ignore
+
+try:  # pragma: no cover - reuse tiny local model when transformers absent
+    from vector_service.vectorizer import _local_embed  # type: ignore
+except Exception:  # pragma: no cover - minimal fallback returning zeros
+    def _local_embed(_text: str) -> List[float]:
+        return []
+
+
+@dataclass
+class IntentVectorizer:
+    """Extract docstrings, names and comments from Python modules."""
+
+    model_name: str = "sentence-transformers/all-MiniLM-L6-v2"
+
+    def __post_init__(self) -> None:
+        self._model: SentenceTransformer | None = None
+        if SentenceTransformer is not None:
+            try:  # pragma: no cover - model load heavy
+                self._model = SentenceTransformer(self.model_name)
+            except Exception:  # pragma: no cover - best effort
+                self._model = None
+
+    # ------------------------------------------------------------------
+    def _encode(self, text: str) -> List[float]:
+        if self._model is not None:
+            vec = governed_embed(text, self._model)
+            if vec is not None:
+                return [float(x) for x in vec]
+        return _local_embed(text)
+
+    # ------------------------------------------------------------------
+    def bundle(self, path: str | Path) -> str:
+        """Return intent text extracted from ``path``."""
+
+        module_path = Path(path)
+        try:
+            with tokenize.open(module_path) as fh:
+                source = fh.read()
+        except OSError:
+            return ""
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            return ""
+
+        docstrings: List[str] = []
+        names: List[str] = []
+
+        mod_doc = ast.get_docstring(tree)
+        if mod_doc:
+            docstrings.append(mod_doc)
+
+        comment_map: dict[int, list[str]] = {}
+        code_lines: set[int] = set()
+        for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+            toknum, tokval, start, _end, _line = tok
+            lineno = start[0]
+            if toknum == tokenize.COMMENT:
+                if lineno not in code_lines:
+                    text = tokval.lstrip("#").strip()
+                    if "coding:" in text:
+                        continue
+                    if text:
+                        comment_map.setdefault(lineno, []).append(text)
+            elif toknum not in {
+                tokenize.NL,
+                tokenize.NEWLINE,
+                tokenize.INDENT,
+                tokenize.DEDENT,
+                tokenize.ENDMARKER,
+                tokenize.ENCODING,
+            }:
+                code_lines.add(lineno)
+
+        comments: List[str] = []
+        lines = source.splitlines()
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                names.append(node.name)
+                doc = ast.get_docstring(node)
+                if doc:
+                    docstrings.append(doc)
+                collected: List[str] = []
+                line = node.lineno - 1
+                while line > 0:
+                    if line in code_lines:
+                        break
+                    if line in comment_map:
+                        parts = [" ".join(c.split()) for c in comment_map[line]]
+                        collected.insert(0, " ".join(parts))
+                        line -= 1
+                        continue
+                    if lines[line - 1].strip() == "":
+                        line -= 1
+                        continue
+                    break
+                if collected:
+                    comments.append(" ".join(collected).strip())
+
+        return "\n".join(docstrings + names + comments)
+
+    # ------------------------------------------------------------------
+    def transform(self, rec: Dict[str, Any]) -> List[float]:
+        """Return an embedding vector for ``rec``.
+
+        ``rec`` must provide a ``path`` pointing to a Python module.
+        """
+
+        path = rec.get("path") or rec.get("module_path") or rec.get("file")
+        if not path:
+            return []
+        text = self.bundle(path)
+        if not text:
+            return []
+        return self._encode(text)
+
+
+DB_MODULE = "intent_db"
+DB_CLASS = "IntentDB"
+
+__all__ = ["IntentVectorizer"]

--- a/vector_service/registry.py
+++ b/vector_service/registry.py
@@ -174,6 +174,13 @@ register_vectorizer(
     db_module="resources_bot",
     db_class="ROIHistoryDB",
 )
+register_vectorizer(
+    "intent",
+    "intent_vectorizer",
+    "IntentVectorizer",
+    db_module="intent_db",
+    db_class="IntentDB",
+)
 
 # Discover any additional vectorisers packaged under vector_service.*
 _discover_vectorizers()


### PR DESCRIPTION
## Summary
- implement `IntentVectorizer` to extract module-level docstrings, names, and comments for embedding
- create `IntentDB` with persistent intent embeddings
- register new “intent” kind with vector service registry

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy.orm')*

------
https://chatgpt.com/codex/tasks/task_e_68aba94110a8832e8d8ba7fd74f97af0