### PR TITLE
Deduplicate errors with content hashes

### DIFF
--- a/error_bot.py
+++ b/error_bot.py
@@ -493,7 +493,7 @@ class ErrorDB(EmbeddableDBMixin):
     ) -> int:
         """Insert a new error if not already present and return its id.
 
-        Deduplicates based on the hash of ``message``, ``type``, ``description`` and
+        Deduplicates based on the hash of ``type``, ``description`` and
         ``resolution``. When a duplicate is detected, a warning is emitted and
         embedding/event hooks are skipped.
         """
@@ -506,7 +506,7 @@ class ErrorDB(EmbeddableDBMixin):
             "resolution": resolution,
             "ts": datetime.utcnow().isoformat(),
         }
-        hash_fields = ["message", "type", "description", "resolution"]
+        hash_fields = ["type", "description", "resolution"]
         content_hash = _hash_fields(values, hash_fields)
         with self.router.get_connection("errors", "write") as conn:
             err_id = insert_if_unique(


### PR DESCRIPTION
## Summary
- compute error content hashes from type, description and resolution
- warn and reuse ID when inserting duplicate errors
- add test ensuring duplicates are rejected even if message differs

## Testing
- `pytest tests/test_error_bot.py::test_add_error_duplicate -q`
- `pytest tests/test_error_bot.py::test_add_error_duplicate_different_message -q`
- `pytest tests/test_error_bot.py -q` *(fails: AttributeError: module 'menace.menace' has no attribute 'MenaceDB')*


------
https://chatgpt.com/codex/tasks/task_e_68abec42332c832eb7fbffb341ffbe1e