### PR TITLE
feat: add workflow overfitting analysis

### DIFF
--- a/tests/test_synergy_metrics_simple.py
+++ b/tests/test_synergy_metrics_simple.py
@@ -1,5 +1,7 @@
 import math
 import pytest
+from pathlib import Path
+
 from menace_sandbox import workflow_synergy_comparator as wsc
 
 
@@ -7,6 +9,12 @@ def _mock_optional(monkeypatch):
     monkeypatch.setattr(wsc, "_HAS_NX", False, raising=False)
     monkeypatch.setattr(wsc, "WorkflowVectorizer", None, raising=False)
     monkeypatch.setattr(wsc, "ROITracker", None, raising=False)
+    monkeypatch.setattr(
+        wsc.WorkflowSynergyComparator,
+        "best_practices_file",
+        Path("/tmp/wsc_best.json"),
+        raising=False,
+    )
 
 
 def test_similarity_and_entropy(monkeypatch):

--- a/tests/test_workflow_entropy.py
+++ b/tests/test_workflow_entropy.py
@@ -2,6 +2,7 @@ import math
 
 from menace.workflow_metrics import compute_workflow_entropy
 from menace.workflow_synergy_comparator import WorkflowSynergyComparator
+from pathlib import Path
 
 
 def test_compute_workflow_entropy_simple_spec():
@@ -24,6 +25,7 @@ def test_workflow_synergy_comparator_uses_entropy():
             {"module": "y"},
         ]
     }
+    WorkflowSynergyComparator.best_practices_file = Path("/tmp/wsc_best.json")
     result = WorkflowSynergyComparator.compare(spec, spec)
     expected_entropy = compute_workflow_entropy(spec)
     assert result.entropy_a == expected_entropy


### PR DESCRIPTION
## Summary
- detect workflow overfitting by flagging low entropy and repeated modules
- record high-performing module sequences in a lightweight best-practices repository
- expose overfitting reports via new fields in `SynergyScores`

## Testing
- `pytest tests/test_workflow_synergy_comparator.py tests/test_synergy_metrics_simple.py tests/test_workflow_entropy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b00ddaec88832e82fc81d1b4a87371