### PR TITLE
Add scope filtering to codex database helpers

### DIFF
--- a/docs/codex_db_helpers.md
+++ b/docs/codex_db_helpers.md
@@ -26,19 +26,22 @@ All helpers share the following keyword arguments:
 - `limit` – maximum number of rows to return (defaults to `100`).
 - `include_embeddings` – attach vector embeddings via `db.vector(id)` when
   available.
+- `scope` – menace query scope. Accepts `Scope` values or the strings
+  `"local"`, `"global"` or `"all"` (default).
 
 ## Scope
 
-Queries apply `Scope.ALL` via `build_scope_clause`, so records from every Menace
-instance participate in fleetwide Codex training. Switching to `Scope.LOCAL` or
-`Scope.GLOBAL` restricts the results to a single instance or global templates.
+Queries default to `Scope.ALL` via `build_scope_clause`, so records from every
+Menace instance participate in fleetwide Codex training. Passing
+`scope="local"` or `scope=Scope.GLOBAL` restricts the results to a single
+instance or global templates.
 
 ## Example
 
 ```python
-from codex_db_helpers import aggregate_samples
+from codex_db_helpers import aggregate_samples, Scope
 
-records = aggregate_samples(sort_by="timestamp", limit=5)
+records = aggregate_samples(sort_by="timestamp", limit=5, scope=Scope.LOCAL)
 
 prompt = "Examples:\n" + "\n\n".join(
     f"{r.source}: {r.content}" for r in records

--- a/docs/codex_training_data.md
+++ b/docs/codex_training_data.md
@@ -11,21 +11,23 @@ These sources are available out of the box:
 - **discrepancy** – discrepancy reports with confidence scores from `DiscrepancyDB`.
 - **workflow** – stored workflows from `task_handoff_bot.WorkflowDB`.
 
-## Sorting and embeddings
+## Sorting, scope and embeddings
 
 All helpers accept:
 
 - `sort_by` – `"confidence"`, `"outcome_score"` or `"timestamp"` determine ordering.
 - `limit` – number of rows to fetch per source.
 - `include_embeddings` – when `True`, attach embedding vectors via the respective database's `vector(id)` API.
+- `scope` – restrict records to a menace instance. Accepts `Scope` values or
+  `"local"`, `"global"` or `"all"` (default).
 
 ## Example
 
 ```python
-from codex_db_helpers import aggregate_samples
+from codex_db_helpers import aggregate_samples, Scope
 import openai
 
-samples = aggregate_samples(sort_by="outcome_score", limit=10)
+samples = aggregate_samples(sort_by="outcome_score", limit=10, scope=Scope.LOCAL)
 
 prompt = "Examples:\n" + "\n\n".join(
     f"{s.source}: {s.content} (score={s.outcome_score})" for s in samples


### PR DESCRIPTION
## Summary
- allow codex helper fetchers to filter by menace scope
- propagate scope through `aggregate_samples`
- document and test new `scope` parameter

## Testing
- `pytest tests/test_codex_db_helpers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac539c5f4c832ea2b8f584073cc9a0