### PR TITLE
Ensure orphan modules included after orchestration and improvement

### DIFF
--- a/sandbox_runner/cycle.py
+++ b/sandbox_runner/cycle.py
@@ -816,16 +816,18 @@ def _sandbox_cycle_runner(
             ctx.orchestrator.run_cycle(ctx.models)
         except Exception as exc:
             record_error(exc)
-        # Include any newly discovered modules after orchestrator modifications
-        include_orphan_modules(ctx)
+        finally:
+            # Include any newly discovered modules after orchestrator modifications
+            include_orphan_modules(ctx)
         logger.info("patch engine start", extra=log_record(cycle=idx))
         try:
             result = ctx.improver.run_cycle()
         except Exception as exc:
             record_error(exc)
             result = SimpleNamespace(roi=None)
-        # Include modules introduced during the improvement cycle
-        include_orphan_modules(ctx)
+        finally:
+            # Include modules introduced during the improvement cycle
+            include_orphan_modules(ctx)
         warnings = getattr(result, "warnings", None)
         if warnings:
             logger.warning("improvement warnings", extra=log_record(warnings=warnings))


### PR DESCRIPTION
## Summary
- Ensure newly generated modules are picked up after orchestrator runs
- Include modules created during patch cycles before proceeding

## Testing
- `pre-commit run --files sandbox_runner/cycle.py` *(fails: E402 module level import not at top of file, etc.)*
- `PYTHONPATH=. pytest tests/test_sandbox_cycle_auto_include_validation.py -k test_cycle_validates_orphans` *(fails: ModuleNotFoundError: No module named 'sandbox_runner.cycle')*

------
https://chatgpt.com/codex/tasks/task_e_68ae74a56410832eb2a98938f30b50b8