### PR TITLE
Add workflow embedding persistence helper

### DIFF
--- a/tests/test_persist_workflow_embedding.py
+++ b/tests/test_persist_workflow_embedding.py
@@ -1,0 +1,36 @@
+import types
+
+import workflow_vectorizer as wv
+
+
+def test_persist_workflow_embedding_includes_metadata(monkeypatch):
+    captured = {}
+
+    def fake_persist(kind, record_id, vec, *, origin_db=None, metadata=None, path="embeddings.jsonl"):
+        captured["kind"] = kind
+        captured["id"] = record_id
+        captured["vec"] = list(vec)
+        captured["origin_db"] = origin_db
+        captured["metadata"] = metadata or {}
+
+    monkeypatch.setattr(wv, "persist_embedding", fake_persist)
+
+    workflow = {
+        "category": "ops",
+        "status": "new",
+        "workflow": [],
+        "roi": 5.0,
+        "failure_rate": 0.25,
+        "failure_reason": "boom",
+    }
+
+    vec = wv.persist_workflow_embedding("w1", workflow)
+
+    assert captured["kind"] == "workflow"
+    assert captured["id"] == "w1"
+    assert captured["origin_db"] == "workflow"
+    assert "roi_curve" in captured["metadata"]
+    assert captured["metadata"]["roi"] == 5.0
+    assert captured["metadata"]["failure_rate"] == 0.25
+    assert captured["metadata"]["failure_reason"] == "boom"
+    assert isinstance(vec, list)


### PR DESCRIPTION
## Summary
- add `persist_workflow_embedding` to store workflow vectors with ROI/failure metadata
- expose helper and ensure workflow vectorizer imports `persist_embedding`
- test workflow embedding persistence metadata handling

## Testing
- `pytest tests/test_embedding_ingestion.py tests/test_shared_vector_interface.py tests/test_persist_workflow_embedding.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0440f7f0c832e881b762dbdc50609