### PR TITLE
feat: include roi delta in workflow lineage

### DIFF
--- a/tests/test_workflow_lineage.py
+++ b/tests/test_workflow_lineage.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 import workflow_lineage as wl
 
 
@@ -10,7 +11,7 @@ def test_lineage_handles_bad_specs_and_missing_parents(tmp_path):
     (wf_dir / "parent.workflow.json").write_text(
         json.dumps({"metadata": {"workflow_id": "parent", "mutation_description": "root"}})
     )
-    (wf_dir / "parent.summary.json").write_text(json.dumps({"roi": 1.23}))
+    (wf_dir / "parent.summary.json").write_text(json.dumps({"roi": 1.0}))
 
     # child referencing existing parent
     (wf_dir / "child.workflow.json").write_text(
@@ -22,6 +23,7 @@ def test_lineage_handles_bad_specs_and_missing_parents(tmp_path):
             }
         })
     )
+    (wf_dir / "child.summary.json").write_text(json.dumps({"roi": 2.0}))
 
     # child referencing missing parent
     (wf_dir / "orphan.workflow.json").write_text(
@@ -36,13 +38,30 @@ def test_lineage_handles_bad_specs_and_missing_parents(tmp_path):
     ids = {s["workflow_id"] for s in specs}
     assert ids == {"parent", "child", "orphan"}
 
+    child_spec = next(s for s in specs if s["workflow_id"] == "child")
+    parent_spec = next(s for s in specs if s["workflow_id"] == "parent")
+    assert child_spec["roi_delta"] == pytest.approx(1.0)
+    assert parent_spec["roi_delta"] is None
+
     graph = wl.build_graph(specs)
     if wl._HAS_NX:
         assert list(graph.successors("parent")) == ["child"]
         assert list(graph.successors("ghost")) == ["orphan"]
-        assert graph.nodes["parent"]["summary"]["roi"] == 1.23
+        assert graph.nodes["parent"]["summary"]["roi"] == 1.0
+        assert graph.nodes["child"]["roi_delta"] == pytest.approx(1.0)
     else:
         edges = graph["edges"]
         assert edges["parent"] == ["child"]
         assert edges["ghost"] == ["orphan"]
-        assert graph["nodes"]["parent"]["summary"]["roi"] == 1.23
+        assert graph["nodes"]["parent"]["summary"]["roi"] == 1.0
+        assert graph["nodes"]["child"]["roi_delta"] == pytest.approx(1.0)
+
+    data = wl.to_json(graph)
+    if wl._HAS_NX:
+        node_map = {n["id"]: n for n in data["nodes"]}
+        assert node_map["child"]["roi_delta"] == pytest.approx(1.0)
+    else:
+        assert data["nodes"]["child"]["roi_delta"] == pytest.approx(1.0)
+
+    dot = wl.to_graphviz(graph)
+    assert 'roi_delta="1.0"' in dot


### PR DESCRIPTION
## Summary
- compute roi_delta from workflow summaries relative to parent workflows
- surface roi_delta as node attribute in JSON and Graphviz lineage outputs
- test workflow lineage loading with roi delta handling

## Testing
- `pytest tests/test_workflow_lineage.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aef8e45524832ea4894fdd43d18f2b