### PR TITLE
Handle duplicate workflows with insert_if_unique

### DIFF
--- a/deployment_bot.py
+++ b/deployment_bot.py
@@ -396,6 +396,9 @@ class DeploymentBot:
                     task_sequence=chunk,
                 )
                 wid = self.workflow_db.add(rec)
+                if wid is None:
+                    self.logger.warning("duplicate workflow ignored for %s", key)
+                    continue
                 existing[key] = wid
             ids.append(wid)
 

--- a/tests/test_workflow_dedup.py
+++ b/tests/test_workflow_dedup.py
@@ -1,0 +1,32 @@
+import logging
+import importlib
+import sys
+
+
+def test_duplicate_workflow_skipped(tmp_path, caplog, monkeypatch):
+    sys.modules.pop("menace.task_handoff_bot", None)
+    thb = importlib.import_module("menace.task_handoff_bot")
+    router = thb.init_db_router(
+        "wfdup", str(tmp_path / "local.db"), str(tmp_path / "shared.db")
+    )
+    monkeypatch.setattr(thb.WorkflowDB, "add_embedding", lambda *a, **k: None)
+    db = thb.WorkflowDB(tmp_path / "wf.db", router=router)
+    wf1 = thb.WorkflowRecord(
+        workflow=["a"],
+        action_chains=["x"],
+        argument_strings=["y"],
+        description="desc",
+    )
+    with caplog.at_level(logging.WARNING):
+        wid1 = db.add(wf1)
+        wid2 = db.add(
+            thb.WorkflowRecord(
+                workflow=["a"],
+                action_chains=["x"],
+                argument_strings=["y"],
+                description="desc",
+            )
+        )
+    assert wid1 == wid2
+    assert db.conn.execute("SELECT COUNT(*) FROM workflows").fetchone()[0] == 1
+    assert "duplicate workflow" in caplog.text.lower()


### PR DESCRIPTION
## Summary
- use `insert_if_unique` to de-duplicate workflow entries
- warn and skip embedding generation when duplicate workflow detected
- cover duplicate workflow scenarios with dedicated test

## Testing
- `pre-commit run --files deployment_bot.py task_handoff_bot.py tests/test_workflow_dedup.py`
- `pytest tests/test_task_handoff_bot.py::test_workflowdb_duplicate tests/test_workflow_dedup.py tests/test_workflow_roundtrip.py::test_workflow_to_dict_from_dict_roundtrip -q`


------
https://chatgpt.com/codex/tasks/task_e_68abb8598cd4832eb71c84b33afdd39c