### PR TITLE
Integrate CodeDB metrics into workflow embeddings

### DIFF
--- a/tests/test_meta_workflow_planner.py
+++ b/tests/test_meta_workflow_planner.py
@@ -86,7 +86,16 @@ def sample_embeddings(tmp_path):
 def test_embedding_generation(sample_embeddings):
     planner, vecs, records = sample_embeddings
     vec = vecs["wf1"]
-    assert len(vec) == 2 + 3 + planner.max_functions + planner.max_modules + planner.max_tags
+    assert (
+        len(vec)
+        == 2
+        + planner.roi_window
+        + 2
+        + planner.roi_window
+        + planner.max_functions
+        + planner.max_modules
+        + planner.max_tags
+    )
     roi_segment = vec[2:5]
     assert roi_segment[:2] == [1.0, 1.0]
     assert records[0]["id"] == "wf1"


### PR DESCRIPTION
## Summary
- Extend MetaWorkflowPlanner to consult CodeDB for module metadata, context tags, dependency depth, branching factor, and ROI curves.
- Expand embedding generation to include code-level depth/branching and ROI curves and persist with `code_tags` metadata.
- Update tests for new embedding dimensionality.

## Testing
- `pytest tests/test_meta_workflow_planner.py tests/integration/test_meta_workflow_planner_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b04ea70dcc832ea02b128628ac555f