### PR TITLE
feat: add LLM summary fallback for cluster labels

### DIFF
--- a/docs/intent_clusterer.md
+++ b/docs/intent_clusterer.md
@@ -77,15 +77,17 @@ any related cluster identifiers and, for cluster entries, a concise
 When synergy groups or `cluster_intents` are processed, the clusterer
 aggregates the intent text of all member modules and extracts the most
 informative keywords using a TF‑IDF weighting scheme.  These keywords are
-joined into a short label summarising the cluster's purpose.  Labels are
-persisted alongside other cluster metadata and exposed via the
-`cluster_label` helper:
+joined into a short label summarising the cluster's purpose.  A short textual
+summary is derived alongside the label to provide additional context.  Labels
+and summaries are persisted alongside other cluster metadata and exposed via
+the `cluster_label` helper:
 
 ```python
 clusterer.index_repository(Path("/path/to/repo"))
-print(clusterer.cluster_label(1))  # -> "auth help" (for example)
+label, summary = clusterer.cluster_label(1)
+print(label, summary)  # -> "auth help", "Authentication helper module" (for example)
 ```
 
-Labels are also returned in the metadata of `find_clusters_related_to` and
-`query` results, enabling quick inspection of the cluster's theme without
+Labels and summaries are also returned in the metadata of `find_clusters_related_to`
+and `query` results, enabling quick inspection of the cluster's theme without
 loading the full intent text.


### PR DESCRIPTION
## Summary
- support generating cluster labels via TF-IDF or an LLM-based summary when sklearn is missing
- store and expose short summary text for each cluster
- ensure query/search paths surface summary metadata

## Testing
- `pytest tests/test_intent_clusterer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68abeed014e8832ea01bc3ddd9770017