### PR TITLE
Add workflow chain simulation with metrics persistence

### DIFF
--- a/unit_tests/test_workflow_chain_simulator.py
+++ b/unit_tests/test_workflow_chain_simulator.py
@@ -1,0 +1,99 @@
+import json
+import sys
+import types
+from pathlib import Path
+
+
+def test_simulate_chains_executes_and_persists(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORKFLOW_ROI_HISTORY_PATH", str(tmp_path / "roi_history.json"))
+
+    wfm = types.ModuleType("workflow_evolution_manager")
+    def _build_callable(sequence: str):
+        modules = [m for m in sequence.split("-") if m]
+        funcs = []
+        for m in modules:
+            try:
+                mod = __import__(m)
+                fn = getattr(mod, "main", getattr(mod, "run", lambda: True))
+            except Exception:
+                fn = lambda: True
+            funcs.append(fn)
+        def _wf():
+            ok = True
+            for fn in funcs:
+                try:
+                    ok = bool(fn()) and ok
+                except Exception:
+                    ok = False
+            return ok
+        return _wf
+    wfm._build_callable = _build_callable
+    sys.modules["workflow_evolution_manager"] = wfm
+
+    class DummyResult:
+        def __init__(self, success: bool):
+            self.success_rate = 1.0 if success else 0.0
+            self.roi_gain = 0.0
+    class DummyScorer:
+        def run(self, fn, wf_id, run_id=None):
+            return DummyResult(bool(fn()))
+    cws = types.ModuleType("composite_workflow_scorer")
+    cws.CompositeWorkflowScorer = DummyScorer
+    sys.modules["composite_workflow_scorer"] = cws
+
+    wsc = types.ModuleType("workflow_synergy_comparator")
+    def _entropy(spec):
+        modules = [s.get("module") for s in spec.get("steps", [])]
+        counts = {}
+        for m in modules:
+            counts[m] = counts.get(m, 0) + 1
+        total = sum(counts.values())
+        import math
+        return -sum((c/total)*math.log(c/total, 2) for c in counts.values()) if total else 0.0
+    wsc.WorkflowSynergyComparator = type("WSC", (), {"_entropy": staticmethod(_entropy)})
+    sys.modules["workflow_synergy_comparator"] = wsc
+
+    stab = types.ModuleType("workflow_stability_db")
+    class DummyStabilityDB:
+        def is_stable(self, *a, **k):
+            return False
+        def mark_stable(self, *a, **k):
+            pass
+    stab.WorkflowStabilityDB = DummyStabilityDB
+    sys.modules["workflow_stability_db"] = stab
+
+    sugg = types.ModuleType("workflow_chain_suggester")
+    class DummySuggester:
+        def suggest_chains(self, *a, **k):
+            return []
+    sugg.WorkflowChainSuggester = DummySuggester
+    sys.modules["workflow_chain_suggester"] = sugg
+
+    summary = types.ModuleType("workflow_run_summary")
+    def record_run(*a, **k):
+        pass
+    summary.record_run = record_run
+    sys.modules["workflow_run_summary"] = summary
+
+    mod_a = types.ModuleType("mod_a")
+    mod_a.main = lambda: True
+    mod_b = types.ModuleType("mod_b")
+    mod_b.main = lambda: False
+    sys.modules["mod_a"] = mod_a
+    sys.modules["mod_b"] = mod_b
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    import workflow_chain_simulator as sim
+    monkeypatch.setattr(sim, "RESULTS_PATH", tmp_path / "results.json")
+    orig_persist = sim._persist_outcomes
+    monkeypatch.setattr(sim, "_persist_outcomes", lambda outcomes, path=sim.RESULTS_PATH: orig_persist(outcomes, path))
+
+    results = sim.simulate_chains([["mod_a"], ["mod_b"]])
+
+    assert len(results) == 2
+    assert results[0]["failure_rate"] == 0.0
+    assert results[1]["failure_rate"] == 1.0
+
+    saved = json.loads((tmp_path / "results.json").read_text())
+    assert saved[0]["chain"] == ["mod_a"]
+    assert saved[1]["chain"] == ["mod_b"]

--- a/workflow_chain_simulator.py
+++ b/workflow_chain_simulator.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+"""Simulate suggested workflow chains and persist outcomes.
+
+This utility composes workflow callables from suggested chains of module names,
+executes them within the :class:`sandbox_runner.WorkflowSandboxRunner` in safe
+mode via :class:`CompositeWorkflowScorer` and records ROI, failure rates and
+entropy/stability metrics.  Results are appended to
+``sandbox_data/chain_simulations.json`` for later retrieval and reinforcement.
+"""
+
+from typing import Sequence, Iterable, List, Dict, Any
+import json
+from pathlib import Path
+
+try:  # pragma: no cover - allow import when used as package or module
+    from .workflow_chain_suggester import WorkflowChainSuggester
+    from .workflow_evolution_manager import _build_callable
+    from .composite_workflow_scorer import CompositeWorkflowScorer
+    from .workflow_synergy_comparator import WorkflowSynergyComparator
+    from .workflow_stability_db import WorkflowStabilityDB
+    from . import workflow_run_summary
+except Exception:  # pragma: no cover - fallback to absolute imports
+    from workflow_chain_suggester import WorkflowChainSuggester  # type: ignore
+    from workflow_evolution_manager import _build_callable  # type: ignore
+    from composite_workflow_scorer import CompositeWorkflowScorer  # type: ignore
+    from workflow_synergy_comparator import WorkflowSynergyComparator  # type: ignore
+    from workflow_stability_db import WorkflowStabilityDB  # type: ignore
+    import workflow_run_summary  # type: ignore
+
+RESULTS_PATH = Path("sandbox_data/chain_simulations.json")
+
+
+def _persist_outcomes(outcomes: List[Dict[str, Any]], path: Path = RESULTS_PATH) -> None:
+    """Append ``outcomes`` to ``path`` best effort."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing: List[Dict[str, Any]] = []
+    if path.exists():
+        try:
+            data = json.loads(path.read_text())
+            if isinstance(data, list):
+                existing = data
+        except Exception:
+            pass
+    existing.extend(outcomes)
+    try:
+        path.write_text(json.dumps(existing, indent=2))
+    except Exception:
+        pass  # pragma: no cover - best effort
+
+
+def simulate_chains(chains: Iterable[Sequence[str]]) -> List[Dict[str, Any]]:
+    """Execute ``chains`` of module names and persist evaluation metrics."""
+
+    scorer = CompositeWorkflowScorer()
+    stability_db = WorkflowStabilityDB()
+    outcomes: List[Dict[str, Any]] = []
+    for idx, chain in enumerate(chains):
+        seq = "-".join(chain)
+        workflow_fn = _build_callable(seq)
+        wf_id = f"chain-{idx}"
+        result = scorer.run(workflow_fn, wf_id, run_id="simulation")
+
+        spec = {"steps": [{"module": m} for m in chain]}
+        entropy = WorkflowSynergyComparator._entropy(spec)
+
+        stable = stability_db.is_stable(wf_id, current_roi=result.roi_gain, threshold=0.0)
+        if not stable:
+            stability_db.mark_stable(wf_id, result.roi_gain)
+
+        workflow_run_summary.record_run(wf_id, result.roi_gain)
+
+        outcomes.append(
+            {
+                "workflow_id": wf_id,
+                "chain": list(chain),
+                "roi_gain": result.roi_gain,
+                "failure_rate": 1.0 - result.success_rate,
+                "entropy": entropy,
+                "stable": stable,
+            }
+        )
+
+    _persist_outcomes(outcomes)
+    return outcomes
+
+
+def simulate_suggested_chains(
+    target_embedding: Sequence[float], top_k: int = 3
+) -> List[Dict[str, Any]]:
+    """Suggest chains via :class:`WorkflowChainSuggester` and evaluate them."""
+
+    suggester = WorkflowChainSuggester()
+    chains = suggester.suggest_chains(target_embedding, top_k)
+    return simulate_chains(chains)
+
+
+__all__ = ["simulate_chains", "simulate_suggested_chains"]


### PR DESCRIPTION
## Summary
- add `workflow_chain_simulator` to execute suggested chains in the sandbox and log ROI, failure rate, entropy and stability metrics
- persist simulation outcomes to `sandbox_data/chain_simulations.json`
- cover workflow chain simulation via unit test

## Testing
- `pytest unit_tests/test_workflow_chain_simulator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b025e96e00832ebf8adbaef2911308