### PR TITLE
Add cluster search helpers to IntentClusterer

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,15 +631,17 @@ helper:
 python -m intent_clusterer "error handling"
 ```
 
-Or import the convenience function directly:
+Or import the convenience helpers directly:
 
 ```python
-from intent_clusterer import find_modules_related_to
+from intent_clusterer import find_modules_related_to, find_clusters_related_to
 find_modules_related_to("error handling")
+find_clusters_related_to("error handling")
 ```
 
-Results include a relevance ``score`` and an ``origin`` field indicating
-whether the match refers to an individual module or a synergy ``cluster``.
+``find_modules_related_to`` returns relevant module paths, while
+``find_clusters_related_to`` surfaces synergy clusters.  Entries include a
+relevance ``score`` and an ``origin`` field indicating the result type.
 
 ### Entropy delta detection
 

--- a/docs/intent_clusterer.md
+++ b/docs/intent_clusterer.md
@@ -28,13 +28,17 @@ clusterer.index_modules(module_paths)
 Retrieve modules or clusters that relate to a textual prompt:
 
 ```python
-matches = clusterer.find_modules_related_to("update configuration", top_k=5)
-for match in matches:
-    print(match["path"], match["score"])
+mods = clusterer.find_modules_related_to("update configuration", top_k=5)
+clusters = clusterer.find_clusters_related_to("update configuration", top_k=5)
+for match in mods:
+    print("module", match["path"], match["score"])
+for match in clusters:
+    print("cluster", match["path"], match.get("members"), match["score"])
 ```
 
-`find_modules_related_to` returns dictionaries describing the best matches.  For
-cluster information use `query`:
+Both functions return dictionaries describing the best matches.  For more
+detailed similarity information including related cluster identifiers use
+`query`:
 
 ```python
 matches = clusterer.query("update configuration")

--- a/tests/integration/test_intent_clusterer_synergy.py
+++ b/tests/integration/test_intent_clusterer_synergy.py
@@ -45,6 +45,6 @@ def test_synergy_cluster_embeddings_and_query(tmp_path: Path, monkeypatch):
     clusterer.index_modules([tmp_path / "a.py", tmp_path / "b.py"])
     db.index_synergy_cluster("a", 0.5)
 
-    res = clusterer.find_modules_related_to("alpha beta", top_k=1)
+    res = clusterer.find_clusters_related_to("alpha beta", top_k=1)
     assert res and res[0]["path"].startswith("cluster:a")
     assert res[0]["origin"] == "cluster"

--- a/tests/test_intent_clusterer.py
+++ b/tests/test_intent_clusterer.py
@@ -135,6 +135,6 @@ def test_synergy_cluster_embeddings_and_query(tmp_path: Path, monkeypatch):
     clusterer.index_modules([tmp_path / "a.py", tmp_path / "b.py"])
     db.index_synergy_cluster("a", 0.5)
 
-    res = clusterer.find_modules_related_to("alpha beta", top_k=1)
+    res = clusterer.find_clusters_related_to("alpha beta", top_k=1)
     assert res and res[0]["path"].startswith("cluster:a")
     assert res[0]["origin"] == "cluster"


### PR DESCRIPTION
## Summary
- expand semantic search with `_search_related` helper
- expose `find_modules_related_to` for modules and new `find_clusters_related_to` for synergy clusters
- document new cluster search utilities

## Testing
- `pre-commit run --files README.md docs/intent_clusterer.md intent_clusterer.py tests/test_intent_clusterer.py tests/integration/test_intent_clusterer_synergy.py`
- `pytest tests/test_intent_clusterer.py tests/integration/test_intent_clusterer_synergy.py`


------
https://chatgpt.com/codex/tasks/task_e_68abc229dbb4832eb12cadf36ba07d23