### PR TITLE
feat: mock httpx requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1072,17 +1072,16 @@ Example network mock:
 
 ```python
 from sandbox_runner import WorkflowSandboxRunner
-from types import SimpleNamespace
+import httpx
 
 def fetch():
-    import requests
-    return requests.get("https://example.com").text
+    return httpx.get("https://example.com").text
 
 runner = WorkflowSandboxRunner()
 metrics = runner.run(
     fetch,
     safe_mode=True,
-    network_mocks={"requests": lambda self, method, url, *a, **kw: SimpleNamespace(text="stubbed")},
+    network_mocks={"httpx": lambda self, method, url, *a, **kw: httpx.Response(200, text="stubbed")},
 )
 print(metrics.modules[0].result)
 ```

--- a/docs/sandbox_runner.md
+++ b/docs/sandbox_runner.md
@@ -512,6 +512,24 @@ print(metrics.modules[0].success)
 print(runner.telemetry["time_per_module"]["read_file"])
 ```
 
+Example network mock:
+
+```python
+from sandbox_runner import WorkflowSandboxRunner
+import httpx
+
+def fetch():
+    return httpx.get("https://example.com").text
+
+runner = WorkflowSandboxRunner()
+metrics = runner.run(
+    fetch,
+    safe_mode=True,
+    network_mocks={"httpx": lambda self, method, url, *a, **kw: httpx.Response(200, text="stubbed")},
+)
+print(metrics.modules[0].result)
+```
+
 Per-module fixtures can be supplied via the ``module_fixtures`` argument. The
 mapping uses each module's ``__name__`` as the key and may define ``files`` and
 ``env`` sub-mappings. ``files`` pre-populate paths inside the sandbox before the

--- a/sandbox_runner/workflow_sandbox_runner.py
+++ b/sandbox_runner/workflow_sandbox_runner.py
@@ -408,14 +408,15 @@ class WorkflowSandboxRunner:
             try:  # pragma: no cover - optional dependency
                 import httpx  # type: ignore
 
+                def _httpx_response(content: str | bytes) -> httpx.Response:
+                    data = content if isinstance(content, (bytes, bytearray)) else str(content).encode()
+                    return httpx.Response(200, content=data)
+
                 orig_httpx_request = httpx.Client.request
 
                 def fake_httpx_request(self, method, url, *a, **kw):
                     if url in network_data:
-                        data = network_data[url]
-                        if isinstance(data, str):
-                            data = data.encode()
-                        return httpx.Response(200, content=data)
+                        return _httpx_response(network_data[url])
                     fn = network_mocks.get("httpx")
                     if fn:
                         return fn(self, method, url, *a, **kw)

--- a/tests/test_workflow_sandbox_runner.py
+++ b/tests/test_workflow_sandbox_runner.py
@@ -117,6 +117,25 @@ def test_httpx_and_fs_wrappers():
         dst.unlink()
 
 
+def test_httpx_network_mock():
+    httpx = pytest.importorskip("httpx")
+
+    def step():
+        import httpx
+        resp = httpx.get("http://example.com")
+        return resp.text
+
+    runner = WorkflowSandboxRunner()
+    metrics = runner.run(
+        [step],
+        safe_mode=True,
+        network_mocks={"httpx": lambda self, method, url, *a, **kw: httpx.Response(200, text="mocked")},
+    )
+
+    assert metrics.crash_count == 0
+    assert metrics.modules[0].result == "mocked"
+
+
 def test_os_shutil_wrappers_redirected():
     src_file = Path("/tmp/wrapper_src.txt")
     src_dir = Path("/tmp/wrapper_dir")


### PR DESCRIPTION
## Summary
- stub `httpx.Client.request` like existing `requests` network patch
- document and test `httpx` network mocking

## Testing
- `pytest tests/test_workflow_sandbox_runner.py::test_httpx_and_fs_wrappers tests/test_workflow_sandbox_runner.py::test_httpx_network_mock -q`

------
https://chatgpt.com/codex/tasks/task_e_68afb38b9e7c832ea7329f055c816020