### PR TITLE
Explore alternative workflows via synergy graph

### DIFF
--- a/tests/test_workflow_synthesizer.py
+++ b/tests/test_workflow_synthesizer.py
@@ -118,7 +118,8 @@ def test_generate_workflows_persist_and_rank(tmp_path, monkeypatch):
     workflows = synth.generate_workflows(start_module="mod_a", problem="finalise", limit=2)
     assert len(workflows) == 2
     assert [step.module for step in workflows[0]] == ["mod_a", "mod_b"]
-    assert [step.module for step in workflows[1]] == ["mod_a", "mod_c"]
+    # The second best workflow follows the next step in the synergy chain
+    assert [step.module for step in workflows[1]] == ["mod_a", "mod_b", "mod_c"]
 
     out_dir = Path("sandbox_data/generated_workflows")
     saved = sorted(out_dir.glob("*.workflow.json"))
@@ -181,5 +182,6 @@ def test_generate_workflows_penalties_and_tiebreak(tmp_path, monkeypatch):
     assert flat[1] == ["mod_a", "mod_b"]
     assert synth.workflow_scores[0] == synth.workflow_scores[1]
 
-    idx = flat.index(["mod_a", "mod_d"])
-    assert synth.workflow_scores[idx] < 0
+    # The deepest explored path incurs the highest penalty
+    assert flat[-1] == ["mod_a", "mod_b", "mod_c", "mod_d"]
+    assert synth.workflow_scores[-1] < 0


### PR DESCRIPTION
## Summary
- traverse synergy graph from the start module to enumerate alternate workflow paths
- rank candidate workflows by synergy and intent scores while respecting the result limit
- update tests to reflect new multi-path behaviour

## Testing
- `pytest tests/test_workflow_synthesizer.py -q`
- `pytest -q` *(fails: Missing system packages: ffmpeg, tesseract, qemu-system-x86_64)*

------
https://chatgpt.com/codex/tasks/task_e_68acfe6e020c832ea4b8f52b0f29f173