### PR TITLE
feat: add depth limiting for workflow synthesis

### DIFF
--- a/tests/test_workflow_synthesizer.py
+++ b/tests/test_workflow_synthesizer.py
@@ -130,6 +130,22 @@ def test_generate_workflows_persist_and_rank(tmp_path, monkeypatch):
     assert synth.workflow_scores == sorted(synth.workflow_scores, reverse=True)
 
 
+def test_generate_workflows_max_depth(tmp_path, monkeypatch):
+    _copy_modules(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    grapher = StubGrapher()
+    synth = ws.WorkflowSynthesizer(module_synergy_grapher=grapher)
+
+    workflows = synth.generate_workflows(start_module="mod_a", limit=5, max_depth=1)
+    flat = [[step.module for step in wf] for wf in workflows]
+    assert all("mod_c" not in order for order in flat)
+
+    workflows = synth.generate_workflows(start_module="mod_a", limit=5, max_depth=2)
+    flat = [[step.module for step in wf] for wf in workflows]
+    assert any(order == ["mod_a", "mod_b", "mod_c"] for order in flat)
+
+
 def test_resolve_dependencies_cycles():
     synth = ws.WorkflowSynthesizer()
 

--- a/workflow_synthesizer.py
+++ b/workflow_synthesizer.py
@@ -616,7 +616,8 @@ class WorkflowSynthesizer:
         limit:
             Maximum number of workflows to return.
         max_depth:
-            Unused but kept for API compatibility.
+            Maximum graph depth to explore from ``start_module``.  ``1``
+            restricts exploration to direct neighbours.
         synergy_weight:
             Multiplier applied to synergy graph edge weights when scoring
             workflows.
@@ -627,7 +628,10 @@ class WorkflowSynthesizer:
         if ModuleSignature is None or get_io_signature is None:
             raise ValueError("Structural analysis helpers are unavailable")
 
-        modules = self.expand_cluster(start_module=start_module, problem=problem)
+        depth = max_depth if max_depth is not None else 1
+        modules = self.expand_cluster(
+            start_module=start_module, problem=problem, max_depth=depth
+        )
         modules.add(start_module)
 
         analyzer = ModuleIOAnalyzer()
@@ -753,6 +757,9 @@ class WorkflowSynthesizer:
                 continue
             seen.add(key)
             orders.append(order.copy())
+
+            if max_depth is not None and len(order) - 1 >= max_depth:
+                continue
 
             available = [m for m in remaining if deps[m].issubset(order)]
             for mod in sorted(available):

--- a/workflow_synthesizer_cli.py
+++ b/workflow_synthesizer_cli.py
@@ -46,7 +46,7 @@ def run(args: argparse.Namespace) -> int:
         start_module=args.start,
         problem=args.problem,
         limit=getattr(args, "limit", 5),
-        max_depth=args.max_depth,
+        max_depth=getattr(args, "max_depth", None),
         synergy_weight=getattr(args, "synergy_weight", 1.0),
         intent_weight=getattr(args, "intent_weight", 1.0),
     )
@@ -117,6 +117,7 @@ def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.Argu
         "--max-depth",
         type=int,
         dest="max_depth",
+        default=None,
         help="Maximum traversal depth when exploring module connections",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- bound module exploration and workflow length using `max_depth`
- forward `--max-depth` option from CLI
- test depth limiting of workflow generation

## Testing
- `pytest tests/test_workflow_synthesizer.py`


------
https://chatgpt.com/codex/tasks/task_e_68acf4712e84832eb8b080861b2d1a33