### PR TITLE
Add thread-safe queue writer for deferred DB inserts

### DIFF
--- a/db_write_queue.py
+++ b/db_write_queue.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+"""Thread-safe persistent queue for deferred database writes.
+
+Each queued entry is stored as a JSON object in a newline delimited file.  A
+separate file is maintained for each target table under a per-instance
+``queues`` directory (``sandbox_data/queues`` by default).  ``fcntl_compat``
+file locks ensure that writes are safe across threads and processes.
+"""
+
+from pathlib import Path
+import json
+import os
+from threading import Lock
+from typing import Iterable, Mapping, Any
+
+from fcntl_compat import flock, LOCK_EX, LOCK_UN
+from db_dedup import compute_content_hash
+
+# Base directory for queue files.  Allow overriding via the SANDBOX_DATA_DIR
+# environment variable so multiple sandbox instances do not collide.
+DEFAULT_QUEUE_DIR = Path(os.getenv("SANDBOX_DATA_DIR", "sandbox_data")) / "queues"
+
+# Global lock for in-process thread safety.  File locks handle cross-process
+# coordination.
+_write_lock = Lock()
+
+
+def _queue_file(table: str, queue_path: str | Path | None) -> Path:
+    """Return the path to the queue file for *table*, ensuring directories exist."""
+    base = Path(queue_path) if queue_path is not None else DEFAULT_QUEUE_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    return base / f"{table}_queue.jsonl"
+
+
+def _write_record(path: Path, record: Mapping[str, Any]) -> None:
+    """Append *record* as JSON to *path* with file locking."""
+    data = json.dumps(record, sort_keys=True)
+    with _write_lock:
+        with path.open("a", encoding="utf-8") as fh:
+            flock(fh.fileno(), LOCK_EX)
+            fh.write(data)
+            fh.write("\n")
+            flock(fh.fileno(), LOCK_UN)
+
+
+def queue_insert(
+    table: str,
+    values: Mapping[str, Any],
+    hash_fields: Iterable[str],
+    queue_path: str | Path | None = None,
+) -> str:
+    """Queue an ``INSERT`` operation for ``table``.
+
+    Parameters
+    ----------
+    table:
+        Target table name.
+    values:
+        Mapping of column names to values for the row.
+    hash_fields:
+        Iterable of field names from ``values`` used to compute a content hash
+        for deduplication.
+    queue_path:
+        Optional directory where queue files are stored.  Defaults to
+        ``sandbox_data/queues``.
+
+    Returns
+    -------
+    str
+        The computed content hash.
+    """
+    missing = [field for field in hash_fields if field not in values]
+    if missing:
+        missing_list = ", ".join(sorted(missing))
+        raise KeyError(f"Missing fields for hashing: {missing_list}")
+
+    payload = {key: values[key] for key in hash_fields}
+    content_hash = compute_content_hash(payload)
+
+    record = {
+        "table": table,
+        "op": "insert",
+        "data": dict(values),
+        "content_hash": content_hash,
+        "source_menace_id": os.getenv("MENACE_ID", ""),
+    }
+
+    file_path = _queue_file(table, queue_path)
+    _write_record(file_path, record)
+    return content_hash


### PR DESCRIPTION
## Summary
- Add `db_write_queue.queue_insert` helper that writes JSONL records with locking
- Compute content hash using existing `db_dedup` helper and include source menace id
- Store queue files under per-instance `sandbox_data/queues/` directory

## Testing
- `pytest tests/test_db_dedup_helper.py -q` *(fails: expected log message 'Duplicate insert ignored')*

------
https://chatgpt.com/codex/tasks/task_e_68accd53ad18832e8270025750ae7dea