### PR TITLE
test: add workflow synthesizer tests

### DIFF
--- a/tests/test_workflow_synthesizer.py
+++ b/tests/test_workflow_synthesizer.py
@@ -1,14 +1,13 @@
+import json
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
 
-import json
 import networkx as nx
 
-# Provide stubs to avoid heavy optional imports
-sys.modules.setdefault(
-    "intent_clusterer", SimpleNamespace(IntentClusterer=None)
-)
+# Stub heavy optional dependencies before importing the module under test.
+sys.modules.setdefault("intent_clusterer", SimpleNamespace(IntentClusterer=None))
 sys.modules.setdefault(
     "module_synergy_grapher",
     SimpleNamespace(ModuleSynergyGrapher=None, get_synergy_cluster=None),
@@ -17,47 +16,52 @@ sys.modules.setdefault(
 import workflow_synthesizer as ws
 
 
-def _write_modules(tmp_path):
+def _write_modules(tmp_path: Path) -> None:
+    """Create tiny modules for synthesizer tests."""
+
     (tmp_path / "mod_a.py").write_text(
-        "def start():\n    data = 'x'\n    return data\n"
+        "def start():\n    data = 'a'\n    return data\n"
     )
     (tmp_path / "mod_b.py").write_text(
         "def middle(data):\n    result = data + 'b'\n    return result\n"
     )
     (tmp_path / "mod_c.py").write_text(
-        "def end(result, extra):\n    pass\n"
+        "def final(result):\n    pass\n"
+    )
+    (tmp_path / "mod_d.py").write_text(
+        "def unrelated(missing):\n    pass\n"
     )
 
 
 class FakeGrapher:
-    def __init__(self):
+    """Minimal synergy grapher used to control expansion."""
+
+    def __init__(self) -> None:
         self.graph = nx.DiGraph()
         self.graph.add_edge("mod_a", "mod_b", weight=2.0)
+        self.graph.add_edge("mod_a", "mod_d", weight=1.0)
         self.graph.add_edge("mod_b", "mod_c", weight=1.0)
-        self.loaded = None
+        self.loaded: Path | None = None
 
-    def load(self, path):
+    def load(self, path: Path) -> None:
         self.loaded = path
 
-    def get_synergy_cluster(self, start):
-        return ["mod_a", "mod_b"] if start == "mod_a" else [start]
+    def get_synergy_cluster(self, start: str):  # pragma: no cover - simple
+        return ["mod_a", "mod_b", "mod_d"] if start == "mod_a" else [start]
 
 
 class FakeIntent:
-    def __init__(self, base):
+    """Return ``mod_c`` as an intent match."""
+
+    def __init__(self, base: Path) -> None:
         self.base = base
 
-    def find_modules_related_to(self, _problem, top_k=10):
+    def find_modules_related_to(self, _problem: str, top_k: int = 10):  # pragma: no cover - trivial
         return [SimpleNamespace(path=str(self.base / "mod_c.py"), score=1.0)]
 
 
-def test_workflow_synthesizer_greedy_chain(tmp_path, monkeypatch):
+def test_cluster_expansion_and_io_matching(tmp_path, monkeypatch):
     _write_modules(tmp_path)
-    repo_root = Path(__file__).resolve().parents[1]
-    sys.path.insert(0, str(repo_root))
-    import menace.task_handoff_bot as thb  # preload with package context
-    sys.modules["task_handoff_bot"] = thb
-
     monkeypatch.chdir(tmp_path)
 
     grapher = FakeGrapher()
@@ -68,22 +72,18 @@ def test_workflow_synthesizer_greedy_chain(tmp_path, monkeypatch):
         synergy_graph_path=tmp_path / "graph.json",
     )
 
-    steps = synth.synthesize(start_module="mod_a", problem="finish", overrides={"mod_c": {"extra"}})
-    assert [s["module"] for s in steps] == ["mod_a", "mod_b", "mod_c"]
-    assert steps[-1]["args"] == []
+    steps = synth.synthesize(start_module="mod_a", problem="finalise")
+
+    assert [s["module"] for s in steps] == ["mod_a", "mod_b", "mod_c", "mod_d"]
+    assert steps[-1]["args"] == ["missing"]
     assert grapher.loaded == tmp_path / "graph.json"
 
-    steps_no_override = synth.synthesize(start_module="mod_a", problem="finish")
-    assert steps_no_override[-1]["args"] == ["extra"]
 
-
-def test_workflow_synthesizer_save_and_helper(tmp_path, monkeypatch):
+def test_generated_json_schema(tmp_path, monkeypatch):
     _write_modules(tmp_path)
-
     monkeypatch.chdir(tmp_path)
 
-    from dataclasses import dataclass
-
+    # Stub out WorkflowDB/Record used by workflow_spec.save
     @dataclass
     class DummyRecord:
         pass
@@ -93,26 +93,34 @@ def test_workflow_synthesizer_save_and_helper(tmp_path, monkeypatch):
             self.path = path
             self.records = []
 
-        def add(self, rec):
+        def add(self, rec):  # pragma: no cover - simple
             self.records.append(rec)
-
-        def fetch(self):  # pragma: no cover - not used but mirrors real API
-            return list(self.records)
 
     sys.modules["task_handoff_bot"] = SimpleNamespace(
         WorkflowDB=DummyDB, WorkflowRecord=DummyRecord
     )
 
-    synth = ws.WorkflowSynthesizer()
-    workflows = synth.generate_workflows(start_module="mod_a")
+    grapher = FakeGrapher()
+    intent = FakeIntent(tmp_path)
+    synth = ws.WorkflowSynthesizer(
+        module_synergy_grapher=grapher, intent_clusterer=intent
+    )
 
-    data = synth.to_dict()
-    assert data["workflows"] == workflows
+    workflows = synth.generate_workflows(start_module="mod_a", problem="finalise")
+    spec = ws.to_workflow_spec(workflows[0])
 
-    json_path = synth.save()
-    assert json_path.exists()
-    assert json.loads(json_path.read_text()) == data
+    assert spec["workflow"] == ["mod_a", "mod_b", "mod_c"]
+    required = {
+        "workflow",
+        "action_chains",
+        "argument_strings",
+        "assigned_bots",
+        "enhancements",
+        "title",
+    }
+    assert required.issubset(spec)
 
     spec_path = ws.save_workflow(workflows[0])
-    assert spec_path.name.endswith(".workflow.json")
-    assert spec_path.exists()
+    saved = json.loads(spec_path.read_text())
+    assert saved["workflow"] == spec["workflow"]
+


### PR DESCRIPTION
## Summary
- add unit tests for workflow synthesizer using fake synergy graph and intent clusterer
- validate greedy chain expansion and IO matching
- verify workflow spec JSON schema is generated correctly

## Testing
- `pytest tests/test_workflow_synthesizer.py::test_cluster_expansion_and_io_matching tests/test_workflow_synthesizer.py::test_generated_json_schema -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac35caa69c832eb63a82852e5418a2