### PR TITLE
Persist workflow summaries and surface ROI in lineage tree

### DIFF
--- a/tests/test_lineage_tree_roi_metrics.py
+++ b/tests/test_lineage_tree_roi_metrics.py
@@ -1,0 +1,66 @@
+import json
+import importlib
+
+
+def test_lineage_tree_contains_roi_metrics(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORKFLOW_ROI_HISTORY_PATH", str(tmp_path / "roi_history.json"))
+    summary_store = tmp_path / "summaries"
+    monkeypatch.setenv("WORKFLOW_SUMMARY_STORE", str(summary_store))
+
+    import menace.workflow_run_summary as wrs
+    wrs = importlib.reload(wrs)
+    wrs.reset_history()
+
+    # create parent workflow summary
+    parent_spec = {"metadata": {"workflow_id": "1", "mutation_description": "root"}}
+    (tmp_path / "1.workflow.json").write_text(json.dumps(parent_spec))
+    wrs.record_run("1", 1.0)
+    wrs.save_summary("1", tmp_path)
+
+    # create child workflow summary referencing parent
+    child_spec = {
+        "metadata": {
+            "workflow_id": "2",
+            "parent_id": "1",
+            "mutation_description": "child",
+        }
+    }
+    (tmp_path / "2.workflow.json").write_text(json.dumps(child_spec))
+    wrs.record_run("2", 2.0)
+    wrs.save_summary("2", tmp_path)
+
+    import menace.evolution_history_db as eh
+    import menace.lineage_tracker as lt
+    lt = importlib.reload(lt)
+
+    edb = eh.EvolutionHistoryDB(tmp_path / "e.db")
+    edb.add(
+        eh.EvolutionEvent(
+            action="root",
+            before_metric=0.0,
+            after_metric=1.0,
+            roi=1.0,
+            workflow_id=1,
+        )
+    )
+    edb.add(
+        eh.EvolutionEvent(
+            action="child",
+            before_metric=1.0,
+            after_metric=2.0,
+            roi=1.0,
+            workflow_id=2,
+        )
+    )
+
+    tracker = lt.LineageTracker(edb)
+    tree = tracker.build_tree()
+    nodes = {n["workflow_id"]: n for n in tree}
+
+    assert nodes[1]["average_roi"] == 1.0
+    assert nodes[1]["mutation_description"] == "root"
+    assert nodes[1]["roi_delta"] is None
+
+    assert nodes[2]["average_roi"] == 2.0
+    assert nodes[2]["roi_delta"] == 1.0
+    assert nodes[2]["mutation_description"] == "child"

--- a/tests/test_workflow_run_summary_persistence.py
+++ b/tests/test_workflow_run_summary_persistence.py
@@ -6,6 +6,7 @@ from pathlib import Path
 def test_roi_history_persistence_and_delta(tmp_path, monkeypatch):
     history_file = tmp_path / "roi_history.json"
     monkeypatch.setenv("WORKFLOW_ROI_HISTORY_PATH", str(history_file))
+    monkeypatch.setenv("WORKFLOW_SUMMARY_STORE", str(tmp_path))
 
     import menace.workflow_run_summary as wrs
     wrs = importlib.reload(wrs)
@@ -32,4 +33,5 @@ def test_roi_history_persistence_and_delta(tmp_path, monkeypatch):
     assert data["avg_roi_delta"] == 1.0
 
     monkeypatch.delenv("WORKFLOW_ROI_HISTORY_PATH", raising=False)
+    monkeypatch.delenv("WORKFLOW_SUMMARY_STORE", raising=False)
     importlib.reload(wrs)

--- a/workflow_run_summary.py
+++ b/workflow_run_summary.py
@@ -23,6 +23,12 @@ _HISTORY_PATH = Path(
     )
 )
 
+# Default location for saved workflow summaries.  Individual tests can override
+# via the ``WORKFLOW_SUMMARY_STORE`` environment variable.
+_SUMMARY_STORE = Path(
+    os.environ.get("WORKFLOW_SUMMARY_STORE", Path("sandbox_data") / "workflows")
+)
+
 
 def _load_history() -> None:
     """Load persisted ROI history into memory."""
@@ -130,6 +136,18 @@ def save_summary(
     out_dir.mkdir(parents=True, exist_ok=True)
     path = out_dir / f"{wid}.summary.json"
     path.write_text(json.dumps(data, indent=2))
+
+    # Also persist a copy to the shared summary store so other components can
+    # easily discover summary information without needing the original
+    # directory.
+    try:
+        _SUMMARY_STORE.mkdir(parents=True, exist_ok=True)
+        (_SUMMARY_STORE / f"{wid}.summary.json").write_text(
+            json.dumps(data, indent=2)
+        )
+    except Exception:
+        pass
+
     return path
 
 


### PR DESCRIPTION
## Summary
- persist workflow run summaries to a shared `sandbox_data/workflows` store
- enrich lineage trees with ROI statistics and mutation details
- expose ROI metrics in monitoring dashboard lineage view

## Testing
- `pre-commit run --files workflow_run_summary.py lineage_tracker.py monitoring_dashboard.py tests/test_workflow_run_summary_persistence.py tests/test_lineage_tree_roi_metrics.py`
- `pytest tests/test_workflow_run_summary_persistence.py tests/test_lineage_tree_roi_metrics.py tests/test_monitoring_dashboard.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aef0436028832ea16f746651e298ed