### PR TITLE
Add genetic operators and selection pressure

### DIFF
--- a/self_improvement_engine.py
+++ b/self_improvement_engine.py
@@ -920,6 +920,10 @@ async def self_improvement_cycle(
                         await _log(rec)
                         next_active.append(rec.get("chain", []))
                 active = next_active
+
+            evolved = planner.iterate_pipelines(workflows)
+            for rec in evolved:
+                await _log(rec)
         except asyncio.CancelledError:  # pragma: no cover - cooperative cancellation
             break
         except Exception:  # pragma: no cover - keep background loop alive

--- a/tests/integration/test_meta_workflow_planner_integration.py
+++ b/tests/integration/test_meta_workflow_planner_integration.py
@@ -1,4 +1,8 @@
 import os
+import random
+import sys
+import types
+
 import networkx as nx
 
 from meta_workflow_planner import MetaWorkflowPlanner
@@ -59,3 +63,99 @@ def test_small_chain_roi_improvement(tmp_path):
     assert roi_b[0] == 2.0
     assert vec_b[0] == 1.0  # depth
     assert roi_a[1] > roi_a[0]
+
+
+def test_genetic_evolution_across_domains(monkeypatch):
+    class StubComparator:
+        @staticmethod
+        def _entropy(spec):
+            return 0.0
+
+    monkeypatch.setitem(
+        sys.modules,
+        "workflow_synergy_comparator",
+        types.SimpleNamespace(WorkflowSynergyComparator=StubComparator),
+    )
+
+    class ModuleMetric:
+        def __init__(self, name, result):
+            self.name = name
+            self.result = result
+            self.success = True
+            self.duration = 0.0
+
+    class Metrics:
+        def __init__(self, modules):
+            self.modules = modules
+            self.crash_count = 0
+
+    class DummyRunner:
+        def run(self, funcs):
+            modules = [ModuleMetric(fn.__name__, fn()) for fn in funcs]
+            return Metrics(modules)
+
+    def f1():
+        return 1.0
+
+    def f2():
+        return 1.0
+
+    def g1():
+        return 1.0
+
+    def g2():
+        return 1.0
+
+    workflows = {"f1": f1, "f2": f2, "g1": g1, "g2": g2}
+
+    planner = MetaWorkflowPlanner()
+
+    def _entry(score: float) -> dict:
+        return {
+            "roi_history": [1.0],
+            "failure_history": [0],
+            "entropy_history": [0.0],
+            "step_metrics": [],
+            "step_deltas": [],
+            "delta_roi": 0.0,
+            "delta_failures": 0.0,
+            "delta_entropy": 0.0,
+            "converged": True,
+            "score": score,
+        }
+
+    planner.cluster_map = {("f1", "f2"): _entry(5.0), ("g1", "g2"): _entry(1.0)}
+
+    monkeypatch.setattr(random, "choices", lambda pop, weights, k: [pop[0], pop[1]])
+    monkeypatch.setattr(random, "randint", lambda a, b: 1)
+    monkeypatch.setattr(random, "random", lambda: 1.0)
+    offspring = planner.mutate_chains(
+        [["f1", "f2"], ["g1", "g2"]],
+        workflows,
+        runner=DummyRunner(),
+    )
+    assert offspring
+    chains = [rec["chain"] for rec in offspring]
+    assert any("f1" in c and "g2" in c for c in chains)
+
+    planner.cluster_map[("f1", "f2")].update(
+        delta_roi=-1.0, delta_failures=0.2, delta_entropy=0.1
+    )
+    planner.cluster_map[("g1", "g2")].update(
+        delta_roi=2.0, delta_failures=-0.1, delta_entropy=-0.2
+    )
+
+    def fake_mutate(chains, workflows, **_):
+        return [
+            {
+                "chain": list(chains[0]) + ["x"],
+                "roi_gain": 1.0,
+                "failures": 0,
+                "entropy": 0.0,
+            }
+        ]
+
+    monkeypatch.setattr(planner, "mutate_chains", fake_mutate)
+    records = planner.iterate_pipelines(workflows)
+    assert any("f1" in r["chain"] for r in records)
+    assert all("g1" not in r["chain"] for r in records)


### PR DESCRIPTION
## Summary
- Introduce crossover and score-weighted mutations in `mutate_chains`
- Apply selection pressure via ROI, failure, and entropy deltas in `iterate_pipelines`
- Run evolved pipelines in self-improvement cycle and add cross-domain integration tests

## Testing
- `pytest tests/integration/test_meta_workflow_planner_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0f72b12e4832eb24f7ad41a597c4d