### PR TITLE
Persist promoted workflows and link lineage

### DIFF
--- a/tests/test_workflow_evolution_behaviour.py
+++ b/tests/test_workflow_evolution_behaviour.py
@@ -132,6 +132,12 @@ def _load_manager(variant_rois, generate_calls=None, diminishing=0.05):
 
     graph_mod = ModuleType("menace_sandbox.workflow_graph")
     class WorkflowGraph:
+        def add_workflow(self, *a, **k):
+            pass
+
+        def add_dependency(self, *a, **k):
+            pass
+
         def update_workflow(self, *a, **k):
             pass
     graph_mod.WorkflowGraph = WorkflowGraph


### PR DESCRIPTION
## Summary
- save promoted workflow sequences and record metadata
- add new workflow nodes and evolution dependencies in WorkflowGraph
- expand tests with stubbed graph methods

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68aed7e98750832ea42e04318063824d