### PR TITLE
Persist intent embeddings in IntentClusterer

### DIFF
--- a/intent_clusterer.py
+++ b/intent_clusterer.py
@@ -22,6 +22,7 @@ import tokenize
 from governed_embeddings import governed_embed
 from embeddable_db_mixin import EmbeddableDBMixin
 from math import sqrt
+from vector_utils import persist_embedding
 
 try:  # pragma: no cover - optional dependency
     from sklearn.cluster import KMeans  # type: ignore
@@ -224,6 +225,16 @@ class IntentClusterer:
             if vec:
                 self.module_ids[str(path)] = rid
                 self.vectors[str(path)] = vec
+                try:
+                    persist_embedding(
+                        "intent",
+                        str(path),
+                        vec,
+                        origin_db="intent",
+                        metadata={"type": "intent", "module": str(path)},
+                    )
+                except TypeError:  # pragma: no cover - backwards compatibility
+                    persist_embedding("intent", str(path), vec)
                 # Persist in retriever for cross-module search when available
                 if hasattr(self.retriever, "add_vector"):
                     try:


### PR DESCRIPTION
## Summary
- import `persist_embedding` in `intent_clusterer`
- save module intent vectors with metadata for each indexed file

## Testing
- `pre-commit run --files intent_clusterer.py`
- `pytest tests/test_intent_clusterer_query.py -q`
- `pytest tests/test_intent_clusterer.py -q`
- `pytest tests/test_intent_clusterer_helper.py -q`
- `pytest tests/integration/test_intent_clusterer_synergy.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68abbbfaed6c832eae9830b6fe8e06d5