### PR TITLE
Add workflow trend retrieval and rolling metrics

### DIFF
--- a/docs/composite_workflow_scorer.md
+++ b/docs/composite_workflow_scorer.md
@@ -89,3 +89,22 @@ PY
 ```
 
 This snippet runs the workflow, stores metrics in `roi_results.db`, and prints a module impact report for the most recent run.
+
+## Trend analysis
+
+Repeated evaluations of the same workflow can be visualised by querying the
+stored trend metrics:
+
+```python
+from menace_sandbox.roi_results_db import ROIResultsDB, compute_rolling_metrics
+
+db = ROIResultsDB("roi_results.db")
+trends = db.fetch_trends("wf_example")
+enriched = compute_rolling_metrics(trends, window=3)
+for point in enriched:
+    print(point["timestamp"], point["roi_gain"], point["roi_gain_avg"], point["roi_gain_slope"])
+```
+
+`fetch_trends` returns the raw ROI gain, synergy, bottleneck and patchability
+metrics ordered by evaluation time. `compute_rolling_metrics` augments the data
+with rolling averages and slope values suitable for plotting.


### PR DESCRIPTION
## Summary
- expose workflow trend metrics via `ROIResultsDB.fetch_trends`
- add rolling average/slope helper for visualising trends
- document trend analysis and add tests for trend retrieval

## Testing
- `pytest tests/test_composite_workflow_scorer.py::test_composite_workflow_scorer_records_metrics tests/test_composite_workflow_scorer.py::test_fetch_trends_returns_time_ordered_metrics -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad7184cad0832e99a2037d2e7861a0