### PR TITLE
Document Codex DB helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,9 @@
 ### Codex database helpers
 
 The `codex_db_helpers` module gathers training samples from Menace's
-enhancement, workflow summary, discrepancy and workflow databases. Each helper
-supports:
+enhancement, workflow summary, discrepancy and workflow databases. It powers
+fleetwide Codex training by aggregating examples from all Menace instances.
+Each helper supports:
 
 - `sort_by` – one of `"confidence"`, `"outcome_score"` or `"timestamp"`.
 - `limit` – maximum number of records to return.

--- a/docs/codex_db_helpers.md
+++ b/docs/codex_db_helpers.md
@@ -1,9 +1,18 @@
 # Codex database helpers
 
 The `codex_db_helpers` module collects training samples from Menace databases so
-they can be fed into language‑model prompts. It exposes fetch helpers for
+they can be fed into language‑model prompts. It exposes dedicated helpers for
 enhancements, workflow summaries, discrepancies and workflows along with an
 `aggregate_samples` convenience wrapper.
+
+## Functions
+
+- `fetch_enhancements` – summaries from `EnhancementDB`.
+- `fetch_summaries` – workflow summaries from `WorkflowSummaryDB`.
+- `fetch_discrepancies` – discrepancy messages from `DiscrepancyDB`.
+- `fetch_workflows` – saved workflows from `WorkflowDB`.
+- `aggregate_samples` – merge and sort samples from all fetchers  
+  (`aggregate_examples` is an alias).
 
 For a higher level overview of available sources and sample prompts see
 [codex_training_data.md](codex_training_data.md).
@@ -12,12 +21,17 @@ For a higher level overview of available sources and sample prompts see
 
 All helpers share the following keyword arguments:
 
-- `sort_by` – one of `"confidence"`, `"outcome_score"` or `"timestamp"`.
+- `sort_by` – one of `"confidence"`, `"outcome_score"` or `"timestamp"`; unknown
+  values fall back to `"timestamp"`.
 - `limit` – maximum number of rows to return (defaults to `100`).
 - `include_embeddings` – attach vector embeddings via `db.vector(id)` when
   available.
 
-Queries use `Scope.ALL` so records from all menace instances are returned.
+## Scope
+
+Queries apply `Scope.ALL` via `build_scope_clause`, so records from every Menace
+instance participate in fleetwide Codex training. Switching to `Scope.LOCAL` or
+`Scope.GLOBAL` restricts the results to a single instance or global templates.
 
 ## Example
 


### PR DESCRIPTION
## Summary
- expand codex_db_helpers docs with function list, sorting options, and scope semantics
- note codex_db_helpers in README as fleetwide training source

## Testing
- `pre-commit run --files docs/codex_db_helpers.md README.md`

------
https://chatgpt.com/codex/tasks/task_e_68ac4b5afa20832ead0bf68640c207fe