### PR TITLE
Include recursive orphan processing after patch integration

### DIFF
--- a/self_improvement_engine.py
+++ b/self_improvement_engine.py
@@ -1652,6 +1652,13 @@ class SelfImprovementEngine:
                                         self.logger.exception(
                                             "post_patch_orphan_integration_failed"
                                         )
+                                    try:
+                                        self._include_recursive_orphans()
+                                    except Exception:
+                                        self.logger.exception(
+                                            "recursive orphan inclusion failed",
+                                            extra=log_record(module=name),
+                                        )
                                 except Exception:
                                     self.logger.exception(
                                         "alignment review failed for %s",
@@ -4916,6 +4923,13 @@ class SelfImprovementEngine:
                             self.logger.exception(
                                 "post_patch_orphan_integration_failed"
                             )
+                        try:
+                            self._include_recursive_orphans()
+                        except Exception:
+                            self.logger.exception(
+                                "recursive orphan inclusion failed",
+                                extra=log_record(module=mod),
+                            )
                 if self.error_bot and hasattr(self.error_bot, "db"):
                     try:
                         self.error_bot.db.add_telemetry(
@@ -5057,6 +5071,13 @@ class SelfImprovementEngine:
                             except Exception:
                                 self.logger.exception(
                                     "post_patch_orphan_integration_failed"
+                                )
+                            try:
+                                self._include_recursive_orphans()
+                            except Exception:
+                                self.logger.exception(
+                                    "recursive orphan inclusion failed",
+                                    extra=log_record(module=mod),
                                 )
                     if self.error_bot and hasattr(self.error_bot, "db"):
                         try:


### PR DESCRIPTION
## Summary
- call `_include_recursive_orphans` after patch integration scenarios and log failures

## Testing
- `pre-commit run --files self_improvement_engine.py` *(fails: F821 undefined name 'auto_include_modules', F841 local variable 'integrated' assigned to but never used, E501 line too long, etc.)*
- `pytest tests/test_recursive_orphan_workflow_integration.py` *(fails: ModuleNotFoundError: No module named 'sandbox_runner.orphan_discovery')*

------
https://chatgpt.com/codex/tasks/task_e_68aeb3b46610832e908b26321a5632e1