### PR TITLE
docs: document content hash migration

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -22,3 +22,24 @@ Databases that inherit from `EmbeddableDBMixin` (bots, workflows, errors,
 enhancements and research info) now also maintain a shared `embeddings` table
 for vector search.  After migrating, run `backfill_embeddings()` on each
 database to populate vectors.
+
+### Content hash column
+
+Version 0.3 adds a `content_hash` column to the `bots`, `workflows`,
+`enhancements`, and `errors` tables for deduplication. New installations create
+the column automatically. For existing databases run the migration or add the
+column manually:
+
+```sql
+ALTER TABLE bots ADD COLUMN content_hash TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_bots_content_hash ON bots(content_hash);
+ALTER TABLE workflows ADD COLUMN content_hash TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_workflows_content_hash ON workflows(content_hash);
+ALTER TABLE enhancements ADD COLUMN content_hash TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_enhancements_content_hash ON enhancements(content_hash);
+ALTER TABLE errors ADD COLUMN content_hash TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_errors_content_hash ON errors(content_hash);
+```
+
+Re-run `alembic upgrade head` after adding the columns so Alembic can create any
+missing indices.


### PR DESCRIPTION
## Summary
- document how to add `content_hash` to existing bots, workflows, enhancements, and errors tables

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'synergy_stats' from 'menace.self_improvement_engine' (unknown location))*

------
https://chatgpt.com/codex/tasks/task_e_68abe25da3e0832e8edbcf6330036f57