### PR TITLE
Add workflow deduplication after evolution promotions

### DIFF
--- a/workflow_evolution_manager.py
+++ b/workflow_evolution_manager.py
@@ -26,6 +26,10 @@ try:  # pragma: no cover - optional at runtime
     from .workflow_graph import WorkflowGraph
 except Exception:  # pragma: no cover - best effort
     WorkflowGraph = None  # type: ignore
+try:  # pragma: no cover - optional at runtime
+    from .workflow_lineage import load_specs as _load_specs
+except Exception:  # pragma: no cover - best effort
+    _load_specs = None  # type: ignore
 try:
     from .evolution_history_db import EvolutionHistoryDB, EvolutionEvent
 except Exception:  # pragma: no cover - optional dependency
@@ -354,6 +358,8 @@ def evolve(
             best_variant_seq = seq
             best_variant_result = variant_result
 
+    # Instantiate comparator for post-promotion duplicate checks
+    comparator = WorkflowSynergyComparator()
     delta = best_delta
 
     # Record final RAROI for history
@@ -485,6 +491,110 @@ def evolve(
         if integrate_orphans is not None:
             repo = Path(os.getenv("SANDBOX_REPO_PATH", "."))
             integrate_orphans(repo, router=GLOBAL_ROUTER)
+
+        # Deduplicate against existing stable workflows
+        merged_callable = best_callable
+        try:
+            promoted_spec = json.loads(saved_path.read_text())
+        except Exception:
+            promoted_spec = None
+        candidates: list[tuple[str, Path]] = []
+        if new_id is not None and promoted_spec is not None:
+            try:
+                if _load_specs is not None:
+                    for spec in _load_specs("workflows"):
+                        wid = str(spec.get("workflow_id"))
+                        if wid and wid != str(new_id) and STABLE_WORKFLOWS.is_stable(wid):
+                            path = Path("workflows") / f"{wid}.workflow.json"
+                            if path.exists():
+                                candidates.append((wid, path))
+                elif WorkflowGraph is not None:
+                    graph = WorkflowGraph()
+                    node_ids = getattr(getattr(graph, "graph", graph), "nodes", lambda: [])
+                    for wid in node_ids() if callable(node_ids) else node_ids:
+                        wid_str = str(wid)
+                        if wid_str != str(new_id) and STABLE_WORKFLOWS.is_stable(wid_str):
+                            path = Path("workflows") / f"{wid_str}.workflow.json"
+                            if path.exists():
+                                candidates.append((wid_str, path))
+            except Exception:  # pragma: no cover - best effort
+                logger.exception("failed loading candidate workflows")
+
+        for cand_id, cand_path in candidates:
+            try:
+                cand_spec = json.loads(cand_path.read_text())
+                if comparator.is_duplicate(promoted_spec, cand_spec):
+                    ent_delta = abs(
+                        compute_workflow_entropy(promoted_spec)
+                        - compute_workflow_entropy(cand_spec)
+                    )
+                    if ent_delta <= settings.workflow_merge_entropy_delta:
+                        base_path = cand_path
+                        a_path = cand_path
+                        b_path = saved_path
+                        out_path = cand_path.with_name(f"{cand_id}.merged.json")
+                        merged_file = workflow_merger.merge_workflows(
+                            base_path, a_path, b_path, out_path
+                        )
+                        try:
+                            merged_data = json.loads(merged_file.read_text())
+                            merged_steps = merged_data.get("steps", [])
+                            seq = "-".join(
+                                s.get("module") for s in merged_steps if s.get("module")
+                            )
+                            merged_callable = _build_callable(seq)
+                            run_id = f"merge-{cand_id}-{new_id}"
+                            scorer = CompositeWorkflowScorer(
+                                results_db=results_db, tracker=tracker
+                            )
+                            merged_result = scorer.run(
+                                merged_callable, str(cand_id), run_id=run_id
+                            )
+                            merged_id = (
+                                merged_data.get("metadata", {}).get("workflow_id")
+                            )
+                            if merged_id:
+                                workflow_run_summary.record_run(
+                                    str(merged_id), merged_result.roi_gain
+                                )
+                                tracker.score_workflow(str(merged_id), final_raroi)
+                                setattr(merged_callable, "workflow_id", merged_id)
+                            if (
+                                EVOLUTION_DB is not None
+                                and EvolutionEvent is not None
+                            ):
+                                try:
+                                    EVOLUTION_DB.add(
+                                        EvolutionEvent(
+                                            action="merge",
+                                            before_metric=best_roi,
+                                            after_metric=merged_result.roi_gain,
+                                            roi=merged_result.roi_gain - best_roi,
+                                            workflow_id=int(
+                                                merged_id if merged_id else cand_id
+                                            ),
+                                            reason="merge",
+                                            trigger="workflow_evolution_manager",
+                                            performance=
+                                                merged_result.roi_gain - best_roi,
+                                        )
+                                    )
+                                except Exception:
+                                    logger.exception(
+                                        "failed logging merged lineage event"
+                                    )
+                            best_callable = merged_callable
+                            saved_path = merged_file
+                            new_id = merged_id or new_id
+                            best_roi = merged_result.roi_gain
+                            break
+                        finally:
+                            try:
+                                out_path.unlink()
+                            except Exception:
+                                pass
+            except Exception:  # pragma: no cover - best effort
+                logger.exception("failed comparing workflow %s", cand_id)
 
         # ensure promoted callable exposes lineage metadata
         setattr(best_callable, "parent_id", workflow_id)


### PR DESCRIPTION
## Summary
- instantiate `WorkflowSynergyComparator` for post-promotion duplicate detection
- compare promoted workflows with existing stable ones and merge duplicates
- add regression test covering duplicate merge behaviour

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'update_relevancy_metrics' from '<unknown module name>' ... and many others)*

------
https://chatgpt.com/codex/tasks/task_e_68afe233b098832e828989d3d0d54acd