### PR TITLE
test: narrow aggregate sample args

### DIFF
--- a/tests/test_codex_db_helpers.py
+++ b/tests/test_codex_db_helpers.py
@@ -262,11 +262,7 @@ def test_bot_development_bot_uses_codex_samples(monkeypatch, tmp_path):
     ]
 
     def fake_aggregate_samples(*, sort_by, limit, include_embeddings):
-        calls.update(
-            sort_by=sort_by,
-            limit=limit,
-            include_embeddings=include_embeddings,
-        )
+        calls["args"] = (sort_by, limit, include_embeddings)
         return samples
 
     monkeypatch.setattr(bdb.cdh, "aggregate_samples", fake_aggregate_samples)
@@ -283,6 +279,4 @@ def test_bot_development_bot_uses_codex_samples(monkeypatch, tmp_path):
 
     assert "### Training Examples" in prompt
     assert "ex1" in prompt and "ex2" in prompt
-    assert calls["limit"] == 2
-    assert calls["sort_by"] == "confidence"
-    assert calls["include_embeddings"] is True
+    assert calls["args"] == ("confidence", 2, True)


### PR DESCRIPTION
## Summary
- tighten fake aggregate_samples stub to only allow `sort_by`, `limit`, and `include_embeddings`
- assert the stub was invoked with expected arguments in a single tuple

## Testing
- `pytest tests/test_codex_db_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac4f8b4a74832e91f9d6a0cfd070ce