### PR TITLE
Refactor ROI scorer initialization

### DIFF
--- a/docs/composite_workflow_scorer.md
+++ b/docs/composite_workflow_scorer.md
@@ -2,6 +2,26 @@
 
 `CompositeWorkflowScorer` runs workflows under simulated environments and aggregates ROI metrics. It wraps `ROITracker` and persists results in `roi_results.db` via `ROIResultsDB`.
 
+## ROI profile configuration
+
+`CompositeWorkflowScorer` initialises an `ROICalculator` which expects ROI
+profiles in `configs/roi_profiles.yaml`. If this configuration file is missing
+or invalid, a `RuntimeError` is raised. Tests or lightweight setups can inject a
+minimal calculator by providing the `calculator_factory` parameter:
+
+```python
+from types import SimpleNamespace
+from menace_sandbox.composite_workflow_scorer import CompositeWorkflowScorer
+
+def stub_calculator():
+    return SimpleNamespace(
+        calculate=lambda metrics, _p: (sum(metrics.values()), False, []),
+        profiles={"default": {}},
+    )
+
+scorer = CompositeWorkflowScorer(calculator_factory=stub_calculator)
+```
+
 ## API overview
 
 ```python

--- a/tests/test_roi_scorer_workflow.py
+++ b/tests/test_roi_scorer_workflow.py
@@ -8,8 +8,15 @@ import pytest
 sys.modules.setdefault(
     "menace_sandbox.roi_tracker", types.SimpleNamespace(ROITracker=object)
 )
+class _StubCalc:
+    profiles = {"default": {}}
+
+    def calculate(self, metrics, _profile):
+        return float(sum(float(v) for v in metrics.values())), False, []
+
+
 sys.modules.setdefault(
-    "menace_sandbox.roi_calculator", types.SimpleNamespace(ROICalculator=object)
+    "menace_sandbox.roi_calculator", types.SimpleNamespace(ROICalculator=_StubCalc)
 )
 sys.modules.setdefault(
     "menace_sandbox.sandbox_runner", types.SimpleNamespace()
@@ -72,10 +79,11 @@ def test_composite_scorer_end_to_end(tmp_path, monkeypatch):
             return float(sum(metrics.values())), False, []
 
     tracker = StubTracker()
-    calc = StubCalc()
     db_path = tmp_path / "roi_results.db"
     results_db = ROIResultsDB(db_path)
-    scorer = CompositeWorkflowScorer(tracker=tracker, calculator=calc, results_db=results_db)
+    scorer = CompositeWorkflowScorer(
+        tracker=tracker, calculator_factory=StubCalc, results_db=results_db
+    )
 
     modules = {"mod_a": lambda: True, "mod_b": lambda: True}
 


### PR DESCRIPTION
## Summary
- raise an informative error when `ROICalculator` fails to initialise
- allow tests to provide a lightweight calculator via `calculator_factory`
- document required ROI profile configuration

## Testing
- `MENACE_LIGHT_IMPORTS=1 pytest tests/test_composite_workflow_scorer.py tests/test_composite_workflow_scorer_methods.py tests/test_roi_scorer_workflow.py` *(fails: `_StubResultsDB` missing attribute)*

------
https://chatgpt.com/codex/tasks/task_e_68ad690e7b70832eafb8dc07e74a1f84