### PR TITLE
Add automatic DB access logging via LoggedConnection

### DIFF
--- a/docs/connectivity.md
+++ b/docs/connectivity.md
@@ -6,9 +6,11 @@ link together for maximum emergent behaviour.
 ## Database Router
 
 Bots should interact with data through `DBRouter`. The router decides whether
-tables reside in the local or shared SQLite database and returns a connection
-via :meth:`get_connection`. The legacy `database_router` module has been
-removed; import `DBRouter` from `db_router` instead:
+tables reside in the local or shared SQLite database and returns a
+``LoggedConnection`` via :meth:`get_connection`. These wrappers automatically
+log the number of rows read or written for each statement. The legacy
+`database_router` module has been removed; import `DBRouter` from `db_router`
+instead:
 
 ```python
 from menace.db_router import DBRouter


### PR DESCRIPTION
## Summary
- Wrap sqlite3 connections/cursors with LoggedConnection/LoggedCursor to record row counts and call `log_db_access`
- Use logged wrappers inside DBRouter so all `execute` calls audit automatically
- Document that `get_connection` returns logging wrappers and discourage raw `sqlite3.connect`

## Testing
- `pytest tests/test_db_router.py tests/test_db_router_queue_insert.py tests/test_db_router_threaded_isolation.py tests/test_db_router_denied_tables.py tests/test_db_router_routing_all_tables.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'synergy_weight_update_failures_total' etc., 251 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3242da84832e9615c2f68a7b19c0