### PR TITLE
Add module IO inspection utilities

### DIFF
--- a/workflow_synthesizer.py
+++ b/workflow_synthesizer.py
@@ -11,9 +11,10 @@ of modules either by following the synergy graph around a starting module or by
 searching for modules related to a textual problem description.
 """
 
-from dataclasses import dataclass
+import ast
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Set
+from typing import Any, Dict, List, Set
 
 try:  # Optional imports; fall back to stubs in tests
     from module_synergy_grapher import ModuleSynergyGrapher
@@ -24,6 +25,155 @@ try:  # Optional dependency
     from intent_clusterer import IntentClusterer
 except Exception:  # pragma: no cover - graceful degradation
     IntentClusterer = None  # type: ignore[misc]
+
+
+@dataclass
+class ModuleIO:
+    """Basic structural information about a Python module."""
+
+    functions: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    inputs: Set[str] = field(default_factory=set)
+    outputs: Set[str] = field(default_factory=set)
+    globals: Set[str] = field(default_factory=set)
+    files_read: Set[str] = field(default_factory=set)
+    files_written: Set[str] = field(default_factory=set)
+
+
+def _parse_module_io(path: Path) -> ModuleIO:
+    """Parse ``path`` and extract high level IO information."""
+
+    module_io = ModuleIO()
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError:
+        return module_io
+
+    tree = ast.parse(source, filename=str(path))
+
+    def _extract_path(node: ast.AST) -> str | None:
+        """Return a string path from ``Path('foo')`` like nodes."""
+
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == "Path":
+                if node.args and isinstance(node.args[0], ast.Constant):
+                    val = node.args[0].value
+                    if isinstance(val, str):
+                        return val
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        if isinstance(node, ast.Name):
+            return node.id
+        return None
+
+    # ---- top level function definitions
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef):
+            args = [a.arg for a in node.args.posonlyargs + node.args.args + node.args.kwonlyargs]
+            if node.args.vararg:
+                args.append(node.args.vararg.arg)
+            if node.args.kwarg:
+                args.append(node.args.kwarg.arg)
+
+            returns = None
+            if getattr(node, "returns", None) is not None:
+                try:
+                    returns = ast.unparse(node.returns)
+                except Exception:  # pragma: no cover - ast.unparse fallback
+                    returns = None
+
+            module_io.functions[node.name] = {"args": args, "returns": returns}
+            module_io.inputs.update(args)
+
+    class Visitor(ast.NodeVisitor):
+        def visit_Global(self, node: ast.Global) -> None:  # noqa: D401
+            module_io.globals.update(node.names)
+
+        def visit_Return(self, node: ast.Return) -> None:  # noqa: D401
+            targets: list[str] = []
+            val = node.value
+            if isinstance(val, ast.Name):
+                targets.append(val.id)
+            elif isinstance(val, ast.Tuple):
+                for elt in val.elts:
+                    if isinstance(elt, ast.Name):
+                        targets.append(elt.id)
+            module_io.outputs.update(targets)
+            self.generic_visit(node)
+
+        def visit_Call(self, node: ast.Call) -> None:  # noqa: D401
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == "open":
+                filename = None
+                if node.args:
+                    arg = node.args[0]
+                    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                        filename = arg.value
+                    elif isinstance(arg, ast.Name):
+                        filename = arg.id
+                    else:
+                        filename = _extract_path(arg)
+
+                mode = None
+                if len(node.args) > 1:
+                    m = node.args[1]
+                    if isinstance(m, ast.Constant) and isinstance(m.value, str):
+                        mode = m.value
+                for kw in node.keywords:
+                    if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
+                        val = kw.value.value
+                        if isinstance(val, str):
+                            mode = val
+
+                if filename:
+                    if mode and any(c in mode for c in "wa+"):
+                        module_io.files_written.add(filename)
+                    else:
+                        module_io.files_read.add(filename)
+
+            elif isinstance(func, ast.Attribute):
+                attr = func.attr
+                base = func.value
+                filename = _extract_path(base)
+                if filename:
+                    if attr in {"read_text", "read_bytes"}:
+                        module_io.files_read.add(filename)
+                    elif attr in {"write_text", "write_bytes"}:
+                        module_io.files_written.add(filename)
+                    elif attr == "open":
+                        mode = None
+                        if node.args:
+                            arg = node.args[0]
+                            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                                mode = arg.value
+                        for kw in node.keywords:
+                            if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
+                                val = kw.value.value
+                                if isinstance(val, str):
+                                    mode = val
+                        if mode and any(c in mode for c in "wa+"):
+                            module_io.files_written.add(filename)
+                        else:
+                            module_io.files_read.add(filename)
+
+            self.generic_visit(node)
+
+    Visitor().visit(tree)
+    return module_io
+
+
+def inspect_module(module_name: str) -> ModuleIO:
+    """Return :class:`ModuleIO` information for ``module_name``.
+
+    Parameters
+    ----------
+    module_name:
+        Dotted module name relative to the repository root.
+    """
+
+    path = Path(module_name.replace(".", "/")).with_suffix(".py")
+    return _parse_module_io(path)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- introduce `ModuleIO` dataclass and AST-based inspection helpers
- add `_parse_module_io` to extract functions, globals, file IO
- expose `inspect_module` for callers

## Testing
- `python -m pytest -k workflow_synthesizer -q` *(fails: ImportError: cannot import name 'EvolutionEvent', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1fbb3f2c832e9939a2cabf9e6ae2