### PR TITLE
feat: support module-specific sandbox fixtures

### DIFF
--- a/sandbox_runner/workflow_sandbox_runner.py
+++ b/sandbox_runner/workflow_sandbox_runner.py
@@ -577,7 +577,10 @@ class WorkflowSandboxRunner:
                 old_env: dict[str, str | None] = {}
                 for key, value in env_vars.items():
                     old_env[key] = os.environ.get(key)
-                    os.environ[key] = value
+                    # ``os.environ`` expects string values.  Coerce anything
+                    # provided via fixtures to ``str`` to avoid ``TypeError``
+                    # when callers supply non-string objects such as numbers.
+                    os.environ[key] = str(value)
 
                 start = perf_counter()
                 mem_before = mem_after = 0


### PR DESCRIPTION
## Summary
- ensure environment variables provided in module fixtures are coerced to strings before injection
- add tests validating per-module file and environment fixtures in WorkflowSandboxRunner

## Testing
- `pytest tests/test_workflow_sandbox_runner.py::test_module_specific_fixtures_apply_files_and_env -q`
- `pytest tests/test_workflow_sandbox_runner_isolation.py::test_module_specific_fixtures_restore_env -q`


------
https://chatgpt.com/codex/tasks/task_e_68afba779cc4832eb8b88ada21f0d2b5