### PR TITLE
Add tests for WorkflowSandboxRunner sandbox behavior

### DIFF
--- a/tests/test_workflow_sandbox_runner.py
+++ b/tests/test_workflow_sandbox_runner.py
@@ -1,0 +1,89 @@
+import importlib.util
+import os
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+import urllib.request
+
+import pytest
+
+os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# ---------------------------------------------------------------------------
+# Dynamically load WorkflowSandboxRunner without importing the heavy package
+package_path = Path(__file__).resolve().parent.parent / "sandbox_runner"
+package = types.ModuleType("sandbox_runner")
+package.__path__ = [str(package_path)]
+sys.modules["sandbox_runner"] = package
+
+spec = importlib.util.spec_from_file_location(
+    "sandbox_runner.workflow_sandbox_runner",
+    package_path / "workflow_sandbox_runner.py",
+)
+wsr = importlib.util.module_from_spec(spec)
+assert spec.loader
+sys.modules[spec.name] = wsr
+spec.loader.exec_module(wsr)
+WorkflowSandboxRunner = wsr.WorkflowSandboxRunner
+
+from tests.fixtures.workflow_modules import mod_a  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _no_psutil(monkeypatch):
+    """Ensure psutil is absent so tests don't depend on it."""
+    monkeypatch.setattr(wsr, "psutil", None, raising=False)
+
+
+def test_files_confined_to_temp_dir(monkeypatch):
+    outside = Path("/tmp/outside_file.txt")
+    if outside.exists():
+        outside.unlink()
+
+    captured: list[Path] = []
+    original_write = Path.write_text
+
+    def record_write(path, data, *a, **kw):
+        p = Path(path)
+        captured.append(p)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        return original_write(p, data, *a, **kw)
+
+    def writer_step():
+        outside.write_text("data")
+
+    runner = WorkflowSandboxRunner()
+    runner.run(
+        [mod_a.start, writer_step],
+        safe_mode=True,
+        fs_mocks={"pathlib.Path.write_text": record_write},
+    )
+
+    assert not outside.exists()
+    assert captured, "file write should have been captured"
+    assert captured[0] != outside
+    assert str(captured[0]).startswith(tempfile.gettempdir())
+
+
+def test_safe_mode_blocks_network_and_reports_telemetry():
+    def network_step():
+        urllib.request.urlopen("http://example.com")
+
+    runner = WorkflowSandboxRunner()
+    metrics = runner.run([mod_a.start, network_step], safe_mode=True)
+
+    assert metrics.crash_count == 1
+    assert len(metrics.modules) == 2
+    assert metrics.modules[1].success is False
+    assert "network access disabled" in (metrics.modules[1].exception or "")
+
+    telemetry = runner.telemetry
+    assert telemetry is not None
+    assert set(telemetry["time_per_module"]) == {"start", "network_step"}
+    assert telemetry["crash_frequency"] == pytest.approx(1 / 2)


### PR DESCRIPTION
## Summary
- add tests for WorkflowSandboxRunner to ensure temp-dir isolation, safe-mode network blocking, and telemetry metrics

## Testing
- `pre-commit run --files tests/test_workflow_sandbox_runner.py`
- `pytest --noconftest tests/test_workflow_sandbox_runner.py`


------
https://chatgpt.com/codex/tasks/task_e_68af8da7038c832e9fd6974385232953