### PR TITLE
refactor: centralize content hashing

### DIFF
--- a/db_dedup.py
+++ b/db_dedup.py
@@ -9,10 +9,10 @@ row's ID is returned.
 """
 
 from collections.abc import Iterable, Mapping
+import hashlib
+import json
 import sqlite3
 from typing import TYPE_CHECKING, Any
-
-from dedup_utils import compute_content_hash
 
 try:  # pragma: no cover - optional dependency
     from sqlalchemy.exc import IntegrityError as SAIntegrityError
@@ -27,6 +27,18 @@ if TYPE_CHECKING:  # pragma: no cover - type checking only
     from sqlalchemy.engine import Engine
 
 __all__ = ["compute_content_hash", "hash_fields", "insert_if_unique"]
+
+
+def compute_content_hash(data: Mapping[str, Any]) -> str:
+    """Return a SHA256 hex digest for ``data``.
+
+    The mapping is JSON encoded with keys sorted to ensure stable hashes for
+    logically equivalent inputs.
+    """
+
+    return hashlib.sha256(
+        json.dumps(data, sort_keys=True).encode("utf-8")
+    ).hexdigest()
 
 
 def hash_fields(data: Mapping[str, Any], fields: Iterable[str]) -> str:

--- a/migrations/versions/0010_content_hash.py
+++ b/migrations/versions/0010_content_hash.py
@@ -6,8 +6,8 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
-import hashlib
-import json
+
+from db_dedup import compute_content_hash
 
 revision: str = "0010"
 down_revision: Union[str, Sequence[str], None] = "0009"
@@ -51,9 +51,7 @@ TABLES: dict[str, list[str]] = {
 
 def _compute_hash(row: dict[str, str], fields: list[str]) -> str:
     payload = {f: row.get(f) for f in fields}
-    return hashlib.sha256(
-        json.dumps(payload, sort_keys=True).encode("utf-8")
-    ).hexdigest()
+    return compute_content_hash(payload)
 
 
 def upgrade() -> None:

--- a/migrations/versions/0011_add_content_hash.py
+++ b/migrations/versions/0011_add_content_hash.py
@@ -6,8 +6,8 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
-import hashlib
-import json
+
+from db_dedup import compute_content_hash
 
 revision: str = "0011"
 down_revision: Union[str, Sequence[str], None] = "0010"
@@ -51,9 +51,7 @@ TABLES: dict[str, list[str]] = {
 
 def _compute_hash(row: dict[str, str], fields: list[str]) -> str:
     payload = {f: row.get(f) for f in fields}
-    return hashlib.sha256(
-        json.dumps(payload, sort_keys=True).encode("utf-8")
-    ).hexdigest()
+    return compute_content_hash(payload)
 
 
 def upgrade() -> None:


### PR DESCRIPTION
## Summary
- move compute_content_hash into db_dedup and expose as shared utility
- delegate hash_fields in dedup_utils to the unified hashing routine
- update migrations and tests to use compute_content_hash for SHA256 JSON hashes

## Testing
- `pytest` *(fails: Missing system packages: ffmpeg, tesseract, qemu-system-x86_64. Install them using your package manager.)*
- `pytest tests/test_db_dedup.py tests/test_db_dedup_helper.py tests/test_error_logger_replicator.py tests/test_menacedb_dedup.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac0a392d74832ebcac4e7ad652b8a5