### PR TITLE
Use dependency graph fallback for intent clustering

### DIFF
--- a/tests/test_intent_clusterer_logging.py
+++ b/tests/test_intent_clusterer_logging.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from pathlib import Path
 
 import intent_clusterer as ic
@@ -18,6 +19,7 @@ def _make_clusterer(tmp_path: Path) -> ic.IntentClusterer:
 
 def test_load_synergy_groups_logs_failure(tmp_path, caplog, monkeypatch):
     monkeypatch.setattr(ic, "governed_embed", lambda text: [0.1, 0.2])
+    monkeypatch.setitem(sys.modules, "module_synergy_grapher", None)
     clusterer = _make_clusterer(tmp_path)
     map_file = tmp_path / "sandbox_data" / "module_map.json"
     map_file.parent.mkdir()
@@ -91,4 +93,3 @@ def test_index_modules_logs_retriever_failure(tmp_path, caplog, monkeypatch):
     caplog.set_level(logging.WARNING)
     clusterer.index_modules([module])
     assert "retriever boom" in caplog.text
-

--- a/tests/test_intent_clusterer_synergy.py
+++ b/tests/test_intent_clusterer_synergy.py
@@ -16,21 +16,16 @@ def _make_clusterer(tmp_path: Path) -> ic.IntentClusterer:
     )
 
 
-def test_fallback_groups_by_prefix_and_import(tmp_path, monkeypatch):
+def test_fallback_groups_by_dependency_graph(tmp_path, monkeypatch):
     monkeypatch.setitem(sys.modules, "module_synergy_grapher", None)
     clusterer = _make_clusterer(tmp_path)
-    a1 = tmp_path / "alpha_one.py"
-    a1.write_text("import os\n")
-    a2 = tmp_path / "alpha_two.py"
-    a2.write_text("import sys\n")
-    b1 = tmp_path / "mod_a.py"
-    b1.write_text("import json\n")
-    b2 = tmp_path / "mod_b.py"
-    b2.write_text("import json\n")
+    a = tmp_path / "a.py"
+    a.write_text("import b\n")
+    b = tmp_path / "b.py"
+    b.write_text("\n")
     solo = tmp_path / "solo.py"
-    solo.write_text("import pickle\n")
+    solo.write_text("\n")
     groups = clusterer._load_synergy_groups(tmp_path)
     gsets = [set(map(Path, members)) for members in groups.values()]
-    assert any(g == {a1, a2} for g in gsets)
-    assert any(g == {b1, b2} for g in gsets)
+    assert any(g == {a, b} for g in gsets)
     assert any(g == {solo} for g in gsets)


### PR DESCRIPTION
## Summary
- build a lightweight dependency graph via `module_graph_analyzer` when `ModuleSynergyGrapher` is unavailable
- cluster modules using connected components of that graph
- add tests for dependency-based fallback and update logging test

## Testing
- `pre-commit run --files intent_clusterer.py tests/test_intent_clusterer_synergy.py tests/test_intent_clusterer_logging.py`
- `pytest tests/test_intent_clusterer_synergy.py tests/test_intent_clusterer_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac1bd6b210832ea62c2cc66f7aab63