### PR TITLE
Refactor Codex prompt context gathering

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,20 +194,20 @@ Tables are expected to expose `id`, a text field (`summary`, `message` or
 `details`), and the numeric fields `score`, `roi`, `confidence` and `ts`.
 
 ```python
-from codex_db_helpers import aggregate_training_samples
+from codex_db_helpers import aggregate_samples
 
-records = aggregate_training_samples(
-    enhancement_db,
-    summary_db,
-    sort_by="score",
-    limit=5,
+records = aggregate_samples(
+    sources=["enhancement", "workflow_summary"],
+    limit_per_source=5,
+    sort_by="outcome_score",
+    with_vectors=False,
 )
 
 prompt = "\n\n".join(r["summary"] for r in records)
 ```
 
 To support additional data types, implement a `fetch_*` helper returning the
-standard columns and register it with `aggregate_training_samples`. See
+standard columns and register it with `aggregate_samples`. See
 [docs/codex_db_helpers.md](docs/codex_db_helpers.md) for more details.
 
 ### ROI toolkit

--- a/docs/codex_db_helpers.md
+++ b/docs/codex_db_helpers.md
@@ -3,7 +3,7 @@
 The `codex_db_helpers` module collects training samples from Menace databases
 so they can be fed into language‑model prompts. It exposes fetch helpers for
 enhancements, workflow summaries, discrepancies and workflow history along with
-an `aggregate_training_samples` convenience wrapper.
+an `aggregate_samples` convenience wrapper.
 
 ## Parameters
 
@@ -23,14 +23,13 @@ The queried tables must expose `id`, a text field (`summary`, `message` or
 ## Example
 
 ```python
-from codex_db_helpers import aggregate_training_samples
+from codex_db_helpers import aggregate_samples
 
-records = aggregate_training_samples(
-    enh_db,
-    sum_db,
-    sort_by="score",
-    limit=5,
-    with_embeddings=False,
+records = aggregate_samples(
+    sources=["enhancement", "workflow_summary"],
+    limit_per_source=5,
+    sort_by="outcome_score",
+    with_vectors=False,
 )
 
 prompt = "Examples:\n" + "\n\n".join(
@@ -45,7 +44,7 @@ To add a new data source:
 1. Implement a `fetch_<name>` helper that selects `id`, the text column,
    `score`, `roi`, `confidence` and `ts` from the target table while forwarding
    the common parameters.
-2. Register the helper in `aggregate_training_samples` so its output participates
+2. Register the helper in `aggregate_samples` so its output participates
    in the combined ranking.
 
 This keeps the API consistent across data types and preserves scoping and


### PR DESCRIPTION
## Summary
- build prompts with codex_db_helpers.aggregate_samples to supply training examples
- allow tuning sample limits and ranking in bot development and error logging
- document aggregate_samples helper and its usage

## Testing
- `pytest -q` *(fails: Missing system packages: ffmpeg, tesseract, qemu-system-x86_64)*

------
https://chatgpt.com/codex/tasks/task_e_68ac251a8e5c832e87143157085f617e