### PR TITLE
Add test for database access audit logging via router

### DIFF
--- a/tests/test_db_access_audit.py
+++ b/tests/test_db_access_audit.py
@@ -1,0 +1,38 @@
+import json
+import importlib
+
+
+def test_db_access_audit(tmp_path, monkeypatch):
+    log_path = tmp_path / "shared_db_access.log"
+    local_db = tmp_path / "local.db"
+    shared_db = tmp_path / "shared.db"
+
+    monkeypatch.setenv("DB_ACCESS_LOG_PATH", str(log_path))
+    import audit_db_access
+    import db_router
+    importlib.reload(audit_db_access)
+    importlib.reload(db_router)
+
+    router = db_router.init_db_router("alpha", str(local_db), str(shared_db))
+    try:
+        conn = router.get_connection("telemetry")
+        cur = conn.cursor()
+        cur.execute("CREATE TABLE telemetry (id INTEGER PRIMARY KEY, data TEXT)")
+        conn.commit()
+        log_path.write_text("")
+        cur.execute("SELECT * FROM telemetry")
+        cur.execute("INSERT INTO telemetry (data) VALUES (?)", ("foo",))
+        conn.commit()
+        entries = [json.loads(line) for line in log_path.read_text().splitlines()]
+        assert len(entries) == 2
+        read, write = entries
+        assert read["action"] == "read"
+        assert read["table"] == "telemetry"
+        assert read["rows"] == 0
+        assert read["menace_id"] == "alpha"
+        assert write["action"] == "write"
+        assert write["table"] == "telemetry"
+        assert write["rows"] == 1
+        assert write["menace_id"] == "alpha"
+    finally:
+        router.close()


### PR DESCRIPTION
## Summary
- test db access logging by initializing router and ensuring read/write events are captured in shared_db_access.log

## Testing
- `pre-commit run --files tests/test_db_access_audit.py`
- `pytest tests/test_db_access_audit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad2bcadc68832eb74a37f4e37d5292