### PR TITLE
feat: add per-module fixtures to WorkflowSandboxRunner

### DIFF
--- a/docs/sandbox_runner.md
+++ b/docs/sandbox_runner.md
@@ -516,6 +516,21 @@ print(metrics["modules"][1]["result"])
 print(runner.telemetry["modules"][0]["duration"])
 ```
 
+Per-module fixtures can be supplied via the ``module_fixtures`` argument. The
+mapping uses each module's ``__name__`` as the key and may define ``files`` and
+``env`` sub-mappings. ``files`` pre-populate paths inside the sandbox before the
+module executes while ``env`` temporarily sets environment variables just for
+that step. Because fixtures are ordinary dictionaries they can be reused across
+multiple runs.
+
+```python
+fixtures = {
+    "writer": {"env": {"TOKEN": "abc"}},
+    "reader": {"files": {"out.txt": "seed"}, "env": {"TOKEN": "def"}},
+}
+runner.run([writer, reader], module_fixtures=fixtures)
+```
+
 Custom stub providers may be supplied via the ``stub_providers`` argument to
 inject domain‑specific payloads. The runner's automatic input generation and
 network/file mocking allow workflows to run without touching the host


### PR DESCRIPTION
## Summary
- allow `WorkflowSandboxRunner.run` to accept `module_fixtures` for per-module file and env injections
- document fixture usage and reuse in sandbox runner docs
- add tests covering module fixture injection and env restoration

## Testing
- `pytest tests/test_workflow_runner.py`


------
https://chatgpt.com/codex/tasks/task_e_68af212835f8832e86e11617c74abd91