### PR TITLE
docs: document workflow synthesizer CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1799,8 +1799,12 @@ accepts a free-text problem description. In both cases an interactive prompt
 allows editing before the workflow specification is written to the chosen file.
 
 Candidates can be exported to `.workflow.json` for registration with
-`WorkflowDB`. See [docs/workflow_synthesizer.md](docs/workflow_synthesizer.md)
-for design notes and more examples.
+`WorkflowDB`. The JSON contains a `steps` list describing each module's inputs
+and outputs, making it consumable by the sandbox evaluation pipeline. Once
+stored in `WorkflowDB`, evaluation services and workers can execute and score
+the workflow alongside existing ones. See
+[docs/workflow_synthesizer.md](docs/workflow_synthesizer.md) for design notes
+and more examples.
 
 ## Vector Analytics
 


### PR DESCRIPTION
## Summary
- describe workflow synthesizer purpose, CLI options, and output format
- explain how generated `.workflow.json` specs fit into sandbox evaluation pipeline
- update README with output format and evaluation pipeline context

## Testing
- `pre-commit run --files README.md docs/workflow_synthesizer.md`


------
https://chatgpt.com/codex/tasks/task_e_68ac502e8320832e81a3c490bca5d7d0