### PR TITLE
docs: document EMA gating and workflow evolution refactor

### DIFF
--- a/docs/self_improvement_engine.md
+++ b/docs/self_improvement_engine.md
@@ -42,6 +42,11 @@ During a cycle the engine can refine workflow definitions through
 best‑performing variant is promoted when it beats the baseline, with outcomes
 logged through ``mutation_logger`` for later analysis.
 
+Calling ``run_all_cycles()`` on an :class:`ImprovementEngineRegistry` simply
+invokes each engine's ``run_cycle``, which now delegates to
+``WorkflowEvolutionManager.evolve`` after the refactor. No additional wiring is
+required to benefit from automatic workflow evolution and gating in batch runs.
+
 ## Algorithm Details
 
 `SelfImprovementEngine` orchestrates a short loop during each cycle:

--- a/docs/workflow_evolution.md
+++ b/docs/workflow_evolution.md
@@ -26,9 +26,10 @@ Workflow ROI improvements are tracked with an exponential moving average (EMA).
 Each workflow's EMA and consecutive failure count are stored alongside stability
 data in `WorkflowStabilityDB`, allowing the gate to survive process restarts.
 The EMA is updated with `alpha * delta + (1 - alpha) * previous_ema` where
-`alpha` defaults to ``SandboxSettings.roi_ema_alpha``. When the EMA remains
-below `ROI_GATING_THRESHOLD` for `ROI_GATING_CONSECUTIVE` consecutive runs,
-`is_stable()` returns `True` and further evolution is skipped.
+`alpha` defaults to ``SandboxSettings.roi_ema_alpha`` (configurable via
+`ROI_EMA_ALPHA`). When the EMA remains below `ROI_GATING_THRESHOLD` for
+`ROI_GATING_CONSECUTIVE` consecutive runs, `is_stable()` returns `True` and
+further evolution is skipped.
 
 The counter resets automatically whenever the EMA rises above the threshold or a
 variant is promoted. Clear the workflow from `WorkflowStabilityDB` to reset the
@@ -39,6 +40,8 @@ Tune the gating behaviour with environment variables:
 ```bash
 export ROI_GATING_THRESHOLD=0.05
 export ROI_GATING_CONSECUTIVE=5
+# Optional smoothing factor for the EMA
+export ROI_EMA_ALPHA=0.1
 ```
 
 ## Enabling in self-improvement cycles
@@ -54,4 +57,6 @@ registry.register_engine("alpha", engine)
 registry.run_all_cycles()
 ```
 
-This executes baseline runs, benchmarks generated variants and promotes the best-performing workflow.
+`run_all_cycles()` delegates to `WorkflowEvolutionManager.evolve()` after the
+refactor, so each cycle benchmarks variants, promotes improvements and marks
+stable workflows automatically.


### PR DESCRIPTION
## Summary
- describe exponential moving average gating with new ROI_EMA_ALPHA env var
- note that ImprovementEngineRegistry.run_all_cycles delegates to WorkflowEvolutionManager.evolve

## Testing
- `pytest tests/test_workflow_evolution_layer.py::test_gating_prevents_further_evolution -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae51b03560832e851dcafde35f17c2