### PR TITLE
Add thread-safe database access audit utility

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from threading import Lock
+
+from fcntl_compat import flock, LOCK_EX, LOCK_UN
+
+
+_write_lock = Lock()
+
+
+def log_db_access(
+    action: str,
+    table_name: str,
+    row_count: int,
+    menace_id: str,
+    log_path: str = "shared_db_access.log",
+) -> None:
+    """Append a database access record to ``log_path``.
+
+    Parameters
+    ----------
+    action:
+        Operation performed (e.g. ``"read"`` or ``"write"``).
+    table_name:
+        Name of the table accessed.
+    row_count:
+        Number of rows affected by the action.
+    menace_id:
+        Identifier of the menace instance performing the operation.
+    log_path:
+        File to append the log line to. Defaults to ``"shared_db_access.log"``.
+    """
+    record = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "action": action,
+        "table": table_name,
+        "rows": row_count,
+        "menace_id": menace_id,
+    }
+    path = Path(log_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = json.dumps(record, sort_keys=True)
+
+    with _write_lock:
+        with path.open("a", encoding="utf-8") as fh:
+            flock(fh.fileno(), LOCK_EX)
+            fh.write(data)
+            fh.write("\n")
+            flock(fh.fileno(), LOCK_UN)
+
+
+__all__ = ["log_db_access"]

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,24 @@
+import json
+import threading
+from pathlib import Path
+
+from audit import log_db_access
+
+
+def test_log_db_access(tmp_path: Path) -> None:
+    log_file = tmp_path / "log.jsonl"
+
+    def writer(idx: int) -> None:
+        log_db_access("read", f"table{idx}", idx, f"id{idx}", log_path=str(log_file))
+
+    threads = [threading.Thread(target=writer, args=(i,)) for i in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    lines = log_file.read_text().splitlines()
+    assert len(lines) == 2
+    records = [json.loads(line) for line in lines]
+    assert {r["table"] for r in records} == {"table0", "table1"}
+    assert all(r["action"] == "read" for r in records)


### PR DESCRIPTION
## Summary
- Introduce `audit.log_db_access` to append structured JSON lines tracking DB interactions
- Guard writes with thread and file locks for safe concurrent logging
- Add unit test verifying multiple threads can log without clobbering entries

## Testing
- `pytest tests/test_audit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad27c195fc832e99b4b760d983c5ca