### PR TITLE
Add workflow results logging helper

### DIFF
--- a/adaptive_roi_cli.py
+++ b/adaptive_roi_cli.py
@@ -207,7 +207,7 @@ def _workflow_eval(args: argparse.Namespace) -> None:
     scorer.evaluate(args.workflow_id, env_presets=presets)
     cur = scorer.results_db.conn.cursor()
     row = cur.execute(
-        "SELECT run_id FROM roi_results WHERE workflow_id=? ORDER BY ts DESC LIMIT 1",
+        "SELECT run_id FROM workflow_results WHERE workflow_id=? ORDER BY timestamp DESC LIMIT 1",
         (args.workflow_id,),
     ).fetchone()
     if row:

--- a/composite_workflow_scorer.py
+++ b/composite_workflow_scorer.py
@@ -199,7 +199,7 @@ class CompositeWorkflowScorer(ROIScorer):
                 "success_rate": 1.0 if self._module_successes.get(mod) else 0.0,
             }
 
-        self.results_db.add_result(
+        self.results_db.log_result(
             workflow_id=workflow_id,
             run_id=run_id,
             runtime=runtime,
@@ -316,7 +316,7 @@ class CompositeWorkflowScorer(ROIScorer):
             per_module_metrics[mod] = {"success_rate": sr, "roi_delta": roi_delta}
 
         run_id = uuid.uuid4().hex
-        self.results_db.add_result(
+        self.results_db.log_result(
             workflow_id=workflow_id,
             run_id=run_id,
             runtime=runtime,

--- a/docs/composite_workflow_scorer.md
+++ b/docs/composite_workflow_scorer.md
@@ -33,12 +33,13 @@ print(result.success_rate, result.roi_gain)
 
 ## Database schema
 
-`ROIResultsDB` creates a local SQLite table `roi_results`:
+`ROIResultsDB` creates a local SQLite table `workflow_results`:
 
 | column | type | description |
 | --- | --- | --- |
 | `workflow_id` | TEXT | identifier of the evaluated workflow |
 | `run_id` | TEXT | unique identifier for this evaluation run |
+| `timestamp` | TEXT | insertion timestamp |
 | `runtime` | REAL | total execution time in seconds |
 | `success_rate` | REAL | successes divided by total module runs |
 | `roi_gain` | REAL | sum of `roi_history` deltas |
@@ -46,7 +47,6 @@ print(result.success_rate, result.roi_gain)
 | `bottleneck_index` | REAL | worst runtime/ROI ratio adjusted by variance |
 | `patchability_score` | REAL | regression slope of ROI history |
 | `module_deltas` | TEXT | JSON mapping `module -> {success_rate, roi_delta}` |
-| `ts` | TEXT | insertion timestamp |
 
 ## CLI example
 
@@ -61,7 +61,7 @@ scorer = CompositeWorkflowScorer()
 res = scorer.evaluate("wf_example")
 cur = scorer.results_db.conn.cursor()
 run_id = cur.execute(
-    "SELECT run_id FROM roi_results WHERE workflow_id=? ORDER BY ts DESC LIMIT 1",
+    "SELECT run_id FROM workflow_results WHERE workflow_id=? ORDER BY timestamp DESC LIMIT 1",
     ("wf_example",),
 ).fetchone()[0]
 print(module_impact_report("wf_example", run_id, scorer.results_db.path))

--- a/tests/test_composite_workflow_scorer.py
+++ b/tests/test_composite_workflow_scorer.py
@@ -105,7 +105,7 @@ def test_composite_workflow_scorer_records_metrics(tmp_path, monkeypatch):
 
     # Ensure results persisted with workflow/run identifiers and per-module deltas.
     cur = scorer.results_db.conn.cursor()
-    cur.execute("SELECT workflow_id, run_id, module_deltas FROM roi_results")
+    cur.execute("SELECT workflow_id, run_id, module_deltas FROM workflow_results")
     wf, run_id, deltas_json = cur.fetchone()
     assert wf == workflow_id
     assert run_id  # run identifier was generated

--- a/tests/test_module_impact_report.py
+++ b/tests/test_module_impact_report.py
@@ -12,7 +12,7 @@ def test_module_impact_report(tmp_path):
     db_path = tmp_path / "roi.db"
     db = ROIResultsDB(db_path)
 
-    db.add_result(
+    db.log_result(
         workflow_id="wf",
         run_id="r1",
         runtime=1.0,
@@ -23,7 +23,7 @@ def test_module_impact_report(tmp_path):
         patchability_score=0.0,
         module_deltas={"alpha": {"roi_delta": 0.1}, "beta": {"roi_delta": -0.1}},
     )
-    db.add_result(
+    db.log_result(
         workflow_id="wf",
         run_id="r2",
         runtime=1.0,

--- a/tests/test_roi_results_db.py
+++ b/tests/test_roi_results_db.py
@@ -15,7 +15,7 @@ def test_roi_results_db_add_and_report(tmp_path):
     db_path = tmp_path / "roi.db"
     db = ROIResultsDB(db_path)
 
-    db.add_result(
+    db.log_result(
         workflow_id="wf",
         run_id="r1",
         runtime=1.0,
@@ -26,7 +26,7 @@ def test_roi_results_db_add_and_report(tmp_path):
         patchability_score=0.0,
         module_deltas={"alpha": {"roi_delta": 0.1}, "beta": {"roi_delta": -0.1}},
     )
-    db.add_result(
+    db.log_result(
         workflow_id="wf",
         run_id="r2",
         runtime=1.0,
@@ -39,7 +39,7 @@ def test_roi_results_db_add_and_report(tmp_path):
     )
 
     cur = db.conn.cursor()
-    cur.execute("SELECT workflow_id, run_id, module_deltas FROM roi_results WHERE run_id='r2'")
+    cur.execute("SELECT workflow_id, run_id, module_deltas FROM workflow_results WHERE run_id='r2'")
     wf, run, deltas_json = cur.fetchone()
     assert wf == "wf"
     assert run == "r2"


### PR DESCRIPTION
## Summary
- add ROIResultsDB with `workflow_results` table and helpers to log and fetch runs
- update scorers and CLI to use new logging API
- document workflow results schema

## Testing
- `pytest tests/test_roi_results_db.py tests/test_module_impact_report.py tests/test_composite_workflow_scorer.py tests/test_workflow_module_deltas.py tests/test_sample_workflow_scoring.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad4d58bd40832e918e00ea4198fc1c