### PR TITLE
Add ROI results DB and integrate workflow scorer

### DIFF
--- a/roi_results_db.py
+++ b/roi_results_db.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+import sqlite3
+
+from db_router import DBRouter, LOCAL_TABLES
+
+# Ensure router treats ``roi_results`` as a local table so test environments can
+# operate on ephemeral SQLite files without external dependencies.
+LOCAL_TABLES.add("roi_results")
+
+
+@dataclass
+class ROIResult:
+    """Record of a single module or workflow ROI measurement."""
+
+    workflow_id: str
+    run_id: str
+    module: Optional[str]
+    runtime: float
+    success_rate: float
+    roi_gain: float
+    workflow_synergy_score: Optional[float] = None
+    bottleneck_index: Optional[float] = None
+    patchability_score: Optional[float] = None
+    ts: str = datetime.utcnow().isoformat()
+
+
+class ROIResultsDB:
+    """SQLite helper providing longitudinal ROI result storage and queries."""
+
+    def __init__(
+        self,
+        db_path: str | Path = "roi_results.db",
+        router: DBRouter | None = None,
+    ) -> None:
+        self.db_path = Path(db_path)
+        # Reuse provided router to share connections with other helpers, falling
+        # back to a standalone ``DBRouter`` if necessary.
+        self.router = router or DBRouter(
+            "roi_results", str(self.db_path), str(self.db_path)
+        )
+        self.conn = self.router.get_connection("roi_results", operation="write")
+        self._init_db()
+
+    def _init_db(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS roi_results(
+                id INTEGER PRIMARY KEY,
+                workflow_id TEXT,
+                run_id TEXT,
+                module TEXT,
+                runtime REAL,
+                success_rate REAL,
+                roi_gain REAL,
+                workflow_synergy_score REAL,
+                bottleneck_index REAL,
+                patchability_score REAL,
+                ts TEXT
+            )
+            """,
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_roi_results_wf_run_mod
+                ON roi_results(workflow_id, run_id, module)
+            """,
+        )
+        self.conn.commit()
+
+    # write ---------------------------------------------------------------
+    def add(self, rec: ROIResult) -> None:
+        """Persist an :class:`ROIResult` record."""
+
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO roi_results(
+                workflow_id, run_id, module, runtime, success_rate, roi_gain,
+                workflow_synergy_score, bottleneck_index, patchability_score, ts
+            ) VALUES(?,?,?,?,?,?,?,?,?,?)
+            """,
+            (
+                rec.workflow_id,
+                rec.run_id,
+                rec.module,
+                rec.runtime,
+                rec.success_rate,
+                rec.roi_gain,
+                rec.workflow_synergy_score,
+                rec.bottleneck_index,
+                rec.patchability_score,
+                rec.ts,
+            ),
+        )
+        self.conn.commit()
+
+    # read ----------------------------------------------------------------
+    def fetch_runs(
+        self, workflow_id: str, module: Optional[str] = None
+    ) -> List[ROIResult]:
+        """Return all recorded runs for ``workflow_id`` optionally filtered by module."""
+
+        cur = self.conn.cursor()
+        base = (
+            "SELECT workflow_id, run_id, module, runtime, success_rate, roi_gain, "
+            "workflow_synergy_score, bottleneck_index, patchability_score, ts "
+            "FROM roi_results WHERE workflow_id=?"
+        )
+        params: list[object] = [workflow_id]
+        if module is not None:
+            base += " AND module=?"
+            params.append(module)
+        base += " ORDER BY ts"
+        cur.execute(base, params)
+        rows = cur.fetchall()
+        return [ROIResult(*row) for row in rows]
+
+    def trend(self, workflow_id: str, metric: str, module: Optional[str] = None) -> float:
+        """Return linear trend slope for ``metric`` across runs.
+
+        The computation uses ordinary least squares on the sequential runs.  If
+        fewer than two points are present, ``0.0`` is returned.
+        """
+
+        rows = self.fetch_runs(workflow_id, module)
+        values = [getattr(r, metric) for r in rows if getattr(r, metric) is not None]
+        n = len(values)
+        if n < 2:
+            return 0.0
+        mean_x = (n - 1) / 2
+        mean_y = sum(values) / n
+        num = sum((i - mean_x) * (v - mean_y) for i, v in enumerate(values))
+        den = sum((i - mean_x) ** 2 for i in range(n))
+        return num / den if den else 0.0
+
+
+__all__ = ["ROIResult", "ROIResultsDB"]

--- a/tests/test_roi_results_db.py
+++ b/tests/test_roi_results_db.py
@@ -1,0 +1,29 @@
+import pytest
+
+from menace_sandbox.db_router import init_db_router
+from menace_sandbox.roi_results_db import ROIResult, ROIResultsDB
+
+
+def test_roi_results_db_trend(tmp_path):
+    init_db_router(
+        "test_roi_results_db",
+        local_db_path=str(tmp_path / "local.db"),
+        shared_db_path=str(tmp_path / "shared.db"),
+    )
+
+    db = ROIResultsDB(tmp_path / "roi.db")
+    for i, gain in enumerate([1.0, 2.0, 3.0]):
+        db.add(
+            ROIResult(
+                workflow_id="wf",
+                run_id=f"run{i}",
+                module=None,
+                runtime=1.0,
+                success_rate=1.0,
+                roi_gain=gain,
+            )
+        )
+    rows = db.fetch_runs("wf")
+    assert len(rows) == 3
+    trend = db.trend("wf", "roi_gain")
+    assert trend == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- add `roi_results_db` helper and ROIResult dataclass for longitudinal ROI storage
- record per-module and aggregate workflow metrics in new `roi_results` table
- expose query helpers to fetch runs and compute metric trends

## Testing
- `pytest tests/test_composite_workflow_scorer.py tests/test_workflow_module_deltas.py tests/test_roi_results_db.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad3aeb3400832ebe606609529e6412