### PR TITLE
Add depth-limited traversal to workflow synthesizer

### DIFF
--- a/tests/test_workflow_synthesizer.py
+++ b/tests/test_workflow_synthesizer.py
@@ -52,7 +52,9 @@ def test_expand_cluster_merges_sources(tmp_path, monkeypatch):
     intent = StubIntent(tmp_path)
     synth = ws.WorkflowSynthesizer(module_synergy_grapher=grapher, intent_clusterer=intent)
 
-    modules = synth.expand_cluster(start_module="mod_a", problem="finalise")
+    modules = synth.expand_cluster(
+        start_module="mod_a", problem="finalise", max_depth=2
+    )
     assert modules == {"mod_a", "mod_b", "mod_c"}
 
 
@@ -63,8 +65,11 @@ def test_expand_cluster_bfs_multi_hop(tmp_path, monkeypatch):
     grapher = StubGrapher()
     synth = ws.WorkflowSynthesizer(module_synergy_grapher=grapher)
 
-    # default depth is 1 -> only direct neighbour
-    assert synth.expand_cluster(start_module="mod_a") == {"mod_a", "mod_b"}
+    # depth 1 restricts exploration to the direct neighbour
+    assert synth.expand_cluster(start_module="mod_a", max_depth=1) == {
+        "mod_a",
+        "mod_b",
+    }
 
     # expanding to depth 2 pulls in mod_c
     modules = synth.expand_cluster(start_module="mod_a", max_depth=2)
@@ -115,7 +120,9 @@ def test_generate_workflows_persist_and_rank(tmp_path, monkeypatch):
     intent = StubIntent(tmp_path)
     synth = ws.WorkflowSynthesizer(module_synergy_grapher=grapher, intent_clusterer=intent)
 
-    workflows = synth.generate_workflows(start_module="mod_a", problem="finalise", limit=2)
+    workflows = synth.generate_workflows(
+        start_module="mod_a", problem="finalise", limit=2, max_depth=2
+    )
     assert len(workflows) == 2
     assert [step.module for step in workflows[0]] == ["mod_a", "mod_b"]
     # The second best workflow follows the next step in the synergy chain

--- a/workflow_synthesizer.py
+++ b/workflow_synthesizer.py
@@ -434,7 +434,7 @@ class WorkflowSynthesizer:
         *,
         problem: str | None = None,
         threshold: float = 0.0,
-        max_depth: int = 1,
+        max_depth: int | None = None,
     ) -> Set[str]:
         """Expand from ``start_module`` and/or ``problem`` to related modules.
 
@@ -448,8 +448,9 @@ class WorkflowSynthesizer:
         threshold:
             Minimum edge weight when traversing the synergy graph.
         max_depth:
-            Maximum graph depth to explore from ``start_module``.  ``1`` restricts
-            expansion to direct neighbours.
+            Maximum graph depth to explore from ``start_module``.  ``None``
+            explores the entire reachable graph. ``1`` restricts expansion to
+            direct neighbours.
         """
 
         modules: Set[str] = set()
@@ -469,7 +470,7 @@ class WorkflowSynthesizer:
                     queue: deque[tuple[str, int]] = deque([(start_module, 0)])
                     while queue:
                         node, depth = queue.popleft()
-                        if depth >= max_depth:
+                        if max_depth is not None and depth >= max_depth:
                             continue
                         for neigh, data in graph[node].items():
                             weight = float(data.get("weight", 0.0))
@@ -538,7 +539,10 @@ class WorkflowSynthesizer:
             raise ValueError("Structural analysis helpers are unavailable")
 
         modules: Set[str] = self.expand_cluster(
-            start_module=start_module, problem=problem, threshold=threshold
+            start_module=start_module,
+            problem=problem,
+            threshold=threshold,
+            max_depth=1,
         )
 
         if start_module:
@@ -629,8 +633,8 @@ class WorkflowSynthesizer:
         limit:
             Maximum number of workflows to return.
         max_depth:
-            Maximum graph depth to explore from ``start_module``.  ``1``
-            restricts exploration to direct neighbours.
+            Maximum graph depth to explore from ``start_module``. ``None``
+            explores the entire reachable graph.
         synergy_weight:
             Multiplier applied to synergy graph edge weights when scoring
             workflows.
@@ -641,9 +645,8 @@ class WorkflowSynthesizer:
         if ModuleSignature is None or get_io_signature is None:
             raise ValueError("Structural analysis helpers are unavailable")
 
-        depth = max_depth if max_depth is not None else 1
         modules = self.expand_cluster(
-            start_module=start_module, problem=problem, max_depth=depth
+            start_module=start_module, problem=problem, max_depth=max_depth
         )
         modules.add(start_module)
 


### PR DESCRIPTION
## Summary
- allow `expand_cluster` to restrict breadth-first traversal via optional `max_depth`
- pass `max_depth` through from `generate_workflows`
- update workflow synthesizer tests to cover depth-limited expansion

## Testing
- `pytest tests/test_workflow_synthesizer.py::test_expand_cluster_bfs_multi_hop -q`
- `pytest tests/test_workflow_synthesizer.py::test_generate_workflows_persist_and_rank -q`
- `pytest tests/test_workflow_synthesizer.py::test_generate_workflows_max_depth -q`
- `pytest tests/test_workflow_synthesizer.py::test_expand_cluster_merges_sources -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad028409a0832e9b327284bd81faba