### PR TITLE
Capture callable results in sandbox telemetry

### DIFF
--- a/docs/sandbox_runner.md
+++ b/docs/sandbox_runner.md
@@ -493,8 +493,8 @@ directory. File mutations such as `open` or `shutil.copy` are redirected into
 this sandbox so the host filesystem remains untouched. When `safe_mode=True`
 the runner monkeypatches `requests`, `httpx`, `urllib` and raw sockets so that
 any outbound network attempt raises `RuntimeError` unless a matching stub is
-provided. Per‑module telemetry reporting execution time, peak memory and crash
-frequency is available through `runner.telemetry`.
+provided. Per‑module telemetry reporting execution time, peak memory, crash
+frequency and return values is available through `runner.telemetry`.
 
 ### Example with injected test data
 

--- a/tests/test_workflow_sandbox_runner.py
+++ b/tests/test_workflow_sandbox_runner.py
@@ -115,3 +115,21 @@ def test_httpx_and_fs_wrappers():
     src.unlink()
     if dst.exists():
         dst.unlink()
+
+
+def test_callable_results_captured():
+    def step1():
+        return "alpha"
+
+    def step2():
+        return 123
+
+    runner = WorkflowSandboxRunner()
+    metrics = runner.run([step1, step2], safe_mode=True)
+
+    assert [m.result for m in metrics.modules] == ["alpha", 123]
+
+    telemetry = runner.telemetry
+    assert telemetry is not None
+    assert telemetry["results"]["step1"] == "alpha"
+    assert telemetry["results"]["step2"] == 123


### PR DESCRIPTION
## Summary
- track callable return values with new `ModuleMetrics.result`
- serialize results alongside module timings and memory stats
- document and test recorded results in workflow sandbox runner

## Testing
- `pytest tests/test_workflow_sandbox_runner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af91dd2070832e9448d4d8b00e5954