### PR TITLE
Add duplicate record tests for database helpers

### DIFF
--- a/tests/test_bot_database.py
+++ b/tests/test_bot_database.py
@@ -1,0 +1,16 @@
+import logging
+import menace.bot_database as bdb
+from menace.db_router import init_db_router
+
+
+def test_add_bot_duplicate(tmp_path, caplog, monkeypatch):
+    init_db_router("botdup", str(tmp_path / "local.db"), str(tmp_path / "shared.db"))
+    monkeypatch.setattr(bdb.BotDB, "_embed_record_on_write", lambda *a, **k: None)
+    db = bdb.BotDB()
+    rec = bdb.BotRecord(name="b1")
+    with caplog.at_level(logging.WARNING):
+        first = db.add_bot(rec)
+        second = db.add_bot(bdb.BotRecord(name="b1"))
+    assert first == second
+    assert "duplicate" in caplog.text.lower()
+    assert db.conn.execute("SELECT COUNT(*) FROM bots").fetchone()[0] == 1

--- a/tests/test_chatgpt_enhancement_bot.py
+++ b/tests/test_chatgpt_enhancement_bot.py
@@ -1,6 +1,5 @@
-import pytest
-pytest.skip("optional dependencies not installed", allow_module_level=True)
 import json
+import logging
 
 import menace.chatgpt_enhancement_bot as ceb
 import menace.chatgpt_idea_bot as cib
@@ -20,10 +19,56 @@ def test_propose(monkeypatch, tmp_path):
         ]
     }
     client = cib.ChatGPTClient("key")
-    monkeypatch.setattr(client, "ask", lambda msgs, **kw: resp)
-    db = ceb.EnhancementDB(tmp_path / "enh.db")
+    monkeypatch.setattr(ceb, "ask_with_memory", lambda *a, **k: resp)
+    router = ceb.init_db_router("enhprop", str(tmp_path / "local.db"), str(tmp_path / "shared.db"))
+    db = ceb.EnhancementDB(tmp_path / "enh.db", router=router)
+    db.add_embedding = lambda *a, **k: None
     bot = ceb.ChatGPTEnhancementBot(client, db=db)
+    monkeypatch.setattr(bot, "_feasible", lambda e: True)
     results = bot.propose("Improve", num_ideas=1, context="ctx")
     assert results and results[0].context == "ctx"
     entries = db.fetch()
     assert entries and entries[0].idea == "New"
+
+
+def test_enhancementdb_duplicate(tmp_path, caplog):
+    router = ceb.init_db_router("enhdup", str(tmp_path / "local.db"), str(tmp_path / "shared.db"))
+    db = ceb.EnhancementDB(tmp_path / "enh.db", router=router)
+    db.add_embedding = lambda *a, **k: None
+    enh = ceb.Enhancement(idea="i", rationale="r")
+    first = db.add(enh)
+    tags = ",".join(enh.tags)
+    assigned = ",".join(enh.assigned_bots)
+    assoc = ",".join(enh.associated_bots)
+    values = {
+        "source_menace_id": db.router.menace_id,
+        "idea": enh.idea,
+        "rationale": enh.rationale,
+        "summary": enh.summary,
+        "score": enh.score,
+        "timestamp": enh.timestamp,
+        "context": enh.context,
+        "before_code": enh.before_code,
+        "after_code": enh.after_code,
+        "title": enh.title,
+        "description": enh.description,
+        "tags": tags,
+        "type": enh.type_,
+        "assigned_bots": assigned,
+        "rejection_reason": enh.rejection_reason,
+        "cost_estimate": enh.cost_estimate,
+        "category": enh.category,
+        "associated_bots": assoc,
+        "triggered_by": enh.triggered_by,
+    }
+    hash_fields = ["idea", "summary", "before_code", "after_code", "description"]
+    with caplog.at_level(logging.WARNING):
+        with db._connect() as conn:
+            dup_id, inserted = ceb.insert_if_unique(
+                conn, "enhancements", values, hash_fields, db.router.menace_id
+            )
+    assert dup_id == first
+    assert not inserted
+    with db._connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM enhancements").fetchone()[0] == 1
+    assert "duplicate" in caplog.text.lower()


### PR DESCRIPTION
## Summary
- test BotDB duplicate insert handling and warning
- cover WorkflowDB duplicate detection and ID reuse
- exercise EnhancementDB deduplication via insert_if_unique
- verify ErrorDB returns existing ID on duplicate errors

## Testing
- `pre-commit run --files tests/test_chatgpt_enhancement_bot.py tests/test_error_bot.py tests/test_task_handoff_bot.py tests/test_bot_database.py`
- `pytest tests/test_bot_database.py tests/test_task_handoff_bot.py tests/test_chatgpt_enhancement_bot.py tests/test_error_bot.py::test_add_error_duplicate`

------
https://chatgpt.com/codex/tasks/task_e_68ababba6fdc832e8907a3c39aa830c1