### PR TITLE
feat: record workflow run summaries after evolution

### DIFF
--- a/workflow_run_summary.py
+++ b/workflow_run_summary.py
@@ -70,3 +70,6 @@ def save_all_summaries(directory: str | Path = ".", *, graph: WorkflowGraph | No
 def reset_history() -> None:
     """Clear stored ROI history. Primarily intended for tests."""
     _WORKFLOW_ROI_HISTORY.clear()
+
+
+__all__ = ["record_run", "save_all_summaries", "reset_history"]


### PR DESCRIPTION
## Summary
- record baseline and promoted workflow ROI runs
- persist workflow run summaries after evolution completes
- expose workflow run summary helpers via `__all__`

## Testing
- `pre-commit run --files workflow_evolution_manager.py workflow_run_summary.py`
- `pytest tests/test_workflow_run_summary.py tests/test_workflow_evolution_manager.py tests/test_workflow_evolution.py tests/test_workflow_evolution_behaviour.py tests/test_workflow_evolution_layer.py tests/test_workflow_variant_scenarios.py tests/test_orphan_auto_indexing.py` *(fails: ModuleNotFoundError: No module named 'sandbox_runner.post_update')*

------
https://chatgpt.com/codex/tasks/task_e_68aeda86bc80832ea5b9b4e3be4a3d66