### PR TITLE
feat: support soft intent clustering

### DIFF
--- a/docs/intent_clusterer.md
+++ b/docs/intent_clusterer.md
@@ -3,10 +3,12 @@
 `IntentClusterer` builds a lightweight semantic index of Python modules by
 collecting docstrings, comments and symbol names.  Embeddings are stored via a
 `UniversalRetriever`-compatible backend so other components can discover modules
-related to a natural language goal.  The clusterer underpins several parts of
-the sandbox self‑improvement loop, including the `self_improvement_engine` and
-`workflow_evolution_bot`.  The class can be imported either directly or via the
-package root:
+related to a natural language goal.  Modules are assigned to intent clusters
+using a soft‑clustering strategy so they may belong to multiple clusters when
+similarity to several centroids exceeds a configurable threshold.  The
+clusterer underpins several parts of the sandbox self‑improvement loop,
+including the `self_improvement_engine` and `workflow_evolution_bot`.  The class
+can be imported either directly or via the package root:
 
 ```python
 from menace import IntentClusterer

--- a/tests/test_intent_clusterer_query.py
+++ b/tests/test_intent_clusterer_query.py
@@ -18,8 +18,8 @@ class DummyRetriever:
 def test_query_normalizes_vectors(monkeypatch):
     retr = DummyRetriever()
     clusterer = ic.IntentClusterer(retr)
-    clusterer.cluster_map["a"] = 1
-    retr.add_vector([0.1, 0.0], {"path": "a.py", "cluster_id": 1})
+    clusterer.cluster_map["a"] = [1]
+    retr.add_vector([0.1, 0.0], {"path": "a.py", "cluster_ids": [1]})
     monkeypatch.setattr(ic, "governed_embed", lambda text: [1.0, 1.0])
     res = clusterer.query("anything", threshold=0.5)
     assert res and res[0].path == "a.py" and res[0].similarity > 0.6
@@ -28,8 +28,8 @@ def test_query_normalizes_vectors(monkeypatch):
 def test_query_falls_back_to_clusters(monkeypatch, tmp_path):
     retr = DummyRetriever()
     clusterer = ic.IntentClusterer(retr)
-    clusterer.cluster_map["a"] = 5
-    retr.add_vector([0.0, 1.0], {"path": "a.py", "cluster_id": 5})
+    clusterer.cluster_map["a"] = [5]
+    retr.add_vector([0.0, 1.0], {"path": "a.py", "cluster_ids": [5]})
     monkeypatch.setattr(ic, "governed_embed", lambda text: [1.0, 0.0])
     # Persist a cluster record with a matching vector so fallback can occur
     member = tmp_path / "b.py"
@@ -38,7 +38,7 @@ def test_query_falls_back_to_clusters(monkeypatch, tmp_path):
     meta = {
         "members": [str(member)],
         "kind": "cluster",
-        "cluster_id": 5,
+        "cluster_ids": [5],
         "path": "cluster:5",
     }
     clusterer.conn.execute(
@@ -56,8 +56,8 @@ def test_query_falls_back_to_clusters(monkeypatch, tmp_path):
 def test_query_without_cluster_ids(monkeypatch):
     retr = DummyRetriever()
     clusterer = ic.IntentClusterer(retr)
-    clusterer.cluster_map["a"] = 1
-    retr.add_vector([1.0, 0.0], {"path": "a.py", "cluster_id": 1})
+    clusterer.cluster_map["a"] = [1]
+    retr.add_vector([1.0, 0.0], {"path": "a.py", "cluster_ids": [1]})
     monkeypatch.setattr(ic, "governed_embed", lambda text: [1.0, 0.0])
     res = clusterer.query("foo", include_clusters=False)
     assert res and res[0].cluster_ids == []


### PR DESCRIPTION
## Summary
- allow modules to join multiple intent clusters using cosine threshold
- keep retriever metadata with `cluster_ids` lists
- update query and related search to surface multiple cluster hits

## Testing
- `pre-commit run --files intent_clusterer.py tests/test_intent_clusterer_query.py docs/intent_clusterer.md`
- `pytest tests/test_intent_clusterer_query.py`

------
https://chatgpt.com/codex/tasks/task_e_68abcca69530832ea4aa8629e182521e