### PR TITLE
Streamline workflow duplicate detection

### DIFF
--- a/docs/autonomous_sandbox.md
+++ b/docs/autonomous_sandbox.md
@@ -121,7 +121,7 @@ variant. The helper exposes:
   entropy gap.
 - `WorkflowSynergyComparator.is_duplicate(result, thresholds=None)` – flag
   near‑identical workflows using the scores returned by
-  `WorkflowSynergyComparator.compare()` or two workflow specifications.
+  `WorkflowSynergyComparator.compare()`.
 - `WorkflowSynergyComparator.merge_duplicate(base_id, dup_id)` – merge the
   duplicate into the canonical workflow.
 

--- a/docs/workflow_synergy_comparator.md
+++ b/docs/workflow_synergy_comparator.md
@@ -30,9 +30,7 @@ print(scores.similarity, scores.expandability)
 is_dup = WorkflowSynergyComparator.is_duplicate(
     scores, {"similarity": 0.95, "entropy": 0.05}
 )
-
-`is_duplicate` also accepts two workflow specifications or identifiers instead of
-precomputed scores.
+``is_duplicate`` expects the ``SynergyScores`` returned by ``compare``.
 ```
 
 ## Configuration

--- a/tests/test_workflow_evolution_manager.py
+++ b/tests/test_workflow_evolution_manager.py
@@ -293,19 +293,20 @@ def test_promoted_duplicate_triggers_merge(monkeypatch, tmp_path):
             return SimpleNamespace(similarity=1.0, entropy_a=0.0, entropy_b=0.0)
 
         @staticmethod
-        def is_duplicate(result, b_spec=None, thresholds=None):
+        def is_duplicate(result, thresholds=None):
             return True
 
-        @classmethod
-        def merge_duplicate(cls, base_id, dup_id, out_dir="workflows"):
-            merge_called["called"] = True
-            out_path = Path(out_dir) / f"{base_id}.merged.json"
-            out_path.write_text(
-                json.dumps({"steps": variant_spec, "metadata": {"workflow_id": 123}})
-            )
-            return out_path
-
     monkeypatch.setattr(wem, "WorkflowSynergyComparator", DummyComparator)
+
+    def fake_merge(base, a, b, out):
+        merge_called["called"] = True
+        out_path = Path(out)
+        out_path.write_text(
+            json.dumps({"steps": variant_spec, "metadata": {"workflow_id": 123}})
+        )
+        return out_path
+
+    monkeypatch.setattr(wem.workflow_merger, "merge_workflows", fake_merge)
 
     wem.evolve(lambda: True, 1, variants=1)
 

--- a/workflow_evolution_manager.py
+++ b/workflow_evolution_manager.py
@@ -299,9 +299,9 @@ def evolve(
             for cand_id, cand_path in candidates:
                 try:
                     cand_spec = json.loads(cand_path.read_text())
+                    scores = comparator.compare({"steps": variant_spec}, cand_spec)
                     if comparator.is_duplicate(
-                        {"steps": variant_spec},
-                        cand_spec,
+                        scores,
                         {
                             "similarity": settings.duplicate_similarity,
                             "entropy": settings.duplicate_entropy,

--- a/workflow_synergy_cli.py
+++ b/workflow_synergy_cli.py
@@ -20,7 +20,8 @@ def cli(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     scores = WorkflowSynergyComparator.compare(args.workflow_a, args.workflow_b)
-    data = json.dumps(asdict(scores), indent=2)
+    duplicate = WorkflowSynergyComparator.is_duplicate(scores)
+    data = json.dumps({"duplicate": duplicate, **asdict(scores)}, indent=2)
 
     if args.out == "-":
         sys.stdout.write(data)

--- a/workflow_synergy_comparator.py
+++ b/workflow_synergy_comparator.py
@@ -337,39 +337,21 @@ class WorkflowSynergyComparator:
     # ------------------------------------------------------------------
     @classmethod
     def is_duplicate(
-        cls,
-        scores_or_a: SynergyScores | Dict[str, Any] | str | Path,
-        b_spec: Dict[str, Any] | str | Path | None = None,
-        thresholds: Optional[Dict[str, float]] = None,
+        cls, scores: SynergyScores, thresholds: Optional[Dict[str, float]] = None
     ) -> bool:
         """Return ``True`` when two workflows are near-identical.
 
-        Parameters
-        ----------
-        scores_or_a:
-            Either a :class:`SynergyScores` instance produced by :meth:`compare`
-            or the first workflow specification/identifier.
-        b_spec:
-            Optional second workflow specification/identifier.  Required when
-            ``scores_or_a`` is not a :class:`SynergyScores` instance.
-        thresholds:
-            Optional mapping providing ``similarity`` and ``entropy`` thresholds.
-            Defaults to ``{"similarity": 0.95, "entropy": 0.05}``.
+        ``scores`` must be the result of :meth:`compare`.  ``thresholds`` may
+        override the default similarity (``0.95``) and entropy gap (``0.05``)
+        limits used to qualify a pair of workflows as duplicates.
         """
 
         thresholds = thresholds or {}
         sim_thr = thresholds.get("similarity", 0.95)
         ent_thr = thresholds.get("entropy", 0.05)
 
-        if isinstance(scores_or_a, SynergyScores):
-            result = scores_or_a
-        else:
-            if b_spec is None:
-                raise TypeError("b_spec must be provided when passing workflow specifications")
-            result = cls.compare(scores_or_a, b_spec)
-
-        ent_gap = abs(result.entropy_a - result.entropy_b)
-        return result.similarity >= sim_thr and ent_gap <= ent_thr
+        ent_gap = abs(scores.entropy_a - scores.entropy_b)
+        return scores.similarity >= sim_thr and ent_gap <= ent_thr
 
     # ------------------------------------------------------------------
     @classmethod


### PR DESCRIPTION
## Summary
- Simplify `WorkflowSynergyComparator.is_duplicate` to accept only `SynergyScores`
- Update workflow evolution manager, CLI, docs, and tests to use the new duplicate check API
- Document Synergy comparator usage and duplicate detection in the autonomous sandbox guide

## Testing
- `pytest tests/test_synergy_metrics_simple.py tests/test_workflow_synergy_comparator.py tests/test_workflow_evolution_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68b00852d370832ea3959388d6ef6284