### PR TITLE
Use ON CONFLICT for dedup inserts

### DIFF
--- a/tests/test_db_dedup_concurrent.py
+++ b/tests/test_db_dedup_concurrent.py
@@ -1,0 +1,43 @@
+import logging
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from db_dedup import insert_if_unique
+
+
+def test_insert_if_unique_concurrent(tmp_path):
+    path = tmp_path / "dedup.sqlite"
+    base_conn = sqlite3.connect(path, check_same_thread=False, isolation_level=None)
+    base_conn.execute(
+        "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, content_hash TEXT UNIQUE)"
+    )
+    base_conn.close()
+
+    logger = logging.getLogger(__name__)
+    barrier = threading.Barrier(5)
+
+    def worker() -> int | None:
+        conn = sqlite3.connect(path, check_same_thread=False, isolation_level=None)
+        try:
+            barrier.wait()
+            return insert_if_unique(
+                "items",
+                {"name": "alpha"},
+                ["name"],
+                "m1",
+                conn=conn,
+                logger=logger,
+            )
+        finally:
+            conn.close()
+
+    with ThreadPoolExecutor(max_workers=5) as ex:
+        futures = [ex.submit(worker) for _ in range(5)]
+        ids = [f.result() for f in futures]
+
+    assert len(set(ids)) == 1
+    conn = sqlite3.connect(path, isolation_level=None)
+    count = conn.execute("SELECT COUNT(*) FROM items").fetchone()[0]
+    conn.close()
+    assert count == 1


### PR DESCRIPTION
## Summary
- use INSERT ... ON CONFLICT/OR IGNORE to avoid race conditions in insert_if_unique
- add regression test for concurrent duplicate inserts

## Testing
- `pytest tests/test_db_dedup_helper.py tests/test_db_dedup.py tests/test_db_dedup_concurrent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac11020eb0832eab26d5ec2ca97250