### PR TITLE
Add helper and CLI for intent clusterer exploration

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,20 @@ python -m menace.self_improvement_engine synergy-dashboard --wsgi flask
 
 Replace `flask` with `gunicorn` or `uvicorn` to use a different server.
 
+To explore the existing module index interactively, use the intent clusterer
+helper:
+
+```bash
+python -m intent_clusterer "error handling"
+```
+
+Or import the convenience function directly:
+
+```python
+from intent_clusterer import find_modules_related_to
+find_modules_related_to("error handling")
+```
+
 ### Entropy delta detection
 
 The sandbox monitors the ROI gain relative to entropy changes for each module.

--- a/intent_clusterer.py
+++ b/intent_clusterer.py
@@ -10,6 +10,7 @@ when available with graceful fallbacks otherwise.
 
 from __future__ import annotations
 
+import argparse
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Iterable, List
@@ -121,5 +122,38 @@ class IntentClusterer:
         return results[:top_k]
 
 
-__all__ = ["IntentClusterer"]
+# ---------------------------------------------------------------------------
+def find_modules_related_to(query: str, top_k: int = 5) -> List[Dict[str, float]]:
+    """Return modules most relevant to ``query`` using a fresh clusterer.
+
+    This helper instantiates :class:`IntentClusterer` with default dependencies
+    and proxies the call to :meth:`IntentClusterer.find_modules_related_to` for
+    quick, interactive exploration.
+    """
+
+    clusterer = IntentClusterer()
+    return clusterer.find_modules_related_to(query, top_k=top_k)
+
+
+def _cli() -> int:
+    """Entry point for the ``python -m intent_clusterer`` command."""
+
+    parser = argparse.ArgumentParser(description="Search for related modules")
+    parser.add_argument("query", help="Natural language search query")
+    parser.add_argument("--top-k", type=int, default=5, dest="top_k")
+    args = parser.parse_args()
+
+    results = find_modules_related_to(args.query, top_k=args.top_k)
+    for res in results:
+        path = res.get("path")
+        score = res.get("score")
+        print(f"{score:.3f}\t{path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())
+
+
+__all__ = ["IntentClusterer", "find_modules_related_to"]
 

--- a/tests/test_intent_clusterer_helper.py
+++ b/tests/test_intent_clusterer_helper.py
@@ -1,0 +1,17 @@
+import intent_clusterer as ic
+
+
+def test_find_modules_related_to_helper(monkeypatch):
+    class Dummy:
+        def __init__(self):
+            self.args = None
+
+        def find_modules_related_to(self, query, top_k=5):
+            self.args = (query, top_k)
+            return [{"path": "x.py", "score": 1.0}]
+
+    dummy = Dummy()
+    monkeypatch.setattr(ic, "IntentClusterer", lambda: dummy)
+    res = ic.find_modules_related_to("demo", top_k=2)
+    assert res == [{"path": "x.py", "score": 1.0}]
+    assert dummy.args == ("demo", 2)


### PR DESCRIPTION
## Summary
- expose a `find_modules_related_to` helper and CLI in `intent_clusterer`
- document usage in the autonomous sandbox section of the README
- add unit test for the helper

## Testing
- `pytest tests/test_intent_clusterer_helper.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68abafa2715c832e958efacfbbe2e499