### PR TITLE
Expose meta planning hooks for cross-domain workflow chains

### DIFF
--- a/workflow_evolution_manager.py
+++ b/workflow_evolution_manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Manage workflow evolution by benchmarking generated variants."""
 
-from typing import Callable, Optional
+from typing import Callable, Optional, Iterable, Sequence
 import importlib
 import json
 import logging
@@ -41,6 +41,16 @@ except Exception:  # pragma: no cover - best effort
     _merge_sibling_branches = None  # type: ignore
 
 logger = logging.getLogger(__name__)
+
+
+def consume_planner_suggestions(chains: Iterable[Sequence[str]]) -> None:
+    """Persist planner-suggested chains for later evaluation."""
+    for idx, chain in enumerate(chains, start=1):
+        try:
+            path = Path("sandbox_data") / f"planner_chain_{idx}.workflow.json"
+            save_workflow([{"module": m} for m in chain], path)
+        except Exception:
+            logger.exception("failed to save planner suggestion", extra={"chain": chain})
 
 STABLE_WORKFLOWS = WorkflowStabilityDB()
 EVOLUTION_DB = EvolutionHistoryDB() if EvolutionHistoryDB is not None else None

--- a/workflow_synthesizer.py
+++ b/workflow_synthesizer.py
@@ -46,6 +46,7 @@ from typing import (
     Tuple,
     Union,
     Sequence,
+    Iterable,
     get_args,
     get_origin,
     get_type_hints,
@@ -1613,6 +1614,22 @@ def evaluate_workflow(
     return success
 
 
+def consume_planner_suggestions(chains: Iterable[Sequence[str]]) -> List[Path]:
+    """Persist planner suggested chains as workflow specs."""
+    paths: List[Path] = []
+    for idx, chain in enumerate(chains, start=1):
+        steps = [WorkflowStep(module=str(m)) for m in chain]
+        path = Path("sandbox_data") / f"planner_chain_{idx}.workflow.json"
+        try:
+            save_workflow(steps, path)
+            paths.append(path)
+        except Exception:
+            logging.getLogger(__name__).exception(
+                "failed to save planner suggestion", extra={"chain": chain}
+            )
+    return paths
+
+
 def synthesise_workflow(**kwargs: Any) -> Dict[str, Any]:
     """Generate a workflow using :class:`WorkflowSynthesizer`.
 
@@ -1994,6 +2011,7 @@ __all__ = [
     "to_yaml",
     "to_workflow_spec",
     "evaluate_workflow",
+    "consume_planner_suggestions",
     "save_workflow",
     "synthesise_workflow",
     "generate_workflow_variants",


### PR DESCRIPTION
## Summary
- wire planner and chain suggester into self improvement engine for periodic cross-domain chain proposals
- allow evolution manager and workflow synthesizer to persist planner suggestions
- extend workflow synergy CLI with meta-planning trigger

## Testing
- `python -m py_compile self_improvement_engine.py workflow_evolution_manager.py workflow_synthesizer.py workflow_synergy_cli.py`
- `pytest -q` *(fails: ImportError: cannot import name 'EvolutionEvent' and numerous module errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b029383de4832eb261bb81ffc34ddb