### PR TITLE
Add module success rate tracking to ROI results

### DIFF
--- a/tests/test_composite_workflow_scorer.py
+++ b/tests/test_composite_workflow_scorer.py
@@ -51,9 +51,9 @@ class _StubPatchDB:
 sys.modules.setdefault(
     "menace_sandbox.code_database", types.SimpleNamespace(PatchHistoryDB=_StubPatchDB)
 )
-sys.modules.setdefault(
-    "menace_sandbox.sandbox_runner", types.SimpleNamespace(environment=types.SimpleNamespace())
-)
+sys.modules[
+    "menace_sandbox.sandbox_runner"
+] = types.SimpleNamespace(environment=types.SimpleNamespace())
 
 
 FIXTURES = Path(__file__).parent / "fixtures" / "workflow_modules"
@@ -171,13 +171,18 @@ def test_composite_workflow_scorer_records_metrics(tmp_path, monkeypatch):
     assert run_id  # run identifier was generated
     deltas = json.loads(deltas_json)
     assert deltas["mod_a"]["roi_delta"] == pytest.approx(1.0)
+    assert deltas["mod_a"]["success_rate"] == pytest.approx(1.0)
     assert deltas["mod_b"]["roi_delta"] == pytest.approx(2.0)
+    assert deltas["mod_b"]["success_rate"] == pytest.approx(0.0)
     assert deltas["mod_c"]["roi_delta"] == pytest.approx(-0.5)
+    assert deltas["mod_c"]["success_rate"] == pytest.approx(1.0)
 
     # Regression coverage for module attribution utilities.
     report = scorer.results_db.module_impact_report(workflow_id, run_id)
-    assert report["improved"]["mod_a"] == pytest.approx(1.0)
-    assert report["regressed"]["mod_c"] == pytest.approx(-0.5)
+    assert report["improved"]["mod_a"]["roi_delta"] == pytest.approx(1.0)
+    assert report["improved"]["mod_a"]["success_rate"] == pytest.approx(1.0)
+    assert report["regressed"]["mod_c"]["roi_delta"] == pytest.approx(-0.5)
+    assert report["regressed"]["mod_c"]["success_rate"] == pytest.approx(1.0)
 
     # Module attribution records were stored and exposed
     attrib = scorer.results_db.fetch_module_attribution()

--- a/tests/test_composite_workflow_scorer_methods.py
+++ b/tests/test_composite_workflow_scorer_methods.py
@@ -138,6 +138,8 @@ def test_run_records_metrics_and_ids(monkeypatch, tmp_path):
     assert kwargs["workflow_id"] == wf_id
     assert kwargs["run_id"] == run_id
     assert set(kwargs["module_deltas"].keys()) == {"mod1", "mod2"}
+    assert kwargs["module_deltas"]["mod1"]["success_rate"] == pytest.approx(1.0)
+    assert kwargs["module_deltas"]["mod2"]["success_rate"] == pytest.approx(0.0)
     assert result.roi_gain == pytest.approx(3.0)
     assert results_db.log_module_attribution.call_count == 2
     expected_patch = (1.0 / np.std([1.0, 2.0])) * 0.25
@@ -187,6 +189,8 @@ def test_score_workflow_persists_results_and_ids(tmp_path):
     assert kwargs["workflow_id"] == "wf2"
     assert kwargs["run_id"] == "rid123"
     assert set(kwargs["module_deltas"].keys()) == {"mod_a", "mod_b"}
+    assert kwargs["module_deltas"]["mod_a"]["success_rate"] == pytest.approx(1.0)
+    assert kwargs["module_deltas"]["mod_b"]["success_rate"] == pytest.approx(0.0)
     assert tracker.roi_history  # tracker.update was invoked
 
 
@@ -300,4 +304,6 @@ def test_evaluate_logs_run_and_workflow(monkeypatch, tmp_path):
     assert kwargs["workflow_id"] == "wf3"
     assert kwargs["run_id"]
     assert set(kwargs["module_deltas"].keys()) == {"m1", "m2"}
+    assert kwargs["module_deltas"]["m1"]["success_rate"] == pytest.approx(1.0)
+    assert kwargs["module_deltas"]["m2"]["success_rate"] == pytest.approx(0.0)
     assert result.success_rate == pytest.approx(0.5)

--- a/tests/test_module_impact_report.py
+++ b/tests/test_module_impact_report.py
@@ -21,7 +21,10 @@ def test_module_impact_report(tmp_path):
         workflow_synergy_score=0.0,
         bottleneck_index=0.0,
         patchability_score=0.0,
-        module_deltas={"alpha": {"roi_delta": 0.1}, "beta": {"roi_delta": -0.1}},
+        module_deltas={
+            "alpha": {"roi_delta": 0.1, "success_rate": 0.5},
+            "beta": {"roi_delta": -0.1, "success_rate": 1.0},
+        },
     )
     db.log_result(
         workflow_id="wf",
@@ -32,10 +35,19 @@ def test_module_impact_report(tmp_path):
         workflow_synergy_score=0.0,
         bottleneck_index=0.0,
         patchability_score=0.0,
-        module_deltas={"alpha": {"roi_delta": 0.2}, "beta": {"roi_delta": -0.2}},
+        module_deltas={
+            "alpha": {"roi_delta": 0.2, "success_rate": 0.25},
+            "beta": {"roi_delta": -0.2, "success_rate": 0.5},
+        },
     )
 
     report = module_impact_report("wf", "r2", db_path)
-    assert report["improved"] == {"alpha": 0.1}
-    assert report["regressed"] == {"beta": -0.1}
+    assert report["improved"]["alpha"] == {
+        "roi_delta": 0.1,
+        "success_rate": 0.25,
+    }
+    assert report["regressed"]["beta"] == {
+        "roi_delta": -0.1,
+        "success_rate": 0.5,
+    }
 

--- a/tests/test_roi_results_db.py
+++ b/tests/test_roi_results_db.py
@@ -46,7 +46,10 @@ def test_roi_results_db_add_and_report(tmp_path):
         workflow_synergy_score=0.0,
         bottleneck_index=0.0,
         patchability_score=0.0,
-        module_deltas={"alpha": {"roi_delta": 0.1}, "beta": {"roi_delta": -0.1}},
+        module_deltas={
+            "alpha": {"roi_delta": 0.1, "success_rate": 0.5},
+            "beta": {"roi_delta": -0.1, "success_rate": 1.0},
+        },
         failure_reason=None,
     )
     db.log_result(
@@ -58,7 +61,10 @@ def test_roi_results_db_add_and_report(tmp_path):
         workflow_synergy_score=0.0,
         bottleneck_index=0.0,
         patchability_score=0.0,
-        module_deltas={"alpha": {"roi_delta": 0.2}, "beta": {"roi_delta": -0.2}},
+        module_deltas={
+            "alpha": {"roi_delta": 0.2, "success_rate": 0.25},
+            "beta": {"roi_delta": -0.2, "success_rate": 0.5},
+        },
         failure_reason="alpha: boom",
     )
 
@@ -69,9 +75,12 @@ def test_roi_results_db_add_and_report(tmp_path):
     assert run == "r2"
     deltas = json.loads(deltas_json)
     assert deltas["alpha"]["roi_delta"] == pytest.approx(0.2)
+    assert deltas["alpha"]["success_rate"] == pytest.approx(0.25)
     assert failure_reason == "alpha: boom"
 
     report = module_impact_report("wf", "r2", db_path)
-    assert report["improved"] == {"alpha": pytest.approx(0.1)}
-    assert report["regressed"] == {"beta": pytest.approx(-0.1)}
+    assert report["improved"]["alpha"]["roi_delta"] == pytest.approx(0.1)
+    assert report["improved"]["alpha"]["success_rate"] == pytest.approx(0.25)
+    assert report["regressed"]["beta"]["roi_delta"] == pytest.approx(-0.1)
+    assert report["regressed"]["beta"]["success_rate"] == pytest.approx(0.5)
 

--- a/tests/test_roi_scorer_workflow.py
+++ b/tests/test_roi_scorer_workflow.py
@@ -130,7 +130,9 @@ def test_composite_scorer_end_to_end(tmp_path, monkeypatch):
     row = results[0]
     assert row.workflow_id == "wf1" and row.run_id == run_id
     assert row.module_deltas["mod_a"]["roi_delta"] == pytest.approx(0.1875)
+    assert row.module_deltas["mod_a"]["success_rate"] == pytest.approx(1.0)
     assert row.module_deltas["mod_b"]["roi_delta"] == pytest.approx(0.25)
+    assert row.module_deltas["mod_b"]["success_rate"] == pytest.approx(1.0)
 
     attrib = results_db.fetch_module_attribution()
     assert attrib["mod_a"]["roi_delta"] == pytest.approx(0.1875)

--- a/tests/test_sample_workflow_scoring.py
+++ b/tests/test_sample_workflow_scoring.py
@@ -26,6 +26,9 @@ def test_sample_workflow_scoring(tmp_path):
                 for m in modules:
                     self.module_deltas.setdefault(m, []).append(delta)
 
+        def cache_correlations(self, pairs):
+            pass
+
     sys.modules.setdefault(
         "menace_sandbox.roi_tracker", types.SimpleNamespace(ROITracker=StubTracker)
     )
@@ -65,9 +68,10 @@ def test_sample_workflow_scoring(tmp_path):
     assert cur.fetchone() == (workflow_id, run_id)
 
     cur.execute(
-        "SELECT module FROM workflow_module_deltas WHERE workflow_id=? AND run_id=?",
+        "SELECT module, success_rate FROM workflow_module_deltas WHERE workflow_id=? AND run_id=?",
         (workflow_id, run_id),
     )
-    modules = {row[0] for row in cur.fetchall()}
-    assert {"step1", "step2"}.issubset(modules)
+    sr_map = {m: sr for m, sr in cur.fetchall()}
+    assert sr_map["step1"] == pytest.approx(1.0)
+    assert sr_map["step2"] == pytest.approx(1.0)
 


### PR DESCRIPTION
## Summary
- track per-module success rates in ROI scoring tables
- surface success rates through results fetchers and impact reports
- test that module success rates are stored and retrieved

## Testing
- `pytest tests/test_composite_workflow_scorer.py`
- `pytest tests/test_roi_results_db.py tests/test_module_impact_report.py tests/test_roi_scorer_workflow.py tests/test_sample_workflow_scoring.py tests/test_workflow_module_deltas.py tests/test_composite_workflow_scorer_methods.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad7aae1c08832ebf8d53afcada22e2