### PR TITLE
feat: enhance dependency resolution and tests

### DIFF
--- a/tests/fixtures/workflow_modules/mod_e.py
+++ b/tests/fixtures/workflow_modules/mod_e.py
@@ -1,0 +1,2 @@
+def produce() -> int:
+    return 1

--- a/tests/fixtures/workflow_modules/mod_f.py
+++ b/tests/fixtures/workflow_modules/mod_f.py
@@ -1,0 +1,2 @@
+def consume(val: int):
+    return str(val)

--- a/tests/fixtures/workflow_modules/mod_g.py
+++ b/tests/fixtures/workflow_modules/mod_g.py
@@ -1,0 +1,4 @@
+from pathlib import Path
+
+def write_file():
+    Path("shared.txt").write_text("hi")

--- a/tests/fixtures/workflow_modules/mod_h.py
+++ b/tests/fixtures/workflow_modules/mod_h.py
@@ -1,0 +1,4 @@
+from pathlib import Path
+
+def read_file():
+    return Path("shared.txt").read_text()

--- a/tests/test_workflow_synthesizer.py
+++ b/tests/test_workflow_synthesizer.py
@@ -90,8 +90,21 @@ def test_resolve_dependencies_ordering_and_unresolved(tmp_path, monkeypatch):
     assert sorted(order[1:]) == ["mod_b", "mod_c"]
 
     bad = [ws.inspect_module(m) for m in ["mod_a", "mod_d"]]
-    with pytest.raises(ValueError, match="mod_d"):
-        synth.resolve_dependencies(bad)
+    steps = synth.resolve_dependencies(bad)
+    unresolved = {s.module: s.unresolved for s in steps}
+    assert unresolved["mod_d"] == ["missing"]
+
+
+def test_resolve_dependencies_types_and_files(tmp_path, monkeypatch):
+    _copy_modules(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    synth = ws.WorkflowSynthesizer()
+    mods = [ws.inspect_module(m) for m in ["mod_f", "mod_h", "mod_e", "mod_g"]]
+    steps = synth.resolve_dependencies(mods)
+    order = [s.module for s in steps]
+    assert order.index("mod_e") < order.index("mod_f")
+    assert order.index("mod_g") < order.index("mod_h")
 
 
 def test_generate_workflows_persist_and_rank(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- broaden dependency matching to include return type annotations and file paths
- distinguish globals, files, and function args when mapping producers/consumers
- accumulate unresolved inputs per module instead of raising immediately
- add fixtures and tests for type- and file-based dependencies

## Testing
- `pytest tests/test_workflow_synthesizer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acefd58884832eabca553adeb82acb