### PR TITLE
Add limit option and interactive workflow selection

### DIFF
--- a/docs/workflow_synthesizer.md
+++ b/docs/workflow_synthesizer.md
@@ -23,13 +23,15 @@ python workflow_synthesizer_cli.py --list
   treated as a free‑text problem description used for intent matching.
 * `--problem` – additional description to bias intent search.
 * `--max-depth` – limit traversal depth when exploring connected modules.
+* `--limit` – maximum number of candidate workflows to generate.
 * `--save` – write the workflow to
   `sandbox_data/generated_workflows/<name>.workflow.json` where `<name>`
   defaults to the start argument.
 * `--list` – print the names of previously saved workflows and exit.
 
-The command prints candidate workflows to stdout. When `--save` or `--out` is
-supplied, the specification is persisted to disk.
+The command prints numbered candidate workflows with their scores. When
+`--save`, `--out` or `--evaluate` is supplied you are prompted to choose a
+workflow to persist or execute.
 
 ## Output format
 

--- a/menace_cli.py
+++ b/menace_cli.py
@@ -20,7 +20,7 @@ LOCAL_DB_PATH = os.getenv("MENACE_LOCAL_DB_PATH", f"./menace_{MENACE_ID}_local.d
 SHARED_DB_PATH = os.getenv("MENACE_SHARED_DB_PATH", "./shared/global.db")
 GLOBAL_ROUTER = init_db_router(MENACE_ID, LOCAL_DB_PATH, SHARED_DB_PATH)
 
-from menace.plugins import load_plugins
+from menace.plugins import load_plugins  # noqa: E402
 
 
 def _run(cmd: list[str]) -> int:
@@ -28,16 +28,16 @@ def _run(cmd: list[str]) -> int:
     return subprocess.call(cmd)
 
 
-from code_database import PatchHistoryDB
-from patch_provenance import (
+from code_database import PatchHistoryDB  # noqa: E402
+from patch_provenance import (  # noqa: E402
     PatchLogger,
     build_chain,
     search_patches_by_vector,
     search_patches_by_license,
 )
-from cache_utils import get_cached_chain, set_cached_chain, _get_cache
-from cache_utils import clear_cache, show_cache, cache_stats
-from workflow_synthesizer_cli import run as handle_workflow
+from cache_utils import get_cached_chain, set_cached_chain, _get_cache  # noqa: E402
+from cache_utils import clear_cache, show_cache, cache_stats  # noqa: E402
+from workflow_synthesizer_cli import run as handle_workflow  # noqa: E402
 
 
 def _normalise_hits(hits, origin=None):
@@ -193,13 +193,19 @@ def handle_retrieve(args: argparse.Namespace) -> int:
             )
             score_values = [f"{r['score']:.4f}" for r in results]
             score_w = max([len(headers[2])] + [len(s) for s in score_values])
-            header_line = f"{headers[0]:<{origin_w}}  {headers[1]:<{record_w}}  {headers[2]:>{score_w}}  {headers[3]}"
+            header_line = (
+                f"{headers[0]:<{origin_w}}  {headers[1]:<{record_w}}  "
+                f"{headers[2]:>{score_w}}  {headers[3]}"
+            )
             print(header_line)
             for r in results:
                 snippet = str(r["snippet"]).replace("\n", " ")
                 if len(snippet) > 80:
                     snippet = snippet[:77] + "..."
-                line = f"{r['origin_db']:<{origin_w}}  {str(r['record_id']):<{record_w}}  {r['score']:{score_w}.4f}  {snippet}"
+                line = (
+                    f"{r['origin_db']:<{origin_w}}  {str(r['record_id']):<{record_w}}  "
+                    f"{r['score']:{score_w}.4f}  {snippet}"
+                )
                 print(line)
     return 0
 
@@ -353,6 +359,13 @@ def main(argv: list[str] | None = None) -> int:
     p_workflow.add_argument("--problem", help="Optional problem statement")
     p_workflow.add_argument(
         "--max-depth", type=int, dest="max_depth", help="Maximum traversal depth"
+    )
+    p_workflow.add_argument(
+        "--limit",
+        type=int,
+        dest="limit",
+        help="Maximum workflows to generate",
+        default=5,
     )
     p_workflow.add_argument(
         "--out", help="File or directory to save generated workflows"


### PR DESCRIPTION
## Summary
- List candidate workflows with scores and prompt for a selection before saving or evaluation
- Expose a --limit flag in both workflow_synthesizer_cli and menace_cli workflow subcommand
- Document workflow limiting and interactive selection

## Testing
- `python -m pre_commit run --files workflow_synthesizer_cli.py menace_cli.py docs/workflow_synthesizer.md`
- `pytest tests/test_workflow_synthesizer.py tests/test_generate_workflows.py`


------
https://chatgpt.com/codex/tasks/task_e_68acf128e528832e81c5df1cc0c5c103