### PR TITLE
Implement cluster intent retrieval and tests

### DIFF
--- a/tests/test_intent_clusterer_helper.py
+++ b/tests/test_intent_clusterer_helper.py
@@ -6,12 +6,12 @@ def test_find_modules_related_to_helper(monkeypatch):
         def __init__(self):
             self.args = None
 
-        def find_modules_related_to(self, query, top_k=5):
-            self.args = (query, top_k)
+        def find_modules_related_to(self, query, top_k=5, *, include_clusters=False):
+            self.args = (query, top_k, include_clusters)
             return [{"path": "x.py", "score": 1.0}]
 
     dummy = Dummy()
     monkeypatch.setattr(ic, "IntentClusterer", lambda: dummy)
     res = ic.find_modules_related_to("demo", top_k=2)
     assert res == [{"path": "x.py", "score": 1.0}]
-    assert dummy.args == ("demo", 2)
+    assert dummy.args == ("demo", 2, False)

--- a/tests/test_intent_clusterer_query.py
+++ b/tests/test_intent_clusterer_query.py
@@ -1,4 +1,7 @@
 import intent_clusterer as ic
+import json
+import pickle
+import sqlite3
 
 
 class DummyRetriever:
@@ -22,15 +25,32 @@ def test_query_normalizes_vectors(monkeypatch):
     assert res and res[0].path == "a.py" and res[0].similarity > 0.6
 
 
-def test_query_falls_back_to_clusters(monkeypatch):
+def test_query_falls_back_to_clusters(monkeypatch, tmp_path):
     retr = DummyRetriever()
     clusterer = ic.IntentClusterer(retr)
     clusterer.cluster_map["a"] = 5
     retr.add_vector([0.0, 1.0], {"path": "a.py", "cluster_id": 5})
     monkeypatch.setattr(ic, "governed_embed", lambda text: [1.0, 0.0])
-    monkeypatch.setattr(ic.IntentClusterer, "get_cluster_intents", lambda self, cid: ("", [1.0, 0.0]))
+    # Persist a cluster record with a matching vector so fallback can occur
+    member = tmp_path / "b.py"
+    member.write_text('"""cluster helper"""')
+    blob = sqlite3.Binary(pickle.dumps([1.0, 0.0]))
+    meta = {
+        "members": [str(member)],
+        "kind": "cluster",
+        "cluster_id": 5,
+        "path": "cluster:5",
+    }
+    clusterer.conn.execute(
+        "REPLACE INTO intent_embeddings (module_path, vector, metadata) VALUES (?, ?, ?)",
+        ("cluster:5", blob, json.dumps(meta)),
+    )
+    clusterer.conn.commit()
     res = clusterer.query("whatever", threshold=0.9)
     assert res and res[0].path is None and res[0].cluster_ids == [5]
+    text, vec = clusterer.get_cluster_intents(5)
+    assert "cluster helper" in text
+    assert vec == [1.0, 0.0]
 
 
 def test_query_without_cluster_ids(monkeypatch):


### PR DESCRIPTION
## Summary
- Implement `get_cluster_intents` to load cluster vectors and descriptive text from the `intent_embeddings` table with graceful fallbacks.
- Exercise cluster-based query fallback by persisting a cluster record in tests.
- Update helper test stubs to support the `include_clusters` argument.

## Testing
- `pytest tests/test_intent_clusterer.py tests/test_intent_clusterer_helper.py tests/test_intent_clusterer_query.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68abcb1de6ac832ea3561ba9a19ee743