### PR TITLE
Expose intent cluster labels in query results

### DIFF
--- a/docs/intent_clusterer.md
+++ b/docs/intent_clusterer.md
@@ -68,5 +68,6 @@ for m in matches:
     print(m.path, m.cluster_ids, m.similarity)
 ```
 
-`query` yields `IntentMatch` objects with module paths, similarity scores and
-any related cluster identifiers.
+`query` yields `IntentMatch` objects with module paths, similarity scores,
+any related cluster identifiers and, for cluster entries, a concise
+``label`` describing the cluster intent.


### PR DESCRIPTION
## Summary
- Attach a concise `label` to each cluster by extracting top keywords
- Add `_get_cluster_label` helper and surface labels in `query` results via `IntentMatch`
- Document new label field in `intent_clusterer` docs

## Testing
- `pytest tests/test_intent_clusterer.py tests/test_intent_clusterer_logging.py tests/test_intent_clusterer_query.py tests/test_intent_clusterer_helper.py tests/integration/test_intent_clusterer_synergy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68abd54e69c4832eb80cfd1a5d1930de