### PR TITLE
Persist and leverage workflow chain embeddings

### DIFF
--- a/tests/test_find_synergy_chain.py
+++ b/tests/test_find_synergy_chain.py
@@ -1,0 +1,21 @@
+from vector_utils import persist_embedding
+import meta_workflow_planner as mwp
+
+
+def test_find_synergy_chain_prefers_persisted(tmp_path, monkeypatch):
+    path = tmp_path / "embeddings.jsonl"
+    persist_embedding("workflow_meta", "a", [1.0, 0.0], path=path)
+    persist_embedding("workflow_meta", "b", [0.0, 1.0], path=path)
+    persist_embedding(
+        "workflow_chain",
+        "a->b",
+        [1.0, 0.0],
+        path=path,
+        metadata={"roi": 1.0, "entropy": 0.0},
+    )
+    orig_emb = mwp._load_embeddings
+    orig_chain = mwp._load_chain_embeddings
+    monkeypatch.setattr(mwp, "_load_embeddings", lambda path=path: orig_emb(path))
+    monkeypatch.setattr(mwp, "_load_chain_embeddings", lambda path=path: orig_chain(path))
+    chain = mwp.find_synergy_chain("a", length=2)
+    assert chain == ["a", "b"]


### PR DESCRIPTION
## Summary
- Persist validated workflow chains as composite embeddings with ROI and entropy metadata
- Query stored chain embeddings when building synergy chains and suggestions
- Prioritize persisted chains via new tests

## Testing
- `pytest tests/test_workflow_chain_suggester.py::test_persisted_chain_is_prioritized tests/test_find_synergy_chain.py::test_find_synergy_chain_prefers_persisted -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0e740bac0832e968bb6023f197a74