### PR TITLE
Add synergy, bottleneck, and patchability metrics to workflow scoring

### DIFF
--- a/tests/test_composite_workflow_scorer.py
+++ b/tests/test_composite_workflow_scorer.py
@@ -71,9 +71,9 @@ def test_composite_workflow_scorer_records_metrics(tmp_path):
     assert result["roi_gain"] > 0
     assert "fast_runtime" in result["metrics"]
     assert "slow_runtime" in result["metrics"]
-    assert "workflow_synergy" in result["metrics"]
+    assert "workflow_synergy_score" in result["metrics"]
     assert "bottleneck_index" in result["metrics"]
-    assert "patchability" in result["metrics"]
+    assert "patchability_score" in result["metrics"]
 
     cur = scorer.conn.cursor()
     cur.execute(


### PR DESCRIPTION
## Summary
- derive workflow_synergy_score from recent synergy_efficiency and synergy_reliability metrics
- calculate bottleneck_index as slowest module runtime share
- compute patchability_score using ROI slope scaled by patch success rate

## Testing
- `pytest tests/test_composite_workflow_scorer.py tests/test_workflow_module_deltas.py`

------
https://chatgpt.com/codex/tasks/task_e_68ad3c427354832e948cd7ec0f6efd71