### PR TITLE
feat: harden queue processing

### DIFF
--- a/queue_cleanup.py
+++ b/queue_cleanup.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Utility to purge stale queue log files.
+
+Removes ``*_queue.jsonl.tmp`` and ``*_queue.failed.jsonl`` files older than a
+specified retention period.
+"""
+
+from argparse import ArgumentParser
+from pathlib import Path
+import logging
+import time
+from typing import Iterable
+
+from db_write_queue import DEFAULT_QUEUE_DIR
+
+
+def _stale_files(queue_dir: Path) -> Iterable[Path]:
+    patterns = ("*_queue.jsonl.tmp", "*_queue.failed.jsonl")
+    for pattern in patterns:
+        yield from queue_dir.glob(pattern)
+
+
+def cleanup(queue_dir: Path, days: int) -> None:
+    """Remove stale temporary and failed queue files."""
+    cutoff = time.time() - days * 86400
+    for path in _stale_files(queue_dir):
+        if path.stat().st_mtime < cutoff:
+            try:
+                path.unlink()
+                logging.info("removed %s", path)
+            except FileNotFoundError:  # pragma: no cover - race condition
+                pass
+
+
+def main() -> None:  # pragma: no cover - CLI wrapper
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("--queue-dir", default=str(DEFAULT_QUEUE_DIR))
+    parser.add_argument("--days", type=int, default=7, help="Retention period in days")
+    parser.add_argument("--log-level", default="INFO")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+    cleanup(Path(args.queue_dir), args.days)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_sync_shared_db_queue.py
+++ b/tests/test_sync_shared_db_queue.py
@@ -1,0 +1,90 @@
+import json
+import logging
+import os
+import time
+from pathlib import Path
+
+import pytest
+from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine
+
+from sync_shared_db import process_queue_file
+from queue_cleanup import cleanup
+
+
+@pytest.fixture
+def engine(tmp_path):
+    db_path = tmp_path / "db.sqlite"
+    engine = create_engine(f"sqlite:///{db_path}")
+    meta = MetaData()
+    Table(
+        "foo",
+        meta,
+        Column("id", Integer, primary_key=True),
+        Column("name", String),
+        Column("content_hash", String, unique=True),
+    )
+    meta.create_all(engine)
+    return engine
+
+
+def _write_records(path: Path, records):
+    with path.open("w", encoding="utf-8") as fh:
+        for rec in records:
+            fh.write(json.dumps(rec))
+            fh.write("\n")
+
+
+def test_process_queue_moves_failed_after_retries(tmp_path, engine, caplog):
+    queue_file = tmp_path / "foo_queue.jsonl"
+    ok = {
+        "table": "foo",
+        "op": "insert",
+        "data": {"name": "ok"},
+        "content_hash": "h1",
+        "source_menace_id": "",
+    }
+    bad = {
+        "table": "missing",
+        "op": "insert",
+        "data": {"name": "bad"},
+        "content_hash": "h2",
+        "source_menace_id": "",
+    }
+    _write_records(queue_file, [ok, bad])
+
+    with caplog.at_level(logging.INFO):
+        process_queue_file(queue_file, engine=engine)
+    # One commit and one rollback logged
+    assert any("\"event\": \"commit\"" in r.message for r in caplog.records)
+    assert any("\"event\": \"rollback\"" in r.message for r in caplog.records)
+
+    # Failing record left in queue with fail_count=1
+    data = json.loads(queue_file.read_text().strip())
+    assert data["fail_count"] == 1
+
+    # Retry twice more -> moved to failed file
+    process_queue_file(queue_file, engine=engine)
+    process_queue_file(queue_file, engine=engine)
+    assert queue_file.read_text() == ""
+    failed = tmp_path / "foo_queue.failed.jsonl"
+    assert failed.exists()
+    rec = json.loads(failed.read_text().strip())
+    assert rec["fail_count"] == 3
+    assert not (tmp_path / "foo_queue.jsonl.tmp").exists()
+
+
+def test_cleanup_removes_old_files(tmp_path):
+    queue_dir = tmp_path
+    old_tmp = queue_dir / "foo_queue.jsonl.tmp"
+    old_fail = queue_dir / "foo_queue.failed.jsonl"
+    recent = queue_dir / "bar_queue.failed.jsonl"
+    for p in (old_tmp, old_fail, recent):
+        p.write_text("x")
+    old_ts = time.time() - 10 * 86400
+    os.utime(old_tmp, (old_ts, old_ts))
+    os.utime(old_fail, (old_ts, old_ts))
+
+    cleanup(queue_dir, days=7)
+    assert not old_tmp.exists()
+    assert not old_fail.exists()
+    assert recent.exists()


### PR DESCRIPTION
## Summary
- ensure daemon queue updates are atomic and move chronic failures to a dedicated log
- add structured commit/rollback logs
- introduce utility for purging stale queue temp/failed files

## Testing
- `pre-commit run --files sync_shared_db.py queue_cleanup.py tests/test_sync_shared_db_queue.py`
- `pytest tests/test_sync_shared_db_queue.py`


------
https://chatgpt.com/codex/tasks/task_e_68acd459e084832eb18f351adfcb721b