### PR TITLE
Implement workflow merge utility and tests

### DIFF
--- a/workflow_synergy_comparator.py
+++ b/workflow_synergy_comparator.py
@@ -542,8 +542,11 @@ def merge_duplicate(
     dup = directory / f"{dup_id}.workflow.json"
     out = directory / f"{base_id}.merged.json"
 
+    if not base.exists() or not dup.exists():
+        return None
+
     try:
-        # Ensure both workflow files exist and contain valid JSON
+        # Ensure both workflow files contain valid JSON
         json.loads(base.read_text())
         json.loads(dup.read_text())
     except Exception:


### PR DESCRIPTION
## Summary
- implement merge_duplicate helper to merge workflow specs and refresh lineage summaries
- add unit tests for successful merges and missing-file fallbacks

## Testing
- `pytest tests/test_workflow_synergy_comparator.py::test_merge_duplicate tests/test_workflow_synergy_comparator.py::test_merge_duplicate_missing_files tests/test_workflow_synergy_comparator.py::test_merge_duplicate_classmethod_delegates -q`

------
https://chatgpt.com/codex/tasks/task_e_68b012dacb54832e97d537f97d1d00f9