### PR TITLE
Add tests for write buffer and sync loop

### DIFF
--- a/tests/test_sync_shared_db_main.py
+++ b/tests/test_sync_shared_db_main.py
@@ -1,0 +1,78 @@
+import json
+import sys
+from pathlib import Path
+from sqlite3 import connect
+
+import sync_shared_db
+from db_write_queue import queue_insert
+
+
+def _run_sync_once(queue_dir: Path, db_path: Path, monkeypatch, max_retries: int = 1) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "sync_shared_db.py",
+            "--queue-dir",
+            str(queue_dir),
+            "--db-path",
+            str(db_path),
+            "--once",
+            "--max-retries",
+            str(max_retries),
+        ],
+    )
+    sync_shared_db.main()
+
+
+def test_sync_main_processes_queue(tmp_path, monkeypatch):
+    db_path = tmp_path / "db.sqlite"
+    conn = connect(db_path)  # noqa: SQL001
+    conn.execute(
+        "CREATE TABLE foo (id INTEGER PRIMARY KEY, name TEXT, content_hash TEXT UNIQUE)"
+    )
+    conn.commit()
+    conn.close()
+
+    queue_dir = tmp_path / "queues"
+    queue_insert("foo", {"name": "ok"}, ["name"], queue_dir)
+
+    _run_sync_once(queue_dir, db_path, monkeypatch)
+
+    conn = connect(db_path)  # noqa: SQL001
+    rows = conn.execute("SELECT name FROM foo").fetchall()
+    conn.close()
+    assert rows == [("ok",)]
+    assert (queue_dir / "foo_queue.jsonl").read_text() == ""
+
+
+def test_sync_main_moves_failed_inserts(tmp_path, monkeypatch):
+    db_path = tmp_path / "db.sqlite"
+    conn = connect(db_path)  # noqa: SQL001
+    conn.execute(
+        "CREATE TABLE foo ("
+        "id INTEGER PRIMARY KEY, "
+        "name TEXT UNIQUE, "
+        "other TEXT, "
+        "content_hash TEXT UNIQUE)"
+    )
+    conn.commit()
+    conn.close()
+
+    queue_dir = tmp_path / "queues"
+    queue_insert("foo", {"name": "dup", "other": "one"}, ["other"], queue_dir)
+    queue_insert("foo", {"name": "dup", "other": "two"}, ["other"], queue_dir)
+
+    _run_sync_once(queue_dir, db_path, monkeypatch, max_retries=1)
+
+    conn = connect(db_path)  # noqa: SQL001
+    rows = conn.execute("SELECT name, other FROM foo").fetchall()
+    conn.close()
+    assert rows == [("dup", "one")]
+
+    queue_file = queue_dir / "foo_queue.jsonl"
+    assert queue_file.read_text() == ""
+    failed_file = queue_dir / "foo_queue.failed.jsonl"
+    rec = json.loads(failed_file.read_text().strip())
+    assert rec["record"]["data"]["other"] == "two"
+    assert "UNIQUE constraint failed" in rec["error"]

--- a/tests/test_write_buffer.py
+++ b/tests/test_write_buffer.py
@@ -1,0 +1,17 @@
+import json
+from db_write_buffer import buffer_shared_insert
+
+
+def test_buffer_shared_insert_writes_valid_jsonl(tmp_path, monkeypatch):
+    monkeypatch.setenv("MENACE_ID", "tester")
+    buffer_shared_insert("foo", {"x": 1}, ["x"], queue_dir=tmp_path)
+    buffer_shared_insert("foo", {"x": 2}, ["x"], queue_dir=tmp_path)
+    queue_file = tmp_path / "foo_queue.jsonl"
+    content = queue_file.read_text(encoding="utf-8")
+    lines = content.splitlines()
+    assert len(lines) == 2
+    records = [json.loads(line) for line in lines]
+    assert records[0]["values"] == {"x": 1}
+    assert records[1]["values"] == {"x": 2}
+    assert all(r["table"] == "foo" for r in records)
+    assert all(r["source_menace_id"] == "tester" for r in records)


### PR DESCRIPTION
## Summary
- test that `buffer_shared_insert` writes multiple valid JSONL entries
- cover `sync_shared_db` main loop inserting records and handling failed inserts

## Testing
- `pre-commit run --files tests/test_write_buffer.py tests/test_sync_shared_db_main.py`
- `pytest tests/test_write_buffer.py tests/test_sync_shared_db_main.py`


------
https://chatgpt.com/codex/tasks/task_e_68acf23aaf74832e9f83ab5b556a840c