### PR TITLE
Explore multiple workflow paths in synthesizer

### DIFF
--- a/tests/test_workflow_synthesizer.py
+++ b/tests/test_workflow_synthesizer.py
@@ -118,7 +118,7 @@ def test_generate_workflows_persist_and_rank(tmp_path, monkeypatch):
     workflows = synth.generate_workflows(start_module="mod_a", problem="finalise", limit=2)
     assert len(workflows) == 2
     assert [step.module for step in workflows[0]] == ["mod_a", "mod_b", "mod_c"]
-    assert [step.module for step in workflows[1]] == ["mod_a", "mod_c", "mod_b"]
+    assert [step.module for step in workflows[1]] == ["mod_a", "mod_b"]
 
     out_dir = Path("sandbox_data/generated_workflows")
     saved = sorted(out_dir.glob("*.workflow.json"))


### PR DESCRIPTION
## Summary
- traverse dependency graph with breadth-first search to gather multiple candidate workflows
- score and rank candidate paths, returning top N workflows
- add tests covering multi-path generation and ranking order

## Testing
- `pre-commit run --files workflow_synthesizer.py tests/test_workflow_synthesizer.py`
- `pytest tests/test_workflow_synthesizer.py`


------
https://chatgpt.com/codex/tasks/task_e_68acf2ca59bc832ea2af9e4cc7106350