### PR TITLE
feat: add optional DB queue

### DIFF
--- a/menace_db.py
+++ b/menace_db.py
@@ -3,23 +3,25 @@
 from __future__ import annotations
 
 from typing import Optional
+from pathlib import Path
 
 from .databases import MenaceDB
 
 DEFAULT_DB_URL = "sqlite:///menace.db"
 
 
-def connect(url: Optional[str] = None) -> MenaceDB:
+def connect(url: Optional[str] = None, queue_path: str | Path | None = None) -> MenaceDB:
     """Return a :class:`MenaceDB` instance using the provided or default URL."""
 
-    return MenaceDB(url or DEFAULT_DB_URL)
+    return MenaceDB(url or DEFAULT_DB_URL, queue_path=queue_path)
 
 
-def initialize(url: Optional[str] = None) -> MenaceDB:
+def initialize(url: Optional[str] = None, queue_path: str | Path | None = None) -> MenaceDB:
     """Create tables and return a connected database."""
 
-    db = connect(url)
-    db.meta.create_all(db.engine)
+    db = connect(url, queue_path)
+    if not db.use_queue:
+        db.meta.create_all(db.engine)
     return db
 
 


### PR DESCRIPTION
## Summary
- allow insert_if_unique to queue writes via JSONL queue when USE_DB_QUEUE or a queue path is provided
- teach MenaceDB to propagate optional queue_path and enqueue add/link operations
- expose queue_path in menace_db.connect/initialize and skip table creation when queueing

## Testing
- `pre-commit run --files databases.py db_dedup.py menace_db.py`
- `pytest tests/test_db_dedup_helper.py tests/test_db_dedup.py tests/test_menacedb_dedup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acceb01f10832e869eb03027d51671