### PR TITLE
Deduplicate promoted workflows using synergy comparator

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -40,7 +40,10 @@ class SandboxSettings(BaseSettings):
     auto_include_isolated: bool = Field(
         True,
         env="SANDBOX_AUTO_INCLUDE_ISOLATED",
-        description="Automatically include isolated modules during orphan scans (enabled by default).",
+        description=(
+            "Automatically include isolated modules during orphan scans "
+            "(enabled by default)."
+        ),
     )
     recursive_orphan_scan: bool = Field(
         True,
@@ -135,6 +138,16 @@ class SandboxSettings(BaseSettings):
         env="WORKFLOW_MERGE_ENTROPY_DELTA",
         description="Maximum entropy difference allowed when merging workflows.",
     )
+    duplicate_similarity: float = Field(
+        0.95,
+        env="WORKFLOW_DUPLICATE_SIMILARITY",
+        description="Minimum cosine similarity to treat workflows as duplicates.",
+    )
+    duplicate_entropy: float = Field(
+        0.05,
+        env="WORKFLOW_DUPLICATE_ENTROPY",
+        description="Maximum entropy delta allowed when deduplicating workflows.",
+    )
     borderline_raroi_threshold: float = Field(
         0.0,
         env="BORDERLINE_RAROI_THRESHOLD",
@@ -172,7 +185,10 @@ class SandboxSettings(BaseSettings):
     entropy_ceiling_consecutive: int | None = Field(
         None,
         env="ENTROPY_CEILING_CONSECUTIVE",
-        description="Number of consecutive cycles below the ceiling threshold before flagging a module.",
+        description=(
+            "Number of consecutive cycles below the ceiling threshold before "
+            "flagging a module."
+        ),
     )
     min_integration_roi: float = Field(
         0.0,
@@ -182,9 +198,15 @@ class SandboxSettings(BaseSettings):
     synergy_threshold_window: int | None = Field(None, env="SYNERGY_THRESHOLD_WINDOW")
     synergy_threshold_weight: float | None = Field(None, env="SYNERGY_THRESHOLD_WEIGHT")
     synergy_ma_window: int | None = Field(None, env="SYNERGY_MA_WINDOW")
-    synergy_stationarity_confidence: float | None = Field(None, env="SYNERGY_STATIONARITY_CONFIDENCE")
-    synergy_std_threshold: float | None = Field(None, env="SYNERGY_STD_THRESHOLD")
-    synergy_variance_confidence: float | None = Field(None, env="SYNERGY_VARIANCE_CONFIDENCE")
+    synergy_stationarity_confidence: float | None = Field(
+        None, env="SYNERGY_STATIONARITY_CONFIDENCE"
+    )
+    synergy_std_threshold: float | None = Field(
+        None, env="SYNERGY_STD_THRESHOLD"
+    )
+    synergy_variance_confidence: float | None = Field(
+        None, env="SYNERGY_VARIANCE_CONFIDENCE"
+    )
 
     relevancy_threshold: int = Field(
         20,
@@ -260,7 +282,10 @@ class SandboxSettings(BaseSettings):
             "upstream_failure_rate": 0.1,
         },
         env="SCENARIO_METRIC_THRESHOLDS",
-        description="Thresholds for scenario-specific metrics returned by _scenario_specific_metrics.",
+        description=(
+            "Thresholds for scenario-specific metrics returned by "
+            "_scenario_specific_metrics."
+        ),
     )
     fail_on_missing_scenarios: bool = Field(
         False,

--- a/tests/test_orphan_auto_indexing.py
+++ b/tests/test_orphan_auto_indexing.py
@@ -161,7 +161,16 @@ def test_evolve_auto_indexes_promoted_orphans(tmp_path, monkeypatch):
         ),
     )
     _stub("workflow_summary_db", WorkflowSummaryDB=object)
-    _stub("sandbox_settings", SandboxSettings=lambda: SimpleNamespace(roi_ema_alpha=0.1))
+    _stub(
+        "sandbox_settings",
+        SandboxSettings=lambda: SimpleNamespace(
+            roi_ema_alpha=0.1,
+            workflow_merge_similarity=0.9,
+            workflow_merge_entropy_delta=0.1,
+            duplicate_similarity=0.95,
+            duplicate_entropy=0.05,
+        ),
+    )
     _stub("evolution_history_db", EvolutionHistoryDB=object, EvolutionEvent=object)
     _stub("workflow_graph", WorkflowGraph=object)
     _stub("mutation_logger", log_mutation=lambda **kw: 1, log_workflow_evolution=lambda **kw: None)

--- a/tests/test_workflow_evolution.py
+++ b/tests/test_workflow_evolution.py
@@ -84,7 +84,13 @@ def _load_manager(variant_seq="mod_a", variant_roi=1.5):
     sys.modules["menace_sandbox.roi_tracker"] = tracker_mod
 
     settings_mod = ModuleType("menace_sandbox.sandbox_settings")
-    settings_mod.SandboxSettings = lambda *a, **k: SimpleNamespace(roi_ema_alpha=0.1)
+    settings_mod.SandboxSettings = lambda *a, **k: SimpleNamespace(
+        roi_ema_alpha=0.1,
+        workflow_merge_similarity=0.9,
+        workflow_merge_entropy_delta=0.1,
+        duplicate_similarity=0.95,
+        duplicate_entropy=0.05,
+    )
     sys.modules["menace_sandbox.sandbox_settings"] = settings_mod
 
     stab_mod = ModuleType("menace_sandbox.workflow_stability_db")

--- a/tests/test_workflow_evolution_behaviour.py
+++ b/tests/test_workflow_evolution_behaviour.py
@@ -80,7 +80,13 @@ def _load_manager(variant_rois, generate_calls=None, diminishing=0.05):
     sys.modules["menace_sandbox.roi_tracker"] = tracker_mod
 
     settings_mod = ModuleType("menace_sandbox.sandbox_settings")
-    settings_mod.SandboxSettings = lambda *a, **k: SimpleNamespace(roi_ema_alpha=0.1)
+    settings_mod.SandboxSettings = lambda *a, **k: SimpleNamespace(
+        roi_ema_alpha=0.1,
+        workflow_merge_similarity=0.9,
+        workflow_merge_entropy_delta=0.1,
+        duplicate_similarity=0.95,
+        duplicate_entropy=0.05,
+    )
     sys.modules["menace_sandbox.sandbox_settings"] = settings_mod
 
     class WorkflowStabilityDB:

--- a/tests/test_workflow_evolution_layer.py
+++ b/tests/test_workflow_evolution_layer.py
@@ -113,7 +113,13 @@ def evolution_setup():
     sys.modules["menace_sandbox.roi_tracker"] = tracker_mod
 
     settings_mod = ModuleType("menace_sandbox.sandbox_settings")
-    settings_mod.SandboxSettings = lambda *a, **k: SimpleNamespace(roi_ema_alpha=0.1)
+    settings_mod.SandboxSettings = lambda *a, **k: SimpleNamespace(
+        roi_ema_alpha=0.1,
+        workflow_merge_similarity=0.9,
+        workflow_merge_entropy_delta=0.1,
+        duplicate_similarity=0.95,
+        duplicate_entropy=0.05,
+    )
     sys.modules["menace_sandbox.sandbox_settings"] = settings_mod
 
     stab_mod = ModuleType("menace_sandbox.workflow_stability_db")
@@ -240,7 +246,9 @@ def test_stable_when_no_variant_improves(evolution_setup, baseline_workflow):
     assert len(scorer.run_ids) == 3
 
 
-def test_gating_prevents_further_evolution(monkeypatch, tmp_path, evolution_setup, baseline_workflow):
+def test_gating_prevents_further_evolution(
+    monkeypatch, tmp_path, evolution_setup, baseline_workflow
+):
     wem = evolution_setup.module
     scorer = evolution_setup.scorer
 

--- a/tests/test_workflow_variant_scenarios.py
+++ b/tests/test_workflow_variant_scenarios.py
@@ -72,7 +72,9 @@ def test_benchmark_workflow_variants_calculates_roi_delta():
     src = Path("self_improvement_engine.py").read_text()
     tree = ast.parse(src)
     func_node = next(
-        n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "benchmark_workflow_variants"
+        n
+        for n in tree.body
+        if isinstance(n, ast.FunctionDef) and n.name == "benchmark_workflow_variants"
     )
     module = ast.Module([func_node], type_ignores=[])
     ns: dict[str, object] = {
@@ -101,6 +103,7 @@ def _import_wem(side_effects, generate_calls=None):
     sys.modules["menace_sandbox"] = pkg
 
     cws_mod = ModuleType("menace_sandbox.composite_workflow_scorer")
+
     class CompositeWorkflowScorer:
         def __init__(self, *a, **k):
             pass
@@ -113,6 +116,7 @@ def _import_wem(side_effects, generate_calls=None):
     sys.modules["menace_sandbox.composite_workflow_scorer"] = cws_mod
 
     bot_mod = ModuleType("menace_sandbox.workflow_evolution_bot")
+
     class WorkflowEvolutionBot:
         _rearranged_events = {}
 
@@ -125,6 +129,7 @@ def _import_wem(side_effects, generate_calls=None):
     sys.modules["menace_sandbox.workflow_evolution_bot"] = bot_mod
 
     db_mod = ModuleType("menace_sandbox.roi_results_db")
+
     class ROIResultsDB:
         def __init__(self, *a, **k):
             pass
@@ -155,6 +160,7 @@ def _import_wem(side_effects, generate_calls=None):
     sys.modules["menace_sandbox.mutation_logger"] = mut_mod
 
     tracker_mod = ModuleType("menace_sandbox.roi_tracker")
+
     class ROITracker:
         def __init__(self, *a, **k):
             self.roi_history = []
@@ -172,10 +178,17 @@ def _import_wem(side_effects, generate_calls=None):
     sys.modules["menace_sandbox.roi_tracker"] = tracker_mod
 
     settings_mod = ModuleType("menace_sandbox.sandbox_settings")
-    settings_mod.SandboxSettings = lambda *a, **k: SimpleNamespace(roi_ema_alpha=0.1)
+    settings_mod.SandboxSettings = lambda *a, **k: SimpleNamespace(
+        roi_ema_alpha=0.1,
+        workflow_merge_similarity=0.9,
+        workflow_merge_entropy_delta=0.1,
+        duplicate_similarity=0.95,
+        duplicate_entropy=0.05,
+    )
     sys.modules["menace_sandbox.sandbox_settings"] = settings_mod
 
     stab_mod = ModuleType("menace_sandbox.workflow_stability_db")
+
     class WorkflowStabilityDB:
         def __init__(self, *a, **k):
             self.data = {}
@@ -216,6 +229,7 @@ def _import_wem(side_effects, generate_calls=None):
     sys.modules["menace_sandbox.workflow_stability_db"] = stab_mod
 
     summary_mod = ModuleType("menace_sandbox.workflow_summary_db")
+
     class WorkflowSummaryDB:
         def set_summary(self, *a, **k):
             pass


### PR DESCRIPTION
## Summary
- add duplicate similarity/entropy thresholds to `SandboxSettings`
- invoke `WorkflowSynergyComparator` after variant promotion to merge duplicates and rescore
- stub tests updated for new settings

## Testing
- `pre-commit run --files sandbox_settings.py workflow_evolution_manager.py`
- `pytest tests/test_workflow_evolution_manager.py::test_promoted_duplicate_triggers_merge` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68afeba79c0c832e956982eb360deee2