### PR TITLE
Handle missing ROI profiles in composite scorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@
 - Self-provisioning of missing packages through `SystemProvisioner`
 - Distributed rollback verification via `RollbackValidator`
 - ROI-driven autoscaling with `ROIScalingPolicy`
-- Profile-based ROI evaluation via `ROICalculator` using YAML-configured weights and veto rules
+- Profile-based ROI evaluation via `ROICalculator` using YAML-configured weights and veto rules. A valid ROI profile file (such as `configs/roi_profiles.yaml`) must be available; otherwise calculator initialisation fails.
 - ROI history forecasting via `ROITracker` ([docs/roi_tracker.md](docs/roi_tracker.md))
  - `calculate_raroi` derives a risk-adjusted ROI (RAROI) by applying
    catastrophic risk, recent stability and safety multipliers. Impact

--- a/composite_workflow_scorer.py
+++ b/composite_workflow_scorer.py
@@ -57,11 +57,15 @@ class ROIScorer(BaseROIScorer):
         calculator_factory: Callable[[], ROICalculator] | None = None,
         profile_type: str | None = None,
     ) -> None:
-        super().__init__(
-            tracker=tracker,
-            calculator_factory=calculator_factory,
-            profile_type=profile_type,
-        )
+        try:
+            super().__init__(
+                tracker=tracker,
+                calculator_factory=calculator_factory,
+                profile_type=profile_type,
+            )
+        except Exception as exc:  # pragma: no cover - configuration errors
+            logging.critical("Failed to initialise ROICalculator: %s", exc)
+            raise
 
 
 class CompositeWorkflowScorer(ROIScorer):


### PR DESCRIPTION
## Summary
- log and propagate ROICalculator init failures in `ROIScorer`
- document required ROI profile configuration
- update tests to supply minimal ROI profile config instead of stubs

## Testing
- `pre-commit run --files tests/test_composite_workflow_scorer_methods.py tests/test_roi_scorer_workflow.py composite_workflow_scorer.py README.md`
- `pytest tests/test_roi_scorer_workflow.py tests/test_composite_workflow_scorer_methods.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad77257194832eba57f00560b898a8