### PR TITLE
Use dedup insert for enhancements

### DIFF
--- a/chatgpt_enhancement_bot.py
+++ b/chatgpt_enhancement_bot.py
@@ -53,7 +53,7 @@ DEFAULT_PROPOSE_RATIO = float(os.environ.get("PROPOSE_SUMMARY_RATIO", "0.3"))
 # Fields used to compute the deduplication content hash for enhancements
 _ENHANCEMENT_HASH_FIELDS = [
     "idea",
-    "summary",
+    "rationale",
     "before_code",
     "after_code",
     "description",


### PR DESCRIPTION
## Summary
- hash enhancement records using idea, rationale and code snippets
- warn and reuse existing record when duplicate content is inserted
- test that duplicate enhancement inserts are ignored

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_enhancement_db.py::test_duplicate_insert -q`


------
https://chatgpt.com/codex/tasks/task_e_68abe425e20c832eb584f398c16d2c64