### PR TITLE
Use core field hash for bot deduplication

### DIFF
--- a/bot_database.py
+++ b/bot_database.py
@@ -62,11 +62,9 @@ _BOT_HASH_FIELDS = [
     "name",
     "type",
     "tasks",
-    "dependencies",
     "purpose",
     "tags",
     "toolchain",
-    "version",
 ]
 
 


### PR DESCRIPTION
## Summary
- Narrow bot deduplication hashing to core identity fields

## Testing
- `pytest tests/test_bot_database.py tests/test_botdb_vector_search.py tests/test_source_menace_id.py -q` *(fails: Duplicate insert ignored for bots)*


------
https://chatgpt.com/codex/tasks/task_e_68abd3f2d098832ea3f712c4172f0207