### PR TITLE
Restrict safe-mode file writes to mocks

### DIFF
--- a/sandbox_runner/workflow_sandbox_runner.py
+++ b/sandbox_runner/workflow_sandbox_runner.py
@@ -186,6 +186,8 @@ class WorkflowSandboxRunner:
                     fn = fs_mocks.get("open")
                     if fn:
                         return fn(path, mode, *a, **kw)
+                    if safe_mode:
+                        raise RuntimeError("file write disabled in safe_mode")
                     pathlib.Path(path).parent.mkdir(parents=True, exist_ok=True)
                 return original_open(path, mode, *a, **kw)
 
@@ -211,6 +213,8 @@ class WorkflowSandboxRunner:
                     fn = fs_mocks.get("pathlib.Path.open")
                     if fn:
                         return fn(path, *a, **kw)
+                    if safe_mode:
+                        raise RuntimeError("file write disabled in safe_mode")
                     path.parent.mkdir(parents=True, exist_ok=True)
                 return original_path_open(path, *a, **kw)
 
@@ -226,6 +230,8 @@ class WorkflowSandboxRunner:
                 fn = fs_mocks.get("pathlib.Path.write_text")
                 if fn:
                     return fn(path, data, *a, **kw)
+                if safe_mode:
+                    raise RuntimeError("file write disabled in safe_mode")
                 path.parent.mkdir(parents=True, exist_ok=True)
                 return original_write_text(path, data, *a, **kw)
 
@@ -252,6 +258,8 @@ class WorkflowSandboxRunner:
                 fn = fs_mocks.get("pathlib.Path.write_bytes")
                 if fn:
                     return fn(path, data, *a, **kw)
+                if safe_mode:
+                    raise RuntimeError("file write disabled in safe_mode")
                 path.parent.mkdir(parents=True, exist_ok=True)
                 return original_write_bytes(path, data, *a, **kw)
 


### PR DESCRIPTION
## Summary
- forbid direct file writes in safe_mode unless a matching fs mock is supplied
- extend write helpers with safe_mode checks
- test that unmocked writes fail and mocked writes succeed

## Testing
- `pytest tests/test_workflow_sandbox_runner.py::test_open_write_requires_mock_in_safe_mode tests/test_workflow_sandbox_runner.py::test_path_write_text_requires_mock_in_safe_mode tests/test_workflow_sandbox_runner.py::test_path_write_bytes_requires_mock_in_safe_mode tests/test_workflow_sandbox_runner.py::test_mocked_writes_succeed_in_safe_mode -q`
- `pytest tests/test_workflow_sandbox_runner.py::test_files_confined_to_temp_dir -q`


------
https://chatgpt.com/codex/tasks/task_e_68afc9f11e9c832eaeca628ccd048caa