### PR TITLE
Record synergy metrics in workflow evolution logs

### DIFF
--- a/mutation_logger.py
+++ b/mutation_logger.py
@@ -97,10 +97,13 @@ def log_workflow_evolution(
     variant_roi: float,
     *,
     mutation_id: int | None = None,
+    baseline_synergy: float = 0.0,
+    variant_synergy: float = 0.0,
 ) -> int:
     """Record evaluation of a workflow variant and return the mutation id."""
 
     roi_delta = variant_roi - baseline_roi
+    synergy_delta = variant_synergy - baseline_synergy
     if mutation_id is None:
         mutation_id = log_mutation(
             change=variant,
@@ -119,6 +122,9 @@ def log_workflow_evolution(
             variant_roi=variant_roi,
             roi_delta=roi_delta,
             mutation_id=mutation_id,
+            baseline_synergy=baseline_synergy,
+            variant_synergy=variant_synergy,
+            synergy_delta=synergy_delta,
         )
     return mutation_id
 

--- a/workflow_evolution_manager.py
+++ b/workflow_evolution_manager.py
@@ -119,6 +119,7 @@ def evolve(
     baseline_scorer = CompositeWorkflowScorer(results_db=results_db)
     baseline_result = baseline_scorer.run(workflow_callable, wf_id_str, run_id="baseline")
     baseline_roi = baseline_result.roi_gain
+    baseline_synergy = getattr(baseline_result, "workflow_synergy_score", 0.0)
 
     bot = WorkflowEvolutionBot()
 
@@ -133,6 +134,7 @@ def evolve(
         scorer = CompositeWorkflowScorer(results_db=results_db)
         variant_result = scorer.run(variant_callable, wf_id_str, run_id=run_id)
         roi_delta = variant_result.roi_gain - baseline_roi
+        variant_synergy = getattr(variant_result, "workflow_synergy_score", 0.0)
 
         # Persist ROI delta with variant identifier
         results_db.log_module_delta(
@@ -151,6 +153,10 @@ def evolve(
                 variant=seq,
                 baseline_roi=baseline_roi,
                 variant_roi=variant_result.roi_gain,
+                baseline_synergy=baseline_synergy,
+                variant_synergy=getattr(
+                    variant_result, "workflow_synergy_score", 0.0
+                ),
                 mutation_id=bot._rearranged_events.get(seq),
             )
         else:


### PR DESCRIPTION
## Summary
- Track baseline and variant synergy scores when benchmarking workflow variants
- Persist synergy metrics alongside ROI in EvolutionHistoryDB via MutationLogger
- Capture baseline synergy in WorkflowEvolutionManager and forward to logging

## Testing
- `pytest tests/test_workflow_evolution.py tests/test_workflow_evolution_layer.py tests/test_workflow_evolution_manager.py tests/test_evolution_history_lineage.py tests/test_mutation_logger_lineage.py tests/test_mutation_logger_event_bus.py` *(failed: AssertionError in test_mutation_logger_lineage)*
- `pytest tests/test_workflow_evolution.py tests/test_workflow_evolution_layer.py tests/test_workflow_evolution_manager.py tests/test_evolution_history_lineage.py tests/test_mutation_logger_lineage.py tests/test_mutation_logger_event_bus.py tests/test_mutation_logger_dashboard_events.py` *(failed: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68adbc720458832eae1bf9bbb359594f