### PR TITLE
gate workflow evolution by diminishing threshold

### DIFF
--- a/unit_tests/test_evolve_workflows.py
+++ b/unit_tests/test_evolve_workflows.py
@@ -51,6 +51,9 @@ def test_evolve_workflows_benchmarks_variants():
         def record_scenario_delta(self, name, delta, **kw):
             recorded[name] = delta
 
+        def diminishing(self):
+            return 0.0
+
     inserted: dict[str, float] = {}
 
     class shd:
@@ -102,6 +105,7 @@ def test_evolve_workflows_benchmarks_variants():
         pathway_db=None,
         roi_tracker=ROITracker(),
         logger=SimpleNamespace(exception=lambda *a, **k: None),
+        meta_logger=None,
     )
     results = evolve(self_obj)
     assert results[1]["baseline"] == 1.0
@@ -112,3 +116,97 @@ def test_evolve_workflows_benchmarks_variants():
     assert recorded[run_id] == 1.0
     assert inserted[run_id] == 1.0
     assert logged[("1", run_id, "workflow")] == 1.0
+
+
+def test_evolve_workflows_skips_flagged_workflow():
+    class WorkflowDB:
+        def __init__(self, *a, **k):
+            pass
+
+        def fetch_workflows(self, limit=10):
+            return [{"workflow": ["a", "b"], "id": 1}]
+
+    class WorkflowGraph:
+        def __init__(self, *a, **k):
+            self.graph = {"nodes": {}}
+
+    class WorkflowEvolutionBot:
+        def __init__(self, *a, **k):
+            pass
+
+        def generate_variants(self, workflow_id):
+            yield "b-a"
+
+    class CompositeWorkflowScorer:
+        def __init__(self, *a, **k):
+            self.results_db = k.get("results_db")
+
+        def run(self, fn, wf_id, run_id):
+            roi = 1.0 if run_id == "baseline" else 2.0
+            return SimpleNamespace(roi_gain=roi, runtime=0.0, success_rate=1.0)
+
+    class ROIResultsDB:
+        def __init__(self, *a, **k):
+            pass
+
+        def log_result(self, *a, **k):
+            pass
+
+        def log_module_delta(self, *a, **k):
+            pass
+
+    class ROITracker:
+        def record_scenario_delta(self, name, delta, **kw):
+            pass
+
+        def diminishing(self):
+            return 0.0
+
+    class MetaLogger:
+        def __init__(self):
+            self.module_deltas = {"workflow:1": [0.0, 0.0, 0.0]}
+            self.flagged_sections = set()
+
+        def diminishing(self, threshold, consecutive=3, entropy_threshold=None):
+            return ["workflow:1"]
+
+    ns = {
+        "WorkflowDB": WorkflowDB,
+        "WorkflowRecord": object,
+        "WorkflowGraph": WorkflowGraph,
+        "WorkflowEvolutionBot": WorkflowEvolutionBot,
+        "CompositeWorkflowScorer": CompositeWorkflowScorer,
+        "ROIResultsDB": ROIResultsDB,
+        "ROITracker": ROITracker,
+        "shd": SimpleNamespace(connect=lambda: SimpleNamespace(close=lambda: None), insert_entry=lambda *a, **k: None),
+        "EvaluationResult": SimpleNamespace,
+        "log_record": lambda **k: k,
+        "Path": Path,
+        "os": os,
+    }
+
+    src = Path("self_improvement_engine.py").read_text()
+    tree = ast.parse(src)
+    class_node = next(
+        n
+        for n in tree.body
+        if isinstance(n, ast.ClassDef) and n.name == "SelfImprovementEngine"
+    )
+    method_node = next(
+        m
+        for m in class_node.body
+        if isinstance(m, ast.FunctionDef) and m.name == "_evolve_workflows"
+    )
+    module = ast.Module([method_node], type_ignores=[])
+    exec(compile(module, "<ast>", "exec"), ns)
+    evolve = ns["_evolve_workflows"]
+
+    self_obj = SimpleNamespace(
+        workflow_evolver=SimpleNamespace(build_callable=lambda seq: lambda: True),
+        pathway_db=None,
+        roi_tracker=ROITracker(),
+        logger=SimpleNamespace(exception=lambda *a, **k: None),
+        meta_logger=MetaLogger(),
+    )
+    results = evolve(self_obj)
+    assert results == {}


### PR DESCRIPTION
## Summary
- compute workflow-level diminishing threshold using ROITracker and meta_logger
- skip evolution for workflows whose ROI delta falls below diminishing threshold
- test workflow evolution gating behaviour

## Testing
- `pytest unit_tests/test_evolve_workflows.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae3faece58832ea8b4a2a6de41ae51