### PR TITLE
Add helper for deduplicated DB inserts

### DIFF
--- a/db_dedup.py
+++ b/db_dedup.py
@@ -1,96 +1,84 @@
 from __future__ import annotations
 
-"""Database deduplication helpers.
+"""Helpers for avoiding duplicate database rows.
 
-This module provides a small utility for inserting rows only if their
-content is unique.  Uniqueness is determined by hashing selected fields
-using JSON encoding with sorted keys.  The resulting SHA256 hash is stored
-in a ``content_hash`` column which should be declared as ``UNIQUE`` in the
-target table.
+This module exposes a small pair of helpers that make it easier to avoid
+inserting duplicate rows into a database table.  A SHA256 hash of selected
+values is stored in a ``content_hash`` column which should be declared as a
+``UNIQUE`` field on the target table.
 """
 
+from collections.abc import Iterable, Mapping
 import hashlib
 import json
-from collections.abc import Iterable, Mapping
-from typing import Any
+import logging
+from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import Table
-from sqlalchemy.engine import Engine
-from sqlalchemy.exc import IntegrityError
+try:  # pragma: no cover - optional dependency
+    from sqlalchemy.exc import IntegrityError
+except Exception:  # pragma: no cover - optional dependency
+    class IntegrityError(Exception):
+        """Fallback when SQLAlchemy isn't installed."""
+
+        pass
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from sqlalchemy import Table
+    from sqlalchemy.engine import Connection
 
 __all__ = ["compute_content_hash", "insert_if_unique"]
 
 
-def compute_content_hash(values: Mapping[str, Any], fields: Iterable[str]) -> str:
-    """Return SHA256 hex digest of ``fields`` from ``values``.
+def compute_content_hash(data: Mapping[str, Any]) -> str:
+    """Return a SHA256 hex digest for ``data``.
 
-    Parameters
-    ----------
-    values:
-        Mapping containing the data to hash.
-    fields:
-        Iterable of keys from ``values`` whose values should be included in the
-        hash calculation.
+    The mapping is JSON encoded with keys sorted to ensure stable hashes for
+    logically equivalent inputs.
     """
 
-    payload = {key: values[key] for key in fields}
     return hashlib.sha256(
-        json.dumps(payload, sort_keys=True).encode("utf-8")
+        json.dumps(data, sort_keys=True).encode("utf-8")
     ).hexdigest()
 
 
 def insert_if_unique(
+    conn: Connection,
     table: Table,
     values: Mapping[str, Any],
     hash_fields: Iterable[str],
     menace_id: str,
-    *,
-    engine: Engine,
-    logger: Any,
 ) -> Any | None:
-    """Insert ``values`` into ``table`` if the hashed content is unique.
+    """Insert ``values`` into ``table`` if their hash is unique.
 
-    The hash of ``hash_fields`` is computed using :func:`compute_content_hash`
-    and stored in the ``content_hash`` column before attempting the insert.
-
-    Parameters
-    ----------
-    table:
-        SQLAlchemy ``Table`` object representing the target table.
-    values:
-        Mapping of column names to values. ``content_hash`` is added to a copy
-        of this mapping prior to insertion.
-    hash_fields:
-        Iterable of keys from ``values`` to include in the hash calculation.
-    menace_id:
-        Identifier of the menace instance performing the insert, included in
-        log messages.
-    engine:
-        SQLAlchemy ``Engine`` used to execute the insert.
-    logger:
-        Logger used for warning messages when duplicates are detected.
-
-    Returns
-    -------
-    Any | None
-        Primary key of the inserted row, or ``None`` if a duplicate was
-        detected.
+    ``hash_fields`` specifies which keys from ``values`` are hashed using
+    :func:`compute_content_hash` to detect duplicates.  The resulting
+    ``content_hash`` is added to the values prior to insertion.  If the hash
+    already exists the insert is skipped and the existing primary key is
+    returned.
     """
 
-    values_copy = dict(values)
-    values_copy["content_hash"] = compute_content_hash(values_copy, hash_fields)
+    logger = logging.getLogger(__name__)
+
+    import sqlalchemy as sa  # Imported lazily to avoid mandatory dependency
+
+    payload = {key: values[key] for key in hash_fields}
+    content_hash = compute_content_hash(payload)
+    values_with_hash = dict(values)
+    values_with_hash["content_hash"] = content_hash
 
     try:
-        with engine.begin() as conn:
-            result = conn.execute(table.insert().values(**values_copy))
-            return result.inserted_primary_key[0]
+        result = conn.execute(table.insert().values(**values_with_hash))
+        return result.inserted_primary_key[0]
     except IntegrityError as exc:
-        # Only treat the error as a duplicate if the unique ``content_hash``
-        # constraint triggered it. Otherwise re-raise for visibility.
+        # Only treat as a duplicate if the ``content_hash`` constraint failed.
         msg = str(getattr(exc, "orig", exc))
         if "content_hash" not in msg:
             raise
         logger.warning(
             "Duplicate insert ignored for %s (menace_id=%s)", table.name, menace_id
         )
-        return None
+        pk_col = list(table.primary_key.columns)[0]
+        row = conn.execute(
+            sa.select(pk_col).where(table.c.content_hash == content_hash)
+        ).first()
+        return row[0] if row else None

--- a/tests/test_db_dedup_helper.py
+++ b/tests/test_db_dedup_helper.py
@@ -1,0 +1,54 @@
+import importlib
+import logging
+import sys
+
+import sqlalchemy as sa
+if not getattr(sa, "__file__", None):  # replace stubs from test harness
+    sys.modules.pop("sqlalchemy", None)
+    sys.modules.pop("sqlalchemy.engine", None)
+    sa = importlib.import_module("sqlalchemy")
+
+from sqlalchemy import Column, Integer, MetaData, Table, Text, create_engine
+
+from db_dedup import compute_content_hash, insert_if_unique
+
+
+def test_compute_content_hash_order_independent():
+    data1 = {"a": 1, "b": 2}
+    data2 = {"b": 2, "a": 1}
+    assert compute_content_hash(data1) == compute_content_hash(data2)
+
+
+def test_insert_if_unique_duplicate_returns_existing_id(caplog):
+    engine = create_engine("sqlite:///:memory:")
+    meta = MetaData()
+    tbl = Table(
+        "items",
+        meta,
+        Column("id", Integer, primary_key=True),
+        Column("name", Text),
+        Column("content_hash", Text, unique=True),
+    )
+    meta.create_all(engine)
+
+    with engine.begin() as conn:
+        id1 = insert_if_unique(
+            conn,
+            tbl,
+            {"name": "alpha"},
+            ["name"],
+            "m1",
+        )
+        assert id1 is not None
+
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            id2 = insert_if_unique(
+                conn,
+                tbl,
+                {"name": "alpha"},
+                ["name"],
+                "m1",
+            )
+        assert id2 == id1
+        assert any("Duplicate insert ignored" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- add reusable `compute_content_hash` and `insert_if_unique` helpers for deduplicated database inserts
- cover helper with unit tests

## Testing
- `pre-commit run --files db_dedup.py tests/test_db_dedup_helper.py`
- `pytest tests/test_db_dedup_helper.py tests/test_db_dedup.py`


------
https://chatgpt.com/codex/tasks/task_e_68abd1ac7738832eb5bb9d9dab289e73