### PR TITLE
Add content hash columns and workflow source id

### DIFF
--- a/migrations/versions/0010_content_hash.py
+++ b/migrations/versions/0010_content_hash.py
@@ -65,7 +65,7 @@ def upgrade() -> None:
             continue
         cols = {c["name"] for c in inspector.get_columns(table)}
         if "content_hash" not in cols:
-            op.add_column(table, sa.Column("content_hash", sa.Text(), nullable=True))
+            op.add_column(table, sa.Column("content_hash", sa.Text(), nullable=True, unique=True))
         idxs = {i["name"] for i in inspector.get_indexes(table)}
         idx_name = f"idx_{table}_content_hash"
         if idx_name not in idxs:
@@ -115,4 +115,3 @@ def downgrade() -> None:
         cols = {c["name"] for c in inspector.get_columns(table)}
         if "content_hash" in cols:
             op.drop_column(table, "content_hash")
-

--- a/migrations/versions/0011_add_content_hash.py
+++ b/migrations/versions/0011_add_content_hash.py
@@ -67,7 +67,7 @@ def upgrade() -> None:
         if "content_hash" not in cols:
             op.add_column(
                 table,
-                sa.Column("content_hash", sa.Text(), nullable=True),
+                sa.Column("content_hash", sa.Text(), nullable=True, unique=True),
             )
         idxs = {i["name"] for i in inspector.get_indexes(table)}
         idx_name = f"idx_{table}_content_hash"


### PR DESCRIPTION
## Summary
- ensure migrations add unique `content_hash` fields
- record `source_menace_id` for workflow records when hashing

## Testing
- `pre-commit run --files task_handoff_bot.py migrations/versions/0010_content_hash.py migrations/versions/0011_add_content_hash.py`
- `pytest -q` *(fails: Missing system packages: ffmpeg, tesseract, qemu-system-x86_64)*

------
https://chatgpt.com/codex/tasks/task_e_68abeec98ef4832eaf7281ce342cffc7