### PR TITLE
feat: weight workflow clustering by ROI

### DIFF
--- a/docs/meta_workflow_planner.md
+++ b/docs/meta_workflow_planner.md
@@ -41,9 +41,9 @@ clusters = planner.cluster_workflows(workflows, threshold=0.8)
 pipeline = planner.compose_pipeline("A", workflows, length=3)
 ```
 
-`cluster_workflows` uses `WorkflowSynergyComparator` to score similarities
-between specifications while `compose_pipeline` iteratively selects the best
-next step based on the same comparator.
+`cluster_workflows` encodes each specification and groups workflows using
+ROI‑weighted cosine similarity, while `compose_pipeline` iteratively selects the
+best next step based on `WorkflowSynergyComparator`.
 
 ## Sandbox simulation
 
@@ -76,8 +76,8 @@ method accepts a custom runner or will instantiate a default
   maintain stable token indices across planner instances.
 - `graph` and `roi_db` – optional helpers providing structural context and ROI
   history. When omitted, lightweight defaults are created.
-- `cluster_workflows(threshold)` controls the similarity cutoff when grouping
-  workflow identifiers.
+- `cluster_workflows(threshold)` controls the similarity cutoff for the
+  ROI‑weighted similarity matrix when grouping workflow identifiers.
 - `compose_pipeline(length)` limits the number of steps in generated chains.
 - `plan_and_validate(top_k, failure_threshold, entropy_threshold)` governs the
   number of candidate chains considered and the acceptance criteria during


### PR DESCRIPTION
## Summary
- cluster workflows using ROI-weighted cosine similarity instead of synergy comparator
- document ROI-based clustering in MetaWorkflowPlanner docs

## Testing
- `pre-commit run --files meta_workflow_planner.py docs/meta_workflow_planner.md`
- `pytest tests/test_meta_workflow_planner.py tests/integration/test_meta_workflow_planner_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b04fe66f8c832e9df5de6ac76a3f1b