### PR TITLE
feat: sandbox os/shutil filesystem wrappers

### DIFF
--- a/sandbox_runner/workflow_sandbox_runner.py
+++ b/sandbox_runner/workflow_sandbox_runner.py
@@ -268,6 +268,7 @@ class WorkflowSandboxRunner:
             original_copy = shutil.copy
             original_copy2 = shutil.copy2
             original_copyfile = shutil.copyfile
+            original_copytree = shutil.copytree
             original_move = shutil.move
 
             def sandbox_remove(path, *a, **kw):
@@ -329,6 +330,15 @@ class WorkflowSandboxRunner:
                 pathlib.Path(d).parent.mkdir(parents=True, exist_ok=True)
                 return original_copyfile(s, d, *a, **kw)
 
+            def sandbox_copytree(src, dst, *a, **kw):
+                s = self._resolve(root, src)
+                d = self._resolve(root, dst)
+                fn = fs_mocks.get("shutil.copytree")
+                if fn:
+                    return fn(s, d, *a, **kw)
+                pathlib.Path(d).parent.mkdir(parents=True, exist_ok=True)
+                return original_copytree(s, d, *a, **kw)
+
             def sandbox_move(src, dst, *a, **kw):
                 s = self._resolve(root, src)
                 d = self._resolve(root, dst)
@@ -345,6 +355,7 @@ class WorkflowSandboxRunner:
             stack.enter_context(mock.patch("shutil.copy", sandbox_copy))
             stack.enter_context(mock.patch("shutil.copy2", sandbox_copy2))
             stack.enter_context(mock.patch("shutil.copyfile", sandbox_copyfile))
+            stack.enter_context(mock.patch("shutil.copytree", sandbox_copytree))
             stack.enter_context(mock.patch("shutil.move", sandbox_move))
 
             # Pre-populate any provided file data into the sandbox.


### PR DESCRIPTION
## Summary
- wrap os.remove/unlink/rename/replace and shutil.copy*/move to resolve through the sandbox
- add copytree support and allow fs_mocks overrides
- test that direct os and shutil calls stay inside the sandbox

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_workflow_sandbox_runner.py -k os_shutil_wrappers_redirected -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_workflow_sandbox_runner.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68afb0bbb774832e853ea0a0eab2a77a