### PR TITLE
Track module-level bottlenecks and ROI attribution

### DIFF
--- a/tests/test_composite_workflow_scorer.py
+++ b/tests/test_composite_workflow_scorer.py
@@ -121,3 +121,10 @@ def test_composite_workflow_scorer_records_metrics(tmp_path, monkeypatch):
     assert report["improved"]["mod_a"] == pytest.approx(1.0)
     assert report["regressed"]["mod_c"] == pytest.approx(-0.5)
 
+    # Module attribution records were stored and exposed
+    attrib = scorer.results_db.fetch_module_attribution()
+    total = 0.1 + 0.2 + 0.3
+    assert attrib["mod_a"]["roi_delta"] == pytest.approx(1.0)
+    assert attrib["mod_a"]["bottleneck"] == pytest.approx(0.1 / total)
+    assert scorer.module_attribution["mod_c"]["bottleneck_contribution"] == pytest.approx(0.3 / total)
+


### PR DESCRIPTION
## Summary
- capture per-module ROI deltas and runtime bottleneck share when workflows run
- persist per-module attribution stats in `module_attribution` table
- expose last run's module attribution data for refinement loops

## Testing
- `pytest tests/test_composite_workflow_scorer.py::test_composite_workflow_scorer_records_metrics -q`
- `python - <<'PY'
from db_router import init_db_router
from roi_results_db import ROIResultsDB, module_impact_report
from pathlib import Path
import json
from tempfile import TemporaryDirectory

tmpdir = TemporaryDirectory()
path = Path(tmpdir.name)
init_db_router('tmp_test', local_db_path=str(path/'local.db'), shared_db_path=str(path/'shared.db'))

db_path = path/'roi.db'
db = ROIResultsDB(db_path)

db.log_result(workflow_id='wf', run_id='r1', runtime=1.0, success_rate=1.0, roi_gain=1.0, workflow_synergy_score=0.0, bottleneck_index=0.0, patchability_score=0.0, module_deltas={'alpha': {'roi_delta':0.1}, 'beta': {'roi_delta': -0.1}})
db.log_result(workflow_id='wf', run_id='r2', runtime=1.0, success_rate=1.0, roi_gain=1.0, workflow_synergy_score=0.0, bottleneck_index=0.0, patchability_score=0.0, module_deltas={'alpha': {'roi_delta':0.2}, 'beta': {'roi_delta': -0.2}})

cur = db.conn.cursor()
cur.execute("SELECT workflow_id, run_id, module_deltas FROM workflow_results WHERE run_id='r2'")
row = cur.fetchone()
print(row[0], row[1], json.loads(row[2])['alpha']['roi_delta'])

report = module_impact_report('wf','r2', db_path)
print(report['improved']['alpha'], report['regressed']['beta'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ad5223f1f0832ebfe56022096827a4