### PR TITLE
Ensure timezone-aware metadata when merging workflows

### DIFF
--- a/tests/test_workflow_merger.py
+++ b/tests/test_workflow_merger.py
@@ -70,6 +70,7 @@ def test_merge_workflows_three_way(tmp_path):
     assert metadata["workflow_id"] not in {"base-id", "branch-a-id", "branch-b-id"}
     assert metadata["mutation_description"] == "merge"
     datetime.fromisoformat(metadata["created_at"])
+    assert metadata["created_at"].endswith("+00:00")
 
     modules = {step["module"] for step in merged_data["steps"]}
     assert modules == {"mod_a", "mod_b", "mod_c"}

--- a/workflow_merger.py
+++ b/workflow_merger.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import difflib
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -148,7 +148,7 @@ def merge_workflows(base: Path, branch_a: Path, branch_b: Path, out_path: Path) 
             "workflow_id": str(uuid4()),
             "parent_id": ancestor_id,
             "mutation_description": "merge",
-            "created_at": datetime.utcnow().isoformat(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
         }
     )
     merged_spec["metadata"] = metadata


### PR DESCRIPTION
## Summary
- use `datetime.now(timezone.utc)` in `merge_workflows` for `created_at`
- assert UTC offset in merge workflow test
- confirm other workflow utilities already use timezone-aware timestamps via `workflow_spec`

## Testing
- `pre-commit run --files workflow_merger.py tests/test_workflow_merger.py`
- `pytest tests/test_workflow_merger.py tests/test_workflow_synthesizer_cli_subprocess.py`


------
https://chatgpt.com/codex/tasks/task_e_68aef62c0f90832e88d1cbf84061b45f