### PR TITLE
Add timestamp tracking to workflow summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@
     from workflow_summary_db import WorkflowSummaryDB
 
     db = WorkflowSummaryDB()
-    db.get_summary(1, scope="local")   # current menace only
-    db.get_summary(1, scope="global")  # other menace instances
-    db.get_summary(1, scope="all")     # all records
+    db.get_summary(1, scope="local")   # -> WorkflowSummary for current menace
+    db.get_summary(1, scope="global")  # -> records from other menace instances
+    db.get_summary(1, scope="all")     # -> records from all menaces
     ```
     Scoping can also be applied manually when building SQL queries:
 

--- a/codex_db_helpers.py
+++ b/codex_db_helpers.py
@@ -112,8 +112,8 @@ def fetch_summaries(
     db = WorkflowSummaryDB()
     menace_id = getattr(getattr(db, "router", None), "menace_id", "")
     clause, params = build_scope_clause("workflow_summaries", Scope.ALL, menace_id)
-    order_col = _resolve_order(sort_by, {}, "workflow_id")
-    sql = "SELECT workflow_id, summary FROM workflow_summaries"
+    order_col = _resolve_order(sort_by, {"timestamp": "timestamp"}, "workflow_id")
+    sql = "SELECT workflow_id, summary, timestamp FROM workflow_summaries"
     if clause:
         sql += f" WHERE {clause}"
     sql += f" ORDER BY {order_col} DESC LIMIT ?"
@@ -132,7 +132,7 @@ def fetch_summaries(
             TrainingSample(
                 source="workflow_summary",
                 content=row["summary"],
-                timestamp=None,
+                timestamp=row["timestamp"],
                 embedding=embedding,
             )
         )

--- a/docs/db_router.md
+++ b/docs/db_router.md
@@ -83,9 +83,9 @@ while ``all`` removes filtering entirely. The parameter accepts:
 from workflow_summary_db import WorkflowSummaryDB
 
 db = WorkflowSummaryDB()
-db.get_summary(1, scope="local")   # current menace only
-db.get_summary(1, scope="global")  # other menace instances
-db.get_summary(1, scope="all")     # all records
+db.get_summary(1, scope="local")   # -> WorkflowSummary for current menace
+db.get_summary(1, scope="global")  # -> records from other menace instances
+db.get_summary(1, scope="all")     # -> records from all menaces
 ```
 
 This ``scope`` parameter replaces the older ``include_cross_instance`` and

--- a/tests/test_workflow_summary_db.py
+++ b/tests/test_workflow_summary_db.py
@@ -14,10 +14,13 @@ def test_workflow_summary_scope_utils_filters(tmp_path):
     db2 = WorkflowSummaryDB(router=router2)
     db2.set_summary(2, "beta")
 
-    assert db1.get_summary(1) == "alpha"
-    assert db2.get_summary(2) == "beta"
+    s1 = db1.get_summary(1)
+    assert s1 and s1.summary == "alpha" and s1.timestamp
+    s2 = db2.get_summary(2)
+    assert s2 and s2.summary == "beta" and s2.timestamp
     assert db1.get_summary(2) is None
-    assert db1.get_summary(2, scope="global") == "beta"
+    sg = db1.get_summary(2, scope="global")
+    assert sg and sg.summary == "beta"
 
     assert [s.workflow_id for s in db1.all_summaries()] == [1]
     assert {s.workflow_id for s in db1.all_summaries(scope="global")} == {2}


### PR DESCRIPTION
## Summary
- track UTC timestamps for workflow summaries with schema migration
- expose timestamps from get_summary/all_summaries and related helpers
- update docs and tests for timestamp support

## Testing
- `pytest tests/test_workflow_summary_db.py tests/test_codex_db_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac3df6e1b8832eb6d7d4302713d96b