### PR TITLE
Run orphan discovery after patch application

### DIFF
--- a/self_improvement_engine.py
+++ b/self_improvement_engine.py
@@ -4988,6 +4988,17 @@ class SelfImprovementEngine:
                 )
             if self.use_adaptive_roi:
                 self._log_action("preventative_patch", mod, roi_est, category)
+            try:
+                self.logger.info(
+                    "post_patch_orphan_discovery",
+                    extra=log_record(module=mod),
+                )
+                self._include_recursive_orphans()
+            except Exception:
+                self.logger.exception(
+                    "post_patch_orphan_discovery_failed",
+                    extra=log_record(module=mod),
+                )
 
     def _apply_high_risk_patches(self) -> None:
         """Predict high-risk modules and attempt preemptive fixes."""
@@ -5111,6 +5122,17 @@ class SelfImprovementEngine:
                     )
                 if self.use_adaptive_roi:
                     self._log_action("high_risk_patch", mod, roi_est, category)
+                try:
+                    self.logger.info(
+                        "post_patch_orphan_discovery",
+                        extra=log_record(module=mod),
+                    )
+                    self._include_recursive_orphans()
+                except Exception:
+                    self.logger.exception(
+                        "post_patch_orphan_discovery_failed",
+                        extra=log_record(module=mod),
+                    )
         except Exception as exc:
             self.logger.exception(
                 "high risk module prediction failed: %s", exc


### PR DESCRIPTION
## Summary
- Invoke post-patch orphan discovery during preventative and high-risk patch loops
- Log orphan discovery runs so callers can trace integration events
- Ensure helper refreshes synergy graph and intent clusters for newly added modules

## Testing
- `pre-commit run --files self_improvement_engine.py` *(fails: undefined names and style issues in existing file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae950e8614832ebc1e58d779f8cba7