### PR TITLE
Add workflow entropy metric for synergy comparisons

### DIFF
--- a/tests/test_workflow_entropy.py
+++ b/tests/test_workflow_entropy.py
@@ -1,0 +1,28 @@
+import math
+
+from menace.workflow_metrics import compute_workflow_entropy
+from menace.workflow_synergy_comparator import WorkflowSynergyComparator
+
+
+def test_compute_workflow_entropy_simple_spec():
+    spec = {
+        "steps": [
+            {"module": "a"},
+            {"module": "a"},
+            {"module": "b"},
+        ]
+    }
+    ent = compute_workflow_entropy(spec)
+    expected = -(2/3)*math.log2(2/3)-(1/3)*math.log2(1/3)
+    assert abs(ent - expected) < 1e-9
+
+
+def test_workflow_synergy_comparator_uses_entropy():
+    spec = {
+        "steps": [
+            {"module": "x"},
+            {"module": "y"},
+        ]
+    }
+    result = WorkflowSynergyComparator.compare(spec, spec)
+    assert result.expandability == compute_workflow_entropy(spec)

--- a/workflow_metrics.py
+++ b/workflow_metrics.py
@@ -1,11 +1,67 @@
+"""Convenience wrappers exposing common workflow metric helpers."""
+
+from __future__ import annotations
+
+from collections import Counter
+import math
+from typing import Any, Dict, Iterable
+
 from .workflow_scorer_core import (
     compute_workflow_synergy,
     compute_bottleneck_index,
     compute_patchability,
 )
 
+
+def compute_workflow_entropy(spec: Dict[str, Any] | Iterable[Any]) -> float:
+    """Return the Shannon entropy of modules used in ``spec``.
+
+    Parameters
+    ----------
+    spec:
+        Workflow specification.  Either a mapping containing a ``steps``
+        sequence or a bare sequence of step mappings/strings.  Each step is
+        expected to expose a ``module`` name; strings are treated directly as
+        module names.
+
+    Returns
+    -------
+    float
+        The Shannon entropy (base 2) of the module frequency distribution.
+    """
+
+    if isinstance(spec, dict):
+        steps = spec.get("steps", [])
+    else:  # Accept raw sequence of steps
+        steps = list(spec) if spec is not None else []
+
+    modules: list[str] = []
+    for step in steps:
+        mod: str | None
+        if isinstance(step, str):
+            mod = step
+        elif isinstance(step, dict):
+            mod = step.get("module")
+        else:
+            mod = None
+        if mod:
+            modules.append(mod)
+
+    total = len(modules)
+    if not total:
+        return 0.0
+
+    counts = Counter(modules)
+    entropy = 0.0
+    for count in counts.values():
+        p = count / total
+        entropy -= p * math.log2(p)
+    return entropy
+
+
 __all__ = [
     "compute_workflow_synergy",
     "compute_bottleneck_index",
     "compute_patchability",
+    "compute_workflow_entropy",
 ]


### PR DESCRIPTION
## Summary
- add `compute_workflow_entropy` helper for calculating module distribution entropy
- integrate entropy helper into `WorkflowSynergyComparator`
- test entropy calculations and comparator integration

## Testing
- `pre-commit run --files workflow_metrics.py workflow_synergy_comparator.py tests/test_workflow_entropy.py`
- `pytest tests/test_workflow_entropy.py`


------
https://chatgpt.com/codex/tasks/task_e_68afd91e4a0c832eb9fa7bfd81e7a963