### PR TITLE
Track workflow lineage in workflow evolution

### DIFF
--- a/self_improvement_engine.py
+++ b/self_improvement_engine.py
@@ -5390,7 +5390,11 @@ class SelfImprovementEngine:
                     if self.workflow_evolver.is_stable(wf_id)
                     else "baseline"
                 )
-            results[int(wf_id)] = {"status": status}
+            results[int(wf_id)] = {
+                "status": status,
+                "parent_id": getattr(evolved, "parent_id", wf_id),
+                "mutation_description": getattr(evolved, "mutation_description", ""),
+            }
             try:
                 self._post_round_orphan_scan()
             except Exception:

--- a/unit_tests/test_evolve_workflows.py
+++ b/unit_tests/test_evolve_workflows.py
@@ -25,7 +25,10 @@ def test_evolve_workflows_calls_evolver():
 
         def evolve(self, fn, wf_id, variants=5):
             self.called.append(wf_id)
-            return lambda: False  # new callable so promoted
+            out = lambda: False  # new callable so promoted
+            out.parent_id = wf_id
+            out.mutation_description = "variant"
+            return out
 
         def is_stable(self, wf_id):
             return False
@@ -61,6 +64,8 @@ def test_evolve_workflows_calls_evolver():
     results = evolve(self_obj)
     assert ev.called == [1]
     assert results[1]["status"] == "promoted"
+    assert results[1]["parent_id"] == 1
+    assert results[1]["mutation_description"] == "variant"
 
 
 def test_evolve_workflows_skips_flagged_workflow():


### PR DESCRIPTION
## Summary
- propagate workflow_id as parent_id and capture variant description during evolution
- surface parent_id and mutation_description from `_evolve_workflows`
- add coverage for lineage metadata

## Testing
- `pytest unit_tests/test_evolve_workflows.py`


------
https://chatgpt.com/codex/tasks/task_e_68aed0f4541c832ea57ff56a1eee68d0