### PR TITLE
Integrate workflow evolution into self-improvement engine

### DIFF
--- a/workflow_evolution_manager.py
+++ b/workflow_evolution_manager.py
@@ -185,4 +185,34 @@ def evolve(
     return workflow_callable
 
 
-__all__ = ["evolve", "is_stable"]
+class WorkflowEvolutionManager:
+    """Lightweight wrapper exposing workflow evolution helpers.
+
+    This class allows embedding the evolution utilities as a dependency
+    without relying on module level functions.  It simply delegates to the
+    functional implementations defined in this module.
+    """
+
+    @staticmethod
+    def build_callable(sequence: str) -> Callable[[], bool]:
+        """Return a callable constructed from *sequence* steps."""
+
+        return _build_callable(sequence)
+
+    def evolve(
+        self,
+        workflow_callable: Callable[[], bool],
+        workflow_id: int | str,
+        variants: int = 5,
+    ) -> Callable[[], bool]:
+        """Proxy to :func:`evolve`."""
+
+        return evolve(workflow_callable, workflow_id, variants)
+
+    def is_stable(self, workflow_id: int | str) -> bool:
+        """Proxy to :func:`is_stable`."""
+
+        return is_stable(workflow_id)
+
+
+__all__ = ["evolve", "is_stable", "WorkflowEvolutionManager"]


### PR DESCRIPTION
## Summary
- add a lightweight `WorkflowEvolutionManager` wrapper and expose it for use
- integrate workflow evolution into `SelfImprovementEngine` run cycle and registry
- extend registry to return workflow evolution data

## Testing
- `pytest tests/test_workflow_evolution_manager.py::test_stability_gate -q`
- `pytest tests/test_improvement_engine_registry.py::test_registry_runs_multiple -q` *(fails: ImportError: cannot import name 'get_recent_messages' from 'neurosales')*

------
https://chatgpt.com/codex/tasks/task_e_68ada8852970832eaf8b3c6bf6c2cc36