### PR TITLE
Ensure orphan inclusion after each workflow evolution

### DIFF
--- a/self_improvement_engine.py
+++ b/self_improvement_engine.py
@@ -5320,7 +5320,10 @@ class SelfImprovementEngine:
         try:
             self._include_recursive_orphans()
         except Exception:
-            self.logger.exception("recursive orphan inclusion failed")
+            self.logger.exception(
+                "recursive orphan inclusion failed",
+                extra=log_record(workflow_id=wf_id),
+            )
         return status
 
     def _evolve_workflows(self, limit: int = 10) -> dict[int, dict[str, str]]:
@@ -5394,7 +5397,10 @@ class SelfImprovementEngine:
             try:
                 self._include_recursive_orphans()
             except Exception:
-                self.logger.exception("recursive orphan inclusion failed")
+                self.logger.exception(
+                    "recursive orphan inclusion failed",
+                    extra=log_record(workflow_id=wf_id),
+                )
 
         return results
 


### PR DESCRIPTION
## Summary
- log failures when including recursive orphans during variant evolution
- log failures when including recursive orphans for each evolved workflow

## Testing
- `python -m pytest tests/test_orphan_inclusion_after_synthesis.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aeb099f81c832e85dded2adc8e2a4b