### PR TITLE
Add confidence and outcome score fields to enhancements

### DIFF
--- a/db_dedup.py
+++ b/db_dedup.py
@@ -144,7 +144,8 @@ def insert_if_unique(
                         return result.lastrowid
 
                 logger.warning(
-                    "Duplicate insert ignored for %s (menace_id=%s)",
+                    "duplicate %s ignored for %s (menace_id=%s)",
+                    table.name.rstrip("s"),
                     table.name,
                     menace_id,
                 )
@@ -166,7 +167,8 @@ def insert_if_unique(
                 if row:
                     return row[0]
                 logger.warning(
-                    "Duplicate insert ignored for %s (menace_id=%s)",
+                    "duplicate %s ignored for %s (menace_id=%s)",
+                    table.name.rstrip("s"),
                     table.name,
                     menace_id,
                 )
@@ -200,7 +202,7 @@ def insert_if_unique(
                 return int(cur.lastrowid)
 
         logger.warning(
-            "Duplicate insert ignored for %s (menace_id=%s)", table, menace_id
+            "duplicate %s ignored for %s (menace_id=%s)", table.rstrip("s"), table, menace_id
         )
         cur = conn.execute(
             f"SELECT id FROM {table} WHERE content_hash=?",


### PR DESCRIPTION
## Summary
- track `confidence` and `outcome_score` for enhancements with schema, dataclass, and CRUD updates
- support ordering enhancement queries by confidence or outcome score
- clarify duplicate insert warnings in `insert_if_unique`

## Testing
- `pytest tests/test_enhancement_db.py tests/test_chatgpt_enhancement_bot.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac2b7ba334832ea1e5f2636ec891d3