### PR TITLE
Record module failure reasons in workflow scoring

### DIFF
--- a/tests/test_roi_results_db.py
+++ b/tests/test_roi_results_db.py
@@ -1,5 +1,27 @@
 import json
 import pytest
+import sqlite3
+import sys
+import types
+
+
+class _StubDBRouter:
+    def __init__(self, _name, local_path, _shared_path):
+        self.path = local_path
+
+    def get_connection(self, _name, operation: str | None = None):
+        return sqlite3.connect(self.path)
+
+
+sys.modules.setdefault(
+    "menace_sandbox.db_router",
+    types.SimpleNamespace(
+        init_db_router=lambda *a, **k: None,
+        DBRouter=_StubDBRouter,
+        LOCAL_TABLES=set(),
+    ),
+)
+sys.modules.setdefault("db_router", sys.modules["menace_sandbox.db_router"])
 
 from menace_sandbox.db_router import init_db_router
 from menace_sandbox.roi_results_db import ROIResultsDB, module_impact_report
@@ -25,6 +47,7 @@ def test_roi_results_db_add_and_report(tmp_path):
         bottleneck_index=0.0,
         patchability_score=0.0,
         module_deltas={"alpha": {"roi_delta": 0.1}, "beta": {"roi_delta": -0.1}},
+        failure_reason=None,
     )
     db.log_result(
         workflow_id="wf",
@@ -36,15 +59,17 @@ def test_roi_results_db_add_and_report(tmp_path):
         bottleneck_index=0.0,
         patchability_score=0.0,
         module_deltas={"alpha": {"roi_delta": 0.2}, "beta": {"roi_delta": -0.2}},
+        failure_reason="alpha: boom",
     )
 
     cur = db.conn.cursor()
-    cur.execute("SELECT workflow_id, run_id, module_deltas FROM workflow_results WHERE run_id='r2'")
-    wf, run, deltas_json = cur.fetchone()
+    cur.execute("SELECT workflow_id, run_id, module_deltas, failure_reason FROM workflow_results WHERE run_id='r2'")
+    wf, run, deltas_json, failure_reason = cur.fetchone()
     assert wf == "wf"
     assert run == "r2"
     deltas = json.loads(deltas_json)
     assert deltas["alpha"]["roi_delta"] == pytest.approx(0.2)
+    assert failure_reason == "alpha: boom"
 
     report = module_impact_report("wf", "r2", db_path)
     assert report["improved"] == {"alpha": pytest.approx(0.1)}


### PR DESCRIPTION
## Summary
- Log exceptions during module execution and track failure reasons in per-module metrics
- Persist aggregated failure reasons via new nullable `failure_reason` column in ROI results DB
- Test coverage for failure logging and persistence

## Testing
- `PYTHONPATH=.. pytest tests/test_composite_workflow_scorer_methods.py::test_score_workflow_logs_failure_reason -q`
- `PYTHONPATH=.. pytest tests/test_roi_results_db.py::test_roi_results_db_add_and_report -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad6ac01558832e9da17b6fffef5b32