### PR TITLE
Add save and list options to workflow synthesizer CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1791,13 +1791,15 @@ Use `workflow_synthesizer_cli.py` to explore and save workflows from the
 command line:
 
 ```bash
-python workflow_synthesizer_cli.py --start module_a --out my.workflow.json
-python workflow_synthesizer_cli.py --start "summarise data" --out summary.workflow.json
+python workflow_synthesizer_cli.py --start module_a --save
+python workflow_synthesizer_cli.py --start "summarise data" --save summary
+python workflow_synthesizer_cli.py --list
 ```
 
-The first example seeds the synthesizer from an existing module. The second
-accepts a free-text problem description. In both cases an interactive prompt
-allows editing before the workflow specification is written to the chosen file.
+The first example seeds the synthesizer from an existing module and stores the
+result under `sandbox_data/generated_workflows/module_a.workflow.json`. The
+second accepts a free-text problem description and saves the spec using the
+provided name. The `--list` flag prints previously saved workflow files.
 
 Candidates can be exported to `.workflow.json` for registration with
 `WorkflowDB`. The JSON contains a `steps` list describing each module's inputs

--- a/docs/workflow_synthesizer.md
+++ b/docs/workflow_synthesizer.md
@@ -14,18 +14,22 @@ The standalone helper `workflow_synthesizer_cli.py` exposes a minimal command
 line interface:
 
 ```bash
-python workflow_synthesizer_cli.py --start module_a --out my.workflow.json
-python workflow_synthesizer_cli.py --start "summarise data" --out summary.workflow.json
+python workflow_synthesizer_cli.py --start module_a --save
+python workflow_synthesizer_cli.py --start "summarise data" --save summary
+python workflow_synthesizer_cli.py --list
 ```
 
 * `--start` – starting module name. When the module does not exist the value is
   treated as a free‑text problem description used for intent matching.
 * `--problem` – additional description to bias intent search.
 * `--max-depth` – limit traversal depth when exploring connected modules.
-* `--out` – file or directory where generated workflows are written.
+* `--save` – write the workflow to
+  `sandbox_data/generated_workflows/<name>.workflow.json` where `<name>`
+  defaults to the start argument.
+* `--list` – print the names of previously saved workflows and exit.
 
-The command prints the candidate workflows to stdout and, when `--out` is
-supplied, persists them to disk.
+The command prints candidate workflows to stdout. When `--save` or `--out` is
+supplied, the specification is persisted to disk.
 
 ## Output format
 


### PR DESCRIPTION
## Summary
- add `--save` flag saving specs to `sandbox_data/generated_workflows/<name>.workflow.json`
- add `--list` flag to show saved workflow specs
- document new CLI options and test `--save`/`--list`

## Testing
- `pytest -q tests/test_workflow_synthesizer.py::test_cli_end_to_end tests/test_workflow_synthesizer.py::test_cli_save_and_list`

------
https://chatgpt.com/codex/tasks/task_e_68accde3f820832ea05796c5670f8160