### PR TITLE
feat: add local summarizer for intent labels

### DIFF
--- a/tests/integration/test_intent_clusterer_synergy.py
+++ b/tests/integration/test_intent_clusterer_synergy.py
@@ -18,6 +18,7 @@ def _fake(text: str, model=None) -> list[float]:
 def patch_embed(monkeypatch):
     monkeypatch.setattr(edm, "governed_embed", _fake)
     monkeypatch.setattr(ic, "governed_embed", _fake)
+    monkeypatch.setattr(ic, "summarise_texts", lambda texts: "alpha beta summary")
 
 
 def test_synergy_cluster_embeddings_and_query(tmp_path: Path, monkeypatch):

--- a/tests/test_intent_clusterer_query.py
+++ b/tests/test_intent_clusterer_query.py
@@ -5,6 +5,13 @@ import sqlite3
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def mock_summariser(monkeypatch):
+    """Replace the heavy summariser with a deterministic stub."""
+
+    monkeypatch.setattr(ic, "summarise_texts", lambda texts: "cluster helper summary")
+
+
 class DummyRetriever:
     def __init__(self):
         self.items = []


### PR DESCRIPTION
## Summary
- switch intent clusterer to use a local summarizer (transformers or sumy) for cluster labels
- keep frequency-based heuristic as the final fallback
- mock summarizer in tests and add coverage for summarizer behaviour

## Testing
- `pytest tests/test_intent_clusterer.py tests/test_intent_clusterer_query.py tests/test_intent_clusterer_logging.py tests/test_intent_clusterer_helper.py tests/integration/test_intent_clusterer_synergy.py -q`
- `pre-commit run --files intent_clusterer.py tests/test_intent_clusterer.py tests/test_intent_clusterer_query.py tests/integration/test_intent_clusterer_synergy.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abfe48aba8832e8e4092f45d09ff32