### PR TITLE
feat: add database de-duplication helper

### DIFF
--- a/db_dedup.py
+++ b/db_dedup.py
@@ -2,16 +2,14 @@ from __future__ import annotations
 
 """Helpers for avoiding duplicate database rows.
 
-This module exposes a small pair of helpers that make it easier to avoid
-inserting duplicate rows into a database table.  A SHA256 hash of selected
-values is stored in a ``content_hash`` column which should be declared as a
-``UNIQUE`` field on the target table.
+The :func:`insert_if_unique` function computes a ``content_hash`` for selected
+fields and attempts to insert a row into a table.  If a duplicate hash is
+detected via a ``UNIQUE`` constraint the insert is skipped.
 """
 
 from collections.abc import Iterable, Mapping
 import hashlib
 import json
-import logging
 from typing import TYPE_CHECKING, Any
 
 try:  # pragma: no cover - optional dependency
@@ -24,7 +22,7 @@ except Exception:  # pragma: no cover - optional dependency
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from sqlalchemy import Table
-    from sqlalchemy.engine import Connection
+    from sqlalchemy.engine import Engine
 
 __all__ = ["compute_content_hash", "insert_if_unique"]
 
@@ -42,32 +40,32 @@ def compute_content_hash(data: Mapping[str, Any]) -> str:
 
 
 def insert_if_unique(
-    conn: Connection,
     table: Table,
     values: Mapping[str, Any],
     hash_fields: Iterable[str],
     menace_id: str,
+    *,
+    engine: Engine,
+    logger: Any,
 ) -> Any | None:
     """Insert ``values`` into ``table`` if their hash is unique.
 
     ``hash_fields`` specifies which keys from ``values`` are hashed using
     :func:`compute_content_hash` to detect duplicates.  The resulting
     ``content_hash`` is added to the values prior to insertion.  If the hash
-    already exists the insert is skipped and the existing primary key is
-    returned.
+    already exists the insert is skipped and ``None`` is returned.
     """
-
-    logger = logging.getLogger(__name__)
 
     import sqlalchemy as sa  # Imported lazily to avoid mandatory dependency
 
     payload = {key: values[key] for key in hash_fields}
     content_hash = compute_content_hash(payload)
-    values_with_hash = dict(values)
-    values_with_hash["content_hash"] = content_hash
+    values = dict(values)
+    values["content_hash"] = content_hash
 
     try:
-        result = conn.execute(table.insert().values(**values_with_hash))
+        with engine.begin() as conn:
+            result = conn.execute(table.insert().values(**values))
         return result.inserted_primary_key[0]
     except IntegrityError as exc:
         # Only treat as a duplicate if the ``content_hash`` constraint failed.
@@ -77,8 +75,4 @@ def insert_if_unique(
         logger.warning(
             "Duplicate insert ignored for %s (menace_id=%s)", table.name, menace_id
         )
-        pk_col = list(table.primary_key.columns)[0]
-        row = conn.execute(
-            sa.select(pk_col).where(table.c.content_hash == content_hash)
-        ).first()
-        return row[0] if row else None
+        return None


### PR DESCRIPTION
## Summary
- add reusable `insert_if_unique` helper that hashes content and skips duplicate inserts
- update tests to cover new helper API

## Testing
- `pytest tests/test_db_dedup_helper.py -q`
- `pytest tests/test_db_dedup_helper.py tests/test_db_dedup.py -q` *(fails: workflow dedup test expects unique title but hash fields exclude it)*

------
https://chatgpt.com/codex/tasks/task_e_68abed79c35c832e993e8453aa31423b