### PR TITLE
Record per-module CPU usage in sandbox runner

### DIFF
--- a/docs/sandbox_runner.md
+++ b/docs/sandbox_runner.md
@@ -519,7 +519,7 @@ metrics = runner.run(read_file, safe_mode=True,
                      test_data={"payload.txt": "fake"})
 print(metrics.modules[0].success)
 print(runner.telemetry["time_per_module"]["read_file"])
-print(runner.telemetry["cpu_time_per_module"]["read_file"])
+print(runner.telemetry["cpu_per_module"]["read_file"])
 print(runner.telemetry["peak_memory_per_module"]["read_file"])
 ```
 
@@ -606,7 +606,7 @@ environment while ``runner.telemetry`` exposes the collected per‑module metric
 Each module may be constrained with a ``timeout`` (seconds) and ``memory_limit``
 (bytes) when calling :meth:`WorkflowSandboxRunner.run`. Exceeding either limit
 aborts the module and records a crash. CPU time and peak RSS memory for every
-module are available in ``runner.telemetry`` under ``cpu_time_per_module``,
+module are available in ``runner.telemetry`` under ``cpu_per_module``,
 ``peak_memory`` and ``peak_memory_per_module`` so downstream tools such as the
 self-improvement engine can consume them.
 

--- a/sandbox_runner/workflow_sandbox_runner.py
+++ b/sandbox_runner/workflow_sandbox_runner.py
@@ -56,7 +56,9 @@ class ModuleMetrics:
 
     name: str
     duration: float
-    cpu_time: float
+    cpu_before: float
+    cpu_after: float
+    cpu_delta: float
     memory_before: int
     memory_after: int
     memory_delta: int
@@ -595,7 +597,7 @@ class WorkflowSandboxRunner:
                     os.environ[key] = str(value)
 
                 start = perf_counter()
-                cpu_before = 0.0
+                cpu_before = cpu_after = 0.0
                 mem_before = mem_after = 0
                 use_psutil = bool(proc)
                 use_psutil_cpu = use_psutil
@@ -748,7 +750,9 @@ class WorkflowSandboxRunner:
                     module_metric = ModuleMetrics(
                         name=name,
                         duration=duration,
-                        cpu_time=cpu_after - cpu_before,
+                        cpu_before=cpu_before,
+                        cpu_after=cpu_after,
+                        cpu_delta=cpu_after - cpu_before,
                         memory_before=mem_before,
                         memory_after=mem_after,
                         memory_delta=mem_after - mem_before,
@@ -763,7 +767,7 @@ class WorkflowSandboxRunner:
             # ------------------------------------------------------------------
             # Aggregate metrics into a simple telemetry dictionary
             times = {m.name: m.duration for m in metrics.modules}
-            cpu_times = {m.name: m.cpu_time for m in metrics.modules}
+            cpu_times = {m.name: m.cpu_delta for m in metrics.modules}
             results = {m.name: m.result for m in metrics.modules}
             fixtures_info: dict[str, Any] = {}
             for m in metrics.modules:
@@ -785,7 +789,7 @@ class WorkflowSandboxRunner:
             )
             telemetry: dict[str, Any] = {
                 "time_per_module": times,
-                "cpu_time_per_module": cpu_times,
+                "cpu_per_module": cpu_times,
                 "results": results,
                 "crash_frequency": crash_freq,
                 "peak_memory": peak_mem,

--- a/tests/test_workflow_sandbox_runner.py
+++ b/tests/test_workflow_sandbox_runner.py
@@ -89,8 +89,8 @@ def test_safe_mode_blocks_network_and_reports_telemetry():
     telemetry = runner.telemetry
     assert telemetry is not None
     assert set(telemetry["time_per_module"]) == {"start", "network_step"}
-    assert set(telemetry["cpu_time_per_module"]) == {"start", "network_step"}
-    for ct in telemetry["cpu_time_per_module"].values():
+    assert set(telemetry["cpu_per_module"]) == {"start", "network_step"}
+    for ct in telemetry["cpu_per_module"].values():
         assert ct >= 0
     assert telemetry["crash_frequency"] == pytest.approx(1 / 2)
 
@@ -369,8 +369,10 @@ def test_async_workflow_metrics():
 
     for mod in metrics.modules:
         assert isinstance(mod.duration, float)
-        assert isinstance(mod.cpu_time, float)
-        assert mod.cpu_time >= 0
+        assert isinstance(mod.cpu_before, float)
+        assert isinstance(mod.cpu_after, float)
+        assert isinstance(mod.cpu_delta, float)
+        assert mod.cpu_delta >= 0
         assert isinstance(mod.memory_before, int)
         assert isinstance(mod.memory_after, int)
         assert isinstance(mod.memory_delta, int)


### PR DESCRIPTION
## Summary
- track CPU times before and after each module execution
- expose per-module CPU deltas in telemetry via `cpu_per_module`
- adjust tests and docs for new CPU telemetry fields

## Testing
- `pytest tests/test_workflow_sandbox_runner.py`

------
https://chatgpt.com/codex/tasks/task_e_68afc86d1740832e83db34367787d444