### PR TITLE
Return metadata from save_workflow

### DIFF
--- a/tests/test_workflow_spec.py
+++ b/tests/test_workflow_spec.py
@@ -36,13 +36,16 @@ def test_save_workflow_with_parent(tmp_path):
 
     steps = [{"module": "step1", "inputs": [], "outputs": []}]
     path = tmp_path / "wf.workflow.json"
-    out = save_workflow(steps, path, parent_id="orig", mutation_description="tweak")
-    data = json.loads(out.read_text())
+    out_path, metadata = save_workflow(
+        steps, path, parent_id="orig", mutation_description="tweak"
+    )
+    data = json.loads(out_path.read_text())
     md = data["metadata"]
-    assert md["parent_id"] == "orig"
-    assert md["mutation_description"] == "tweak"
-    assert md["workflow_id"]
-    assert md["created_at"]
+    assert metadata["parent_id"] == "orig"
+    assert metadata["mutation_description"] == "tweak"
+    assert metadata["workflow_id"]
+    assert metadata["created_at"]
+    assert md == metadata
     diff_path = Path(md["diff_path"])
     assert diff_path.is_file()
     assert diff_path.name == f"{md['workflow_id']}.diff"

--- a/workflow_evolution_manager.py
+++ b/workflow_evolution_manager.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Callable, Optional
 import importlib
-import json
 import logging
 import os
 from pathlib import Path
@@ -312,16 +311,11 @@ def evolve(
                 for s in best_variant_seq.split("-")
                 if s
             ]
-            path = workflow_synthesizer.save_workflow(
+            _path, metadata = workflow_synthesizer.save_workflow(
                 steps,
                 parent_id=str(workflow_id),
                 mutation_description=best_variant_seq,
             )
-            metadata = {}
-            try:
-                metadata = json.loads(Path(path).read_text()).get("metadata", {})
-            except Exception:
-                logger.exception("failed reading workflow metadata")
             new_id = metadata.get("workflow_id")
             created_at = metadata.get("created_at")
             if new_id is not None:


### PR DESCRIPTION
## Summary
- expose workflow metadata from `save_workflow` including generated `workflow_id` and timestamp
- update workflow evolution manager and tests to handle new `(path, metadata)` return value

## Testing
- `pytest tests/test_workflow_spec.py::test_save_workflow_with_parent -q`
- `pytest tests/test_workflow_spec.py::test_to_spec_and_save -q`
- `pytest tests/test_workflow_synthesizer_cli_subprocess.py::test_cli_save_and_list -q`


------
https://chatgpt.com/codex/tasks/task_e_68aed9436880832e9d5dc6f7c0c5263e