### PR TITLE
docs: expand intent clusterer guide

### DIFF
--- a/docs/intent_clusterer.md
+++ b/docs/intent_clusterer.md
@@ -1,28 +1,46 @@
 # Intent Clusterer
 
-The `IntentClusterer` indexes Python modules by capturing docstrings,
-comments and symbol names, storing embeddings via a retriever backend.
-It can then answer semantic queries and surface related modules or
-clusters.
+`IntentClusterer` builds a lightweight semantic index of Python modules by
+collecting docstrings, comments and symbol names.  Embeddings are stored via a
+`UniversalRetriever`-compatible backend so other components can discover modules
+related to a natural language goal.  The clusterer underpins several parts of
+the sandbox self‑improvement loop, including the `self_improvement_engine` and
+`workflow_evolution_bot`.
 
-## Indexing a repository
+## Indexing modules
 
 ```python
+from pathlib import Path
 from intent_clusterer import IntentClusterer
 from universal_retriever import UniversalRetriever
 
 retriever = UniversalRetriever(...)
 clusterer = IntentClusterer(retriever)
-clusterer.index_repository("/path/to/repo")
+module_paths = [
+    Path("self_improvement_engine.py"),
+    Path("bot_creation_bot.py"),
+]
+clusterer.index_modules(module_paths)
 ```
 
-## Querying intents
+## Retrieving intent results
+
+Retrieve modules or clusters that relate to a textual prompt:
 
 ```python
-matches = clusterer.query("update configuration", top_k=5)
+matches = clusterer.find_modules_related_to("update configuration", top_k=5)
 for match in matches:
-    print(match.path, match.cluster_ids, match.similarity)
+    print(match["path"], match["score"])
 ```
 
-`query` returns `IntentMatch` objects with module paths, similarity
-scores and any related cluster identifiers.
+`find_modules_related_to` returns dictionaries describing the best matches.  For
+cluster information use `query`:
+
+```python
+matches = clusterer.query("update configuration")
+for m in matches:
+    print(m.path, m.cluster_ids, m.similarity)
+```
+
+`query` yields `IntentMatch` objects with module paths, similarity scores and
+any related cluster identifiers.


### PR DESCRIPTION
## Summary
- document the IntentClusterer's role in the sandbox self-improvement loop
- show how to index modules and search for intent-related results

## Testing
- `pre-commit run --files docs/intent_clusterer.md`


------
https://chatgpt.com/codex/tasks/task_e_68abbb49a824832e989a585a6c39035d