### PR TITLE
Add logging for workflow synthesizer failures

### DIFF
--- a/docs/workflow_synthesizer.md
+++ b/docs/workflow_synthesizer.md
@@ -56,3 +56,10 @@ runner and evaluation workers will schedule, execute and score the workflow like
 any other entry. Results flow through `EvaluationHistoryDB` and surface on the
 standard dashboards without additional configuration.
 
+## Logging
+
+`WorkflowSynthesizer` emits warnings via the `workflow_synthesizer` logger when
+optional resources fail to load. Messages include the path that caused the
+failure and the underlying exception to aid troubleshooting. Configure the
+module logger to capture these diagnostics.
+


### PR DESCRIPTION
## Summary
- add explicit logger for WorkflowSynthesizer
- log missing or failing synergy graph loads
- log intent cluster and database initialization failures
- document logging behavior and locations

## Testing
- `pytest tests/test_workflow_synthesizer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acd3b96454832eb58beddadb38c3f6