### PR TITLE
Remove scope parameter from Codex sample retrieval calls

### DIFF
--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -1014,7 +1014,6 @@ class BotDevelopmentBot:
                     sort_by=sample_sort_by,
                     limit=sample_limit,
                     include_embeddings=sample_with_vectors,
-                    scope="all",
                 )
             except Exception:
                 samples = []

--- a/enhancement_bot.py
+++ b/enhancement_bot.py
@@ -114,7 +114,6 @@ class EnhancementBot:
                     sort_by="confidence",
                     limit=3,
                     include_embeddings=False,
-                    scope="all",
                 )
             except Exception:  # pragma: no cover - helper failures
                 examples = []

--- a/error_logger.py
+++ b/error_logger.py
@@ -644,7 +644,6 @@ class ErrorLogger:
                     sort_by=sample_sort_by,
                     limit=sample_limit,
                     include_embeddings=with_vectors,
-                    scope="all",
                 )
             except Exception:  # pragma: no cover - helper failures
                 samples = []
@@ -653,7 +652,6 @@ class ErrorLogger:
                     sort_by="confidence",
                     limit=sample_limit,
                     include_embeddings=False,
-                    scope="all",
                 )
             except Exception:  # pragma: no cover - helper failures
                 discrepancies = []

--- a/tests/test_codex_db_helpers.py
+++ b/tests/test_codex_db_helpers.py
@@ -261,12 +261,11 @@ def test_bot_development_bot_uses_codex_samples(monkeypatch, tmp_path):
         helpers.TrainingSample(source="workflow", content="ex2"),
     ]
 
-    def fake_aggregate_samples(*, sort_by, limit, include_embeddings, scope):
+    def fake_aggregate_samples(*, sort_by, limit, include_embeddings):
         calls.update(
             sort_by=sort_by,
             limit=limit,
             include_embeddings=include_embeddings,
-            scope=scope,
         )
         return samples
 
@@ -287,4 +286,3 @@ def test_bot_development_bot_uses_codex_samples(monkeypatch, tmp_path):
     assert calls["limit"] == 2
     assert calls["sort_by"] == "confidence"
     assert calls["include_embeddings"] is True
-    assert calls["scope"] == "all"


### PR DESCRIPTION
## Summary
- Drop explicit `scope="all"` from Codex helper calls in prompt-building utilities so default scoping is used
- Ensure retrieved samples and discrepancies are still incorporated into error and enhancement prompts
- Adjust tests for new Codex helper signatures

## Testing
- `pytest tests/test_codex_db_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac4d5f77c0832e8b7fefd483d8b410