### PR TITLE
Add meta workflow planner tests and docs

### DIFF
--- a/docs/meta_workflow_planner.md
+++ b/docs/meta_workflow_planner.md
@@ -1,0 +1,43 @@
+# Meta Workflow Planner
+
+The `MetaWorkflowPlanner` encodes workflows into fixed-size vectors combining
+structural information, recent ROI trends and semantic tokens. Embeddings are
+persisted with `vector_utils.persist_embedding` so they can be clustered or
+retrieved later.
+
+## Usage
+
+```python
+import networkx as nx
+from meta_workflow_planner import MetaWorkflowPlanner
+
+# Build a minimal dependency graph
+g = nx.DiGraph()
+g.add_edge("A", "B")
+planner = MetaWorkflowPlanner(graph=type("G", (), {"graph": g})())
+
+workflow = {"workflow": ["fetch", "process", "store"]}
+vector = planner.encode("A", workflow)
+```
+
+The embedding is written to `embeddings.jsonl` in the current working directory
+along with metadata such as the ROI curve and dependency depth.
+
+## Configuration
+
+`MetaWorkflowPlanner` accepts several knobs to tailor the generated vectors:
+
+- `max_functions`, `max_modules`, `max_tags` – size of the one-hot sections for
+  function names, module identifiers and tags.
+- `roi_window` – number of recent ROI measurements incorporated into the
+  embedding.
+- `function_index`, `module_index`, `tag_index` – optional dictionaries used to
+  maintain stable token indices across planner instances.
+- `graph` and `roi_db` – optional helpers providing structural context and ROI
+  history. When omitted, lightweight defaults are created.
+
+The resulting embedding structure is:
+
+1. Dependency depth and branching factor.
+2. ROI curve of length `roi_window`.
+3. One-hot vectors for functions, modules and tags.

--- a/tests/integration/test_meta_workflow_planner_integration.py
+++ b/tests/integration/test_meta_workflow_planner_integration.py
@@ -1,0 +1,61 @@
+import os
+import networkx as nx
+
+from meta_workflow_planner import MetaWorkflowPlanner
+from roi_results_db import ROIResultsDB
+
+
+class DummyGraph:
+    def __init__(self, g: nx.DiGraph) -> None:
+        self.graph = g
+
+
+def test_small_chain_roi_improvement(tmp_path):
+    db = ROIResultsDB(path=tmp_path / "roi.db")
+    db.log_result(
+        workflow_id="A",
+        run_id="1",
+        runtime=1.0,
+        success_rate=1.0,
+        roi_gain=-1.0,
+        workflow_synergy_score=0.0,
+        bottleneck_index=0.0,
+        patchability_score=0.0,
+    )
+    db.log_result(
+        workflow_id="A",
+        run_id="2",
+        runtime=1.0,
+        success_rate=1.0,
+        roi_gain=3.0,
+        workflow_synergy_score=0.0,
+        bottleneck_index=0.0,
+        patchability_score=0.0,
+    )
+    db.log_result(
+        workflow_id="B",
+        run_id="1",
+        runtime=1.0,
+        success_rate=1.0,
+        roi_gain=2.0,
+        workflow_synergy_score=0.0,
+        bottleneck_index=0.0,
+        patchability_score=0.0,
+    )
+
+    g = nx.DiGraph()
+    g.add_edge("A", "B")
+    planner = MetaWorkflowPlanner(graph=DummyGraph(g), roi_db=db, roi_window=5)
+    old_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    vec_a = planner.encode("A", {"workflow": []})
+    vec_b = planner.encode("B", {"workflow": []})
+    os.chdir(old_cwd)
+
+    roi_a = vec_a[2:7]
+    assert roi_a[0] == -1.0 and roi_a[1] == 3.0
+    assert vec_a[1] == 1.0  # branching
+    roi_b = vec_b[2:7]
+    assert roi_b[0] == 2.0
+    assert vec_b[0] == 1.0  # depth
+    assert roi_a[1] > roi_a[0]

--- a/tests/test_meta_workflow_planner.py
+++ b/tests/test_meta_workflow_planner.py
@@ -1,0 +1,105 @@
+import json
+import os
+from pathlib import Path
+
+import networkx as nx
+import pytest
+
+from meta_workflow_planner import MetaWorkflowPlanner
+from vector_utils import cosine_similarity
+
+
+class DummyGraph:
+    """Wrapper exposing ``graph`` attribute for the planner."""
+
+    def __init__(self, g: nx.DiGraph) -> None:
+        self.graph = g
+
+
+class DummyROI:
+    """Return pre-seeded ROI trends for workflows."""
+
+    def __init__(self, trends):
+        self.trends = trends
+
+    def fetch_trends(self, workflow_id: str):
+        return self.trends.get(workflow_id, [])
+
+
+def _load_records(path: Path):
+    with path.open("r", encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh]
+
+
+def _cluster(records, threshold: float = 0.72):
+    clusters = []
+    for rec in records:
+        placed = False
+        for cluster in clusters:
+            if cosine_similarity(rec["vector"], cluster[0]["vector"]) >= threshold:
+                cluster.append(rec)
+                placed = True
+                break
+        if not placed:
+            clusters.append([rec])
+    return clusters
+
+
+def _retrieve(records, query_vec):
+    best_id = None
+    best_score = -1.0
+    for rec in records:
+        score = cosine_similarity(rec["vector"], query_vec)
+        if score > best_score:
+            best_id = rec["id"]
+            best_score = score
+    return best_id
+
+
+@pytest.fixture
+def sample_embeddings(tmp_path):
+    g = nx.DiGraph()
+    trends = {
+        "wf1": [{"roi_gain": 1.0}, {"roi_gain": 1.0}],
+        "wf2": [{"roi_gain": 1.0}, {"roi_gain": 1.0}],
+        "wf3": [{"roi_gain": 5.0}, {"roi_gain": 5.0}],
+    }
+    planner = MetaWorkflowPlanner(
+        graph=DummyGraph(g), roi_db=DummyROI(trends), roi_window=3
+    )
+    old_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    workflows = {
+        "wf1": {"workflow": ["common", "a"]},
+        "wf2": {"workflow": ["common", "b"]},
+        "wf3": {"workflow": ["x"]},
+    }
+    vecs = {wid: planner.encode(wid, wf) for wid, wf in workflows.items()}
+    records = _load_records(Path("embeddings.jsonl"))
+    yield planner, vecs, records
+    os.chdir(old_cwd)
+
+
+def test_embedding_generation(sample_embeddings):
+    planner, vecs, records = sample_embeddings
+    vec = vecs["wf1"]
+    assert len(vec) == 2 + 3 + planner.max_functions + planner.max_modules + planner.max_tags
+    roi_segment = vec[2:5]
+    assert roi_segment[:2] == [1.0, 1.0]
+    assert records[0]["id"] == "wf1"
+
+
+def test_embedding_clustering(sample_embeddings):
+    _planner, _vecs, records = sample_embeddings
+    clusters = _cluster(records)
+    cluster_ids = [sorted(rec["id"] for rec in group) for group in clusters]
+    assert ["wf1", "wf2"] in cluster_ids
+    assert ["wf3"] in cluster_ids
+
+
+def test_embedding_retrieval(sample_embeddings):
+    _planner, vecs, records = sample_embeddings
+    query_vec = vecs["wf1"]
+    best = _retrieve(records, query_vec)
+    assert best == "wf1"
+


### PR DESCRIPTION
## Summary
- add documentation for MetaWorkflowPlanner with usage and configuration notes
- add unit tests covering embedding generation, clustering, and retrieval
- add integration test verifying ROI improvements across a workflow chain

## Testing
- `pytest tests/test_meta_workflow_planner.py tests/integration/test_meta_workflow_planner_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b02af02e20832eb1357af8fdbae5e8