### PR TITLE
Capture CPU usage in workflow sandbox runner

### DIFF
--- a/tests/test_workflow_sandbox_runner.py
+++ b/tests/test_workflow_sandbox_runner.py
@@ -88,6 +88,9 @@ def test_safe_mode_blocks_network_and_reports_telemetry():
     telemetry = runner.telemetry
     assert telemetry is not None
     assert set(telemetry["time_per_module"]) == {"start", "network_step"}
+    assert set(telemetry["cpu_time_per_module"]) == {"start", "network_step"}
+    for ct in telemetry["cpu_time_per_module"].values():
+        assert ct >= 0
     assert telemetry["crash_frequency"] == pytest.approx(1 / 2)
 
 
@@ -359,6 +362,8 @@ def test_async_workflow_metrics():
 
     for mod in metrics.modules:
         assert isinstance(mod.duration, float)
+        assert isinstance(mod.cpu_time, float)
+        assert mod.cpu_time >= 0
         assert isinstance(mod.memory_before, int)
         assert isinstance(mod.memory_after, int)
         assert isinstance(mod.memory_delta, int)


### PR DESCRIPTION
## Summary
- track per-module CPU time in `ModuleMetrics`
- include `cpu_time_per_module` in sandbox telemetry
- adjust safe-mode socket patching to allow internal AF_UNIX sockets
- verify CPU time metrics via expanded workflow sandbox tests

## Testing
- `pytest tests/test_workflow_sandbox_runner.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68afc1c52cf0832e86c80e6d624f36c8