### PR TITLE
Use content hashes for error deduplication

### DIFF
--- a/error_bot.py
+++ b/error_bot.py
@@ -31,7 +31,6 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     pd = None  # type: ignore
 
-_ERROR_HASH_FIELDS = ["type", "description", "resolution"]
 
 from .data_bot import MetricsDB, DataBot
 from .error_forecaster import ErrorForecaster
@@ -502,10 +501,11 @@ class ErrorDB(EmbeddableDBMixin):
             "resolution": resolution,
             "ts": datetime.utcnow().isoformat(),
         }
-        content_hash = _hash_fields(values, _ERROR_HASH_FIELDS)
+        hash_fields = ["message", "type", "description", "resolution"]
+        content_hash = _hash_fields(values, hash_fields)
         with self.router.get_connection("errors", "write") as conn:
             err_id = insert_if_unique(
-                conn, "errors", values, _ERROR_HASH_FIELDS, menace_id, logger
+                conn, "errors", values, hash_fields, menace_id, logger
             )
             conn.commit()
         if err_id is None:


### PR DESCRIPTION
## Summary
- Hash error records using message, type, description, and resolution
- Deduplicate via `insert_if_unique` without manual lookup
- Only publish events and embeddings for newly inserted errors

## Testing
- `pytest tests/test_error_bot.py::test_add_error_duplicate -q` *(fails: assert 1 == 2)*
- `pytest tests/test_db_dedup.py::test_errordb_dedup -q` *(error: No module named 'sqlalchemy.exc'; 'sqlalchemy' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68abc44b6cd0832eac4edd2a8b50c79c