### PR TITLE
Use rotating file handler for DB audit logs

### DIFF
--- a/docs/db_auditing.md
+++ b/docs/db_auditing.md
@@ -29,6 +29,21 @@ Example log line:
 `logs/shared_db_access.log`. Callers of `audit.log_db_access` may also override
 the destination by passing the `log_path` argument directly.
 
+## Log rotation
+
+`audit.log_db_access` uses Python's `RotatingFileHandler` to automatically
+rotate the JSONL log. Rotation thresholds can be configured via environment
+variables:
+
+- `DB_AUDIT_LOG_MAX_BYTES` – maximum size in bytes before a new file is created
+  (defaults to 10MB).
+- `DB_AUDIT_LOG_BACKUPS` – number of rotated log files to retain (defaults to 5).
+
+Both settings are optional; sensible defaults are applied when the variables are
+unset or invalid. Rotation occurs with the same file-locking semantics as
+regular writes, so multiple processes can safely append to the log without
+interleaving.
+
 ## Querying the audit table
 
 If `log_db_access` receives a SQLite connection via the `db_conn` parameter the


### PR DESCRIPTION
## Summary
- refactor `audit.log_db_access` to use `RotatingFileHandler` with file locking
- allow configuring rotation via `DB_AUDIT_LOG_MAX_BYTES` and `DB_AUDIT_LOG_BACKUPS`
- document new rotation behavior

## Testing
- `pytest tests/test_audit.py tests/test_audit_db_log_to_db.py`
- `pre-commit run --files audit.py docs/db_auditing.md`


------
https://chatgpt.com/codex/tasks/task_e_68ad45e9d770832eb3e584a60e273c1e