### PR TITLE
Add tests for workflow similarity and evolution merging

### DIFF
--- a/tests/test_evolution_lineage_merge.py
+++ b/tests/test_evolution_lineage_merge.py
@@ -1,0 +1,194 @@
+import json
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+# Setup package context and stub heavy dependencies before import
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+pkg = types.ModuleType("menace_sandbox")
+pkg.__path__ = [str(ROOT / "menace_sandbox")]
+sys.modules.setdefault("menace_sandbox", pkg)
+
+
+def _stub(name: str, **attrs):
+    mod = types.ModuleType(f"menace_sandbox.{name}")
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[f"menace_sandbox.{name}"] = mod
+
+
+_stub("composite_workflow_scorer", CompositeWorkflowScorer=object)
+_stub("workflow_evolution_bot", WorkflowEvolutionBot=object)
+_stub("roi_results_db", ROIResultsDB=object)
+_stub("roi_tracker", ROITracker=object)
+_stub(
+    "workflow_stability_db",
+    WorkflowStabilityDB=type(
+        "WorkflowStabilityDB",
+        (),
+        {
+            "is_stable": lambda self, wid, *a, **k: False,
+            "mark_stable": lambda self, *a, **k: None,
+            "clear": lambda self, *a, **k: None,
+            "get_ema": lambda self, wid: (0.0, 0),
+            "set_ema": lambda self, wid, ema, count: None,
+        },
+    ),
+)
+_stub("evolution_history_db", EvolutionHistoryDB=object, EvolutionEvent=object)
+_stub("mutation_logger", log_mutation=lambda **kw: 1, log_workflow_evolution=lambda **kw: None)
+_stub("workflow_summary_db", WorkflowSummaryDB=object)
+_stub(
+    "sandbox_settings",
+    SandboxSettings=lambda: SimpleNamespace(
+        roi_ema_alpha=0.1,
+        workflow_merge_similarity=0.9,
+        workflow_merge_entropy_delta=0.1,
+        duplicate_similarity=0.9,
+        duplicate_entropy=0.1,
+    ),
+)
+_stub("workflow_synergy_comparator", WorkflowSynergyComparator=object)
+_stub("workflow_metrics", compute_workflow_entropy=lambda spec: 0.0)
+_stub("workflow_benchmark", benchmark_workflow=lambda *a, **k: None)
+_stub("workflow_merger", merge_workflows=lambda *a, **k: Path("merged.json"))
+_stub(
+    "workflow_run_summary",
+    record_run=lambda *a, **k: None,
+    save_all_summaries=lambda *a, **k: None,
+)
+_stub(
+    "sandbox_runner",
+    WorkflowSandboxRunner=type(
+        "Runner",
+        (),
+        {"run": lambda self, fn, safe_mode=True: SimpleNamespace(modules=[])},
+    ),
+)
+_stub(
+    "workflow_synthesizer",
+    save_workflow=lambda *a, **k: (Path("dummy.json"), {"workflow_id": "merged", "created_at": ""}),
+)
+_stub(
+    "workflow_graph",
+    WorkflowGraph=type(
+        "Graph",
+        (),
+        {
+            "add_workflow": lambda self, *a, **k: None,
+            "add_dependency": lambda self, *a, **k: None,
+        },
+    ),
+)
+_stub("workflow_lineage", load_specs=lambda path: [])
+
+import menace_sandbox.workflow_evolution_manager as wem  # noqa: E402
+
+# Restore real modules for other tests
+for mod in [
+    "menace_sandbox.composite_workflow_scorer",
+    "menace_sandbox.workflow_evolution_bot",
+    "menace_sandbox.roi_results_db",
+    "menace_sandbox.roi_tracker",
+    "menace_sandbox.workflow_stability_db",
+    "menace_sandbox.evolution_history_db",
+    "menace_sandbox.mutation_logger",
+    "menace_sandbox.workflow_summary_db",
+    "menace_sandbox.sandbox_settings",
+    "menace_sandbox.workflow_synergy_comparator",
+    "menace_sandbox.workflow_metrics",
+    "menace_sandbox.workflow_merger",
+    "menace_sandbox.workflow_run_summary",
+    "menace_sandbox.sandbox_runner",
+    "menace_sandbox.workflow_synthesizer",
+    "menace_sandbox.workflow_graph",
+    "menace_sandbox.workflow_lineage",
+]:
+    sys.modules.pop(mod, None)
+
+
+def test_merge_similar_workflows(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    baseline_spec = [{"module": "a"}]
+    variant_spec = [{"module": "a"}]
+
+    class FakeBot:
+        _rearranged_events: dict[str, int] = {}
+
+        def generate_variants(self, limit, workflow_id):
+            yield "a"
+
+    monkeypatch.setattr(wem, "WorkflowEvolutionBot", lambda: FakeBot())
+
+    class FakeScorer:
+        def __init__(self, results_db, tracker):
+            pass
+
+        def run(self, fn, wf_id, run_id):
+            if run_id == "baseline":
+                roi, spec = 1.0, baseline_spec
+            elif run_id.startswith("merge-"):
+                roi, spec = 3.0, variant_spec
+            else:
+                roi, spec = 2.0, variant_spec
+            return SimpleNamespace(
+                roi_gain=roi, runtime=0.0, success_rate=1.0, workflow_spec=spec
+            )
+
+    monkeypatch.setattr(wem, "CompositeWorkflowScorer", FakeScorer)
+    monkeypatch.setattr(
+        wem,
+        "ROIResultsDB",
+        lambda: SimpleNamespace(log_module_delta=lambda *a, **k: None),
+    )
+    monkeypatch.setattr(
+        wem,
+        "ROITracker",
+        lambda: SimpleNamespace(
+            calculate_raroi=lambda roi: (0, roi, 0),
+            score_workflow=lambda wf, raroi: None,
+            diminishing=lambda: 0,
+        ),
+    )
+    monkeypatch.setattr(
+        wem,
+        "MutationLogger",
+        SimpleNamespace(
+            log_mutation=lambda **kw: 1,
+            log_workflow_evolution=lambda **kw: None,
+        ),
+    )
+    monkeypatch.setattr(wem, "EVOLUTION_DB", SimpleNamespace(add=lambda *a, **k: None))
+    monkeypatch.setattr(wem, "EvolutionEvent", lambda *a, **k: None)
+    monkeypatch.setattr(wem, "_update_ema", lambda *a, **k: False)
+    monkeypatch.setattr(wem.STABLE_WORKFLOWS, "mark_stable", lambda *a, **k: None)
+    monkeypatch.setattr(wem.STABLE_WORKFLOWS, "clear", lambda *a, **k: None)
+    monkeypatch.setattr(wem.STABLE_WORKFLOWS, "is_stable", lambda wid, *a, **k: False)
+
+    merge_called: dict[str, tuple] = {}
+
+    def fake_merge(base, a, b, out):
+        merge_called["paths"] = (base, a, b, out)
+        out.write_text(
+            json.dumps({"steps": variant_spec, "metadata": {"workflow_id": "merged"}})
+        )
+        return out
+
+    monkeypatch.setattr(
+        wem, "workflow_merger", SimpleNamespace(merge_workflows=fake_merge)
+    )
+
+    class FakeComparator:
+        @staticmethod
+        def compare(a, b):
+            return SimpleNamespace(similarity=1.0, entropy_a=0.0, entropy_b=0.0)
+
+    monkeypatch.setattr(wem, "WorkflowSynergyComparator", FakeComparator)
+
+    result_callable = wem.evolve(lambda: True, 1, variants=1)
+    assert "paths" in merge_called
+    assert getattr(result_callable, "workflow_id") == "merged"
+    assert getattr(result_callable, "parent_id") == 1

--- a/tests/test_synergy_metrics_simple.py
+++ b/tests/test_synergy_metrics_simple.py
@@ -1,0 +1,37 @@
+import math
+import pytest
+from menace_sandbox import workflow_synergy_comparator as wsc
+
+
+def _mock_optional(monkeypatch):
+    monkeypatch.setattr(wsc, "_HAS_NX", False, raising=False)
+    monkeypatch.setattr(wsc, "WorkflowVectorizer", None, raising=False)
+    monkeypatch.setattr(wsc, "ROITracker", None, raising=False)
+
+
+def test_similarity_and_entropy(monkeypatch):
+    _mock_optional(monkeypatch)
+    spec_a = {"steps": [{"module": "a"}, {"module": "b"}, {"module": "c"}]}
+    spec_b = {
+        "steps": [
+            {"module": "a"},
+            {"module": "b"},
+            {"module": "a"},
+            {"module": "b"},
+        ]
+    }
+    scores = wsc.WorkflowSynergyComparator.compare(spec_a, spec_b)
+    expected_sim = 4 / (math.sqrt(3) * math.sqrt(8))
+    assert scores.similarity == pytest.approx(expected_sim)
+    assert scores.entropy_a == pytest.approx(math.log2(3))
+    assert scores.entropy_b == pytest.approx(1.0)
+
+
+def test_duplicate_detection_thresholds(monkeypatch):
+    _mock_optional(monkeypatch)
+    spec_a = {"steps": [{"module": "x"}, {"module": "x"}]}
+    spec_b = {"steps": [{"module": "x"}, {"module": "y"}]}
+    assert not wsc.WorkflowSynergyComparator.is_duplicate(spec_a, spec_b)
+    assert wsc.WorkflowSynergyComparator.is_duplicate(
+        spec_a, spec_b, {"similarity": 0.7, "entropy": 1.0}
+    )


### PR DESCRIPTION
## Summary
- add lightweight tests for workflow similarity/entropy and duplicate detection
- cover evolution loop merging similar workflows into a single lineage
- stub optional dependencies to keep tests fast

## Testing
- `pre-commit run --files tests/test_synergy_metrics_simple.py tests/test_evolution_lineage_merge.py`
- `pytest tests/test_synergy_metrics_simple.py tests/test_evolution_lineage_merge.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aff82c3824832ebbbf07301937b6d8