### PR TITLE
Ensure orphan modules discovered after patch completion

### DIFF
--- a/sandbox_runner/cycle.py
+++ b/sandbox_runner/cycle.py
@@ -816,6 +816,8 @@ def _sandbox_cycle_runner(
             "patch engine complete",
             extra=log_record(cycle=idx, roi=result.roi.roi if result.roi else 0.0),
         )
+        # Ensure modules introduced by patches are discovered before testing
+        include_orphan_modules(ctx)
         logger.info("tester run", extra=log_record(cycle=idx))
         try:
             ctx.tester.run_once()


### PR DESCRIPTION
## Summary
- Re-run orphan discovery after the patch engine completes so new dependencies are integrated before tests

## Testing
- ⚠️ `pytest tests/test_orphan_module_integration.py::test_include_orphan_modules_validates_and_integrates -q` (missing system packages: ffmpeg, tesseract, qemu-system-x86_64)
- ⚠️ `PYTHONPATH=. pytest tests/test_sandbox_cycle_redundant.py::test_cycle_skips_redundant_modules -q` (missing system packages: ffmpeg, tesseract, qemu-system-x86_64)


------
https://chatgpt.com/codex/tasks/task_e_68ae6be9bc90832eb95619ff609a9e11