### PR TITLE
docs: document codex training data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,9 @@ prompt = "\n\n".join(r["summary"] for r in records)
 
 To support additional data types, implement a `fetch_*` helper returning the
 standard columns and register it with `aggregate_samples`. See
-[docs/codex_db_helpers.md](docs/codex_db_helpers.md) for more details.
+[docs/codex_db_helpers.md](docs/codex_db_helpers.md) for more details and
+[docs/codex_training_data.md](docs/codex_training_data.md) for a tour of the
+available sources and prompt-building examples.
 
 ### ROI toolkit
 

--- a/docs/codex_db_helpers.md
+++ b/docs/codex_db_helpers.md
@@ -5,6 +5,9 @@ so they can be fed into language‑model prompts. It exposes fetch helpers for
 enhancements, workflow summaries, discrepancies and workflow history along with
 an `aggregate_samples` convenience wrapper.
 
+For a higher level overview of available sources and sample prompts see
+[codex_training_data.md](codex_training_data.md).
+
 ## Parameters
 
 All helpers share the following keyword arguments:

--- a/docs/codex_training_data.md
+++ b/docs/codex_training_data.md
@@ -1,0 +1,49 @@
+# Codex training data
+
+The `codex_db_helpers` module unifies access to textual training samples stored across Menace databases. It exposes fetch helpers for multiple sources and an `aggregate_samples` wrapper that merges them into a single ordered list.
+
+## Data sources
+
+These sources are available out of the box:
+
+- **enhancement** – summaries and outcome scores from `EnhancementDB`.
+- **workflow_summary** – short workflow descriptions from `WorkflowSummaryDB`.
+- **discrepancy** – discrepancy reports with confidence scores from `DiscrepancyDB`.
+- **evolution** – evolution history entries containing ROI and performance metrics from `EvolutionHistoryDB`.
+
+## Sorting and embeddings
+
+All helpers accept:
+
+- `sort_by` – `"confidence"`, `"outcome_score"`, `"ts"`/`"timestamp"` determine ordering.
+- `limit` – number of rows to fetch per source.
+- `with_vectors` – when `True`, attach embedding vectors via the respective database's `vector(id)` API.
+
+## Example
+
+```python
+from codex_db_helpers import aggregate_samples
+import openai
+
+samples = aggregate_samples(
+    sources=["enhancement", "workflow_summary", "evolution"],
+    limit_per_source=10,
+    sort_by="outcome_score",
+    with_vectors=False,
+)
+
+prompt = "Examples:\n" + "\n\n".join(
+    f"{s.source}: {s.text} (score={s.score})" for s in samples
+)
+
+completion = openai.Completion.create(
+    model="code-davinci-002",
+    prompt=prompt,
+    max_tokens=200,
+)
+print(completion["choices"][0]["text"])
+```
+
+The snippet aggregates recent records, formats them as a prompt and sends it to a Codex model for completion.
+
+For an API reference and extension guidelines see [codex_db_helpers.md](codex_db_helpers.md).


### PR DESCRIPTION
## Summary
- document codex training data sources and sample prompt usage
- cross-link existing Codex docs to training data guide

## Testing
- `pytest tests/test_codex_db_helpers.py tests/test_codex_output_analyzer.py tests/test_enhancement_bot.py tests/test_error_logger_fix_suggestions.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac2f39d0f0832e8d199de6c9d92461