### PR TITLE
Deduplicate enhancements using summary hash field

### DIFF
--- a/chatgpt_enhancement_bot.py
+++ b/chatgpt_enhancement_bot.py
@@ -54,6 +54,7 @@ DEFAULT_PROPOSE_RATIO = float(os.environ.get("PROPOSE_SUMMARY_RATIO", "0.3"))
 _ENHANCEMENT_HASH_FIELDS = [
     "idea",
     "rationale",
+    "summary",
     "before_code",
     "after_code",
     "description",
@@ -329,7 +330,7 @@ class EnhancementDB(EmbeddableDBMixin):
                 "enhancements",
                 values,
                 _ENHANCEMENT_HASH_FIELDS,
-                self.router.menace_id if self.router else "",
+                menace_id,
                 logger,
             )
         if enh_id is None:


### PR DESCRIPTION
## Summary
- Include `summary` among enhancement content-hash fields
- Ensure EnhancementDB.add passes router menace ID when inserting with `insert_if_unique`

## Testing
- `pytest -q` *(fails: Missing system packages: ffmpeg, tesseract, qemu-system-x86_64)*
- `pytest tests/test_db_dedup.py::test_enhancementdb_dedup tests/test_chatgpt_enhancement_bot.py::test_enhancementdb_duplicate -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pytest tests/test_enhancement_db.py -q` *(fails: sqlite3.OperationalError: table enhancements has no column named content_hash)*

------
https://chatgpt.com/codex/tasks/task_e_68abc1043698832e88e9e625c9c8f275