### PR TITLE
Clarify error deduplication and update tests

### DIFF
--- a/error_bot.py
+++ b/error_bot.py
@@ -491,7 +491,12 @@ class ErrorDB(EmbeddableDBMixin):
         source_menace_id: str | None = None,
         scope: Literal["local", "global", "all"] = "local",
     ) -> int:
-        """Insert a new error if not already present and return its id."""
+        """Insert a new error if not already present and return its id.
+
+        Deduplicates based on the hash of ``message``, ``type``, ``description`` and
+        ``resolution``. When a duplicate is detected, a warning is emitted and
+        embedding/event hooks are skipped.
+        """
         menace_id = self._menace_id(source_menace_id)
         values = {
             "source_menace_id": menace_id,

--- a/tests/test_error_bot.py
+++ b/tests/test_error_bot.py
@@ -32,9 +32,10 @@ def test_add_error_duplicate(tmp_path, caplog, monkeypatch):
         first = db.add_error("dup", type_="t", description="d", resolution="r")
         second = db.add_error("dup", type_="t", description="d", resolution="r")
         third = db.add_error("other", type_="t", description="d", resolution="r")
-    assert first == second == third
-    assert caplog.text.lower().count("duplicate error") >= 2
-    assert db.conn.execute("SELECT COUNT(*) FROM errors").fetchone()[0] == 1
+    assert first == second
+    assert third != first
+    assert caplog.text.lower().count("duplicate error detected") >= 1
+    assert db.conn.execute("SELECT COUNT(*) FROM errors").fetchone()[0] == 2
 
 
 def test_handle_known(tmp_path):


### PR DESCRIPTION
## Summary
- Expand `add_error` docstring to describe hash-based deduping and warning behavior
- Update duplicate error test for new insert-if-unique workflow

## Testing
- `pre-commit run --files error_bot.py tests/test_error_bot.py`
- `pytest tests/test_error_bot.py::test_add_error_duplicate -q`


------
https://chatgpt.com/codex/tasks/task_e_68abdac71f94832eb551789dd59f32dc