### PR TITLE
Add queue write and sync_shared_db tests

### DIFF
--- a/tests/test_sync_shared_db.py
+++ b/tests/test_sync_shared_db.py
@@ -1,0 +1,47 @@
+import json
+from sqlite3 import connect
+
+import pytest
+
+from db_write_queue import append_record
+from sync_shared_db import _sync_once
+
+
+@pytest.fixture
+def queue_dir(tmp_path):
+    return tmp_path
+
+
+@pytest.fixture
+def sqlite_conn():
+    conn = connect(":memory:")  # noqa: SQL001
+    conn.execute(
+        "CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "value TEXT NOT NULL, content_hash TEXT UNIQUE)"
+    )
+    yield conn
+    conn.close()
+
+
+def test_sync_once_processes_records(queue_dir, sqlite_conn):
+    append_record("test", {"value": "a"}, "m1", queue_dir)
+    append_record("test", {"value": "a"}, "m1", queue_dir)
+    append_record("test", {"value": None}, "m1", queue_dir)
+
+    stats = _sync_once(queue_dir, sqlite_conn)
+    assert stats.processed == 1
+    assert stats.duplicates == 1
+    assert stats.failures == 1
+
+    rows = sqlite_conn.execute("SELECT value FROM test").fetchall()
+    assert rows == [("a",)]
+
+    queue_file = queue_dir / "m1.jsonl"
+    assert queue_file.read_text() == ""
+
+    failed_path = queue_dir / "queue.failed.jsonl"
+    lines = failed_path.read_text().splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["record"]["data"]["value"] is None
+    assert "error" in entry

--- a/tests/test_write_queue.py
+++ b/tests/test_write_queue.py
@@ -1,0 +1,46 @@
+import json
+import threading
+
+from db_write_queue import append_record, read_queue, remove_processed_lines
+
+
+def test_append_read_remove(tmp_path):
+    """Records can be appended, read back and removed from queue files."""
+    queue_dir = tmp_path
+    append_record("example", {"a": 1}, "m1", queue_dir)
+    append_record("example", {"b": 2}, "m1", queue_dir)
+
+    path = queue_dir / "m1.jsonl"
+    records = read_queue(path)
+    assert records == [
+        {"table": "example", "data": {"a": 1}, "source_menace_id": "m1"},
+        {"table": "example", "data": {"b": 2}, "source_menace_id": "m1"},
+    ]
+
+    remove_processed_lines(path, 1)
+    assert read_queue(path) == [records[1]]
+
+    backup = queue_dir / "queue.log.bak"
+    with backup.open("r", encoding="utf-8") as fh:
+        bak_records = [json.loads(line) for line in fh if line.strip()]
+    assert bak_records == [records[0]]
+
+
+def test_threaded_writes_are_atomic(tmp_path):
+    """File locks prevent interleaved writes from multiple threads."""
+    queue_dir = tmp_path
+    path = queue_dir / "m1.jsonl"
+
+    def worker(n: int) -> None:
+        append_record("example", {"n": n}, "m1", queue_dir)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 20
+    payloads = [json.loads(line)["data"]["n"] for line in lines]
+    assert set(payloads) == set(range(20))


### PR DESCRIPTION
## Summary
- test write queue append/read/remove semantics and lock-protected writes
- test sync_shared_db in once mode inserts records, skips duplicates and logs failures

## Testing
- `pre-commit run --files tests/test_write_queue.py tests/test_sync_shared_db.py`
- `pytest tests/test_write_queue.py tests/test_sync_shared_db.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad02932c44832e96a27e49d05c0bd1