### PR TITLE
Implement three-way workflow merger

### DIFF
--- a/tests/test_workflow_merger.py
+++ b/tests/test_workflow_merger.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from workflow_merger import merge_workflows
 
 
-def test_merge_workflows_lineage_and_diff(tmp_path):
+def test_merge_workflows_three_way(tmp_path):
     workflows_dir = tmp_path / "workflows"
     workflows_dir.mkdir()
 
@@ -20,36 +20,48 @@ def test_merge_workflows_lineage_and_diff(tmp_path):
             "created_at": "2023-01-01T00:00:00",
         },
     }
-    branch_data = {
-        "steps": [
-            {"module": "mod_a", "inputs": [], "outputs": [], "files": [], "globals": []},
-            {"module": "mod_b", "inputs": [], "outputs": [], "files": [], "globals": []},
-        ],
+    branch_a_data = {
+        "steps": base_data["steps"] + [{"module": "mod_b", "inputs": [], "outputs": [], "files": [], "globals": []}],
         "metadata": {
-            "workflow_id": "branch-id",
+            "workflow_id": "branch-a-id",
             "parent_id": "base-id",
-            "mutation_description": "branch",
+            "mutation_description": "branch_a",
             "created_at": "2023-01-02T00:00:00",
+        },
+    }
+    branch_b_data = {
+        "steps": base_data["steps"] + [{"module": "mod_c", "inputs": [], "outputs": [], "files": [], "globals": []}],
+        "metadata": {
+            "workflow_id": "branch-b-id",
+            "parent_id": "base-id",
+            "mutation_description": "branch_b",
+            "created_at": "2023-01-03T00:00:00",
         },
     }
 
     base_path = workflows_dir / "base.workflow.json"
-    branch_path = workflows_dir / "branch.workflow.json"
+    branch_a_path = workflows_dir / "branch_a.workflow.json"
+    branch_b_path = workflows_dir / "branch_b.workflow.json"
     base_path.write_text(json.dumps(base_data, indent=2))
-    branch_path.write_text(json.dumps(branch_data, indent=2))
+    branch_a_path.write_text(json.dumps(branch_a_data, indent=2))
+    branch_b_path.write_text(json.dumps(branch_b_data, indent=2))
 
     out_path = workflows_dir / "merged.workflow.json"
-    merged_path = merge_workflows(base_path, branch_path, out_path)
+    merged_path = merge_workflows(base_path, branch_a_path, branch_b_path, out_path)
 
     merged_data = json.loads(merged_path.read_text())
     metadata = merged_data["metadata"]
 
     assert metadata["parent_id"] == "base-id"
-    assert metadata["workflow_id"] not in {"base-id", "branch-id"}
-    assert metadata["mutation_description"].startswith("Merged")
+    assert metadata["workflow_id"] not in {"base-id", "branch-a-id", "branch-b-id"}
+    assert metadata["mutation_description"] == "merge"
     datetime.fromisoformat(metadata["created_at"])
+
+    modules = {step["module"] for step in merged_data["steps"]}
+    assert modules == {"mod_a", "mod_b", "mod_c"}
 
     diff_path = Path(metadata["diff_path"])
     diff_text = diff_path.read_text()
     assert '"module": "mod_b"' in diff_text
+    assert '"module": "mod_c"' in diff_text
     assert diff_text.startswith("---")

--- a/workflow_merger.py
+++ b/workflow_merger.py
@@ -2,60 +2,140 @@ from __future__ import annotations
 
 import json
 import difflib
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
+from typing import Any
 from uuid import uuid4
 
 import workflow_spec
 
 
-def merge_workflows(base: Path, branch: Path, out: Path) -> Path:
-    """Merge two workflow specifications.
+class MergeConflictError(RuntimeError):
+    """Raised when a merge conflict cannot be automatically resolved."""
+
+
+def _merge(base: Any, a: Any, b: Any, path: str = "") -> Any:
+    """Recursively merge ``a`` and ``b`` with ``base`` as common ancestor.
+
+    On conflicting changes a :class:`MergeConflictError` is raised with a path
+    describing the location of the conflict and an inline diff between the
+    competing values.
+    """
+
+    if isinstance(base, dict) and isinstance(a, dict) and isinstance(b, dict):
+        result: dict[str, Any] = {}
+        keys = set(base) | set(a) | set(b)
+        for key in keys:
+            sub_path = f"{path}/{key}" if path else key
+            base_val = base.get(key)
+            a_val = a.get(key, base_val)
+            b_val = b.get(key, base_val)
+            result[key] = _merge(base_val, a_val, b_val, sub_path)
+        return result
+
+    if isinstance(base, list) and isinstance(a, list) and isinstance(b, list):
+        # Reconcile lists by analysing element wise changes. Elements present in
+        # ``a`` or ``b`` beyond the length of ``base`` are treated as new
+        # additions. If both branches modify the same element in different ways
+        # a conflict is raised.
+        result: list[Any] = []
+        base_len = len(base)
+        for idx in range(base_len):
+            base_item = base[idx]
+            a_item = a[idx] if idx < len(a) else base_item
+            b_item = b[idx] if idx < len(b) else base_item
+            if a_item == b_item:
+                result.append(a_item)
+            elif a_item == base_item:
+                result.append(b_item)
+            elif b_item == base_item:
+                result.append(a_item)
+            else:
+                raise MergeConflictError(_format_conflict(f"{path}[{idx}]", a_item, b_item))
+
+        # Collect new items appended in each branch
+        for seq in (a[base_len:], b[base_len:]):
+            for item in seq:
+                if item not in result:
+                    result.append(item)
+
+        return result
+
+    if a == b:
+        return a
+    if a == base:
+        return b
+    if b == base:
+        return a
+
+    raise MergeConflictError(_format_conflict(path, a, b))
+
+
+def _format_conflict(path: str, a: Any, b: Any) -> str:
+    """Return a descriptive conflict message including a diff."""
+
+    a_lines = json.dumps(a, indent=2, sort_keys=True).splitlines()
+    b_lines = json.dumps(b, indent=2, sort_keys=True).splitlines()
+    diff = "\n".join(
+        difflib.unified_diff(a_lines, b_lines, fromfile="branch_a", tofile="branch_b", lineterm="")
+    )
+    return f"Conflict at {path or '/'}:\n{diff}"
+
+
+def merge_workflows(base: Path, branch_a: Path, branch_b: Path, out_path: Path) -> Path:
+    """Merge ``branch_a`` and ``branch_b`` against ``base`` and write result.
 
     Parameters
     ----------
     base:
-        Path to the workflow JSON representing the common ancestor.
-    branch:
-        Path to the workflow JSON representing the changes to merge.
-    out:
-        Destination for the merged workflow specification.  The resulting file
+        Path to the JSON workflow serving as the common ancestor.
+    branch_a:
+        Path to the first branch to merge.
+    branch_b:
+        Path to the second branch to merge.
+    out_path:
+        Destination for the merged workflow specification. The resulting file
         will live beneath a ``workflows`` directory as enforced by
         :func:`workflow_spec.save_spec`.
     """
 
     base_path = Path(base)
-    branch_path = Path(branch)
-    out_path = Path(out)
+    branch_a_path = Path(branch_a)
+    branch_b_path = Path(branch_b)
+    out_path = Path(out_path)
 
-    base_spec = json.loads(base_path.read_text())
-    branch_spec = json.loads(branch_path.read_text())
+    base_spec_full = json.loads(base_path.read_text())
+    a_spec_full = json.loads(branch_a_path.read_text())
+    b_spec_full = json.loads(branch_b_path.read_text())
 
-    base_lines = json.dumps(base_spec, indent=2, sort_keys=True).splitlines()
-    branch_lines = json.dumps(branch_spec, indent=2, sort_keys=True).splitlines()
-
-    diff_lines = list(
-        difflib.unified_diff(
-            base_lines,
-            branch_lines,
-            fromfile=base_path.name,
-            tofile=branch_path.name,
-            lineterm="",
-        )
+    # Compute diffs for reference (not used directly but retained for metadata)
+    base_lines = json.dumps(base_spec_full, indent=2, sort_keys=True).splitlines()
+    a_lines = json.dumps(a_spec_full, indent=2, sort_keys=True).splitlines()
+    b_lines = json.dumps(b_spec_full, indent=2, sort_keys=True).splitlines()
+    _ = list(
+        difflib.unified_diff(base_lines, a_lines, fromfile=base_path.name, tofile=branch_a_path.name, lineterm="")
+    )
+    _ = list(
+        difflib.unified_diff(base_lines, b_lines, fromfile=base_path.name, tofile=branch_b_path.name, lineterm="")
     )
 
-    # If there are differences favour the branch specification; otherwise keep
-    # the base.  ``diff_lines`` is still computed to surface the unified diff
-    # in the saved metadata via :func:`workflow_spec.save_spec`.
-    merged_spec = branch_spec if diff_lines else base_spec
+    # Remove metadata before merging to avoid spurious conflicts
+    base_spec = dict(base_spec_full)
+    a_spec = dict(a_spec_full)
+    b_spec = dict(b_spec_full)
+    base_spec.pop("metadata", None)
+    a_spec.pop("metadata", None)
+    b_spec.pop("metadata", None)
 
-    ancestor_id = base_spec.get("metadata", {}).get("workflow_id")
+    merged_spec = _merge(base_spec, a_spec, b_spec)
+
+    ancestor_id = base_spec_full.get("metadata", {}).get("workflow_id")
     metadata = dict(merged_spec.get("metadata") or {})
     metadata.update(
         {
             "workflow_id": str(uuid4()),
             "parent_id": ancestor_id,
-            "mutation_description": f"Merged {base_path.name} and {branch_path.name}",
+            "mutation_description": "merge",
             "created_at": datetime.utcnow().isoformat(),
         }
     )


### PR DESCRIPTION
## Summary
- add `merge_workflows` supporting three-way merges with conflict detection
- include detailed conflict diffs and metadata updates
- test workflow merger across three branches

## Testing
- `pytest tests/test_workflow_merger.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeeae5a700832e829199092cce41d9