### PR TITLE
Log DB access with configurable path

### DIFF
--- a/tests/test_db_router_audit_log.py
+++ b/tests/test_db_router_audit_log.py
@@ -22,6 +22,7 @@ def test_accesses_are_audited(tmp_path, monkeypatch):
         importlib.reload(db_router)
 
     entries = [json.loads(line) for line in audit_log.read_text().strip().splitlines()]
+    entries = [e for e in entries if "table_name" in e]
     assert {e["menace_id"] for e in entries} == {"alpha"}
     assert {e["table_name"] for e in entries} == {"bots", "models"}
     assert {e["operation"] for e in entries} == {"write", "read"}
@@ -44,5 +45,6 @@ def test_shared_table_access_logged(tmp_path, monkeypatch):
         importlib.reload(db_router)
 
     entries = [json.loads(line) for line in audit_log.read_text().splitlines()]
+    entries = [e for e in entries if "table_name" in e]
     assert entries[0]["table_name"] == "bots"
     assert entries[0]["operation"] == "write"

--- a/tests/test_db_router_read_write_logging.py
+++ b/tests/test_db_router_read_write_logging.py
@@ -6,12 +6,10 @@ def test_db_router_logs_read_and_write(tmp_path, monkeypatch):
     log_path = tmp_path / "shared_db_access.log"
     local_db = tmp_path / "local.db"
     shared_db = tmp_path / "shared.db"
-    monkeypatch.setenv("DB_ACCESS_LOG_PATH", str(log_path))
+    monkeypatch.setenv("DB_ROUTER_AUDIT_LOG", str(log_path))
 
-    import audit_db_access
     import db_router
 
-    importlib.reload(audit_db_access)
     importlib.reload(db_router)
 
     router = db_router.DBRouter("alpha", str(local_db), str(shared_db))
@@ -29,6 +27,7 @@ def test_db_router_logs_read_and_write(tmp_path, monkeypatch):
         assert rows == [(1, "foo")]
 
         entries = [json.loads(line) for line in log_path.read_text().splitlines()]
+        entries = [e for e in entries if "action" in e]
         assert len(entries) == 2
         write_entry = next(e for e in entries if e["action"] == "write")
         read_entry = next(e for e in entries if e["action"] == "read")


### PR DESCRIPTION
## Summary
- route all DB log events through audit.log_db_access
- support DB_ROUTER_AUDIT_LOG for write/read metrics
- expand tests for new logging and mixed audit entries

## Testing
- `pytest tests/test_db_router_read_write_logging.py tests/test_db_router_audit_log.py tests/test_db_router_get_connection.py tests/test_db_router_table_sharing.py tests/test_audit.py tests/test_audit_db_log_to_db.py`
- `pytest` *(fails: Missing system packages: ffmpeg, tesseract, qemu-system-x86_64)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3cf05dc0832ea5f1e18b216ff8f2