### PR TITLE
Weight workflow synergy by historical co-performance

### DIFF
--- a/roi_scorer.py
+++ b/roi_scorer.py
@@ -4,16 +4,79 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, Mapping, Tuple
+from typing import Any, Callable, Dict, Mapping, Tuple, Iterable
 import sqlite3
 import uuid
 import statistics
 
+import numpy as np
+
 from .workflow_metrics import (
     compute_bottleneck_index,
     compute_patchability,
-    compute_workflow_synergy,
 )
+
+
+def compute_workflow_synergy(
+    roi_history: Iterable[float],
+    module_history: Mapping[str, Iterable[float]],
+    window: int = 5,
+    history_loader: Callable[[], Iterable[Dict[str, float]]] | None = None,
+) -> float:
+    """Weighted correlation between module ROI deltas and overall ROI.
+
+    Uses pairwise module synergy from ``synergy_history_db`` to weight
+    correlations.  ``history_loader`` may be provided to inject a custom
+    loader in tests.
+    """
+
+    roi_list = list(roi_history)[-window:]
+    if len(roi_list) < 2 or not module_history:
+        return 0.0
+
+    if history_loader is None:
+        try:
+            from .synergy_history_db import load_history as history_loader
+        except Exception:  # pragma: no cover - optional dependency
+            history_loader = lambda: []  # type: ignore
+
+    history = list(history_loader() or [])
+    pair_totals: Dict[tuple[str, str], float] = {}
+    pair_counts: Dict[tuple[str, str], int] = {}
+    for entry in history:
+        for key, val in entry.items():
+            key = key.replace(",", "|")
+            parts = [p.strip() for p in key.split("|") if p.strip()]
+            if len(parts) != 2:
+                continue
+            a, b = parts
+            pair_totals[(a, b)] = pair_totals.get((a, b), 0.0) + float(val)
+            pair_totals[(b, a)] = pair_totals.get((b, a), 0.0) + float(val)
+            pair_counts[(a, b)] = pair_counts.get((a, b), 0) + 1
+            pair_counts[(b, a)] = pair_counts.get((b, a), 0) + 1
+    pair_avg = {p: pair_totals[p] / pair_counts[p] for p in pair_totals}
+
+    correlations: list[float] = []
+    weights: list[float] = []
+    for mod, deltas in module_history.items():
+        mod_list = list(deltas)[-window:]
+        if len(mod_list) != len(roi_list):
+            continue
+        if np.std(mod_list) == 0 or np.std(roi_list) == 0:
+            continue
+        corr = float(np.corrcoef(roi_list, mod_list)[0, 1])
+        if pair_avg:
+            w_vals = [pair_avg.get((mod, other), 0.0) for other in module_history if other != mod]
+            w_pos = [v for v in w_vals if v > 0]
+            if not w_pos:
+                continue
+            weight = float(np.mean(w_pos))
+        else:
+            weight = 1.0
+        correlations.append(corr)
+        weights.append(weight)
+
+    return float(np.average(correlations, weights=weights)) if correlations else 0.0
 
 from db_router import DBRouter, GLOBAL_ROUTER, LOCAL_TABLES, init_db_router
 from .roi_tracker import ROITracker

--- a/tests/test_roi_scorer_workflow.py
+++ b/tests/test_roi_scorer_workflow.py
@@ -27,8 +27,17 @@ from menace_sandbox.roi_results_db import ROIResultsDB
 
 def test_compute_metric_helpers():
     roi_hist = [1.0, 2.0, 3.0]
-    module_hist = {"a": [0.5, 1.0, 1.5], "b": [0.5, 1.0, 1.5]}
-    assert compute_workflow_synergy(roi_hist, module_hist, window=3) == pytest.approx(1.0)
+    module_hist = {
+        "a": [1.0, 2.0, 3.0],
+        "b": [1.0, 2.0, 3.0],
+        "c": [3.0, 2.0, 1.0],
+    }
+    baseline = compute_workflow_synergy(roi_hist, module_hist, window=3, history_loader=lambda: [])
+    assert baseline == pytest.approx((1.0 + 1.0 - 1.0) / 3.0)
+
+    loader = lambda: [{"a|b": 1.0}]
+    weighted = compute_workflow_synergy(roi_hist, module_hist, window=3, history_loader=loader)
+    assert weighted == pytest.approx(1.0)
 
     tracker = types.SimpleNamespace(timings={"a": 2.0, "b": 1.0})
     assert compute_bottleneck_index(tracker) == pytest.approx(1.0 / 6.0)


### PR DESCRIPTION
## Summary
- incorporate pairwise synergy history when computing workflow synergy in ROI scorers
- allow dependency injection of synergy history loader for tests
- add tests covering synergy weighting in workflow metrics

## Testing
- `pytest tests/test_roi_scorer_workflow.py tests/test_composite_workflow_scorer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad63a50df8832eb2986bcb7e7d749c