### PR TITLE
Add CLI for displaying workflow diffs

### DIFF
--- a/docs/workflow_diff_cli.md
+++ b/docs/workflow_diff_cli.md
@@ -1,0 +1,21 @@
+# Workflow Diff CLI
+
+`tools/workflow_diff_cli.py` prints a unified diff between two workflow
+specifications.
+
+The command looks for workflow specification files saved by
+[`workflow_spec.save_spec`](../workflow_spec.py) inside a `workflows`
+subdirectory.  If the child workflow's metadata references a stored diff
+(`diff_path`) for the supplied parent it is printed directly.  Otherwise the
+diff is regenerated on the fly using Python's standard `difflib`.
+
+## Usage
+
+```bash
+python -m tools.workflow_diff_cli <parent_id> <child_id>
+python -m tools.workflow_diff_cli <parent_id> <child_id> --dir /path/to/run
+```
+
+The optional `--dir` flag points to the directory containing the `workflows`
+folder.  If omitted it defaults to the current directory or the value of the
+`WORKFLOW_OUTPUT_DIR` environment variable.

--- a/tests/test_workflow_diff_cli.py
+++ b/tests/test_workflow_diff_cli.py
@@ -1,0 +1,47 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import workflow_spec as ws
+
+
+def _create_parent_child(tmp_path: Path) -> tuple[str, str, Path]:
+    parent_spec = {
+        "steps": [{"module": "base", "inputs": [], "outputs": []}],
+        "metadata": {"workflow_id": "parent"},
+    }
+    ws.save_spec(parent_spec, tmp_path / "parent.workflow.json")
+
+    child_spec = {
+        "steps": [
+            {"module": "base", "inputs": [], "outputs": []},
+            {"module": "child", "inputs": [], "outputs": []},
+        ],
+        "metadata": {"parent_id": "parent"},
+    }
+    child_path = ws.save_spec(child_spec, tmp_path / "child.workflow.json")
+    child_md = json.loads(child_path.read_text())["metadata"]
+    diff_file = Path(child_md["diff_path"])
+    return "parent", child_md["workflow_id"], diff_file
+
+
+def test_workflow_diff_cli(tmp_path: Path):
+    parent_id, child_id, diff_path = _create_parent_child(tmp_path)
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "tools.workflow_diff_cli",
+        parent_id,
+        child_id,
+        "--dir",
+        str(tmp_path),
+    ]
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    expected = diff_path.read_text().strip()
+    assert result.stdout.strip() == expected
+
+    diff_path.unlink()
+    regen = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    assert regen.stdout.strip() == expected

--- a/tools/workflow_diff_cli.py
+++ b/tools/workflow_diff_cli.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Print a unified diff between two workflow specifications.
+
+The CLI locates workflow specifications saved by :mod:`workflow_spec` and
+prints the diff between a parent and child workflow.  When the child workflow's
+metadata references a stored diff (``diff_path``) for the given parent it is
+used directly, otherwise the diff is regenerated using :mod:`difflib`.
+
+Examples
+--------
+    python -m tools.workflow_diff_cli 1234 5678
+    python -m tools.workflow_diff_cli parent child --dir /tmp/run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import difflib
+from pathlib import Path
+from typing import Tuple
+
+
+def _load_spec(base: Path, workflow_id: str) -> Tuple[Path, dict]:
+    """Return the path and data for ``workflow_id`` within ``base``.
+
+    The directory is expected to contain ``*.workflow.json`` files produced by
+    :func:`workflow_spec.save_spec`.
+    """
+
+    for candidate in base.glob("*.workflow.json"):
+        try:
+            data = json.loads(candidate.read_text())
+        except Exception:
+            continue
+        md = data.get("metadata", {})
+        if md.get("workflow_id") == workflow_id:
+            return candidate, data
+    raise FileNotFoundError(f"workflow {workflow_id!r} not found in {base}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Show diff between two workflow specifications"
+    )
+    parser.add_argument("parent_id", help="ID of the parent workflow")
+    parser.add_argument("child_id", help="ID of the child workflow")
+    parser.add_argument(
+        "--dir",
+        default=os.environ.get("WORKFLOW_OUTPUT_DIR", "."),
+        help="Directory containing workflow specs (defaults to WORKFLOW_OUTPUT_DIR or current directory)",
+    )
+    args = parser.parse_args()
+
+    base_dir = Path(args.dir)
+    workflows_dir = base_dir / "workflows" if base_dir.name != "workflows" else base_dir
+
+    child_path, child_data = _load_spec(workflows_dir, str(args.child_id))
+    md = child_data.get("metadata", {})
+    diff_path = md.get("diff_path")
+    if diff_path and md.get("parent_id") == str(args.parent_id):
+        diff_file = Path(diff_path)
+        if not diff_file.is_absolute():
+            diff_file = workflows_dir / diff_file.name
+        if diff_file.exists():
+            print(diff_file.read_text())
+            return
+
+    parent_path, parent_data = _load_spec(workflows_dir, str(args.parent_id))
+
+    # ``diff_path`` is added *after* the diff is generated when saving a spec;
+    # remove it to regenerate the original diff.
+    md.pop("diff_path", None)
+
+    parent_lines = json.dumps(parent_data, indent=2, sort_keys=True).splitlines()
+    child_lines = json.dumps(child_data, indent=2, sort_keys=True).splitlines()
+    diff_lines = difflib.unified_diff(
+        parent_lines,
+        child_lines,
+        fromfile=parent_path.name,
+        tofile=child_path.name,
+        lineterm="",
+    )
+    print("\n".join(diff_lines))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- add `workflow_diff_cli` utility to show stored or regenerated diffs between two workflows
- document workflow diff CLI usage
- test workflow diff CLI with parent/child workflow specs

## Testing
- `pytest tests/test_workflow_diff_cli.py tests/test_workflow_spec.py::test_save_spec_with_parent -q`

------
https://chatgpt.com/codex/tasks/task_e_68aef9e769bc832e8ee5191ee3e5a9d6