### PR TITLE
Re-run orphan discovery after patch application

### DIFF
--- a/sandbox_runner/cycle.py
+++ b/sandbox_runner/cycle.py
@@ -824,6 +824,9 @@ def _sandbox_cycle_runner(
                 record_error(exc)
         except Exception as exc:
             record_error(exc)
+        # Re-run orphan discovery after patches have been applied so that any
+        # newly generated modules are considered in subsequent metrics.
+        include_orphan_modules(ctx)
         logger.info("patch application", extra=log_record(cycle=idx))
         roi = result.roi.roi if result.roi else 0.0
         logger.info(


### PR DESCRIPTION
## Summary
- Re-run orphan module discovery after applying patches in each sandbox cycle
- Ensure newly generated modules are included before ROI metrics are calculated

## Testing
- `MENACE_LIGHT_IMPORTS=1 pytest tests/test_recursive_module_auto_inclusion.py tests/test_orphan_rerun_on_change.py tests/test_sandbox_runner_metrics.py` *(failed: ModuleNotFoundError: No module named 'sandbox_runner.cycle')*


------
https://chatgpt.com/codex/tasks/task_e_68ae61903340832e913fa6386ed8e7d4