### PR TITLE
Refine workflow scoring with correlation and volatility metrics

### DIFF
--- a/composite_workflow_scorer.py
+++ b/composite_workflow_scorer.py
@@ -34,38 +34,71 @@ def compute_workflow_synergy(
     module_history: Mapping[str, Iterable[float]],
     window: int = 5,
 ) -> float:
-    """Ratio of summed per-module ROI gains to combined ROI gain."""
+    """Mean correlation between module ROI deltas and overall ROI.
 
-    combined = sum(list(roi_history)[-window:])
-    if combined == 0:
+    The score examines the ``window`` most recent ROI values along with the
+    corresponding per-module ROI deltas.  For each module a Pearson
+    correlation coefficient with the overall ROI history is computed and the
+    average of all valid correlations is returned.  Modules with insufficient
+    variance or history are ignored.  A value close to ``1.0`` indicates strong
+    positive alignment between modules and overall ROI while ``0.0`` denotes no
+    discernible relationship.
+    """
+
+    roi_list = list(roi_history)[-window:]
+    if len(roi_list) < 2 or not module_history:
         return 0.0
-    individual = 0.0
+    correlations: list[float] = []
     for deltas in module_history.values():
-        individual += sum(list(deltas)[-window:])
-    return individual / combined
+        mod_list = list(deltas)[-window:]
+        if len(mod_list) != len(roi_list):
+            continue
+        if np.std(mod_list) == 0 or np.std(roi_list) == 0:
+            continue
+        corr = float(np.corrcoef(roi_list, mod_list)[0, 1])
+        correlations.append(corr)
+    return float(np.mean(correlations)) if correlations else 0.0
 
 
 def compute_bottleneck_index(tracker: ROITracker, _workflow_id: str | None = None) -> float:
-    """Return max module runtime divided by total runtime."""
+    """Root mean square deviation of normalised module runtimes.
+
+    The metric first normalises module runtimes so they sum to one.  It then
+    computes the root mean square deviation from an ideal uniform distribution
+    where all modules consume equal runtime.  Higher values therefore indicate
+    a more pronounced bottleneck.
+    """
 
     runtimes: Mapping[str, float] = getattr(tracker, "timings", {})
+    if not runtimes:
+        return 0.0
     total = sum(runtimes.values())
     if total <= 0:
         return 0.0
-    return max(runtimes.values()) / total
+    norm = np.array(list(runtimes.values()), dtype=float) / total
+    uniform = 1.0 / len(norm)
+    return float(np.sqrt(np.mean((norm - uniform) ** 2)))
 
 
 def compute_patchability(history: Iterable[float], window: int = 5) -> float:
-    """Derivative of ROI trend adjusted by historical volatility."""
+    """ROI trend slope normalised by recent volatility.
 
-    hist_list = list(history)
+    A simple linear regression is fit to the last ``window`` ROI values to
+    obtain the improvement slope.  This slope is divided by the standard
+    deviation of the same window, yielding a volatility-adjusted indicator of
+    how patchable the workflow appears.  Higher values indicate a consistent
+    upward trend with low variance.
+    """
+
+    hist_list = list(history)[-window:]
     if len(hist_list) < 2:
         return 0.0
-    recent = hist_list[-window:]
-    x = np.arange(len(recent))
-    slope = float(np.polyfit(x, recent, 1)[0])
+    x = np.arange(len(hist_list))
+    slope = float(np.polyfit(x, hist_list, 1)[0])
     volatility = float(np.std(hist_list))
-    return slope / (1.0 + volatility)
+    if volatility == 0:
+        return 0.0
+    return slope / volatility
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- compute workflow synergy as average correlation between module ROI deltas and overall ROI
- measure bottlenecks via normalized runtime variance
- derive patchability from volatility-adjusted ROI slope and align roi_scorer tests

## Testing
- `pytest tests/test_roi_scorer_workflow.py`

------
https://chatgpt.com/codex/tasks/task_e_68ad580fd5cc832e880d2fe64c149052