### PR TITLE
Use post-update helper to integrate new orphan modules

### DIFF
--- a/sandbox_runner/post_update.py
+++ b/sandbox_runner/post_update.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pathlib import Path
+from logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+def integrate_orphans(repo: Path, router=None) -> list[str]:
+    """Integrate newly created orphan modules.
+
+    Parameters
+    ----------
+    repo:
+        Root directory of the repository.
+    router:
+        Optional database router forwarded to helpers.
+
+    Returns
+    -------
+    list[str]
+        Repository-relative paths of modules added to the module map.
+    """
+
+    try:
+        from .orphan_discovery import discover_recursive_orphans
+    except Exception:  # pragma: no cover - best effort
+        logger.exception("discover_recursive_orphans import failed")
+        return []
+
+    try:
+        mapping = discover_recursive_orphans(str(repo))
+    except Exception:  # pragma: no cover - best effort
+        logger.exception("discover_recursive_orphans failed")
+        return []
+
+    if not mapping:
+        return []
+
+    try:
+        from .environment import auto_include_modules, try_integrate_into_workflows
+    except Exception:  # pragma: no cover - best effort
+        logger.exception("environment helpers import failed")
+        return []
+
+    paths = [
+        Path(name.replace(".", "/")).with_suffix(".py").as_posix()
+        for name in mapping
+    ]
+
+    added: list[str] = []
+    try:
+        _, tested = auto_include_modules(paths, recursive=True, router=router)
+        added = tested.get("added", [])
+    except Exception:  # pragma: no cover - best effort
+        logger.exception("auto include of discovered orphans failed")
+        return []
+
+    if not added:
+        return []
+
+    try:
+        from module_synergy_grapher import ModuleSynergyGrapher, load_graph
+
+        grapher = ModuleSynergyGrapher(root=repo)
+        graph_path = repo / "sandbox_data" / "module_synergy_graph.json"
+        if getattr(grapher, "graph", None) is None:
+            try:
+                if graph_path.exists():
+                    grapher.graph = load_graph(graph_path)
+                else:
+                    grapher.graph = grapher.build_graph(repo)
+            except Exception:  # pragma: no cover - best effort
+                grapher.graph = None
+        if getattr(grapher, "graph", None) is not None:
+            names = [Path(m).with_suffix("").as_posix() for m in added]
+            grapher.update_graph(names)
+    except Exception:  # pragma: no cover - best effort
+        logger.warning("module synergy update failed", exc_info=True)
+
+    try:
+        from intent_clusterer import IntentClusterer
+
+        clusterer = IntentClusterer()
+        clusterer.index_modules([repo / m for m in added])
+    except Exception:  # pragma: no cover - best effort
+        logger.warning("intent clustering update failed", exc_info=True)
+
+    try:
+        try_integrate_into_workflows(sorted(added), router=router)
+    except Exception:  # pragma: no cover - best effort
+        logger.warning("workflow integration failed", exc_info=True)
+
+    return added

--- a/self_improvement_engine.py
+++ b/self_improvement_engine.py
@@ -95,6 +95,7 @@ try:
 except Exception:  # pragma: no cover - fallback for flat layout
     import security_auditor  # type: ignore
 import sandbox_runner.environment as environment
+from sandbox_runner.post_update import integrate_orphans
 from .self_test_service import SelfTestService
 try:
     from . import self_test_service as sts
@@ -4774,7 +4775,7 @@ class SelfImprovementEngine:
 
         try:
             repo = Path(__file__).resolve().parent
-            environment.integrate_new_orphans(repo, router=GLOBAL_ROUTER)
+            integrate_orphans(repo, router=GLOBAL_ROUTER)
         except Exception:
             self.logger.exception("post_patch_orphan_integration_failed")
 

--- a/workflow_evolution_manager.py
+++ b/workflow_evolution_manager.py
@@ -313,17 +313,10 @@ def evolve(
 
         # Post-promotion orphan discovery and integration
         from db_router import GLOBAL_ROUTER
-        import sandbox_runner
+        from sandbox_runner.post_update import integrate_orphans
 
         repo = Path(os.getenv("SANDBOX_REPO_PATH", "."))
-        router = GLOBAL_ROUTER
-        integrate = getattr(
-            sandbox_runner, "integrate_new_orphans", lambda *_a, **_k: []
-        )
-        added_modules = integrate(repo, router=router)
-        try_integrate = getattr(sandbox_runner, "try_integrate_into_workflows", None)
-        if added_modules and callable(try_integrate):
-            try_integrate(added_modules)
+        integrate_orphans(repo, router=GLOBAL_ROUTER)
 
         return best_callable
 

--- a/workflow_synthesizer.py
+++ b/workflow_synthesizer.py
@@ -1330,17 +1330,10 @@ class WorkflowSynthesizer:
             path = out_dir / f"{name}_{idx}.workflow.json"
             path.write_text(to_json(wf, metadata=details), encoding="utf-8")
         from db_router import GLOBAL_ROUTER
-        import sandbox_runner
+        from sandbox_runner.post_update import integrate_orphans
 
         repo = Path(os.getenv("SANDBOX_REPO_PATH", ".")).resolve()
-        router = GLOBAL_ROUTER
-        integrate = getattr(
-            sandbox_runner, "integrate_new_orphans", lambda *_a, **_k: []
-        )
-        added_modules = integrate(repo, router=router)
-        try_integrate = getattr(sandbox_runner, "try_integrate_into_workflows", None)
-        if added_modules and callable(try_integrate):
-            try_integrate(added_modules)
+        integrate_orphans(repo, router=GLOBAL_ROUTER)
 
         return self.generated_workflows
 


### PR DESCRIPTION
## Summary
- Add `sandbox_runner.post_update.integrate_orphans` to discover and integrate new modules
- Call `integrate_orphans` after patches, workflow synthesis, workflow promotion, and sandbox cycle orphan checks

## Testing
- `pytest` *(fails: Interrupted: 254 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68aea5688bb4832ea801a84346ded6c0