### PR TITLE
Persist workflow ROI history across restarts

### DIFF
--- a/tests/test_workflow_run_summary_persistence.py
+++ b/tests/test_workflow_run_summary_persistence.py
@@ -1,0 +1,35 @@
+import json
+import importlib
+from pathlib import Path
+
+
+def test_roi_history_persistence_and_delta(tmp_path, monkeypatch):
+    history_file = tmp_path / "roi_history.json"
+    monkeypatch.setenv("WORKFLOW_ROI_HISTORY_PATH", str(history_file))
+
+    import menace.workflow_run_summary as wrs
+    wrs = importlib.reload(wrs)
+    wrs.reset_history()
+
+    parent_spec = {"metadata": {"workflow_id": "parent"}}
+    (tmp_path / "parent.workflow.json").write_text(json.dumps(parent_spec))
+    wrs.record_run("parent", 1.0)
+    wrs.save_summary("parent", tmp_path)
+
+    child_spec = {"metadata": {"workflow_id": "child", "parent_id": "parent"}}
+    (tmp_path / "child.workflow.json").write_text(json.dumps(child_spec))
+    wrs.record_run("child", 2.0)
+
+    # simulate restart
+    wrs = importlib.reload(wrs)
+
+    assert wrs._WORKFLOW_ROI_HISTORY["parent"] == [1.0]
+    assert wrs._WORKFLOW_ROI_HISTORY["child"] == [2.0]
+
+    summary_path = wrs.save_summary("child", tmp_path)
+    data = json.loads(Path(summary_path).read_text())
+    assert data["roi_delta"] == 1.0
+    assert data["avg_roi_delta"] == 1.0
+
+    monkeypatch.delenv("WORKFLOW_ROI_HISTORY_PATH", raising=False)
+    importlib.reload(wrs)


### PR DESCRIPTION
## Summary
- add JSON-backed store for workflow ROI history with environment-configurable path
- compute ROI deltas relative to parent summaries and expose them in output
- ensure workflow graph passed to summary writer is used for parent/child relationships
- test ROI history persistence and delta calculations across reloads

## Testing
- `pre-commit run --files workflow_run_summary.py tests/test_workflow_run_summary_persistence.py tests/test_workflow_run_summary.py`
- `pytest tests/test_workflow_run_summary.py tests/test_workflow_run_summary_persistence.py`

------
https://chatgpt.com/codex/tasks/task_e_68aeecb40894832e88db97aecba2fb44