### PR TITLE
chore: guard sqlite access

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,9 @@
 Use `DBRouter` for all database access. Direct calls to `sqlite3.connect` are not
 permitted outside approved scaffolding scripts
 (`scripts/new_db.py`, `scripts/new_db_template.py`, `scripts/scaffold_db.py`, and
-`scripts/new_vector_module.py`).
+`scripts/new_vector_module.py`).  In the rare case a raw connection is required,
+include explicit audit logging and add the module to
+`tests/approved_sqlite3_usage.txt` with a justification.
 
 To avoid accidental direct connections, CI runs
 `tests/test_db_router_enforcement.py` and a pre-commit hook which executes


### PR DESCRIPTION
## Summary
- ensure sqlite connection hook shares allow list with enforcement test
- document requirement for audit logging when bypassing DBRouter

## Testing
- `pre-commit run --files scripts/check_sqlite_connections.py CONTRIBUTING.md`
- `pytest tests/test_db_router_enforcement.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad57b1d5e8832ea8b4545f56960dee