### PR TITLE
feat: allow saving synthesized workflows

### DIFF
--- a/docs/workflow_synthesizer.md
+++ b/docs/workflow_synthesizer.md
@@ -19,3 +19,16 @@ The :meth:`WorkflowSynthesizer.synthesize` method returns a structured list of
 steps where each entry describes the module name, unresolved arguments and the
 values it provides.  These steps can be transformed into a workflow
 specification or executed directly.
+
+Once a set of candidate workflows has been produced via
+``generate_workflows`` the synthesizer can serialise them for later reuse:
+
+```python
+workflows = synth.generate_workflows(start_module="module_a")
+data = synth.to_dict()          # JSON serialisable mapping
+path = synth.save()             # writes JSON/YAML to sandbox_data/generated_workflows
+
+# create a .workflow.json file compatible with WorkflowDB
+from workflow_synthesizer import save_workflow
+save_workflow(workflows[0])
+```


### PR DESCRIPTION
## Summary
- track generated workflows in `WorkflowSynthesizer` and expose JSON/YAML serialization helpers
- persist synthesized workflows to `sandbox_data/generated_workflows` and offer helper for `.workflow.json`
- document and test new workflow saving utilities

## Testing
- `python - <<'PY'
import sys, types, pathlib, pytest
pkg = types.ModuleType('menace_sandbox'); pkg.__path__ = [str(pathlib.Path('.').resolve())]
sys.modules['menace_sandbox'] = pkg
sys.modules['menace_sandbox.tests'] = types.ModuleType('menace_sandbox.tests'); sys.modules['menace_sandbox.tests'].__path__ = [str(pathlib.Path('tests').resolve())]
sys.path.insert(0, str(pathlib.Path('.').resolve()))
pytest.main(['tests/test_workflow_synthesizer.py::test_workflow_synthesizer_greedy_chain','tests/test_workflow_synthesizer.py::test_workflow_synthesizer_save_and_helper','-q'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ac2ce62a20832ebfdb248978864f6f