### PR TITLE
Document shared database queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,9 @@
 SQLite's coarse file locking can stall concurrent writers. When `USE_DB_QUEUE`
 is set, calls to `insert_if_unique` are queued as JSONL records under
 `SANDBOX_DATA_DIR/queues`. Each entry stores the source `MENACE_ID` and a
-content hash for deduplication.
+content hash for deduplication. See
+[docs/shared_db_queue.md](docs/shared_db_queue.md) for queue layout,
+environment variables and recovery steps.
 
 A background daemon flushes the queue into the shared database:
 
@@ -195,7 +197,8 @@ python sync_shared_db.py --db-url sqlite:///menace.db --queue-dir sandbox_data/q
 
 Successful rows are committed and removed, retries happen up to three times and
 then move to `<table>_queue.failed.jsonl`. Override the queue directory with
-`SANDBOX_DATA_DIR` when running multiple instances.
+`DB_QUEUE_DIR` (or `DB_ROUTER_QUEUE_DIR` when using `DBRouter`) when running
+multiple instances.
 
 For PostgreSQL or other backends that handle concurrent writes, disable the
 buffer by unsetting `USE_DB_QUEUE` (or passing `queue_path=None`) so inserts go

--- a/docs/db_router.md
+++ b/docs/db_router.md
@@ -4,7 +4,8 @@ The `DBRouter` routes SQLite queries to either a local database specific to a
 Menace instance or to a shared database used by all instances.
 
 Buffered writes destined for the shared database are described in
-[write_buffer.md](write_buffer.md).
+[write_buffer.md](write_buffer.md); queue layout and synchroniser behaviour
+are detailed in [shared_db_queue.md](shared_db_queue.md).
 
 The maintenance script `sync_shared_db.py` performs low-level database
 synchronisation and therefore calls `sqlite3.connect` directly. It is explicitly

--- a/docs/shared_db_queue.md
+++ b/docs/shared_db_queue.md
@@ -1,0 +1,55 @@
+# Shared Database Queue
+
+## Rationale
+SQLite allows only one writer at a time because it uses coarse file locks.\
+Multiple Menace instances writing directly to the shared database can block
+or fail with `database is locked` errors.  Queueing writes to disk lets each
+instance append new records quickly and flush them later without holding the
+shared database write lock.
+
+## Queue file format and location
+Queued writes are stored as JSON Lines files.  Each line contains a mapping::
+
+    {"table": "<table>", "data": {...}, "source_menace_id": "<id>"}
+
+Files are grouped by menace under the directory defined by `DB_QUEUE_DIR`
+(`logs/queue` by default).  Each instance appends records to
+`<menace_id>.jsonl`.  `DBRouter.queue_insert` respects an optional
+`DB_ROUTER_QUEUE_DIR` which overrides the base location when routing writes.
+
+## How `sync_shared_db.py` processes queues
+The synchroniser scans the queue directory for `*.jsonl` files and handles
+each line independently:
+
+1. Parse the JSON payload and insert the record into the target table using
+   `db_dedup.insert_if_unique`.
+2. On success or duplicate detection the line is removed from the queue.
+3. Failures are logged to `queue.failed.jsonl` with error details.
+
+Processed lines are trimmed from the queue and backed up to `queue.log.bak`
+for manual rollback.
+
+## Environment variables and daemon options
+- `DB_QUEUE_DIR` – base directory for queue files (`logs/queue` by default).
+- `DB_ROUTER_QUEUE_DIR` – override used by `DBRouter.queue_insert` when
+  queuing shared writes.
+- `sync_shared_db.py` options:
+  - `--queue-dir` – directory to scan for queues (defaults to
+    `DB_QUEUE_DIR`).
+  - `--db-path` – path to the shared SQLite database.
+  - `--interval` – polling interval in seconds when running continuously.
+  - `--once` – process queues once and exit.
+  - `--watch` – watch for filesystem events using `watchdog` if available.
+  - `--replay-failed` – requeue entries from `queue.failed.jsonl`.
+
+## Rollback and recovery
+- Review `queue.failed.jsonl` for records that could not be inserted.
+- Requeue failed entries by running:
+
+  ```bash
+  python sync_shared_db.py --queue-dir <dir> --db-path <db> --once --replay-failed
+  ```
+
+- `queue.log.bak` retains processed lines.  Copy relevant lines back into the
+  original queue file and rerun the synchroniser to roll back a previous
+  sync.

--- a/docs/write_buffer.md
+++ b/docs/write_buffer.md
@@ -1,5 +1,8 @@
 # SQLite Write Buffer
 
+For queue layout, environment variables and recovery procedures see
+[shared_db_queue.md](shared_db_queue.md).
+
 ## Why SQLite needs buffering
 SQLite uses file-level locks and permits only one writer at a time. Multiple Menace
 instances writing directly to the shared database can contend for locks or block


### PR DESCRIPTION
## Summary
- document rationale, format, environment variables, options and recovery steps for shared database queues
- link README and developer guides to shared queue docs

## Testing
- `pre-commit run --files README.md docs/shared_db_queue.md docs/write_buffer.md docs/db_router.md`
- `pytest tests/test_sync_shared_db_queue.py tests/test_db_router_queue_insert.py`

------
https://chatgpt.com/codex/tasks/task_e_68ad05078430832e9c3af2fdf789fef3