### PR TITLE
docs: describe per-menace write queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@
 
 SQLite's coarse file locking can stall concurrent writers. When `USE_DB_QUEUE`
 is set, calls to `insert_if_unique` are queued as JSONL records under
-`SANDBOX_DATA_DIR/queues`. Each entry stores the source `MENACE_ID` and a
-content hash for deduplication. See
+`SANDBOX_DATA_DIR/queues`, grouped per menace in `<menace_id>.jsonl` files. Each
+entry stores the source `MENACE_ID` and a content hash for deduplication. See
 [docs/shared_db_queue.md](docs/shared_db_queue.md) for queue layout,
 environment variables and recovery steps.
 
@@ -198,7 +198,7 @@ python sync_shared_db.py --db-url sqlite:///menace.db --queue-dir sandbox_data/q
 ```
 
 Successful rows are committed and removed, retries happen up to three times and
-then move to `<table>_queue.failed.jsonl`. Override the queue directory with
+then move to `queue.failed.jsonl`. Override the queue directory with
 `SHARED_QUEUE_DIR` (or `DB_ROUTER_QUEUE_DIR` when using `DBRouter`) when running
 multiple instances. The daemon polls for new records every `SYNC_INTERVAL`
 seconds (default `10`) and creates the queue directory if it is missing.

--- a/docs/shared_db_queue.md
+++ b/docs/shared_db_queue.md
@@ -10,13 +10,15 @@ shared database write lock.
 ## Queue file format and location
 Queued writes are stored as JSON Lines files.  Each line contains a mapping::
 
-    {"table": "<table>", "data": {...}, "source_menace_id": "<id>"}
+    {"table": "<table>", "data": {...}, "source_menace_id": "<id>", "hash": "<digest>"}
 
 Files are grouped by menace under the directory defined by `SHARED_QUEUE_DIR`
 (defaults to `logs/queue`). The `env_config` module ensures this directory
-exists. Each instance appends records to `<menace_id>.jsonl`.
-`DBRouter.queue_insert` respects an optional `DB_ROUTER_QUEUE_DIR` which
-overrides the base location when routing writes.
+exists. Each instance appends records to `<menace_id>.jsonl` using
+`db_write_queue.append_record`, which supersedes older per-table helpers such as
+`db_write_queue.queue_insert`. `DBRouter.queue_insert` remains for compatibility
+and respects an optional `DB_ROUTER_QUEUE_DIR` which overrides the base location
+when routing writes.
 
 ## How `sync_shared_db.py` processes queues
 The synchroniser scans the queue directory for `*.jsonl` files and handles


### PR DESCRIPTION
## Summary
- document menace-specific queue files and example payload format
- note `db_write_queue.append_record` supersedes per-table helpers
- update README references to new queue filenames

## Testing
- `pre-commit run --files docs/write_queue.md docs/shared_db_queue.md README.md`
- `pytest` *(fails: Missing system packages: ffmpeg, tesseract, qemu-system-x86_64)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1bf0764c832ea337ac5b9d9956a0