### PR TITLE
Store aggregated intent text for clusters

### DIFF
--- a/tests/test_intent_clusterer_query.py
+++ b/tests/test_intent_clusterer_query.py
@@ -40,6 +40,7 @@ def test_query_falls_back_to_clusters(monkeypatch, tmp_path):
         "kind": "cluster",
         "cluster_ids": [5],
         "path": "cluster:5",
+        "text": "cluster helper",
     }
     clusterer.conn.execute(
         "REPLACE INTO intent_embeddings (module_path, vector, metadata) VALUES (?, ?, ?)",


### PR DESCRIPTION
## Summary
- capture combined intent text for each cluster and persist alongside averaged vectors
- fetch stored cluster vectors and aggregated text from `intent_embeddings` or `ModuleVectorDB`
- test updates for new cluster metadata

## Testing
- `pre-commit run --files intent_clusterer.py tests/test_intent_clusterer_query.py`
- `pytest tests/test_intent_clusterer_query.py::test_query_falls_back_to_clusters -q`


------
https://chatgpt.com/codex/tasks/task_e_68abd18b5ea8832ebf4a2856a7363042