### PR TITLE
Add workflow benchmark CLI and ROI logging example

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@
 - Schema migrations managed through Alembic
 - Long-term metrics dashboards with Prometheus ([docs/metrics_dashboard.md](docs/metrics_dashboard.md))
 - Workflow benchmarking metrics exported to Prometheus with automatic early stopping when improvements level off. Additional gauges track CPU time, memory usage, network and disk I/O with statistical significance tests.
+- Lightweight CLI for ad-hoc workflow scoring that logs results to ``roi_results.db`` (see ``docs/workflow_benchmark.md``).
 - `metrics_exporter` tries to install `prometheus_client` during bootstrap and
   serves a fallback HTTP endpoint if the install fails
 - Centralised logging via Elasticsearch or Splunk and optional Sentry alerts ([docs/monitoring_pipeline.md](docs/monitoring_pipeline.md))

--- a/docs/examples/roi_results_logging.py
+++ b/docs/examples/roi_results_logging.py
@@ -1,0 +1,31 @@
+"""Example showing how to log workflow metrics to ``roi_results.db``.
+
+Run with ``python docs/examples/roi_results_logging.py``.
+"""
+
+from menace_sandbox.roi_results_db import ROIResultsDB
+
+if __name__ == "__main__":
+    db = ROIResultsDB("roi_results.db")
+    db.log_result(
+        workflow_id="wf_demo",
+        run_id="run_001",
+        runtime=0.5,
+        success_rate=1.0,
+        roi_gain=1.2,
+        workflow_synergy_score=0.9,
+        bottleneck_index=0.1,
+        patchability_score=0.05,
+        module_deltas={
+            "step_a": {
+                "runtime": 0.5,
+                "roi_delta": 1.2,
+                "success_rate": 1.0,
+                "bottleneck_contribution": 0.1,
+            }
+        },
+    )
+    rows = db.conn.execute(
+        "SELECT workflow_id, run_id, roi_gain FROM workflow_results"
+    ).fetchall()
+    print(rows)

--- a/docs/workflow_benchmark.md
+++ b/docs/workflow_benchmark.md
@@ -1,0 +1,29 @@
+# Workflow Benchmark CLI
+
+The `workflow_benchmark` module provides a light command line interface for
+scoring a single workflow and recording the results in local databases.
+
+## Basic usage
+
+```bash
+python workflow_benchmark.py my_module:my_workflow --workflow-id wf_demo --run-id test1
+```
+
+The first argument is a dotted path to a callable returning `True` on success.
+The CLI executes the function, computes performance metrics via
+`CompositeWorkflowScorer` and stores the aggregated ROI metrics in
+`roi_results.db`. The resulting JSON output includes the run identifier and
+aggregate metrics:
+
+```json
+{
+  "run_id": "test1",
+  "runtime": 0.01,
+  "success_rate": 1.0,
+  "roi_gain": 0.0,
+  ...
+}
+```
+
+Subsequent runs with different `--run-id` values are appended under the same
+`workflow_id`, allowing historical comparisons.


### PR DESCRIPTION
## Summary
- document workflow benchmark CLI
- add command line entry for workflow_benchmark
- add example for logging results to roi_results.db

## Testing
- `pre-commit run --files workflow_benchmark.py README.md docs/workflow_benchmark.md docs/examples/roi_results_logging.py`
- `pytest` *(fails: Missing system packages ffmpeg, tesseract, qemu-system-x86_64)*

------
https://chatgpt.com/codex/tasks/task_e_68ad539051a4832e9f2b4f22daa09c07