### PR TITLE
Refactor orphan integration into shared utility

### DIFF
--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -15,6 +15,8 @@ from logging_utils import get_logger
 from alert_dispatcher import dispatch_alert
 import re
 
+from .orphan_integration import integrate_and_graph_orphans
+
 try:
     import resource
 except Exception:  # pragma: no cover - not available on some platforms
@@ -7735,64 +7737,14 @@ def discover_and_integrate_orphans(
     """
 
     try:
-        from .orphan_discovery import discover_recursive_orphans
-    except Exception:
-        logger.exception("discover_recursive_orphans import failed")
+        _, tested, _, _, _ = integrate_and_graph_orphans(
+            repo, logger=logger, router=router
+        )
+    except Exception:  # pragma: no cover - best effort
+        logger.exception("discover_and_integrate_orphans failed")
         return []
 
-    try:
-        mapping = discover_recursive_orphans(str(repo))
-    except Exception:
-        logger.exception("discover_recursive_orphans failed")
-        return []
-
-    if not mapping:
-        return []
-
-    paths = [
-        Path(name.replace(".", "/")).with_suffix(".py").as_posix()
-        for name in mapping
-    ]
-
-    added: list[str] = []
-    try:
-        _, tested = auto_include_modules(paths, recursive=True, router=router)
-        added = tested.get("added", [])
-    except Exception:
-        logger.exception("auto include of discovered orphans failed")
-        return []
-
-    if not added:
-        return []
-
-    try:
-        from module_synergy_grapher import ModuleSynergyGrapher, load_graph
-
-        grapher = ModuleSynergyGrapher(root=repo)
-        graph_path = repo / "sandbox_data" / "module_synergy_graph.json"
-        if getattr(grapher, "graph", None) is None:
-            try:
-                if graph_path.exists():
-                    grapher.graph = load_graph(graph_path)
-                else:
-                    grapher.graph = grapher.build_graph(repo)
-            except Exception:
-                grapher.graph = None
-        if getattr(grapher, "graph", None) is not None:
-            names = [Path(m).with_suffix("").as_posix() for m in added]
-            grapher.update_graph(names)
-    except Exception:
-        logger.warning("module synergy update failed", exc_info=True)
-
-    try:
-        from intent_clusterer import IntentClusterer
-
-        clusterer = IntentClusterer()
-        clusterer.index_modules([repo / m for m in added])
-    except Exception:
-        logger.warning("intent clustering update failed", exc_info=True)
-
-    return added
+    return tested.get("added", [])
 
 
 # ----------------------------------------------------------------------

--- a/sandbox_runner/orphan_integration.py
+++ b/sandbox_runner/orphan_integration.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:  # pragma: no cover - heavy import for type checking only
     from roi_tracker import ROITracker
 
 
-def integrate_orphans(
+def integrate_and_graph_orphans(
     repo: Path,
     modules: Iterable[str] | None = None,
     *,
@@ -119,3 +119,11 @@ def integrate_orphans(
         updated = []
 
     return tracker, tested, updated, synergy_ok, cluster_ok
+
+
+# Backwards compatibility -------------------------------------------------
+# Historically this utility was exported as ``integrate_orphans``.  Preserve
+# the old name so existing callers continue to function while new code uses the
+# more descriptive ``integrate_and_graph_orphans``.
+integrate_orphans = integrate_and_graph_orphans
+

--- a/sandbox_runner/post_update.py
+++ b/sandbox_runner/post_update.py
@@ -3,92 +3,25 @@ from __future__ import annotations
 from pathlib import Path
 from logging_utils import get_logger
 
+from .orphan_integration import integrate_and_graph_orphans
+
 logger = get_logger(__name__)
 
 
 def integrate_orphans(repo: Path, router=None) -> list[str]:
     """Integrate newly created orphan modules.
 
-    Parameters
-    ----------
-    repo:
-        Root directory of the repository.
-    router:
-        Optional database router forwarded to helpers.
-
-    Returns
-    -------
-    list[str]
-        Repository-relative paths of modules added to the module map.
+    This function now delegates to
+    :func:`sandbox_runner.orphan_integration.integrate_and_graph_orphans`
+    so that discovery, module inclusion and graph updates follow a single
+    implementation.
     """
 
     try:
-        from .orphan_discovery import discover_recursive_orphans
+        _, tested, _, _, _ = integrate_and_graph_orphans(
+            repo, logger=logger, router=router
+        )
     except Exception:  # pragma: no cover - best effort
-        logger.exception("discover_recursive_orphans import failed")
+        logger.exception("orphan integration failed")
         return []
-
-    try:
-        mapping = discover_recursive_orphans(str(repo))
-    except Exception:  # pragma: no cover - best effort
-        logger.exception("discover_recursive_orphans failed")
-        return []
-
-    if not mapping:
-        return []
-
-    try:
-        from .environment import auto_include_modules, try_integrate_into_workflows
-    except Exception:  # pragma: no cover - best effort
-        logger.exception("environment helpers import failed")
-        return []
-
-    paths = [
-        Path(name.replace(".", "/")).with_suffix(".py").as_posix()
-        for name in mapping
-    ]
-
-    added: list[str] = []
-    try:
-        _, tested = auto_include_modules(paths, recursive=True, router=router)
-        added = tested.get("added", [])
-    except Exception:  # pragma: no cover - best effort
-        logger.exception("auto include of discovered orphans failed")
-        return []
-
-    if not added:
-        return []
-
-    try:
-        from module_synergy_grapher import ModuleSynergyGrapher, load_graph
-
-        grapher = ModuleSynergyGrapher(root=repo)
-        graph_path = repo / "sandbox_data" / "module_synergy_graph.json"
-        if getattr(grapher, "graph", None) is None:
-            try:
-                if graph_path.exists():
-                    grapher.graph = load_graph(graph_path)
-                else:
-                    grapher.graph = grapher.build_graph(repo)
-            except Exception:  # pragma: no cover - best effort
-                grapher.graph = None
-        if getattr(grapher, "graph", None) is not None:
-            names = [Path(m).with_suffix("").as_posix() for m in added]
-            grapher.update_graph(names)
-    except Exception:  # pragma: no cover - best effort
-        logger.warning("module synergy update failed", exc_info=True)
-
-    try:
-        from intent_clusterer import IntentClusterer
-
-        clusterer = IntentClusterer()
-        clusterer.index_modules([repo / m for m in added])
-    except Exception:  # pragma: no cover - best effort
-        logger.warning("intent clustering update failed", exc_info=True)
-
-    try:
-        try_integrate_into_workflows(sorted(added), router=router)
-    except Exception:  # pragma: no cover - best effort
-        logger.warning("workflow integration failed", exc_info=True)
-
-    return added
+    return tested.get("added", [])


### PR DESCRIPTION
## Summary
- centralize orphan discovery and integration in `integrate_and_graph_orphans`
- replace duplicated orphan integration code in environment and post-update routines
- simplify self-improvement orphan inclusion to use new utility

## Testing
- `pytest` *(fails: 260 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68aec4dfe528832e9451cefca9d4685e