### PR TITLE
Add write buffer for queued DB inserts

### DIFF
--- a/db_write_buffer.py
+++ b/db_write_buffer.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+"""Utilities for buffering database writes to disk.
+
+Records are appended to per-table JSONL files under a configurable queue
+directory.  File locking ensures that writes are atomic across threads and
+processes.  This is a lightweight helper used to collect writes that may be
+replayed later by another process.
+"""
+
+from pathlib import Path
+import json
+import os
+from threading import Lock
+from typing import Mapping, Iterable, Any
+
+from fcntl_compat import flock, LOCK_EX, LOCK_UN
+
+# Default directory where queue files are stored.  Callers may override via the
+# ``MENACE_QUEUE_DIR`` environment variable.
+DEFAULT_QUEUE_DIR = Path(os.getenv("MENACE_QUEUE_DIR", "./queue"))
+
+# In-process lock to guard concurrent writers.  ``flock`` handles cross-process
+# safety but a threading lock avoids interleaving within a process.
+_write_lock = Lock()
+
+
+def append_to_queue(
+    table_name: str,
+    values: Mapping[str, Any],
+    menace_id: str,
+    *,
+    hash_fields: Iterable[str] | None = None,
+    queue_dir: str | os.PathLike[str] | None = None,
+) -> None:
+    """Append a record to the table-specific queue file.
+
+    Parameters
+    ----------
+    table_name:
+        Name of the target table.
+    values:
+        Mapping of column names to values for the pending row.
+    menace_id:
+        Identifier of the menace instance generating the record.
+    hash_fields:
+        Iterable of field names describing how to deduplicate the record.  The
+        names are stored verbatim without additional processing.
+    queue_dir:
+        Optional directory where queue files are stored.  Defaults to the path
+        defined by ``MENACE_QUEUE_DIR`` or ``./queue``.
+    """
+    payload = {
+        "table": table_name,
+        "values": dict(values),
+        "source_menace_id": menace_id,
+        "hash_fields": list(hash_fields or []),
+    }
+
+    base = Path(queue_dir) if queue_dir is not None else DEFAULT_QUEUE_DIR
+    base.mkdir(parents=True, exist_ok=True)
+    file_path = base / f"{table_name}_queue.jsonl"
+
+    data = json.dumps(payload, ensure_ascii=False)
+
+    with _write_lock:
+        with file_path.open("a", encoding="utf-8") as fh:
+            flock(fh.fileno(), LOCK_EX)
+            fh.write(data)
+            fh.write("\n")
+            flock(fh.fileno(), LOCK_UN)
+
+
+def buffer_shared_insert(
+    table_name: str,
+    values: Mapping[str, Any],
+    hash_fields: Iterable[str] | None = None,
+    *,
+    queue_dir: str | os.PathLike[str] | None = None,
+) -> None:
+    """Helper for queuing inserts into shared database tables.
+
+    The ``source_menace_id`` is populated from the ``MENACE_ID`` environment
+    variable and the resulting record is delegated to :func:`append_to_queue`.
+    """
+    menace_id = os.getenv("MENACE_ID", "")
+    append_to_queue(
+        table_name,
+        values,
+        menace_id,
+        hash_fields=hash_fields,
+        queue_dir=queue_dir,
+    )

--- a/tests/test_db_write_buffer.py
+++ b/tests/test_db_write_buffer.py
@@ -1,0 +1,27 @@
+import json
+
+from db_write_buffer import append_to_queue, buffer_shared_insert
+
+
+def test_append_to_queue_writes_record(tmp_path):
+    append_to_queue("foo", {"x": 1}, "m1", hash_fields=["x"], queue_dir=tmp_path)
+    queue_file = tmp_path / "foo_queue.jsonl"
+    data = queue_file.read_text(encoding="utf-8")
+    assert data.endswith("\n")
+    rec = json.loads(data)
+    assert rec == {
+        "table": "foo",
+        "values": {"x": 1},
+        "source_menace_id": "m1",
+        "hash_fields": ["x"],
+    }
+
+
+def test_buffer_shared_insert_enriches_menace_id(tmp_path, monkeypatch):
+    monkeypatch.setenv("MENACE_ID", "alpha")
+    buffer_shared_insert("bar", {"y": 2}, ["y"], queue_dir=tmp_path)
+    queue_file = tmp_path / "bar_queue.jsonl"
+    rec = json.loads(queue_file.read_text())
+    assert rec["source_menace_id"] == "alpha"
+    assert rec["hash_fields"] == ["y"]
+    assert rec["values"] == {"y": 2}


### PR DESCRIPTION
## Summary
- add `db_write_buffer.append_to_queue` for atomic JSONL queueing with file locks
- expose `buffer_shared_insert` helper that pulls menace ID from `MENACE_ID`
- cover queueing helpers with unit tests

## Testing
- `pytest tests/test_db_write_buffer.py tests/test_sync_shared_db_queue.py::test_cleanup_removes_old_files -q`

------
https://chatgpt.com/codex/tasks/task_e_68acd9153b1c832ebfba052f9f2e14ff