### PR TITLE
feat: add workflow synthesizer CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ adaptive-roi = "adaptive_roi_cli:main"
 backfill-embeddings = "scripts.backfill_embeddings:cli"
 retrieval-ranker = "retrieval_ranker:main"
 knowledge-cli = "knowledge_cli:main"
-workflow-synthesizer = "tools.workflow_synthesizer_cli:main"
+workflow-synth = "workflow_synthesizer:main"
 
 [project.entry-points."menace.plugins"]
 sample = "menace.plugins.sample:register"


### PR DESCRIPTION
## Summary
- add argparse-based `workflow_synthesizer` CLI with `synthesize` command
- support interactive mode when run without arguments
- register `workflow-synth` console script

## Testing
- `pre-commit run --files workflow_synthesizer.py pyproject.toml`
- `pytest` *(fails: Missing system packages: ffmpeg, tesseract, qemu-system-x86_64)*

------
https://chatgpt.com/codex/tasks/task_e_68ac40806400832e8e8b0938309a0ea3