### PR TITLE
document codex db helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,36 @@
    run. See [docs/deployment_governance.md](docs/deployment_governance.md) for
    rule syntax, configuration paths and example policy/scorecard templates.
 
+### Codex database helpers
+
+The `codex_db_helpers` module pulls training samples from multiple Menace
+databases. Each fetch helper accepts:
+
+- `scope` – record visibility (`"local"`, `"global"` or `"all"`, default).
+- `sort_by` – order column (`"score"`, `"roi"`, `"confidence"` or `"ts"`).
+- `limit` – maximum number of records to return.
+- `with_embeddings` – attach vector embeddings when available.
+
+Tables are expected to expose `id`, a text field (`summary`, `message` or
+`details`), and the numeric fields `score`, `roi`, `confidence` and `ts`.
+
+```python
+from codex_db_helpers import aggregate_training_samples
+
+records = aggregate_training_samples(
+    enhancement_db,
+    summary_db,
+    sort_by="score",
+    limit=5,
+)
+
+prompt = "\n\n".join(r["summary"] for r in records)
+```
+
+To support additional data types, implement a `fetch_*` helper returning the
+standard columns and register it with `aggregate_training_samples`. See
+[docs/codex_db_helpers.md](docs/codex_db_helpers.md) for more details.
+
 ### ROI toolkit
 
 ROI evaluation combines `ROICalculator`, `ROITracker` and the RAROI formula to

--- a/docs/codex_db_helpers.md
+++ b/docs/codex_db_helpers.md
@@ -1,0 +1,53 @@
+# Codex database helpers
+
+The `codex_db_helpers` module collects training samples from Menace databases
+so they can be fed into language‑model prompts. It exposes fetch helpers for
+enhancements, workflow summaries, discrepancies and workflow history along with
+an `aggregate_training_samples` convenience wrapper.
+
+## Parameters
+
+All helpers share the following keyword arguments:
+
+- `scope` – visibility of records (`"local"`, `"global"` or `"all"`, default)
+  forwarded to `scope_utils.apply_scope_to_query`.
+- `sort_by` – column used for ordering; one of `"score"`, `"roi"`,
+  `"confidence"` or `"ts"`.
+- `limit` – maximum number of rows to return (defaults to `100`).
+- `with_embeddings` – attach vector embeddings via `db.vector(id)` when
+  available.
+
+The queried tables must expose `id`, a text field (`summary`, `message` or
+`details`), and the numeric columns `score`, `roi`, `confidence` and `ts`.
+
+## Example
+
+```python
+from codex_db_helpers import aggregate_training_samples
+
+records = aggregate_training_samples(
+    enh_db,
+    sum_db,
+    sort_by="score",
+    limit=5,
+    with_embeddings=False,
+)
+
+prompt = "Examples:\n" + "\n\n".join(
+    f"{r['summary']} (ROI={r['roi']:.2f})" for r in records
+)
+```
+
+## Extending
+
+To add a new data source:
+
+1. Implement a `fetch_<name>` helper that selects `id`, the text column,
+   `score`, `roi`, `confidence` and `ts` from the target table while forwarding
+   the common parameters.
+2. Register the helper in `aggregate_training_samples` so its output participates
+   in the combined ranking.
+
+This keeps the API consistent across data types and preserves scoping and
+embedding support.
+


### PR DESCRIPTION
## Summary
- add Codex database helpers section describing scope, sorting, limits and embeddings
- document helper API and extension guidance in new docs/codex_db_helpers.md

## Testing
- `pytest tests/test_codex_db_helpers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac219c3200832eb7e102b6957e0d5a