### PR TITLE
Enumerate and rank workflow permutations

### DIFF
--- a/tests/fixtures/workflow_modules/mod_c.py
+++ b/tests/fixtures/workflow_modules/mod_c.py
@@ -1,2 +1,2 @@
-def final(result):
+def final(data):
     pass


### PR DESCRIPTION
## Summary
- explore all dependency-respecting permutations when generating workflows
- score workflows by combined synergy and intent weights normalized by length
- test multiple workflow outputs sorted by score

## Testing
- `pytest tests/test_workflow_synthesizer.py -q`
- `pytest -q` *(fails: Missing system packages: ffmpeg, tesseract, qemu-system-x86_64)*

------
https://chatgpt.com/codex/tasks/task_e_68acee2d66f0832ea8295c831e093b99