### PR TITLE
Add deduplicated insert helpers for MenaceDB

### DIFF
--- a/databases.py
+++ b/databases.py
@@ -666,6 +666,146 @@ class MenaceDB:
                 .where(self.models.c.model_id == model_id)
                 .values(current_status=status)
             )
+    # ------------------------------------------------------------------
+    # Core record helpers
+    # ------------------------------------------------------------------
+
+    def add_bot(
+        self,
+        bot_name: str,
+        bot_type: str,
+        assigned_task: str,
+        *,
+        parent_bot_id: int | None = None,
+        dependencies: str = "[]",
+        resource_estimates: str = "{}",
+        creation_date: str | None = None,
+        last_modification_date: str | None = None,
+        status: str = "",
+        version: str = "",
+        estimated_profit: float = 0.0,
+        source_menace_id: str | None = None,
+    ) -> int:
+        """Insert a bot and return its id, deduplicating on key fields."""
+        menace_id = self._current_menace_id(source_menace_id)
+        values = {
+            "bot_name": bot_name,
+            "bot_type": bot_type,
+            "assigned_task": assigned_task,
+            "parent_bot_id": parent_bot_id,
+            "dependencies": dependencies,
+            "resource_estimates": resource_estimates,
+            "creation_date": creation_date,
+            "last_modification_date": last_modification_date,
+            "status": status,
+            "version": version,
+            "estimated_profit": estimated_profit,
+            "source_menace_id": menace_id,
+        }
+        values = {k: v for k, v in values.items() if v is not None}
+        hash_fields = [
+            "bot_name",
+            "bot_type",
+            "assigned_task",
+            "dependencies",
+            "resource_estimates",
+        ]
+        inserted = insert_if_unique(
+            self.bots,
+            values,
+            hash_fields,
+            menace_id,
+            engine=self.engine,
+            logger=logger,
+        )
+        if inserted is None:
+            raise RuntimeError("bot record not inserted")
+        return int(inserted)
+
+    def add_workflow(
+        self,
+        workflow_name: str,
+        task_tree: str,
+        dependencies: str,
+        resource_allocation_plan: str,
+        status: str,
+        *,
+        created_from: str = "",
+        enhancement_links: str = "",
+        discrepancy_links: str = "",
+        estimated_profit_per_bot: float = 0.0,
+        source_menace_id: str | None = None,
+    ) -> int:
+        """Insert a workflow and return its id, deduplicating on key fields."""
+        menace_id = self._current_menace_id(source_menace_id)
+        values = {
+            "workflow_name": workflow_name,
+            "task_tree": task_tree,
+            "dependencies": dependencies,
+            "resource_allocation_plan": resource_allocation_plan,
+            "created_from": created_from,
+            "enhancement_links": enhancement_links,
+            "discrepancy_links": discrepancy_links,
+            "status": status,
+            "estimated_profit_per_bot": estimated_profit_per_bot,
+        }
+        hash_fields = [
+            "workflow_name",
+            "task_tree",
+            "dependencies",
+            "resource_allocation_plan",
+            "status",
+        ]
+        inserted = insert_if_unique(
+            self.workflows,
+            values,
+            hash_fields,
+            menace_id,
+            engine=self.engine,
+            logger=logger,
+        )
+        if inserted is None:
+            raise RuntimeError("workflow record not inserted")
+        return int(inserted)
+
+    def add_enhancement(
+        self,
+        description_of_change: str,
+        reason_for_change: str,
+        performance_delta: float,
+        timestamp: str,
+        triggered_by: str,
+        *,
+        source_menace_id: str | None = None,
+    ) -> int:
+        """Insert an enhancement and return its id, deduplicating on key fields."""
+        menace_id = self._current_menace_id(source_menace_id)
+        values = {
+            "description_of_change": description_of_change,
+            "reason_for_change": reason_for_change,
+            "performance_delta": performance_delta,
+            "timestamp": timestamp,
+            "triggered_by": triggered_by,
+            "source_menace_id": menace_id,
+        }
+        hash_fields = [
+            "description_of_change",
+            "reason_for_change",
+            "performance_delta",
+            "timestamp",
+            "triggered_by",
+        ]
+        inserted = insert_if_unique(
+            self.enhancements,
+            values,
+            hash_fields,
+            menace_id,
+            engine=self.engine,
+            logger=logger,
+        )
+        if inserted is None:
+            raise RuntimeError("enhancement record not inserted")
+        return int(inserted)
 
     # ------------------------------------------------------------------
     # Error helpers

--- a/tests/test_menacedb_add_helpers.py
+++ b/tests/test_menacedb_add_helpers.py
@@ -1,0 +1,62 @@
+import logging
+import pytest
+from menace import MenaceDB
+
+sa = pytest.importorskip("sqlalchemy")
+
+
+@pytest.mark.parametrize(
+    "method,table,kwargs",
+    [
+        (
+            "add_bot",
+            "bots",
+            {
+                "bot_name": "alpha",
+                "bot_type": "worker",
+                "assigned_task": "[]",
+                "dependencies": "[]",
+                "resource_estimates": "{}",
+            },
+        ),
+        (
+            "add_workflow",
+            "workflows",
+            {
+                "workflow_name": "wf1",
+                "task_tree": "[]",
+                "dependencies": "[]",
+                "resource_allocation_plan": "{}",
+                "status": "active",
+            },
+        ),
+        (
+            "add_enhancement",
+            "enhancements",
+            {
+                "description_of_change": "desc",
+                "reason_for_change": "why",
+                "performance_delta": 0.1,
+                "timestamp": "now",
+                "triggered_by": "unit",
+                "source_menace_id": "m1",
+            },
+        ),
+    ],
+)
+
+def test_menacedb_add_helpers_dedup(tmp_path, caplog, method, table, kwargs):
+    db = MenaceDB(url=f"sqlite:///{tmp_path / 'menace.db'}")
+    func = getattr(db, method)
+    id1 = func(**kwargs)
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        id2 = func(**kwargs)
+    assert id1 == id2
+    tbl = getattr(db, table)
+    with db.engine.begin() as conn:
+        count = conn.execute(sa.select(sa.func.count()).select_from(tbl)).scalar()
+    assert count == 1
+    assert any(
+        f"Duplicate insert ignored for {table}" in r.message for r in caplog.records
+    )


### PR DESCRIPTION
## Summary
- add `add_bot`, `add_workflow`, and `add_enhancement` helpers using hashed fields for uniqueness
- return existing IDs when attempting to insert duplicates
- test deduplicated inserts via new helper methods

## Testing
- `pytest tests/test_menacedb_add_helpers.py tests/test_menacedb_dedup.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac087c794c832e92b5dd51360b0e85