### PR TITLE
Add per-module peak memory telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1046,10 +1046,11 @@ metrics = runner.run(writer, safe_mode=True)  # network disabled
 
 ``run`` returns a :class:`RunMetrics` object and the same data is stored on
 ``runner.telemetry``. Each ``ModuleMetrics`` entry includes ``duration``,
-``memory_before``, ``memory_after``, ``memory_delta``, ``success``,
-``exception`` and ``result`` fields. ``crash_count`` records how many modules
-failed. Callers can interpret these values to evaluate resource usage and error
-rates.
+``memory_before``, ``memory_after``, ``memory_delta``, ``memory_peak``,
+``success``, ``exception`` and ``result`` fields. ``crash_count`` records how
+many modules failed. Callers can interpret these values to evaluate resource
+usage and error rates. Telemetry also exposes ``peak_memory_per_module`` and the
+overall ``peak_memory`` across all modules.
 
 Key arguments include:
 

--- a/tests/test_workflow_sandbox_runner_isolation.py
+++ b/tests/test_workflow_sandbox_runner_isolation.py
@@ -81,6 +81,8 @@ def test_telemetry_includes_timing_and_memory(runner):
     assert isinstance(mod.memory_after, int)
     assert mod.memory_after >= mod.memory_before
     assert mod.memory_delta == mod.memory_after - mod.memory_before
+    assert isinstance(mod.memory_peak, int)
+    assert mod.memory_peak >= mod.memory_after
 
 
 def test_module_specific_fixtures_restore_env(runner):


### PR DESCRIPTION
## Summary
- track per-module peak memory usage when psutil is unavailable
- include peak memory metrics in ModuleMetrics and telemetry summary
- validate memory_peak via new tests

## Testing
- `pre-commit run --files sandbox_runner/workflow_sandbox_runner.py tests/test_workflow_sandbox_runner.py tests/test_workflow_sandbox_runner_isolation.py README.md`
- `pytest tests/test_workflow_sandbox_runner.py tests/test_workflow_sandbox_runner_isolation.py`


------
https://chatgpt.com/codex/tasks/task_e_68afc42ce490832eab8ac39d8a77eddd