### PR TITLE
Handle modules with mixed intent across clusters

### DIFF
--- a/intent_clusterer.py
+++ b/intent_clusterer.py
@@ -787,9 +787,9 @@ class IntentClusterer:
                             label = self._get_cluster_label(cluster_ids[0])
             if sim < threshold:
                 continue
-            if include_clusters and not cluster_ids and cids:
+            if not cluster_ids and cids:
                 cluster_ids = [int(c) for c in cids]
-                if cluster_ids and label is None:
+                if include_clusters and cluster_ids and label is None:
                     label = self._get_cluster_label(cluster_ids[0])
             results.append(
                 IntentMatch(path=path, similarity=sim, cluster_ids=cluster_ids, label=label)


### PR DESCRIPTION
## Summary
- capture cluster IDs for modules even when cluster results are suppressed
- add mixed-intent sample module and tests verifying multi-cluster mapping

## Testing
- `pre-commit run --files intent_clusterer.py tests/test_intent_clusterer.py`
- `pytest tests/test_intent_clusterer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68abe4a791c8832e8ba8d854485457bb