### PR TITLE
Document workflow synergy merging thresholds

### DIFF
--- a/docs/workflow_evolution.md
+++ b/docs/workflow_evolution.md
@@ -20,6 +20,24 @@ Each candidate sequence is validated for structural soundness before evaluation.
 
 Every variant is converted into a callable and scored by `CompositeWorkflowScorer`. The variant with the highest ROI gain is promoted when its ROI exceeds the baseline. Outcomes are logged via `ROIResultsDB` and `mutation_logger` for later analysis.
 
+## Synergy comparison and merging
+
+`WorkflowSynergyComparator` analyses the baseline and each variant for
+structural similarity. It reports **efficiency** (embedding cosine
+similarity), **modularity** (Jaccard overlap) and **expandability** (average
+step entropy). When the mean of efficiency and modularity meets
+`SandboxSettings.workflow_merge_similarity` and the entropy difference stays
+below `SandboxSettings.workflow_merge_entropy_delta`, the manager attempts to
+merge both specifications via `workflow_merger.merge_workflows`. The merged
+workflow is re-scored and promoted if it outperforms the baseline.
+
+Tune the merge thresholds with environment variables:
+
+```bash
+export WORKFLOW_MERGE_SIMILARITY=0.95
+export WORKFLOW_MERGE_ENTROPY_DELTA=0.05
+```
+
 ## Diminishing-returns gating
 
 Workflow ROI improvements are tracked with an exponential moving average (EMA).

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -125,6 +125,16 @@ class SandboxSettings(BaseSettings):
     synergy_threshold: float | None = Field(None, env="SYNERGY_THRESHOLD")
     roi_confidence: float | None = Field(None, env="ROI_CONFIDENCE")
     synergy_confidence: float | None = Field(None, env="SYNERGY_CONFIDENCE")
+    workflow_merge_similarity: float = Field(
+        0.9,
+        env="WORKFLOW_MERGE_SIMILARITY",
+        description="Minimum average efficiency/modularity required to merge workflows.",
+    )
+    workflow_merge_entropy_delta: float = Field(
+        0.1,
+        env="WORKFLOW_MERGE_ENTROPY_DELTA",
+        description="Maximum entropy difference allowed when merging workflows.",
+    )
     borderline_raroi_threshold: float = Field(
         0.0,
         env="BORDERLINE_RAROI_THRESHOLD",

--- a/tests/test_workflow_evolution_manager.py
+++ b/tests/test_workflow_evolution_manager.py
@@ -40,7 +40,14 @@ _stub(
     log_workflow_evolution=lambda **kw: None,
 )
 _stub("workflow_summary_db", WorkflowSummaryDB=object)
-_stub("sandbox_settings", SandboxSettings=lambda: SimpleNamespace(roi_ema_alpha=0.1))
+_stub(
+    "sandbox_settings",
+    SandboxSettings=lambda: SimpleNamespace(
+        roi_ema_alpha=0.1,
+        workflow_merge_similarity=0.9,
+        workflow_merge_entropy_delta=0.1,
+    ),
+)
 _stub("workflow_synergy_comparator", WorkflowSynergyComparator=object)
 _stub("workflow_metrics", compute_workflow_entropy=lambda spec: 0.0)
 _stub("workflow_merger", merge_workflows=lambda *a, **k: Path("merged.json"))

--- a/workflow_evolution_manager.py
+++ b/workflow_evolution_manager.py
@@ -179,6 +179,7 @@ def evolve(
         return workflow_callable
 
     bot = WorkflowEvolutionBot()
+    settings = SandboxSettings()
 
     best_callable = workflow_callable
     best_roi = baseline_roi
@@ -207,12 +208,8 @@ def evolve(
                 ent_a = compute_workflow_entropy({"steps": baseline_spec})
                 ent_b = compute_workflow_entropy({"steps": variant_spec})
                 ent_delta = abs(ent_a - ent_b)
-                sim_thresh = float(
-                    os.getenv("WORKFLOW_MERGE_SIMILARITY", "0.9") or 0.9
-                )
-                ent_thresh = float(
-                    os.getenv("WORKFLOW_MERGE_ENTROPY_DELTA", "0.1") or 0.1
-                )
+                sim_thresh = settings.workflow_merge_similarity
+                ent_thresh = settings.workflow_merge_entropy_delta
                 if similarity >= sim_thresh and ent_delta <= ent_thresh:
                     base_path = Path(f"{wf_id_str}.base.json")
                     a_path = Path(f"{wf_id_str}.a.json")


### PR DESCRIPTION
## Summary
- explain WorkflowSynergyComparator merge logic and configurable thresholds
- centralize merge thresholds in `SandboxSettings` with env var overrides
- use settings in `WorkflowEvolutionManager` and adjust tests

## Testing
- `pytest tests/test_workflow_synergy_comparator.py tests/test_workflow_entropy.py tests/test_workflow_evolution_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68afddba8738832e984f2a6edd948f8e