### PR TITLE
Add workflow merging utility with lineage tracking

### DIFF
--- a/tests/test_workflow_merger.py
+++ b/tests/test_workflow_merger.py
@@ -1,0 +1,55 @@
+import json
+from datetime import datetime
+from pathlib import Path
+
+from workflow_merger import merge_workflows
+
+
+def test_merge_workflows_lineage_and_diff(tmp_path):
+    workflows_dir = tmp_path / "workflows"
+    workflows_dir.mkdir()
+
+    base_data = {
+        "steps": [
+            {"module": "mod_a", "inputs": [], "outputs": [], "files": [], "globals": []}
+        ],
+        "metadata": {
+            "workflow_id": "base-id",
+            "parent_id": None,
+            "mutation_description": "base",
+            "created_at": "2023-01-01T00:00:00",
+        },
+    }
+    branch_data = {
+        "steps": [
+            {"module": "mod_a", "inputs": [], "outputs": [], "files": [], "globals": []},
+            {"module": "mod_b", "inputs": [], "outputs": [], "files": [], "globals": []},
+        ],
+        "metadata": {
+            "workflow_id": "branch-id",
+            "parent_id": "base-id",
+            "mutation_description": "branch",
+            "created_at": "2023-01-02T00:00:00",
+        },
+    }
+
+    base_path = workflows_dir / "base.workflow.json"
+    branch_path = workflows_dir / "branch.workflow.json"
+    base_path.write_text(json.dumps(base_data, indent=2))
+    branch_path.write_text(json.dumps(branch_data, indent=2))
+
+    out_path = workflows_dir / "merged.workflow.json"
+    merged_path = merge_workflows(base_path, branch_path, out_path)
+
+    merged_data = json.loads(merged_path.read_text())
+    metadata = merged_data["metadata"]
+
+    assert metadata["parent_id"] == "base-id"
+    assert metadata["workflow_id"] not in {"base-id", "branch-id"}
+    assert metadata["mutation_description"].startswith("Merged")
+    datetime.fromisoformat(metadata["created_at"])
+
+    diff_path = Path(metadata["diff_path"])
+    diff_text = diff_path.read_text()
+    assert '"module": "mod_b"' in diff_text
+    assert diff_text.startswith("---")

--- a/workflow_merger.py
+++ b/workflow_merger.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import difflib
+from pathlib import Path
+from datetime import datetime
+from uuid import uuid4
+
+import workflow_spec
+
+
+def merge_workflows(base: Path, branch: Path, out: Path) -> Path:
+    """Merge two workflow specifications.
+
+    Parameters
+    ----------
+    base:
+        Path to the workflow JSON representing the common ancestor.
+    branch:
+        Path to the workflow JSON representing the changes to merge.
+    out:
+        Destination for the merged workflow specification.  The resulting file
+        will live beneath a ``workflows`` directory as enforced by
+        :func:`workflow_spec.save_spec`.
+    """
+
+    base_path = Path(base)
+    branch_path = Path(branch)
+    out_path = Path(out)
+
+    base_spec = json.loads(base_path.read_text())
+    branch_spec = json.loads(branch_path.read_text())
+
+    base_lines = json.dumps(base_spec, indent=2, sort_keys=True).splitlines()
+    branch_lines = json.dumps(branch_spec, indent=2, sort_keys=True).splitlines()
+
+    diff_lines = list(
+        difflib.unified_diff(
+            base_lines,
+            branch_lines,
+            fromfile=base_path.name,
+            tofile=branch_path.name,
+            lineterm="",
+        )
+    )
+
+    # If there are differences favour the branch specification; otherwise keep
+    # the base.  ``diff_lines`` is still computed to surface the unified diff
+    # in the saved metadata via :func:`workflow_spec.save_spec`.
+    merged_spec = branch_spec if diff_lines else base_spec
+
+    ancestor_id = base_spec.get("metadata", {}).get("workflow_id")
+    metadata = dict(merged_spec.get("metadata") or {})
+    metadata.update(
+        {
+            "workflow_id": str(uuid4()),
+            "parent_id": ancestor_id,
+            "mutation_description": f"Merged {base_path.name} and {branch_path.name}",
+            "created_at": datetime.utcnow().isoformat(),
+        }
+    )
+    merged_spec["metadata"] = metadata
+
+    return workflow_spec.save_spec(merged_spec, out_path)


### PR DESCRIPTION
## Summary
- add `merge_workflows` helper to reconcile workflow specs and emit unified diffs
- record fresh workflow metadata including parent lineage
- test merged workflows for correct metadata and diff output

## Testing
- `pre-commit run --files workflow_merger.py tests/test_workflow_merger.py`
- `pytest tests/test_workflow_merger.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aee01e847c832eb7ccd767ca62a62f