### PR TITLE
Add test data prepopulation and output validation to sandbox runner

### DIFF
--- a/tests/test_workflow_sandbox_runner.py
+++ b/tests/test_workflow_sandbox_runner.py
@@ -1,0 +1,45 @@
+import importlib.util
+import logging
+from pathlib import Path
+
+module_path = (
+    Path(__file__).resolve().parent.parent
+    / "sandbox_runner"
+    / "workflow_sandbox_runner.py"
+)
+spec = importlib.util.spec_from_file_location(
+    "workflow_sandbox_runner", module_path
+)
+workflow_module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader  # for type checkers
+spec.loader.exec_module(workflow_module)  # type: ignore[attr-defined]
+WorkflowSandboxRunner = workflow_module.WorkflowSandboxRunner
+
+
+def _sample_workflow():
+    with open("input.txt") as fh:
+        data = fh.read()
+    with open("output.txt", "w") as fh:
+        fh.write(data.upper())
+
+
+def test_prepopulated_inputs_and_expected_outputs(caplog):
+    runner = WorkflowSandboxRunner()
+    with caplog.at_level(logging.WARNING):
+        runner.run(
+            _sample_workflow,
+            test_data={"input.txt": "hello"},
+            expected_outputs={"output.txt": "HELLO"},
+        )
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_expected_output_mismatch_logged(caplog):
+    runner = WorkflowSandboxRunner()
+    with caplog.at_level(logging.WARNING):
+        runner.run(
+            _sample_workflow,
+            test_data={"input.txt": "hello"},
+            expected_outputs={"output.txt": "WRONG"},
+        )
+    assert any("output mismatch" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- allow WorkflowSandboxRunner to write `test_data` into the sandbox before execution
- support optional `expected_outputs` for validating workflow results and logging mismatches
- add tests covering file prepopulation and output validation behavior

## Testing
- `pytest tests/test_workflow_sandbox_runner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af064ac280832eb35ec16429647272