### PR TITLE
docs: clarify content_hash usage in shared tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@
     # params == ["alpha"]
     ```
   - Shared tables include a `content_hash` column storing a SHA256 hash of JSON-encoded core fields.
-    The `insert_if_unique` helper computes this hash and skips inserts when the value already exists,
-    preventing cross-instance duplicates. Existing databases will auto-add the column on startup,
+    A new `insert_if_unique` utility computes this hash and skips inserts when the value already exists,
+    suppressing cross-instance duplicates. Existing databases will auto-add the column on startup,
     or can be updated manually with:
 
     ```sql


### PR DESCRIPTION
## Summary
- document `content_hash` as SHA256 of JSON-encoded fields for shared tables
- note `insert_if_unique` utility that uses the hash to skip cross-instance duplicates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy.orm'; 'sqlalchemy' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68abcc82dde0832e8f6b1deeda5b50ab