### PR TITLE
feat: add repository watcher

### DIFF
--- a/docs/intent_clusterer.md
+++ b/docs/intent_clusterer.md
@@ -45,6 +45,26 @@ clusterer = IntentClusterer()
 clusterer.index_repository(Path("/path/to/repo"))
 ```
 
+## Watching a repository
+
+Keep an index up to date by watching a repository for changes.  The watcher
+returns a callable that should be invoked to stop monitoring.
+
+```python
+from pathlib import Path
+from menace import IntentClusterer
+
+clusterer = IntentClusterer()
+stop = clusterer.watch_repository(Path("/path/to/repo"))
+# ... perform work ...
+stop()
+```
+
+`watch_repository` relies on the lightweight `watchfiles` package.  It watches
+for creation, modification and deletion of `.py` files, re-indexes the
+repository and rebuilds clusters on each change.  Errors are logged and do not
+crash the watcher thread.
+
 ## Retrieving intent results
 
 Retrieve modules or clusters that relate to a textual prompt:


### PR DESCRIPTION
## Summary
- add `watch_repository` helper to monitor Python files and refresh intent clusters
- document repository watcher usage

## Testing
- `pre-commit run --files intent_clusterer.py docs/intent_clusterer.md`
- `pytest tests/test_intent_clusterer.py tests/test_intent_clusterer_helper.py tests/test_intent_clusterer_synergy.py tests/test_intent_clusterer_logging.py tests/test_intent_clusterer_async.py tests/test_intent_clusterer_query.py tests/integration/test_intent_clusterer_synergy.py` *(fails: AttributeError: 'Dummy' object has no attribute 'add_vector', async functions not natively supported, ValueError in test_query_falls_back_to_cluster_vectors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac10e3bf0c832eaa06b7c94da88d5f