### PR TITLE
Add workflow lineage merging

### DIFF
--- a/tests/test_workflow_evolution_manager.py
+++ b/tests/test_workflow_evolution_manager.py
@@ -40,6 +40,9 @@ _stub(
 )
 _stub("workflow_summary_db", WorkflowSummaryDB=object)
 _stub("sandbox_settings", SandboxSettings=lambda: SimpleNamespace(roi_ema_alpha=0.1))
+_stub("workflow_synergy_comparator", WorkflowSynergyComparator=object)
+_stub("workflow_metrics", compute_workflow_entropy=lambda spec: 0.0)
+_stub("workflow_merger", merge_workflows=lambda *a, **k: Path("merged.json"))
 
 import menace_sandbox.workflow_evolution_manager as wem
 


### PR DESCRIPTION
## Summary
- compare workflow variants against baseline using WorkflowSynergyComparator
- merge similar variants and re-evaluate merged lineage, recording history
- update tests with stubs for synergy comparator and merger

## Testing
- `pytest tests/test_workflow_evolution_manager.py::test_variant_promotion_updates_graph -q`
- `pytest tests/test_workflow_evolution_manager.py::test_no_improvement_marks_stable -q`


------
https://chatgpt.com/codex/tasks/task_e_68afda5a5214832ea0a338a06876e888