### PR TITLE
Add tests for workflow synthesizer and CLI

### DIFF
--- a/tests/test_workflow_synthesizer_cli_args.py
+++ b/tests/test_workflow_synthesizer_cli_args.py
@@ -1,0 +1,52 @@
+import json
+
+import workflow_synthesizer_cli as cli
+from workflow_synthesizer import WorkflowStep
+
+
+class DummySynth:
+    def __init__(self, *a, **k):
+        self.workflow_score_details = [
+            {"score": 1.0, "synergy": 1.0, "intent": 0.0, "penalty": 0.0}
+        ]
+
+    def generate_workflows(self, **_kwargs):
+        return [[WorkflowStep("mod_a")]]
+
+
+def test_cli_argument_parsing():
+    parser = cli.build_parser()
+    args = parser.parse_args(
+        [
+            "mod_a",
+            "--limit",
+            "3",
+            "--max-depth",
+            "2",
+            "--synergy-weight",
+            "0.5",
+            "--intent-weight",
+            "0.25",
+            "--min-score",
+            "0.1",
+        ]
+    )
+    assert args.start == "mod_a"
+    assert args.limit == 3
+    assert args.max_depth == 2
+    assert args.synergy_weight == 0.5
+    assert args.intent_weight == 0.25
+    assert args.min_score == 0.1
+
+
+def test_cli_out_saves_workflow(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli, "WorkflowSynthesizer", DummySynth)
+    parser = cli.build_parser()
+    out = tmp_path / "wf.workflow.json"
+    args = parser.parse_args(["mod_a", "--out", str(out)])
+    monkeypatch.chdir(tmp_path)
+    rc = cli.run(args)
+    assert rc == 0
+    saved = tmp_path / "workflows" / out.name
+    data = json.loads(saved.read_text())
+    assert [s["module"] for s in data["steps"]] == ["mod_a"]

--- a/tests/test_workflow_synthesizer_functions.py
+++ b/tests/test_workflow_synthesizer_functions.py
@@ -1,0 +1,76 @@
+import shutil
+from pathlib import Path
+
+import networkx as nx
+
+import workflow_synthesizer as ws
+
+FIXTURES = Path(__file__).parent / "fixtures" / "workflow_modules"
+
+
+def _copy_modules(tmp_path: Path) -> None:
+    for mod in FIXTURES.glob("*.py"):
+        shutil.copy(mod, tmp_path / mod.name)
+
+
+class DummyGrapher:
+    def __init__(self) -> None:
+        self.graph = nx.DiGraph()
+        self.graph.add_edge("mod_a", "mod_b", weight=1.0)
+        self.graph.add_edge("mod_b", "mod_c", weight=1.0)
+
+
+def test_expand_cluster_basic(tmp_path, monkeypatch):
+    _copy_modules(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    synth = ws.WorkflowSynthesizer(module_synergy_grapher=DummyGrapher())
+    mods = synth.expand_cluster(start_module="mod_a", max_depth=2)
+    assert mods == {"mod_a", "mod_b", "mod_c"}
+    mods = synth.expand_cluster(start_module="mod_a", max_depth=2, threshold=1.5)
+    assert mods == {"mod_a"}
+
+
+def test_resolve_dependencies_basic(tmp_path, monkeypatch):
+    _copy_modules(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    synth = ws.WorkflowSynthesizer()
+    mods = [ws.inspect_module(m) for m in ["mod_b", "mod_a"]]
+    steps = synth.resolve_dependencies(mods)
+    assert [s.module for s in steps] == ["mod_a", "mod_b"]
+    bad = [ws.inspect_module("mod_d")]
+    steps = synth.resolve_dependencies(bad)
+    assert steps[0].unresolved == ["missing"]
+
+
+def test_generate_workflows_limit(tmp_path, monkeypatch):
+    _copy_modules(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    synth = ws.WorkflowSynthesizer(module_synergy_grapher=DummyGrapher())
+    workflows = synth.generate_workflows(start_module="mod_a", limit=1, max_depth=2)
+    assert len(workflows) == 1
+    assert [s.module for s in workflows[0]] == ["mod_a", "mod_b"]
+
+
+def test_synthesize_routing(tmp_path, monkeypatch):
+    (tmp_path / "mod_a.py").write_text("def start():\n    return 1\n")
+    monkeypatch.chdir(tmp_path)
+
+    called = {}
+
+    def fake_greedy(self, start_module=None, problem=None, threshold=0.0, **kwargs):
+        called["start_module"] = start_module
+        called["problem"] = problem
+        called["threshold"] = threshold
+        return [{"module": start_module or "mod_z", "inputs": [], "outputs": []}]
+
+    monkeypatch.setattr(ws.WorkflowSynthesizer, "_synthesize_greedy", fake_greedy)
+    synth = ws.WorkflowSynthesizer()
+
+    result = synth.synthesize("mod_a", threshold=0.2)
+    assert called == {"start_module": "mod_a", "problem": None, "threshold": 0.2}
+    assert result["steps"][0]["module"] == "mod_a"
+
+    result = synth.synthesize("a problem")
+    assert called["start_module"] is None
+    assert called["problem"] == "a problem"
+    assert result["steps"][0]["module"] == "mod_z"


### PR DESCRIPTION
## Summary
- add unit tests for expand_cluster, resolve_dependencies, generate_workflows and synthesize
- add CLI tests for argument parsing and output saving

## Testing
- `pytest tests/test_workflow_synthesizer_functions.py tests/test_workflow_synthesizer_cli_args.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad1f3bd50c832eaf8ea939b3dbc014