### PR TITLE
Add clustering and mutation unit tests

### DIFF
--- a/unit_tests/test_workflow_chain_simulator.py
+++ b/unit_tests/test_workflow_chain_simulator.py
@@ -28,7 +28,7 @@ def test_simulate_chains_executes_and_persists(tmp_path, monkeypatch):
             return ok
         return _wf
     wfm._build_callable = _build_callable
-    sys.modules["workflow_evolution_manager"] = wfm
+    monkeypatch.setitem(sys.modules, "workflow_evolution_manager", wfm)
 
     class DummyResult:
         def __init__(self, success: bool):
@@ -39,7 +39,7 @@ def test_simulate_chains_executes_and_persists(tmp_path, monkeypatch):
             return DummyResult(bool(fn()))
     cws = types.ModuleType("composite_workflow_scorer")
     cws.CompositeWorkflowScorer = DummyScorer
-    sys.modules["composite_workflow_scorer"] = cws
+    monkeypatch.setitem(sys.modules, "composite_workflow_scorer", cws)
 
     wsc = types.ModuleType("workflow_synergy_comparator")
     def _entropy(spec):
@@ -51,7 +51,7 @@ def test_simulate_chains_executes_and_persists(tmp_path, monkeypatch):
         import math
         return -sum((c/total)*math.log(c/total, 2) for c in counts.values()) if total else 0.0
     wsc.WorkflowSynergyComparator = type("WSC", (), {"_entropy": staticmethod(_entropy)})
-    sys.modules["workflow_synergy_comparator"] = wsc
+    monkeypatch.setitem(sys.modules, "workflow_synergy_comparator", wsc)
 
     stab = types.ModuleType("workflow_stability_db")
     class DummyStabilityDB:
@@ -60,30 +60,33 @@ def test_simulate_chains_executes_and_persists(tmp_path, monkeypatch):
         def mark_stable(self, *a, **k):
             pass
     stab.WorkflowStabilityDB = DummyStabilityDB
-    sys.modules["workflow_stability_db"] = stab
+    monkeypatch.setitem(sys.modules, "workflow_stability_db", stab)
 
     sugg = types.ModuleType("workflow_chain_suggester")
     class DummySuggester:
         def suggest_chains(self, *a, **k):
             return []
     sugg.WorkflowChainSuggester = DummySuggester
-    sys.modules["workflow_chain_suggester"] = sugg
+    monkeypatch.setitem(sys.modules, "workflow_chain_suggester", sugg)
 
     summary = types.ModuleType("workflow_run_summary")
     def record_run(*a, **k):
         pass
     summary.record_run = record_run
-    sys.modules["workflow_run_summary"] = summary
+    monkeypatch.setitem(sys.modules, "workflow_run_summary", summary)
 
     mod_a = types.ModuleType("mod_a")
     mod_a.main = lambda: True
     mod_b = types.ModuleType("mod_b")
     mod_b.main = lambda: False
-    sys.modules["mod_a"] = mod_a
-    sys.modules["mod_b"] = mod_b
+    monkeypatch.setitem(sys.modules, "mod_a", mod_a)
+    monkeypatch.setitem(sys.modules, "mod_b", mod_b)
 
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    import importlib
+    sys.modules.pop("workflow_chain_simulator", None)
     import workflow_chain_simulator as sim
+    sim = importlib.reload(sim)
     monkeypatch.setattr(sim, "RESULTS_PATH", tmp_path / "results.json")
     orig_persist = sim._persist_outcomes
     monkeypatch.setattr(sim, "_persist_outcomes", lambda outcomes, path=sim.RESULTS_PATH: orig_persist(outcomes, path))
@@ -97,3 +100,81 @@ def test_simulate_chains_executes_and_persists(tmp_path, monkeypatch):
     saved = json.loads((tmp_path / "results.json").read_text())
     assert saved[0]["chain"] == ["mod_a"]
     assert saved[1]["chain"] == ["mod_b"]
+
+
+def test_simulate_suggested_chains_handles_failed_runs(tmp_path, monkeypatch):
+    """Chains suggested by the suggester are executed and failures recorded."""
+    monkeypatch.setenv("WORKFLOW_ROI_HISTORY_PATH", str(tmp_path / "roi_history.json"))
+
+    wfm = types.ModuleType("workflow_evolution_manager")
+
+    def _build_callable(sequence: str):
+        def _wf():
+            if "error" in sequence:
+                raise RuntimeError("boom")
+            return True
+
+        return _wf
+
+    wfm._build_callable = _build_callable
+    monkeypatch.setitem(sys.modules, "workflow_evolution_manager", wfm)
+
+    class DummyResult:
+        def __init__(self, ok: bool):
+            self.success_rate = 1.0 if ok else 0.0
+            self.roi_gain = 0.0
+
+    class DummyScorer:
+        def run(self, fn, wf_id, run_id=None):
+            try:
+                ok = bool(fn())
+            except Exception:
+                ok = False
+            return DummyResult(ok)
+
+    cws = types.ModuleType("composite_workflow_scorer")
+    cws.CompositeWorkflowScorer = DummyScorer
+    monkeypatch.setitem(sys.modules, "composite_workflow_scorer", cws)
+
+    wsc = types.ModuleType("workflow_synergy_comparator")
+    wsc.WorkflowSynergyComparator = type("WSC", (), {"_entropy": staticmethod(lambda spec: 0.0)})
+    monkeypatch.setitem(sys.modules, "workflow_synergy_comparator", wsc)
+
+    stab = types.ModuleType("workflow_stability_db")
+
+    class DummyStabilityDB:
+        def is_stable(self, *a, **k):
+            return False
+
+        def mark_stable(self, *a, **k):
+            pass
+
+    stab.WorkflowStabilityDB = DummyStabilityDB
+    monkeypatch.setitem(sys.modules, "workflow_stability_db", stab)
+
+    summary = types.ModuleType("workflow_run_summary")
+    summary.record_run = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "workflow_run_summary", summary)
+
+    mod_ok = types.ModuleType("mod_ok")
+    mod_ok.main = lambda: True
+    monkeypatch.setitem(sys.modules, "mod_ok", mod_ok)
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    import importlib
+    import workflow_chain_simulator as sim
+    sim = importlib.reload(sim)
+
+    class DummySuggester:
+        def suggest_chains(self, *a, **k):
+            return [["mod_ok"], ["mod_error"]]
+
+    monkeypatch.setattr(sim, "WorkflowChainSuggester", DummySuggester)
+    monkeypatch.setattr(sim, "RESULTS_PATH", tmp_path / "results.json")
+    monkeypatch.setattr(sim, "_persist_outcomes", lambda *a, **k: None)
+
+    results = sim.simulate_suggested_chains([0.0], top_k=2)
+
+    assert len(results) == 2
+    assert results[0]["failure_rate"] == 0.0
+    assert results[1]["failure_rate"] == 1.0

--- a/unit_tests/test_workflow_chain_suggester.py
+++ b/unit_tests/test_workflow_chain_suggester.py
@@ -1,0 +1,97 @@
+import sys
+import types
+import importlib.util
+from pathlib import Path
+
+
+def _load_wcs(monkeypatch):
+    vector_utils = types.ModuleType("vector_utils")
+    vector_utils.cosine_similarity = (
+        lambda a, b: sum(x * y for x, y in zip(a, b))
+        / ((sum(x * x for x in a) ** 0.5) * (sum(y * y for y in b) ** 0.5) or 1.0)
+    )
+    monkeypatch.setitem(sys.modules, "vector_utils", vector_utils)
+
+    class DummyROIResultsDB:
+        def fetch_trends(self, wid):
+            return []
+
+    roi_mod = types.ModuleType("roi_results_db")
+    roi_mod.ROIResultsDB = DummyROIResultsDB
+    monkeypatch.setitem(sys.modules, "roi_results_db", roi_mod)
+
+    class DummyStabilityDB:
+        def is_stable(self, wid):
+            return False
+
+        def get_ema(self, wid):
+            return 0.0, None
+
+    stab_mod = types.ModuleType("workflow_stability_db")
+    stab_mod.WorkflowStabilityDB = DummyStabilityDB
+    monkeypatch.setitem(sys.modules, "workflow_stability_db", stab_mod)
+
+    class DummyWSC:
+        @staticmethod
+        def _entropy(spec):
+            return 0.0
+
+    wsc_mod = types.ModuleType("workflow_synergy_comparator")
+    wsc_mod.WorkflowSynergyComparator = DummyWSC
+    monkeypatch.setitem(sys.modules, "workflow_synergy_comparator", wsc_mod)
+
+    monkeypatch.setitem(sys.modules, "task_handoff_bot", types.ModuleType("task_handoff_bot"))
+
+    spec = importlib.util.spec_from_file_location(
+        "workflow_chain_suggester",
+        Path(__file__).resolve().parent.parent / "workflow_chain_suggester.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["workflow_chain_suggester"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_kmeans_clusters_vectors(monkeypatch):
+    wcs = _load_wcs(monkeypatch)
+    sugg = wcs.WorkflowChainSuggester(wf_db=None, roi_db=None, stability_db=None)
+    vectors = [
+        ("a", [0.0, 0.1]),
+        ("b", [0.0, 1.0]),
+        ("c", [10.0, 10.0]),
+        ("d", [10.0, 11.0]),
+    ]
+    monkeypatch.setattr(wcs.random, "sample", lambda seq, k: [seq[0], seq[2]])
+    clusters = sugg._kmeans(vectors, k=2, iterations=5)
+    cluster_sets = {frozenset(c) for c in clusters}
+    assert cluster_sets == {frozenset({"a", "b"}), frozenset({"c", "d"})}
+
+
+def test_suggest_chains_roi_weighted_selection(monkeypatch):
+    wcs = _load_wcs(monkeypatch)
+
+    class DummyDB:
+        def search_by_vector(self, vec, top_k):
+            return [("1", 0.0), ("2", 0.0)]
+
+        def get_vector(self, wid):
+            return [1.0, 0.0]
+
+    sugg = wcs.WorkflowChainSuggester(wf_db=DummyDB(), roi_db=None, stability_db=None)
+    monkeypatch.setattr(sugg, "_roi_score", lambda wid: 1.0 if wid == "1" else 0.0)
+    monkeypatch.setattr(sugg, "_roi_delta", lambda wid: 0.0)
+    monkeypatch.setattr(sugg, "_stability_weight", lambda wid: 1.0)
+    monkeypatch.setattr(sugg, "_kmeans", lambda vectors, k: [[wid] for wid, _ in vectors])
+
+    chains = sugg.suggest_chains([0.0, 0.0], top_k=2)
+    assert chains == [["1"], ["2"]]
+
+
+def test_mutation_helpers(monkeypatch):
+    wcs = _load_wcs(monkeypatch)
+    chain = ["a", "b", "c"]
+    assert wcs.WorkflowChainSuggester.swap_steps(chain, 0, 2) == ["c", "b", "a"]
+    assert wcs.WorkflowChainSuggester.split_sequence(chain, 1) == [["a"], ["b", "c"]]
+    merged = wcs.WorkflowChainSuggester.merge_partial_chains([["a", "b"], ["b", "c"]])
+    assert merged == ["a", "b", "c"]
+

--- a/unit_tests/test_workflow_synergy_comparator.py
+++ b/unit_tests/test_workflow_synergy_comparator.py
@@ -1,5 +1,9 @@
 import pytest
+import sys
+from pathlib import Path
+import pytest
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from workflow_synergy_comparator import WorkflowSynergyComparator as WSC
 
 


### PR DESCRIPTION
## Summary
- Add unit tests for workflow chain suggester covering K-means clustering, ROI-weighted chain selection, and mutation helpers
- Extend chain simulator tests to verify sandbox failures when suggested chains error
- Fix synergy comparator tests to run directly from repository root

## Testing
- `pytest unit_tests/test_workflow_chain_suggester.py -q`
- `pytest unit_tests/test_workflow_chain_simulator.py -q`
- `pytest unit_tests -q` *(fails: Missing system packages: ffmpeg, tesseract, qemu-system-x86_64)*

------
https://chatgpt.com/codex/tasks/task_e_68b03f067114832e8dba81c3ce7120df