### PR TITLE
docs: clarify EMA gating for workflow evolution

### DIFF
--- a/docs/autonomous_sandbox.md
+++ b/docs/autonomous_sandbox.md
@@ -59,7 +59,20 @@ Tune the gating behaviour with the environment variables
 `ROI_GATING_THRESHOLD` and `ROI_GATING_CONSECUTIVE`. Evolution is skipped when
 the exponential moving average of ROI deltas fails to exceed these thresholds.
 
-Example:
+Example configuration:
+
+```bash
+export ROI_GATING_THRESHOLD=0.05
+export ROI_GATING_CONSECUTIVE=5
+```
+
+Once the gate fires the manager logs messages such as:
+
+```
+INFO workflow 42 stable (ema gating)
+```
+
+Example usage:
 
 ```python
 from menace_sandbox.self_improvement_engine import (

--- a/docs/workflow_evolution.md
+++ b/docs/workflow_evolution.md
@@ -22,7 +22,17 @@ Every variant is converted into a callable and scored by `CompositeWorkflowScore
 
 ## Diminishing-returns gating
 
-An exponential moving average of ROI deltas tracks improvement over time. When the EMA stays below `ROI_GATING_THRESHOLD` for `ROI_GATING_CONSECUTIVE` consecutive cycles, `is_stable()` returns `True` and further evolution is skipped.
+Workflow ROI improvements are tracked with an exponential moving average (EMA).
+Each workflow's EMA and consecutive failure count are persisted to
+`sandbox_data/workflow_roi_ema.json`, allowing the gate to survive process
+restarts. The EMA is updated with `0.3 * delta + 0.7 * previous_ema` on each
+cycle. When the EMA remains below `ROI_GATING_THRESHOLD` for
+`ROI_GATING_CONSECUTIVE` consecutive runs, `is_stable()` returns `True` and
+further evolution is skipped.
+
+The counter resets automatically whenever the EMA rises above the threshold or a
+variant is promoted. Remove `sandbox_data/workflow_roi_ema.json` or clear the
+workflow from `WorkflowStabilityDB` to reset the gate manually.
 
 Tune the gating behaviour with environment variables:
 


### PR DESCRIPTION
## Summary
- document EMA-based ROI gating persistence and reset behaviour
- show environment variables and log output when gating activates

## Testing
- `pytest tests/test_workflow_evolution_layer.py -q` *(fails: KeyboardInterrupt during heavy dependency import)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4b2e882c832e826f64faf6c6337b