### PR TITLE
Invoke orphan integration after generating patches

### DIFF
--- a/error_logger.py
+++ b/error_logger.py
@@ -9,6 +9,7 @@ import traceback
 import json
 import hashlib
 import math
+from pathlib import Path
 try:
     import yaml
 except Exception:  # pragma: no cover - optional dependency
@@ -731,7 +732,18 @@ class ErrorLogger:
 
             if generate_patch is not None and module:
                 try:
-                    generate_patch(module)
+                    patch_id = generate_patch(module)
+                    if patch_id is not None:
+                        try:
+                            from sandbox_runner import integrate_new_orphans
+
+                            integrate_new_orphans(Path.cwd(), router=GLOBAL_ROUTER)
+                        except Exception as e2:  # pragma: no cover - integration issues
+                            self.logger.error(
+                                "integrate_new_orphans after patch for %s failed: %s",
+                                module,
+                                e2,
+                            )
                 except Exception as e:  # pragma: no cover - patch failures
                     self.logger.error(
                         "quick fix generation failed for %s: %s", module, e


### PR DESCRIPTION
## Summary
- call `integrate_new_orphans` after generating a quick-fix patch to fold in newly generated modules
- import `Path` and handle orphan integration errors gracefully

## Testing
- `pytest tests/test_error_logger_fix_suggestions.py`
- `python -m py_compile error_logger.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae90cc80e0832ea946a57497e34ed7