### PR TITLE
Use local TF-IDF summarizer and deterministic intent cluster tests

### DIFF
--- a/tests/integration/test_intent_clusterer_synergy.py
+++ b/tests/integration/test_intent_clusterer_synergy.py
@@ -2,6 +2,12 @@ import pytest
 from pathlib import Path
 
 import json
+import sys
+import types
+
+st_stub = types.ModuleType("sentence_transformers")
+st_stub.SentenceTransformer = None
+sys.modules.setdefault("sentence_transformers", st_stub)
 
 import embeddable_db_mixin as edm
 import intent_db
@@ -18,7 +24,9 @@ def _fake(text: str, model=None) -> list[float]:
 def patch_embed(monkeypatch):
     monkeypatch.setattr(edm, "governed_embed", _fake)
     monkeypatch.setattr(ic, "governed_embed", _fake)
-    monkeypatch.setattr(ic, "summarise_texts", lambda texts: "alpha beta summary")
+    monkeypatch.setattr(
+        ic, "summarise_texts", lambda texts, **_: "alpha beta summary"
+    )
 
 
 def test_synergy_cluster_embeddings_and_query(tmp_path: Path, monkeypatch):

--- a/tests/test_intent_clusterer_async.py
+++ b/tests/test_intent_clusterer_async.py
@@ -1,6 +1,12 @@
 from pathlib import Path
 
 import pytest
+import sys
+import types
+
+st_stub = types.ModuleType("sentence_transformers")
+st_stub.SentenceTransformer = None
+sys.modules.setdefault("sentence_transformers", st_stub)
 
 import intent_clusterer as ic
 
@@ -9,7 +15,9 @@ import intent_clusterer as ic
 def mock_summariser(monkeypatch):
     """Replace the heavy summariser with a deterministic stub."""
 
-    monkeypatch.setattr(ic, "summarise_texts", lambda texts: "cluster helper summary")
+    monkeypatch.setattr(
+        ic, "summarise_texts", lambda texts, **_: "cluster helper summary"
+    )
 
 
 class DummyRetriever:


### PR DESCRIPTION
## Summary
- implement offline TF-IDF noun-phrase summarizer and configurable top-k
- allow IntentClusterer to select summarization method and term count
- test intent clustering queries without network, asserting labels and summaries

## Testing
- `pytest tests/test_intent_clusterer_query.py tests/test_intent_clusterer.py tests/test_intent_clusterer_async.py tests/integration/test_intent_clusterer_synergy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac057415a0832e94cdd0c931458ecb