### PR TITLE
Enforce non-null content_hash across key tables

### DIFF
--- a/bot_database.py
+++ b/bot_database.py
@@ -167,7 +167,8 @@ class BotDB(EmbeddableDBMixin):
                 status TEXT,
                 version TEXT,
                 estimated_profit REAL,
-                source_menace_id TEXT NOT NULL
+                source_menace_id TEXT NOT NULL,
+                content_hash TEXT NOT NULL UNIQUE
             )
             """
         )
@@ -193,7 +194,7 @@ class BotDB(EmbeddableDBMixin):
             # directly via ALTER TABLE, so we add the column first and create
             # the uniqueness constraint via an explicit index below.
             self.conn.execute(
-                "ALTER TABLE bots ADD COLUMN content_hash TEXT"
+                "ALTER TABLE bots ADD COLUMN content_hash TEXT NOT NULL"
             )
         idxs = [r[1] for r in self.conn.execute("PRAGMA index_list('bots')").fetchall()]
         if "ix_bots_source_menace_id" in idxs:

--- a/chatgpt_enhancement_bot.py
+++ b/chatgpt_enhancement_bot.py
@@ -174,7 +174,8 @@ class EnhancementDB(EmbeddableDBMixin):
                         category TEXT,
                         associated_bots TEXT,
                         triggered_by TEXT,
-                        source_menace_id TEXT NOT NULL
+                        source_menace_id TEXT NOT NULL,
+                        content_hash TEXT NOT NULL UNIQUE
                     )
                     """
                 )
@@ -208,7 +209,7 @@ class EnhancementDB(EmbeddableDBMixin):
                     # ALTER TABLE, so add the column and create a unique index
                     # separately below.
                     conn.execute(
-                        "ALTER TABLE enhancements ADD COLUMN content_hash TEXT"
+                        "ALTER TABLE enhancements ADD COLUMN content_hash TEXT NOT NULL"
                     )
                 idxs = [
                     r[1]

--- a/databases.py
+++ b/databases.py
@@ -88,7 +88,7 @@ class MenaceDB:
             Column("discrepancy_links", Text),
             Column("status", String),
             Column("estimated_profit_per_bot", Float, default=0.0),
-            Column("content_hash", Text, unique=True),
+            Column("content_hash", Text, unique=True, nullable=False),
         )
         Index("idx_workflows_content_hash", self.workflows.c.content_hash, unique=True)
 
@@ -192,7 +192,7 @@ class MenaceDB:
                 nullable=False,
                 server_default="",
             ),
-            Column("content_hash", Text, unique=True),
+            Column("content_hash", Text, unique=True, nullable=False),
         )
         Index("idx_bots_source_menace_id", self.bots.c.source_menace_id)
         Index("idx_bots_content_hash", self.bots.c.content_hash, unique=True)
@@ -255,7 +255,7 @@ class MenaceDB:
             Column("timestamp", String),
             Column("triggered_by", String),
             Column("source_menace_id", Text, nullable=False),
-            Column("content_hash", Text, unique=True),
+            Column("content_hash", Text, unique=True, nullable=False),
         )
         Index(
             "idx_enhancements_source_menace_id",
@@ -377,7 +377,7 @@ class MenaceDB:
             Column("error_description", Text),
             Column("resolution_status", String),
             Column("source_menace_id", Text, nullable=False, server_default=""),
-            Column("content_hash", Text, unique=True),
+            Column("content_hash", Text, unique=True, nullable=False),
         )
         Index("idx_errors_source_menace_id", self.errors.c.source_menace_id)
         Index("idx_errors_content_hash", self.errors.c.content_hash, unique=True)
@@ -591,7 +591,7 @@ class MenaceDB:
             cols = conn.exec_driver_sql(f"PRAGMA table_info({table_name})").fetchall()
             if "content_hash" not in [c[1] for c in cols]:
                 conn.exec_driver_sql(
-                    f"ALTER TABLE {table_name} ADD COLUMN content_hash TEXT"
+                    f"ALTER TABLE {table_name} ADD COLUMN content_hash TEXT NOT NULL"
                 )
 
     # ------------------------------------------------------------------

--- a/error_bot.py
+++ b/error_bot.py
@@ -135,7 +135,7 @@ class ErrorDB(EmbeddableDBMixin):
                 cause TEXT,
                 frequency INTEGER,
                 source_menace_id TEXT NOT NULL DEFAULT '',
-                content_hash TEXT UNIQUE
+                content_hash TEXT NOT NULL UNIQUE
             )
             """
         )
@@ -152,7 +152,7 @@ class ErrorDB(EmbeddableDBMixin):
             )
         if "content_hash" not in cols:
             self.conn.execute(
-                "ALTER TABLE errors ADD COLUMN content_hash TEXT UNIQUE"
+                "ALTER TABLE errors ADD COLUMN content_hash TEXT NOT NULL"
             )
         self.conn.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_errors_content_hash ON errors(content_hash)"

--- a/migrations/versions/0012_content_hash_not_null.py
+++ b/migrations/versions/0012_content_hash_not_null.py
@@ -1,0 +1,96 @@
+"""make content_hash non-null"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from db_dedup import compute_content_hash
+
+revision: str = "0012"
+down_revision: Union[str, Sequence[str], None] = "0011"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLES: dict[str, list[str]] = {
+    "bots": [
+        "name",
+        "type",
+        "tasks",
+        "dependencies",
+        "purpose",
+        "tags",
+        "toolchain",
+        "version",
+    ],
+    "workflows": [
+        "workflow",
+        "action_chains",
+        "argument_strings",
+        "title",
+        "description",
+        "task_sequence",
+    ],
+    "enhancements": [
+        "idea",
+        "rationale",
+        "summary",
+        "before_code",
+        "after_code",
+        "description",
+    ],
+    "errors": [
+        "type",
+        "description",
+        "resolution",
+    ],
+}
+
+
+def _compute_hash(row: dict[str, str], fields: list[str]) -> str:
+    payload = {f: row.get(f) for f in fields}
+    return compute_content_hash(payload)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = set(inspector.get_table_names())
+    for table, fields in TABLES.items():
+        if table not in existing:
+            continue
+        pk_cols = inspector.get_pk_constraint(table)["constrained_columns"]
+        if not pk_cols:
+            continue
+        pk = pk_cols[0]
+        rows = (
+            bind.execute(
+                sa.text(
+                    "SELECT {pk}, {cols} FROM {table} WHERE content_hash IS NULL".format(
+                        pk=pk,
+                        cols=", ".join(fields),
+                        table=table,
+                    )
+                )
+            )
+            .mappings()
+            .all()
+        )
+        for row in rows:
+            content_hash = _compute_hash(row, fields)
+            bind.execute(
+                sa.text(
+                    f"UPDATE {table} SET content_hash=:h WHERE {pk}=:id"
+                ),
+                {"h": content_hash, "id": row[pk]},
+            )
+        with op.batch_alter_table(table, recreate="always") as batch:
+            batch.alter_column("content_hash", existing_type=sa.Text(), nullable=False)
+
+
+def downgrade() -> None:
+    for table in TABLES:
+        with op.batch_alter_table(table, recreate="always") as batch:
+            batch.alter_column("content_hash", existing_type=sa.Text(), nullable=True)

--- a/task_handoff_bot.py
+++ b/task_handoff_bot.py
@@ -133,7 +133,8 @@ class WorkflowDB(EmbeddableDBMixin):
                 performance_data TEXT,
                 estimated_profit_per_bot REAL,
                 timestamp TEXT,
-                source_menace_id TEXT
+                source_menace_id TEXT,
+                content_hash TEXT NOT NULL UNIQUE
             )
             """,
         )
@@ -151,7 +152,7 @@ class WorkflowDB(EmbeddableDBMixin):
             # SQLite cannot add a column with a UNIQUE constraint via ALTER TABLE.
             # Add the column first and rely on the index below for uniqueness.
             self.conn.execute(
-                "ALTER TABLE workflows ADD COLUMN content_hash TEXT"
+                "ALTER TABLE workflows ADD COLUMN content_hash TEXT NOT NULL"
             )
         self.conn.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS "

--- a/tests/test_db_dedup.py
+++ b/tests/test_db_dedup.py
@@ -57,7 +57,9 @@ def test_enhancementdb_dedup(tmp_path, caplog, monkeypatch, router):
     # ``content_hash`` column may not be added on older SQLite versions; ensure
     # it exists so deduplication can be tested reliably.
     try:
-        db.conn.execute("ALTER TABLE enhancements ADD COLUMN content_hash TEXT")
+        db.conn.execute(
+            "ALTER TABLE enhancements ADD COLUMN content_hash TEXT NOT NULL"
+        )
     except Exception:
         pass
     db.conn.execute(
@@ -174,7 +176,7 @@ def test_insert_if_unique_duplicate_returns_existing_id(tmp_path, caplog):
     router = db_router.init_db_router("test", str(path), str(path))
     conn = router.local_conn
     conn.execute(
-        "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, content_hash TEXT UNIQUE)"
+        "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, content_hash TEXT UNIQUE NOT NULL)"
     )
     logger = logging.getLogger(__name__)
 
@@ -210,7 +212,7 @@ def test_insert_if_unique_missing_field_sqlite(tmp_path):
     router = db_router.init_db_router("test", str(path), str(path))
     conn = router.local_conn
     conn.execute(
-        "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, content_hash TEXT UNIQUE)"
+        "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, content_hash TEXT UNIQUE NOT NULL)"
     )
     logger = logging.getLogger(__name__)
 

--- a/tests/test_db_dedup_concurrent.py
+++ b/tests/test_db_dedup_concurrent.py
@@ -10,7 +10,7 @@ def test_insert_if_unique_concurrent(tmp_path):
     path = tmp_path / "dedup.sqlite"
     base_conn = sqlite3.connect(path, check_same_thread=False, isolation_level=None)
     base_conn.execute(
-        "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, content_hash TEXT UNIQUE)"
+        "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT, content_hash TEXT UNIQUE NOT NULL)"
     )
     base_conn.close()
 

--- a/tests/test_db_dedup_helper.py
+++ b/tests/test_db_dedup_helper.py
@@ -40,7 +40,7 @@ def test_insert_if_unique_duplicate_returns_existing_id(caplog):
         meta,
         Column("id", Integer, primary_key=True),
         Column("name", Text),
-        Column("content_hash", Text, unique=True),
+        Column("content_hash", Text, unique=True, nullable=False),
     )
     meta.create_all(engine)
     logger = logging.getLogger(__name__)
@@ -80,7 +80,7 @@ def test_insert_if_unique_missing_field_sqlalchemy():
         meta,
         Column("id", Integer, primary_key=True),
         Column("name", Text),
-        Column("content_hash", Text, unique=True),
+        Column("content_hash", Text, unique=True, nullable=False),
     )
     meta.create_all(engine)
     logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- make content_hash mandatory in database models and SQLite helpers
- backfill existing hashes and set NOT NULL via migration
- update tests for stricter content_hash constraint

## Testing
- `python -m pytest tests/test_db_dedup.py tests/test_db_dedup_helper.py tests/test_db_dedup_concurrent.py tests/test_error_bot.py tests/test_task_handoff_bot.py tests/test_chatgpt_enhancement_bot.py tests/test_bot_database.py` *(fails: Missing system packages: ffmpeg, tesseract, qemu-system-x86_64)*

------
https://chatgpt.com/codex/tasks/task_e_68ac148da82c832ebeaebced29542b61