### PR TITLE
Return IntentMatch objects from intent search helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,8 +640,9 @@ find_clusters_related_to("error handling")
 ```
 
 ``find_modules_related_to`` returns relevant module paths, while
-``find_clusters_related_to`` surfaces synergy clusters.  Entries include a
-relevance ``score`` and an ``origin`` field indicating the result type.
+``find_clusters_related_to`` surfaces synergy clusters.  Each result is an
+``IntentMatch`` carrying a similarity ``score`` and an ``origin`` attribute
+indicating the result type.
 
 The underlying ``IntentClusterer`` is available at the package root for custom
 workflows:

--- a/bot_creation_bot.py
+++ b/bot_creation_bot.py
@@ -239,21 +239,13 @@ class BotCreationBot(AdminBotBase):
         for chunk in ordered:
             if self.intent_clusterer:
                 try:
-                    matches = self.intent_clusterer.find_modules_related_to(" ".join(chunk))
-                    paths = [
-                        m.get("path")
-                        for m in matches
-                        if isinstance(m, dict) and m.get("path")
-                    ]
-                    clusters = [
-                        m.get("cluster_id")
-                        for m in matches
-                        if isinstance(m, dict) and m.get("cluster_id") is not None
-                    ]
+                    matches = self.intent_clusterer.find_modules_related_to(
+                        " ".join(chunk)
+                    )
+                    paths = [m.path for m in matches if m.path]
+                    clusters = [cid for m in matches for cid in m.cluster_ids]
                     if paths:
-                        self.logger.info(
-                            "intent matches for %s: %s", chunk, paths
-                        )
+                        self.logger.info("intent matches for %s: %s", chunk, paths)
                         for p in paths:
                             name = Path(p).stem
                             if name not in chunk:

--- a/docs/intent_clusterer.md
+++ b/docs/intent_clusterer.md
@@ -53,13 +53,13 @@ Retrieve modules or clusters that relate to a textual prompt:
 mods = clusterer.find_modules_related_to("update configuration", top_k=5)
 clusters = clusterer.find_clusters_related_to("update configuration", top_k=5)
 for match in mods:
-    print("module", match["path"], match["score"])
+    print("module", match.path, match.similarity)
 for match in clusters:
-    print("cluster", match["path"], match.get("members"), match["score"])
+    print("cluster", match.path, match.members, match.similarity)
 ```
 
-Both functions return dictionaries describing the best matches.  For more
-detailed similarity information including related cluster identifiers use
+Both functions return :class:`IntentMatch` objects describing the best matches.
+For more detailed similarity information including related cluster identifiers use
 `query`:
 
 ```python
@@ -88,6 +88,6 @@ label, summary = clusterer.cluster_label(1)
 print(label, summary)  # -> "auth help", "Authentication helper module" (for example)
 ```
 
-Labels and summaries are also returned in the metadata of `find_clusters_related_to`
-and `query` results, enabling quick inspection of the cluster's theme without
-loading the full intent text.
+Labels and summaries are also returned in the fields of ``IntentMatch`` objects
+from ``find_clusters_related_to`` and ``query`` results, enabling quick
+inspection of the cluster's theme without loading the full intent text.

--- a/self_improvement_engine.py
+++ b/self_improvement_engine.py
@@ -3690,20 +3690,10 @@ class SelfImprovementEngine:
             for rel in list(expanded):
                 try:
                     matches = self.intent_clusterer.find_modules_related_to(rel)
-                    paths = [
-                        m.get("path")
-                        for m in matches
-                        if isinstance(m, dict) and m.get("path")
-                    ]
-                    clusters = [
-                        m.get("cluster_id")
-                        for m in matches
-                        if isinstance(m, dict) and m.get("cluster_id") is not None
-                    ]
+                    paths = [m.path for m in matches if m.path]
+                    clusters = [cid for m in matches for cid in m.cluster_ids]
                     if paths:
-                        self.logger.info(
-                            "intent matches for %s: %s", rel, paths
-                        )
+                        self.logger.info("intent matches for %s: %s", rel, paths)
                     if clusters:
                         self.logger.info(
                             "intent clusters for %s: %s", rel, clusters

--- a/tests/integration/test_intent_clusterer_synergy.py
+++ b/tests/integration/test_intent_clusterer_synergy.py
@@ -53,13 +53,13 @@ def test_synergy_cluster_embeddings_and_query(tmp_path: Path, monkeypatch):
     clusterer.index_repository(tmp_path)
 
     res = clusterer.find_clusters_related_to("alpha beta", top_k=5)
-    assert res and res[0]["origin"] == "cluster"
+    assert res and res[0].origin == "cluster"
     members = {str(tmp_path / "a.py"), str(tmp_path / "b.py")}
-    assert set(res[0]["members"]) == members
-    assert res[0]["intent_text"]
+    assert set(res[0].members or []) == members
+    assert res[0].intent_text
     row = clusterer.conn.execute(
         "SELECT metadata FROM intent_embeddings WHERE module_path = ?",
-        (res[0]["path"],),
+        (res[0].path,),
     ).fetchone()
     meta = json.loads(row[0])
     assert meta.get("intent_text")

--- a/tests/test_intent_clusterer.py
+++ b/tests/test_intent_clusterer.py
@@ -187,10 +187,10 @@ def test_find_modules_related_to_prompts(clusterer: ic.IntentClusterer, sample_r
     clusterer.index_repository(sample_repo)
 
     res = clusterer.find_modules_related_to("authentication help", top_k=2)
-    assert any(Path(r["path"]).name == "helper.py" for r in res)
+    assert any(Path(r.path).name == "helper.py" for r in res if r.path)
 
     res = clusterer.find_modules_related_to("process payment", top_k=2)
-    assert any(Path(r["path"]).name == "payment.py" for r in res)
+    assert any(Path(r.path).name == "payment.py" for r in res if r.path)
 
 
 def test_cluster_lookup_uses_synergy_groups(
@@ -200,11 +200,11 @@ def test_cluster_lookup_uses_synergy_groups(
 
     clusterer.index_repository(sample_repo)
     res = clusterer.find_clusters_related_to("auth help", top_k=5)
-    cluster_items = [r for r in res if r.get("origin") == "cluster"]
+    cluster_items = res
     assert cluster_items
-    assert cluster_items[0]["path"].startswith("cluster:1")
-    assert "label" in cluster_items[0] and "auth" in cluster_items[0]["label"].lower()
-    assert "summary" in cluster_items[0]
+    assert cluster_items[0].path.startswith("cluster:1")
+    assert cluster_items[0].label and "auth" in cluster_items[0].label.lower()
+    assert cluster_items[0].summary is not None
     # ``cluster_label`` should expose the persisted label and summary
     label, summary = clusterer.cluster_label(1)
     assert label and "auth" in label.lower()
@@ -280,13 +280,13 @@ def test_query_and_find_helpers_respect_thresholds(
     mods = clustered_clusterer.find_modules_related_to(
         "authentication help", top_k=5, include_clusters=True
     )
-    mod_entry = next(m for m in mods if m.get("path"))
-    assert mod_entry.get("cluster_ids")
-    cluster_entry = next(m for m in mods if m.get("origin") == "cluster")
-    assert cluster_entry.get("cluster_ids")
+    mod_entry = next(m for m in mods if m.path)
+    assert mod_entry.cluster_ids
+    cluster_entry = next(m for m in mods if m.origin == "cluster")
+    assert cluster_entry.cluster_ids
 
     clusters = clustered_clusterer.find_clusters_related_to("authentication help", top_k=5)
-    assert clusters and clusters[0]["origin"] == "cluster"
+    assert clusters and clusters[0].origin == "cluster"
 
 
 def test_mixed_intent_module_gets_multiple_cluster_ids(

--- a/tests/test_intent_clusterer_helper.py
+++ b/tests/test_intent_clusterer_helper.py
@@ -8,10 +8,10 @@ def test_find_modules_related_to_helper(monkeypatch):
 
         def find_modules_related_to(self, query, top_k=5, *, include_clusters=False):
             self.args = (query, top_k, include_clusters)
-            return [{"path": "x.py", "score": 1.0}]
+            return [ic.IntentMatch(path="x.py", similarity=1.0, cluster_ids=[])]
 
     dummy = Dummy()
     monkeypatch.setattr(ic, "IntentClusterer", lambda: dummy)
     res = ic.find_modules_related_to("demo", top_k=2)
-    assert res == [{"path": "x.py", "score": 1.0}]
+    assert res == [ic.IntentMatch(path="x.py", similarity=1.0, cluster_ids=[])]
     assert dummy.args == ("demo", 2, False)

--- a/tests/test_intent_clusterer_query.py
+++ b/tests/test_intent_clusterer_query.py
@@ -93,4 +93,4 @@ def test_find_clusters_related_to_from_existing_store(monkeypatch, tmp_path):
     fresh = ic.IntentClusterer(retr)
     monkeypatch.setattr(ic, "governed_embed", lambda text: [1.0, 0.0])
     res = fresh.find_clusters_related_to("cluster helper", top_k=1)
-    assert res and res[0]["cluster_id"] == 7
+    assert res and res[0].cluster_ids == [7]

--- a/workflow_evolution_bot.py
+++ b/workflow_evolution_bot.py
@@ -72,16 +72,8 @@ class WorkflowEvolutionBot:
             if self.intent_clusterer:
                 try:
                     matches = self.intent_clusterer.find_modules_related_to(seq)
-                    paths = [
-                        m.get("path")
-                        for m in matches
-                        if isinstance(m, dict) and m.get("path")
-                    ]
-                    clusters = [
-                        m.get("cluster_id")
-                        for m in matches
-                        if isinstance(m, dict) and m.get("cluster_id") is not None
-                    ]
+                    paths = [m.path for m in matches if m.path]
+                    clusters = [cid for m in matches for cid in m.cluster_ids]
                     if paths:
                         logger.info("intent matches for %s: %s", seq, paths)
                     if clusters:


### PR DESCRIPTION
## Summary
- refactor intent search to emit `IntentMatch` dataclasses and expose origin/metadata
- adjust module helpers and bots to consume the dataclass results
- update docs and tests for the new API

## Testing
- `pre-commit run --files intent_clusterer.py bot_creation_bot.py self_improvement_engine.py workflow_evolution_bot.py tests/test_intent_clusterer_helper.py tests/test_intent_clusterer_query.py tests/test_intent_clusterer.py tests/integration/test_intent_clusterer_synergy.py docs/intent_clusterer.md README.md` *(fails: flake8 errors in self_improvement_engine.py)*
- `pre-commit run --files intent_clusterer.py bot_creation_bot.py workflow_evolution_bot.py tests/test_intent_clusterer_helper.py tests/test_intent_clusterer_query.py tests/test_intent_clusterer.py tests/integration/test_intent_clusterer_synergy.py docs/intent_clusterer.md README.md`
- `pytest tests/test_intent_clusterer_helper.py tests/test_intent_clusterer_query.py tests/test_intent_clusterer.py tests/integration/test_intent_clusterer_synergy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68abf2f5d4b0832ea61fc6693d666b9d