### PR TITLE
Call orphan discovery after orchestrator and improver cycles

### DIFF
--- a/sandbox_runner/cycle.py
+++ b/sandbox_runner/cycle.py
@@ -712,12 +712,16 @@ def _sandbox_cycle_runner(
             ctx.orchestrator.run_cycle(ctx.models)
         except Exception as exc:
             record_error(exc)
+        # Include any newly discovered modules after orchestrator modifications
+        include_orphan_modules(ctx)
         logger.info("patch engine start", extra=log_record(cycle=idx))
         try:
             result = ctx.improver.run_cycle()
         except Exception as exc:
             record_error(exc)
             result = SimpleNamespace(roi=None)
+        # Include modules introduced during the improvement cycle
+        include_orphan_modules(ctx)
         warnings = getattr(result, "warnings", None)
         if warnings:
             logger.warning("improvement warnings", extra=log_record(warnings=warnings))


### PR DESCRIPTION
## Summary
- Rerun orphan discovery after orchestrator and improver phases to include newly created modules

## Testing
- `pytest tests/test_sandbox_cycle_auto_include_validation.py::test_cycle_validates_orphans -q` *(fails: ModuleNotFoundError: No module named 'sandbox_runner.cycle')*


------
https://chatgpt.com/codex/tasks/task_e_68ae58edcdd4832ea2a3d0bea344d897