### PR TITLE
Expose moving average and variance for module trajectories

### DIFF
--- a/tests/test_module_trajectory_stats.py
+++ b/tests/test_module_trajectory_stats.py
@@ -1,0 +1,47 @@
+import os
+from statistics import fmean, pvariance
+
+import pytest
+
+os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
+
+from menace_sandbox.roi_results_db import (  # noqa: E402
+    ROIResultsDB,
+    module_performance_trajectories,
+    module_volatility,
+)
+
+
+def test_module_trajectories_expose_moving_stats(tmp_path):
+    db_path = tmp_path / "roi.db"
+    db = ROIResultsDB(db_path)
+
+    deltas = [0.2, 0.4, -0.1]
+    for i, delta in enumerate(deltas, 1):
+        db.log_result(
+            workflow_id="wf",
+            run_id=f"r{i}",
+            runtime=0.0,
+            success_rate=1.0,
+            roi_gain=0.0,
+            workflow_synergy_score=0.0,
+            bottleneck_index=0.0,
+            patchability_score=0.0,
+            module_deltas={"alpha": {"roi_delta": delta, "success_rate": 1.0}},
+        )
+
+    trajectories = module_performance_trajectories("wf", "alpha", db_path)["alpha"]
+
+    expected_ma = []
+    expected_var = []
+    for i in range(len(deltas)):
+        subset = deltas[: i + 1]
+        expected_ma.append(fmean(subset))
+        expected_var.append(pvariance(subset) if len(subset) > 1 else 0.0)
+
+    assert [t["moving_avg"] for t in trajectories] == pytest.approx(expected_ma)
+    assert [t["variance"] for t in trajectories] == pytest.approx(expected_var)
+
+    latest = module_volatility("wf", "alpha", db_path)
+    assert latest["moving_avg"] == pytest.approx(expected_ma[-1])
+    assert latest["variance"] == pytest.approx(expected_var[-1])


### PR DESCRIPTION
## Summary
- document that `fetch_module_trajectories` returns stored moving averages and variance from `roi_delta_ma` and `roi_delta_var`
- ensure module trajectory queries and volatility lookup use stored statistics reliably
- add test covering retrieval of per-module moving averages and variance

## Testing
- `pre-commit run --files roi_results_db.py tests/test_module_trajectory_stats.py`
- `pytest tests/test_module_trajectory_stats.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad952cb2a4832eb0636c7f1d967376