### PR TITLE
Generate workflow summaries during merge

### DIFF
--- a/tests/test_workflow_merger.py
+++ b/tests/test_workflow_merger.py
@@ -20,8 +20,15 @@ def test_merge_workflows_three_way(tmp_path):
             "created_at": "2023-01-01T00:00:00",
         },
     }
+    branch_a_step = {
+        "module": "mod_b",
+        "inputs": [],
+        "outputs": [],
+        "files": [],
+        "globals": [],
+    }
     branch_a_data = {
-        "steps": base_data["steps"] + [{"module": "mod_b", "inputs": [], "outputs": [], "files": [], "globals": []}],
+        "steps": base_data["steps"] + [branch_a_step],
         "metadata": {
             "workflow_id": "branch-a-id",
             "parent_id": "base-id",
@@ -29,8 +36,15 @@ def test_merge_workflows_three_way(tmp_path):
             "created_at": "2023-01-02T00:00:00",
         },
     }
+    branch_b_step = {
+        "module": "mod_c",
+        "inputs": [],
+        "outputs": [],
+        "files": [],
+        "globals": [],
+    }
     branch_b_data = {
-        "steps": base_data["steps"] + [{"module": "mod_c", "inputs": [], "outputs": [], "files": [], "globals": []}],
+        "steps": base_data["steps"] + [branch_b_step],
         "metadata": {
             "workflow_id": "branch-b-id",
             "parent_id": "base-id",
@@ -65,3 +79,8 @@ def test_merge_workflows_three_way(tmp_path):
     assert '"module": "mod_b"' in diff_text
     assert '"module": "mod_c"' in diff_text
     assert diff_text.startswith("---")
+
+    summary_path = Path(metadata["summary_path"])
+    assert summary_path.exists()
+    summary_data = json.loads(summary_path.read_text())
+    assert summary_data["workflow_id"] == metadata["workflow_id"]


### PR DESCRIPTION
## Summary
- save merged workflow specs and generate run summaries
- record summary_path alongside diff_path in workflow metadata
- test that merged workflows expose both diff and summary paths

## Testing
- `pre-commit run --files workflow_merger.py tests/test_workflow_merger.py`
- `pytest tests/test_workflow_merger.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aef42022a0832e88f89f8f91faf807