### PR TITLE
Integrate workflow evolution into run cycle

### DIFF
--- a/self_improvement_engine.py
+++ b/self_improvement_engine.py
@@ -6426,6 +6426,13 @@ class SelfImprovementEngine:
                             "workflow evolution failed",
                             extra=log_record(workflow_id=wf_id),
                         )
+                try:
+                    evo_results = self._evolve_workflows()
+                    for wf_id, summary in evo_results.items():
+                        detail = {"workflow_id": wf_id, **summary}
+                        workflow_evolution_details.append(detail)
+                except Exception:
+                    self.logger.exception("workflow evolution layer failed")
             try:
                 flags = radar_scan()
                 if flags:


### PR DESCRIPTION
## Summary
- evolve workflows within `SelfImprovementEngine.run_cycle` after module-level improvements
- add regression test exercising workflow evolution hook

## Testing
- `pre-commit run --files self_improvement_engine.py tests/test_self_improvement_engine.py` *(fails: line length, undefined names)*
- `pytest unit_tests/test_evolve_workflows.py tests/test_workflow_evolution_layer.py` *(fails: ModuleNotFoundError for workflow evolution layer)*
- `pytest tests/test_self_improvement_engine.py::test_run_cycle_triggers_workflow_evolution` *(fails: ModuleNotFoundError for sandbox_runner.orphan_discovery)*
- `pytest tests/test_improvement_engine_registry.py` *(fails: missing system packages ffmpeg, tesseract, qemu-system-x86_64)*

------
https://chatgpt.com/codex/tasks/task_e_68ae41ce0e64832e9a91ebfd91a93c50