### PR TITLE
Queue shared table writes via router

### DIFF
--- a/sync_shared_db.py
+++ b/sync_shared_db.py
@@ -74,7 +74,8 @@ def process_queue_file(path: Path, *, conn: sqlite3.Connection, max_retries: int
             data = record.get("data", {})
             menace_id = record.get("source_menace_id", "")
             retries = int(record.get("retries", 0))
-            hash_fields = list(data.keys())
+            hash_fields = record.get("hash_fields") or data.pop("hash_fields", None)
+            hash_fields = list(hash_fields or data.keys())
 
             try:
                 payload = {k: data[k] for k in hash_fields}


### PR DESCRIPTION
## Summary
- route bot, error, workflow, and enhancement inserts through `router.queue_insert`
- carry hash fields in queue records and handle them in `sync_shared_db`
- convert MenaceDB seed helpers to use the router queue when targeting shared tables

## Testing
- `python -m py_compile bot_database.py error_bot.py task_handoff_bot.py chatgpt_enhancement_bot.py databases.py sync_shared_db.py`
- `pytest tests/test_db_router_queue_insert.py tests/test_sync_shared_db_queue.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68acf8f22fe8832e9a5e51f4ee5ac127