### PR TITLE
feat: track ROI EMA for workflow stability gating

### DIFF
--- a/docs/workflow_evolution.md
+++ b/docs/workflow_evolution.md
@@ -23,16 +23,16 @@ Every variant is converted into a callable and scored by `CompositeWorkflowScore
 ## Diminishing-returns gating
 
 Workflow ROI improvements are tracked with an exponential moving average (EMA).
-Each workflow's EMA and consecutive failure count are persisted to
-`sandbox_data/workflow_roi_ema.json`, allowing the gate to survive process
-restarts. The EMA is updated with `0.3 * delta + 0.7 * previous_ema` on each
-cycle. When the EMA remains below `ROI_GATING_THRESHOLD` for
-`ROI_GATING_CONSECUTIVE` consecutive runs, `is_stable()` returns `True` and
-further evolution is skipped.
+Each workflow's EMA and consecutive failure count are stored alongside stability
+data in `WorkflowStabilityDB`, allowing the gate to survive process restarts.
+The EMA is updated with `alpha * delta + (1 - alpha) * previous_ema` where
+`alpha` defaults to ``SandboxSettings.roi_ema_alpha``. When the EMA remains
+below `ROI_GATING_THRESHOLD` for `ROI_GATING_CONSECUTIVE` consecutive runs,
+`is_stable()` returns `True` and further evolution is skipped.
 
 The counter resets automatically whenever the EMA rises above the threshold or a
-variant is promoted. Remove `sandbox_data/workflow_roi_ema.json` or clear the
-workflow from `WorkflowStabilityDB` to reset the gate manually.
+variant is promoted. Clear the workflow from `WorkflowStabilityDB` to reset the
+gate manually.
 
 Tune the gating behaviour with environment variables:
 

--- a/tests/test_workflow_evolution.py
+++ b/tests/test_workflow_evolution.py
@@ -83,24 +83,31 @@ def _load_manager(variant_seq="mod_a", variant_roi=1.5):
     tracker_mod.ROITracker = ROITracker
     sys.modules["menace_sandbox.roi_tracker"] = tracker_mod
 
+    settings_mod = ModuleType("menace_sandbox.sandbox_settings")
+    settings_mod.SandboxSettings = lambda *a, **k: SimpleNamespace(roi_ema_alpha=0.1)
+    sys.modules["menace_sandbox.sandbox_settings"] = settings_mod
+
     stab_mod = ModuleType("menace_sandbox.workflow_stability_db")
 
     class WorkflowStabilityDB:
         def __init__(self, *a, **k):
-            self.data: dict[str, float] = {}
+            self.data: dict[str, dict[str, float | int]] = {}
 
         def is_stable(self, wf, current_roi=None, threshold=None):
-            if wf not in self.data:
+            entry = self.data.get(wf)
+            if not entry:
                 return False
             if current_roi is not None and threshold is not None:
-                prev = self.data[wf]
+                prev = entry.get("roi", 0.0)
                 if abs(current_roi - prev) > threshold:
                     del self.data[wf]
                     return False
             return True
 
         def mark_stable(self, wf, roi):
-            self.data[wf] = roi
+            entry = self.data.get(wf, {})
+            entry["roi"] = roi
+            self.data[wf] = entry
 
         def clear(self, wf):
             self.data.pop(wf, None)
@@ -108,8 +115,24 @@ def _load_manager(variant_seq="mod_a", variant_roi=1.5):
         def clear_all(self):
             self.data.clear()
 
+        def get_ema(self, wf):
+            entry = self.data.get(wf, {})
+            return entry.get("ema", 0.0), entry.get("count", 0)
+
+        def set_ema(self, wf, ema, count):
+            entry = self.data.get(wf, {})
+            entry.update({"ema": ema, "count": count})
+            self.data[wf] = entry
+
     stab_mod.WorkflowStabilityDB = WorkflowStabilityDB
     sys.modules["menace_sandbox.workflow_stability_db"] = stab_mod
+
+    summary_mod = ModuleType("menace_sandbox.workflow_summary_db")
+    class WorkflowSummaryDB:
+        def set_summary(self, *a, **k):
+            pass
+    summary_mod.WorkflowSummaryDB = WorkflowSummaryDB
+    sys.modules["menace_sandbox.workflow_summary_db"] = summary_mod
 
     # Load the workflow_evolution_manager module under the package namespace
     spec = importlib.util.spec_from_file_location(

--- a/tests/test_workflow_evolution_manager.py
+++ b/tests/test_workflow_evolution_manager.py
@@ -39,6 +39,7 @@ _stub(
     log_workflow_evolution=lambda **kw: None,
 )
 _stub("workflow_summary_db", WorkflowSummaryDB=object)
+_stub("sandbox_settings", SandboxSettings=lambda: SimpleNamespace(roi_ema_alpha=0.1))
 
 import menace_sandbox.workflow_evolution_manager as wem
 
@@ -94,6 +95,7 @@ def _setup(monkeypatch, baseline_roi=1.0, variant_roi=2.0, variant="b-a"):
     monkeypatch.setattr(wem.STABLE_WORKFLOWS, "mark_stable", lambda *a, **k: None)
     monkeypatch.setattr(wem.STABLE_WORKFLOWS, "clear", lambda *a, **k: None)
     monkeypatch.setattr(wem.STABLE_WORKFLOWS, "is_stable", lambda *a, **k: False)
+    monkeypatch.setattr(wem, "_update_ema", lambda *a, **k: False)
 
     graph_called = {}
     class FakeGraph:


### PR DESCRIPTION
## Summary
- track workflow ROI improvement EMA and consecutive low gains in `WorkflowStabilityDB`
- gate workflow evolution when EMA stays below `ROI_GATING_THRESHOLD`
- document ROI gating behavior

## Testing
- `pytest tests/test_workflow_evolution_manager.py tests/test_workflow_variant_scenarios.py tests/test_workflow_evolution.py tests/test_workflow_evolution_behaviour.py tests/test_workflow_evolution_layer.py`

------
https://chatgpt.com/codex/tasks/task_e_68ae4be06fb0832e98671a65a65eaf60