### PR TITLE
Deduplicate enhancement entries via content hash

### DIFF
--- a/chatgpt_enhancement_bot.py
+++ b/chatgpt_enhancement_bot.py
@@ -53,7 +53,6 @@ DEFAULT_PROPOSE_RATIO = float(os.environ.get("PROPOSE_SUMMARY_RATIO", "0.3"))
 # Fields used to compute the deduplication content hash for enhancements
 _ENHANCEMENT_HASH_FIELDS = [
     "idea",
-    "rationale",
     "summary",
     "before_code",
     "after_code",
@@ -205,8 +204,11 @@ class EnhancementDB(EmbeddableDBMixin):
                         )
                     )
                 if "content_hash" not in cols:
+                    # SQLite does not allow adding a column with a UNIQUE constraint via
+                    # ALTER TABLE, so add the column and create a unique index
+                    # separately below.
                     conn.execute(
-                        "ALTER TABLE enhancements ADD COLUMN content_hash TEXT UNIQUE"
+                        "ALTER TABLE enhancements ADD COLUMN content_hash TEXT"
                     )
                 idxs = [
                     r[1]


### PR DESCRIPTION
## Summary
- hash enhancements on core fields to detect duplicates
- add content_hash column without UNIQUE constraint and index separately

## Testing
- `pre-commit run --files chatgpt_enhancement_bot.py`
- `pytest tests/test_chatgpt_enhancement_bot.py::test_enhancementdb_duplicate -q` *(fails: insert_if_unique() missing 1 required positional argument: 'logger')*


------
https://chatgpt.com/codex/tasks/task_e_68abd8276744832eb6170ae2e687a44b