### PR TITLE
Add workflow synergy comparison CLI

### DIFF
--- a/workflow_synergy_cli.py
+++ b/workflow_synergy_cli.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""CLI for comparing two workflow specifications using synergy heuristics."""
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+from workflow_synergy_comparator import WorkflowSynergyComparator
+
+
+def cli(argv: list[str] | None = None) -> int:
+    """Run the workflow synergy comparison command line interface."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("workflow_a", help="First workflow file or identifier")
+    parser.add_argument("workflow_b", help="Second workflow file or identifier")
+    parser.add_argument("--out", default="-", help="Output file or '-' for stdout")
+    args = parser.parse_args(argv)
+
+    scores = WorkflowSynergyComparator.compare(args.workflow_a, args.workflow_b)
+    data = json.dumps(asdict(scores), indent=2)
+
+    if args.out == "-":
+        sys.stdout.write(data)
+    else:
+        Path(args.out).write_text(data, encoding="utf-8")
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> None:
+    sys.exit(cli(argv))
+
+
+__all__ = ["cli", "main"]
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()


### PR DESCRIPTION
## Summary
- add `workflow_synergy_cli` to compare two workflow specifications and output synergy scores

## Testing
- `pre-commit run --files workflow_synergy_cli.py`
- `pytest` *(fails: 261 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68affc38d73c832e8e5d76beb5a4b473