### PR TITLE
Add DB access audit utility

### DIFF
--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -9,7 +9,7 @@ def test_log_db_access(tmp_path: Path) -> None:
     log_file = tmp_path / "log.jsonl"
 
     def writer(idx: int) -> None:
-        log_db_access("read", f"table{idx}", idx, f"id{idx}", log_path=str(log_file))
+        log_db_access("read", f"table{idx}", idx, f"id{idx}", log_path=log_file)
 
     threads = [threading.Thread(target=writer, args=(i,)) for i in range(2)]
     for t in threads:

--- a/tests/test_audit_db_log_to_db.py
+++ b/tests/test_audit_db_log_to_db.py
@@ -1,32 +1,26 @@
 import json
-
-import db_router
+import sqlite3
 
 from audit import log_db_access
 
 
 def test_log_db_access_inserts_into_db(tmp_path):
     log_file = tmp_path / "shared_db_access.log"
-    local_db = tmp_path / "local.db"
-    shared_db = tmp_path / "shared.db"
+    conn = sqlite3.connect(tmp_path / "audit.db")
 
-    router = db_router.init_db_router("beta", str(local_db), str(shared_db))
-    try:
-        log_db_access(
-            "write",
-            "telemetry",
-            3,
-            "beta",
-            log_to_db=True,
-            log_path=str(log_file),
-        )
-        entries = [json.loads(line) for line in log_file.read_text().splitlines()]
-        assert entries[0]["action"] == "write"
-        cur = router.local_conn.cursor()
-        cur.execute(
-            "SELECT action, table_name, row_count, menace_id FROM db_access_audit"
-        )
-        assert cur.fetchone() == ("write", "telemetry", 3, "beta")
-    finally:
-        router.close()
-        db_router.GLOBAL_ROUTER = None
+    log_db_access(
+        "write",
+        "telemetry",
+        3,
+        "beta",
+        log_path=log_file,
+        db_conn=conn,
+    )
+
+    entries = [json.loads(line) for line in log_file.read_text().splitlines()]
+    assert entries[0]["action"] == "write"
+
+    cur = conn.cursor()
+    cur.execute('SELECT action, "table", rows, menace_id FROM shared_db_audit')
+    assert cur.fetchone() == ("write", "telemetry", 3, "beta")
+    conn.close()


### PR DESCRIPTION
## Summary
- implement `log_db_access` for JSONL file logging and optional SQLite audit table
- record audit entries to `logs/shared_db_access.log` by default
- test file logging and database insertion

## Testing
- `pytest tests/test_audit.py tests/test_audit_db_log_to_db.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad3c4ddbc0832eb76544d46d58b98b