### PR TITLE
feat: add synergy fallback clustering

### DIFF
--- a/intent_clusterer.py
+++ b/intent_clusterer.py
@@ -407,9 +407,52 @@ class IntentClusterer:
             graph = grapher.load()
             for idx, comp in enumerate(nx.connected_components(graph.to_undirected())):
                 groups[str(idx)] = [str(root / f"{m}.py") for m in comp]
+            return groups
         except Exception as exc:
             logger.exception("failed to build synergy graph under %s: %s", root, exc)
-            return {}
+
+        # Fallback: group modules by shared imports or common name prefixes
+        modules = [p for p in root.glob("*.py") if p.is_file()]
+        import_map: Dict[str, set[str]] = {}
+        prefix_map: Dict[str, List[str]] = {}
+        for path in modules:
+            imports: set[str] = set()
+            try:
+                tree = ast.parse(path.read_text())
+                for node in ast.walk(tree):
+                    if isinstance(node, ast.Import):
+                        imports.update(alias.name.split(".")[0] for alias in node.names)
+                    elif isinstance(node, ast.ImportFrom):
+                        if node.module:
+                            imports.add(node.module.split(".")[0])
+            except Exception:
+                pass
+            import_map[str(path)] = imports
+            prefix = path.stem.split("_", 1)[0]
+            prefix_map.setdefault(prefix, []).append(str(path))
+
+        gid = 0
+        used: set[str] = set()
+        for prefix, paths in prefix_map.items():
+            if len(paths) > 1:
+                groups[str(gid)] = list(paths)
+                used.update(paths)
+                gid += 1
+
+        remaining = [p for p in import_map if p not in used]
+        while remaining:
+            base = remaining.pop(0)
+            base_imports = import_map[base]
+            cluster = [base]
+            rest: List[str] = []
+            for other in remaining:
+                if import_map[other] & base_imports:
+                    cluster.append(other)
+                else:
+                    rest.append(other)
+            groups[str(gid)] = cluster
+            gid += 1
+            remaining = rest
         return groups
 
     # ------------------------------------------------------------------

--- a/tests/test_intent_clusterer_synergy.py
+++ b/tests/test_intent_clusterer_synergy.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+import intent_clusterer as ic
+
+
+def _make_clusterer(tmp_path: Path) -> ic.IntentClusterer:
+    db = ic.ModuleVectorDB(
+        index_path=tmp_path / "idx.ann", metadata_path=tmp_path / "idx.json"
+    )
+    return ic.IntentClusterer(
+        db=db,
+        menace_id="t",
+        local_db_path=tmp_path / "local.db",
+        shared_db_path=tmp_path / "shared.db",
+    )
+
+
+def test_fallback_groups_by_prefix_and_import(tmp_path, monkeypatch):
+    monkeypatch.setitem(sys.modules, "module_synergy_grapher", None)
+    clusterer = _make_clusterer(tmp_path)
+    a1 = tmp_path / "alpha_one.py"
+    a1.write_text("import os\n")
+    a2 = tmp_path / "alpha_two.py"
+    a2.write_text("import sys\n")
+    b1 = tmp_path / "mod_a.py"
+    b1.write_text("import json\n")
+    b2 = tmp_path / "mod_b.py"
+    b2.write_text("import json\n")
+    solo = tmp_path / "solo.py"
+    solo.write_text("import pickle\n")
+    groups = clusterer._load_synergy_groups(tmp_path)
+    gsets = [set(map(Path, members)) for members in groups.values()]
+    assert any(g == {a1, a2} for g in gsets)
+    assert any(g == {b1, b2} for g in gsets)
+    assert any(g == {solo} for g in gsets)


### PR DESCRIPTION
## Summary
- fallback to import/prefix grouping when synergy graph or map missing
- test synergy fallback grouping logic

## Testing
- `pytest tests/test_intent_clusterer_synergy.py tests/test_intent_clusterer_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68abffde799c832eb041ca0001b24d09