### PR TITLE
Add shared queue env config and sync interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,9 @@ python sync_shared_db.py --db-url sqlite:///menace.db --queue-dir sandbox_data/q
 
 Successful rows are committed and removed, retries happen up to three times and
 then move to `<table>_queue.failed.jsonl`. Override the queue directory with
-`DB_QUEUE_DIR` (or `DB_ROUTER_QUEUE_DIR` when using `DBRouter`) when running
-multiple instances.
+`SHARED_QUEUE_DIR` (or `DB_ROUTER_QUEUE_DIR` when using `DBRouter`) when running
+multiple instances. The daemon polls for new records every `SYNC_INTERVAL`
+seconds (default `10`) and creates the queue directory if it is missing.
 
 For PostgreSQL or other backends that handle concurrent writes, disable the
 buffer by unsetting `USE_DB_QUEUE` (or passing `queue_path=None`) so inserts go

--- a/db_write_queue.py
+++ b/db_write_queue.py
@@ -9,7 +9,7 @@ shared database:
 * :func:`append_record` – new helper that appends records to per-menace queue
   files.  These files may later be processed by a background worker.
 
-Queue files live under the directory specified by the ``DB_QUEUE_DIR"
+Queue files live under the directory specified by the ``SHARED_QUEUE_DIR"
 environment variable (``logs/queue`` by default).  ``fcntl_compat`` file locks
 are used to avoid interleaving writes from concurrent threads or processes.
 """
@@ -22,10 +22,11 @@ from typing import Iterable, Iterator, List, Mapping, Any
 
 from fcntl_compat import flock, LOCK_EX, LOCK_UN
 from db_dedup import compute_content_hash
+from env_config import SHARED_QUEUE_DIR
 
-# Base directory for queue files.  Allow overriding via the ``DB_QUEUE_DIR``
-# environment variable.  By default queue files are stored under ``logs/queue``.
-DEFAULT_QUEUE_DIR = Path(os.getenv("DB_QUEUE_DIR", "logs/queue"))
+# Base directory for queue files defined by ``SHARED_QUEUE_DIR``.
+DEFAULT_QUEUE_DIR = Path(SHARED_QUEUE_DIR)
+DEFAULT_QUEUE_DIR.mkdir(parents=True, exist_ok=True)
 
 # Global lock for in-process thread safety.  File locks handle cross-process
 # coordination.
@@ -69,7 +70,7 @@ def append_record(
     queue_dir:
         Optional base directory for queue files.  If omitted the directory is
         derived from :data:`DEFAULT_QUEUE_DIR` which may be overridden via the
-        ``DB_QUEUE_DIR`` environment variable.
+        ``SHARED_QUEUE_DIR`` environment variable.
     """
 
     base = queue_dir if queue_dir is not None else DEFAULT_QUEUE_DIR

--- a/env_config.py
+++ b/env_config.py
@@ -15,6 +15,7 @@ def load_env(path: str | None = None) -> None:
         key, value = line.split('=', 1)
         os.environ.setdefault(key.strip(), value.strip())
 
+
 # Optionally load variables from MENACE_ENV_FILE if set
 load_env(os.getenv('MENACE_ENV_FILE'))
 
@@ -73,6 +74,11 @@ BOT_PERFORMANCE_DB = os.getenv('BOT_PERFORMANCE_DB', 'bot_performance_history.db
 MAINTENANCE_DB = os.getenv('MAINTENANCE_DB', 'maintenance.db')
 # Optional PostgreSQL connection string for Maintenance logs
 MAINTENANCE_DB_URL = os.getenv('MAINTENANCE_DB_URL')
+
+# Shared queue configuration
+SHARED_QUEUE_DIR = os.getenv("SHARED_QUEUE_DIR", "logs/queue")
+Path(SHARED_QUEUE_DIR).mkdir(parents=True, exist_ok=True)
+SYNC_INTERVAL = float(os.getenv("SYNC_INTERVAL", "10"))
 
 # Cloud configuration ---------------------------------------------------------
 # DATABASE_URL defines the persistent database connection string.  When unset


### PR DESCRIPTION
## Summary
- expose SHARED_QUEUE_DIR and SYNC_INTERVAL env vars via env_config
- default queue path and sync interval used by db_write_queue and sync_shared_db
- document queue dir and sync interval defaults

## Testing
- `pre-commit run --files env_config.py db_write_queue.py sync_shared_db.py README.md`
- `pytest tests/test_sync_shared_db.py tests/test_sync_shared_db_main.py tests/test_sync_shared_db_queue.py tests/test_write_queue.py tests/test_db_write_queue_backup.py tests/test_db_write_buffer.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad0c5a9474832e9ff4cd4b690d2635