### PR TITLE
Add per-module memory telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1049,8 +1049,8 @@ metrics = runner.run(writer, safe_mode=True)  # network disabled
 ``memory_before``, ``memory_after``, ``memory_delta``, ``memory_peak``,
 ``success``, ``exception`` and ``result`` fields. ``crash_count`` records how
 many modules failed. Callers can interpret these values to evaluate resource
-usage and error rates. Telemetry also exposes ``peak_memory_per_module`` and the
-overall ``peak_memory`` across all modules.
+usage and error rates. Telemetry also exposes ``memory_per_module``,
+``peak_memory_per_module`` and the overall ``peak_memory`` across all modules.
 
 Key arguments include:
 

--- a/docs/sandbox_runner.md
+++ b/docs/sandbox_runner.md
@@ -520,6 +520,7 @@ metrics = runner.run(read_file, safe_mode=True,
 print(metrics.modules[0].success)
 print(runner.telemetry["time_per_module"]["read_file"])
 print(runner.telemetry["cpu_per_module"]["read_file"])
+print(runner.telemetry["memory_per_module"]["read_file"])
 print(runner.telemetry["peak_memory_per_module"]["read_file"])
 ```
 
@@ -605,8 +606,9 @@ environment while ``runner.telemetry`` exposes the collected per‑module metric
 
 Each module may be constrained with a ``timeout`` (seconds) and ``memory_limit``
 (bytes) when calling :meth:`WorkflowSandboxRunner.run`. Exceeding either limit
-aborts the module and records a crash. CPU time and peak RSS memory for every
-module are available in ``runner.telemetry`` under ``cpu_per_module``,
+aborts the module and records a crash. CPU time and RSS deltas for every
+module are available in ``runner.telemetry`` under ``cpu_per_module`` and
+``memory_per_module`` while overall peak RSS metrics appear under
 ``peak_memory`` and ``peak_memory_per_module`` so downstream tools such as the
 self-improvement engine can consume them.
 

--- a/sandbox_runner/workflow_sandbox_runner.py
+++ b/sandbox_runner/workflow_sandbox_runner.py
@@ -776,6 +776,7 @@ class WorkflowSandboxRunner:
             # Aggregate metrics into a simple telemetry dictionary
             times = {m.name: m.duration for m in metrics.modules}
             cpu_times = {m.name: m.cpu_delta for m in metrics.modules}
+            memory_deltas = {m.name: m.memory_delta for m in metrics.modules}
             results = {m.name: m.result for m in metrics.modules}
             fixtures_info: dict[str, Any] = {}
             for m in metrics.modules:
@@ -798,6 +799,7 @@ class WorkflowSandboxRunner:
             telemetry: dict[str, Any] = {
                 "time_per_module": times,
                 "cpu_per_module": cpu_times,
+                "memory_per_module": memory_deltas,
                 "results": results,
                 "crash_frequency": crash_freq,
                 "peak_memory": peak_mem,

--- a/tests/test_workflow_sandbox_runner.py
+++ b/tests/test_workflow_sandbox_runner.py
@@ -434,12 +434,14 @@ def test_async_workflow_metrics():
     telemetry = runner.telemetry
     assert telemetry is not None
     assert set(telemetry["time_per_module"]) == {"ok", "returns_coroutine", "crash"}
+    assert set(telemetry["memory_per_module"]) == {"ok", "returns_coroutine", "crash"}
     assert set(telemetry["peak_memory_per_module"]) == {
         "ok",
         "returns_coroutine",
         "crash",
     }
     for mod in metrics.modules:
+        assert telemetry["memory_per_module"][mod.name] == mod.memory_delta
         assert telemetry["peak_memory_per_module"][mod.name] == mod.memory_peak
     assert telemetry["crash_frequency"] == pytest.approx(1 / 3)
 

--- a/tests/test_workflow_sandbox_runner_isolation.py
+++ b/tests/test_workflow_sandbox_runner_isolation.py
@@ -84,6 +84,10 @@ def test_telemetry_includes_timing_and_memory(runner):
     assert isinstance(mod.memory_peak, int)
     assert mod.memory_peak >= mod.memory_after
 
+    telemetry = runner.telemetry
+    assert telemetry is not None
+    assert telemetry["memory_per_module"][mod.name] == mod.memory_delta
+
 
 def test_module_specific_fixtures_restore_env(runner):
     values: list[str | None] = []


### PR DESCRIPTION
## Summary
- Track per-module memory deltas and expose them in `WorkflowSandboxRunner.telemetry`
- Document memory metrics in README and sandbox runner docs
- Test telemetry now asserts per-module memory mapping

## Testing
- `pytest tests/test_workflow_sandbox_runner.py tests/test_workflow_sandbox_runner_isolation.py::test_telemetry_includes_timing_and_memory -q`


------
https://chatgpt.com/codex/tasks/task_e_68afcbc7e068832ebf343b8919ba4712