### PR TITLE
Add post-round orphan integration helper and update patch routines

### DIFF
--- a/quick_fix_engine.py
+++ b/quick_fix_engine.py
@@ -202,17 +202,12 @@ def generate_patch(
                     except BaseException:  # pragma: no cover - best effort
                         logger.debug("embedding backfill failed", exc_info=True)
             try:
-                from sandbox_runner import (
-                    integrate_new_orphans,
-                    try_integrate_into_workflows,
-                )
+                from sandbox_runner import post_round_orphan_scan
 
-                added_modules = integrate_new_orphans(Path.cwd())
-                if added_modules:
-                    try_integrate_into_workflows(added_modules)
+                post_round_orphan_scan(Path.cwd())
             except Exception:
                 logger.exception(
-                    "integrate_new_orphans after preemptive patch failed"
+                    "post_round_orphan_scan after preemptive patch failed"
                 )
             return patch_id
     except Exception as exc:  # pragma: no cover - runtime issues

--- a/sandbox_runner/__init__.py
+++ b/sandbox_runner/__init__.py
@@ -141,6 +141,7 @@ from .stub_providers import (
 )
 
 from .orphan_discovery import discover_orphan_modules, discover_recursive_orphans
+from .orphan_integration import post_round_orphan_scan, integrate_and_graph_orphans, integrate_orphans
 
 __all__ = [
     "simulate_execution_environment",
@@ -155,6 +156,9 @@ __all__ = [
     "integrate_new_orphans",
     "discover_orphan_modules",
     "discover_recursive_orphans",
+    "integrate_and_graph_orphans",
+    "integrate_orphans",
+    "post_round_orphan_scan",
     "simulate_full_environment",
     "generate_input_stubs",
     "record_module_usage",

--- a/sandbox_runner/orphan_integration.py
+++ b/sandbox_runner/orphan_integration.py
@@ -121,6 +121,28 @@ def integrate_and_graph_orphans(
     return tracker, tested, updated, synergy_ok, cluster_ok
 
 
+def post_round_orphan_scan(
+    repo: Path,
+    modules: Iterable[str] | None = None,
+    *,
+    logger=None,
+    router=None,
+) -> List[str]:
+    """Integrate orphan modules discovered after a round of code changes.
+
+    This helper wraps :func:`integrate_and_graph_orphans` to perform
+    recursive discovery via :func:`discover_recursive_orphans`, include any
+    modules using :func:`auto_include_modules`, update the module synergy graph
+    and intent clustering, and finally return the list of newly added module
+    paths.
+    """
+
+    _tracker, tested, _updated, _syn_ok, _cl_ok = integrate_and_graph_orphans(
+        repo, modules, logger=logger, router=router
+    )
+    return tested.get("added", [])
+
+
 # Backwards compatibility -------------------------------------------------
 # Historically this utility was exported as ``integrate_orphans``.  Preserve
 # the old name so existing callers continue to function while new code uses the

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -927,12 +927,11 @@ class SelfCodingEngine:
                     except Exception:
                         self.logger.exception("event bus publish failed")
             try:
-                from sandbox_runner import integrate_new_orphans, try_integrate_into_workflows
-                added_modules = integrate_new_orphans(Path.cwd(), router=self.router)
-                try_integrate_into_workflows(added_modules)
+                from sandbox_runner import post_round_orphan_scan
+                post_round_orphan_scan(Path.cwd(), router=self.router)
             except Exception:
                 self.logger.exception(
-                    "integrate_new_orphans after apply_patch failed"
+                    "post_round_orphan_scan after apply_patch failed"
                 )
         elif patch_id is not None and self.rollback_mgr:
             self.rollback_mgr.rollback(patch_key, requesting_bot=requesting_bot)

--- a/self_debugger_sandbox.py
+++ b/self_debugger_sandbox.py
@@ -36,9 +36,9 @@ from .self_improvement_policy import SelfImprovementPolicy
 from .roi_tracker import ROITracker
 from .error_cluster_predictor import ErrorClusterPredictor
 try:
-    from .sandbox_runner import integrate_new_orphans
+    from .sandbox_runner import post_round_orphan_scan
 except Exception:  # pragma: no cover - fallback for flat layout
-    from sandbox_runner import integrate_new_orphans  # type: ignore
+    from sandbox_runner import post_round_orphan_scan  # type: ignore
 
 
 class CoverageSubprocessError(RuntimeError):
@@ -219,10 +219,12 @@ class SelfDebuggerSandbox(AutomatedDebugger):
                     patch_id = generate_patch(mod, self.engine)
                     if patch_id is not None:
                         try:
-                            integrate_new_orphans(Path.cwd(), router=router)
+                            post_round_orphan_scan(
+                                Path.cwd(), logger=self.logger, router=router
+                            )
                         except Exception:
                             self.logger.exception(
-                                "integrate_new_orphans after preemptive patch failed",
+                                "post_round_orphan_scan after preemptive patch failed",
                                 extra=log_record(module=mod),
                             )
                         after_target = Path(after_dir) / rel
@@ -1125,11 +1127,14 @@ class SelfDebuggerSandbox(AutomatedDebugger):
                         )
                         try:
                             await asyncio.to_thread(
-                                integrate_new_orphans, Path.cwd(), router=router
+                                post_round_orphan_scan,
+                                Path.cwd(),
+                                logger=self.logger,
+                                router=router,
                             )
                         except Exception:
                             self.logger.exception(
-                                "integrate_new_orphans after apply_patch failed"
+                                "post_round_orphan_scan after apply_patch failed"
                             )
                         after_cov, after_runtime = await asyncio.to_thread(
                             self._run_tests, root_test
@@ -1305,10 +1310,12 @@ class SelfDebuggerSandbox(AutomatedDebugger):
                     trigger="self_debugger_sandbox",
                 )
                 try:
-                    integrate_new_orphans(Path.cwd(), router=router)
+                    post_round_orphan_scan(
+                        Path.cwd(), logger=self.logger, router=router
+                    )
                 except Exception:
                     self.logger.exception(
-                        "integrate_new_orphans after apply_patch failed"
+                        "post_round_orphan_scan after apply_patch failed"
                     )
                 if self.policy:
                     try:

--- a/tests/test_orphan_auto_indexing.py
+++ b/tests/test_orphan_auto_indexing.py
@@ -24,18 +24,15 @@ def test_generate_workflows_indexes_discovered_modules(tmp_path, monkeypatch):
     # Stub orphan integration via centralized helper and record indexing calls
     calls: dict[str, list] = {}
 
-    def fake_integrate(repo, router=None):
+    def fake_scan(repo, modules=None, *, logger=None, router=None):
         calls["synergy"] = ["extra.mod"]
         calls["intent"] = [Path(repo) / "extra/mod.py"]
+        calls["workflow"] = ["extra/mod.py"]
         return ["extra/mod.py"]
-
-    def fake_try(mods, router=None):
-        calls["workflow"] = list(mods)
 
     pkg = types.ModuleType("sandbox_runner")
     pkg.__path__ = []
-    pkg.integrate_new_orphans = fake_integrate
-    pkg.try_integrate_into_workflows = fake_try
+    pkg.post_round_orphan_scan = fake_scan
     monkeypatch.setitem(sys.modules, "sandbox_runner", pkg)
     monkeypatch.setitem(sys.modules, "db_router", SimpleNamespace(GLOBAL_ROUTER=None))
 

--- a/workflow_synthesizer.py
+++ b/workflow_synthesizer.py
@@ -1335,16 +1335,9 @@ class WorkflowSynthesizer:
         try:
             import sandbox_runner
 
-            added = sandbox_runner.integrate_new_orphans(
+            sandbox_runner.post_round_orphan_scan(
                 Path.cwd(), router=GLOBAL_ROUTER
             )
-            if added:
-                try:
-                    sandbox_runner.try_integrate_into_workflows(
-                        sorted(added), router=GLOBAL_ROUTER
-                    )
-                except Exception:  # pragma: no cover - best effort
-                    logger.warning("workflow integration failed", exc_info=True)
         except Exception:  # pragma: no cover - best effort
             logger.warning("orphan integration failed", exc_info=True)
 
@@ -1626,18 +1619,9 @@ def generate_workflow_variants(
         try:  # pragma: no cover - optional dependency
             import sandbox_runner
 
-            added = sandbox_runner.integrate_new_orphans(
+            sandbox_runner.post_round_orphan_scan(
                 Path.cwd(), router=GLOBAL_ROUTER
             )
-            if added:
-                try:
-                    sandbox_runner.try_integrate_into_workflows(
-                        sorted(added), router=GLOBAL_ROUTER
-                    )
-                except Exception:  # pragma: no cover - best effort
-                    logger.warning(
-                        "workflow integration failed", exc_info=True
-                    )
         except Exception:  # pragma: no cover - best effort
             logger.warning("orphan integration failed", exc_info=True)
         return variants
@@ -1768,18 +1752,9 @@ def generate_variants(
         try:  # pragma: no cover - optional dependency
             import sandbox_runner
 
-            added = sandbox_runner.integrate_new_orphans(
+            sandbox_runner.post_round_orphan_scan(
                 Path.cwd(), router=GLOBAL_ROUTER
             )
-            if added:
-                try:
-                    sandbox_runner.try_integrate_into_workflows(
-                        sorted(added), router=GLOBAL_ROUTER
-                    )
-                except Exception:  # pragma: no cover - best effort
-                    logger.warning(
-                        "workflow integration failed", exc_info=True
-                    )
         except Exception:  # pragma: no cover - best effort
             logger.warning("orphan integration failed", exc_info=True)
         return variants[:n]


### PR DESCRIPTION
## Summary
- add `post_round_orphan_scan` to wrap orphan discovery and integration
- replace direct orphan integration calls in patch routines with new helper
- export helper from `sandbox_runner` for reuse

## Testing
- `pytest tests/test_orphan_inclusion_after_synthesis.py tests/test_generate_variant_orphan_integration.py tests/test_orphan_integration_rounds.py tests/test_orphan_auto_indexing.py -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68aec76d9264832ea3d035e00fc3b4ce