### PR TITLE
Load ROI history from existing workflow summaries

### DIFF
--- a/tests/test_workflow_run_summary_load_merge.py
+++ b/tests/test_workflow_run_summary_load_merge.py
@@ -1,0 +1,35 @@
+import json
+import importlib
+from pathlib import Path
+from pytest import approx
+
+
+def test_load_and_merge_existing_summaries(tmp_path, monkeypatch):
+    summary_store = tmp_path / "workflows"
+    summary_store.mkdir()
+    (summary_store / "foo.summary.json").write_text(
+        json.dumps(
+            {
+                "workflow_id": "foo",
+                "cumulative_roi": 10.0,
+                "num_runs": 2,
+                "average_roi": 5.0,
+            }
+        )
+    )
+
+    monkeypatch.setenv("WORKFLOW_SUMMARY_STORE", str(summary_store))
+    monkeypatch.setenv("WORKFLOW_ROI_HISTORY_PATH", str(tmp_path / "roi_history.json"))
+
+    import menace.workflow_run_summary as wrs
+    wrs = importlib.reload(wrs)
+
+    assert wrs._WORKFLOW_ROI_HISTORY["foo"] == [5.0, 5.0]
+
+    wrs.reset_history()
+    wrs.record_run("foo", 7.0)
+    path = wrs.save_summary("foo", summary_store)
+    data = json.loads(Path(path).read_text())
+    assert data["cumulative_roi"] == approx(17.0)
+    assert data["num_runs"] == 3
+    assert data["average_roi"] == approx(17.0 / 3)


### PR DESCRIPTION
## Summary
- load ROI histories from existing `*.summary.json` files on module import
- merge previously saved ROI data when writing workflow summaries
- test loading and merging of historical ROI data

## Testing
- `pytest tests/test_workflow_run_summary.py tests/test_workflow_run_summary_persistence.py tests/test_lineage_tree_roi_metrics.py tests/test_workflow_run_summary_load_merge.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aef7a0dccc832eb2c101f4ad340c52