### PR TITLE
Enforce retriever-based workflow clustering

### DIFF
--- a/docs/meta_workflow_planner.md
+++ b/docs/meta_workflow_planner.md
@@ -35,14 +35,16 @@ workflows = {
 }
 
 # Cluster similar workflow specs
-clusters = planner.cluster_workflows(workflows, threshold=0.8)
+retr = Retriever()
+clusters = planner.cluster_workflows(workflows, threshold=0.8, retriever=retr)
 
 # Build a high‑synergy chain starting from A
 pipeline = planner.compose_pipeline("A", workflows, length=3)
 ```
 
-`cluster_workflows` encodes each specification and groups workflows using
-ROI‑weighted cosine similarity, while `compose_pipeline` iteratively selects the
+`cluster_workflows` encodes each specification, persists the embedding and
+groups workflows using ROI‑weighted cosine similarity via the provided
+`Retriever`, while `compose_pipeline` iteratively selects the
 best next step based on `WorkflowSynergyComparator` scores scaled by recent ROI
 trends.  The scoring formula is ``synergy_score * (1 + ROI)`` and the
 ``synergy_weight`` and ``roi_weight`` parameters expose knobs to tune the
@@ -79,8 +81,9 @@ method accepts a custom runner or will instantiate a default
   maintain stable token indices across planner instances.
 - `graph` and `roi_db` – optional helpers providing structural context and ROI
   history. When omitted, lightweight defaults are created.
-- `cluster_workflows(threshold)` controls the similarity cutoff for the
-  ROI‑weighted similarity matrix when grouping workflow identifiers.
+- `cluster_workflows(threshold, retriever)` controls the similarity cutoff for
+  the ROI‑weighted similarity matrix when grouping workflow identifiers using a
+  provided `Retriever` instance.
 - `compose_pipeline(length, synergy_weight, roi_weight)` limits the number of
   steps in generated chains and exposes weights to balance synergy against ROI.
 - `plan_and_validate(top_k, failure_threshold, entropy_threshold)` governs the

--- a/workflow_evolution_manager.py
+++ b/workflow_evolution_manager.py
@@ -21,6 +21,10 @@ from . import workflow_run_summary
 from . import sandbox_runner
 from .workflow_synergy_comparator import WorkflowSynergyComparator
 from .meta_workflow_planner import MetaWorkflowPlanner
+try:  # pragma: no cover - optional dependency
+    from vector_service.retriever import Retriever  # type: ignore
+except Exception:  # pragma: no cover - allow running without retriever
+    Retriever = None  # type: ignore
 try:  # pragma: no cover - optional at runtime
     from .workflow_graph import WorkflowGraph
 except Exception:  # pragma: no cover - best effort
@@ -66,6 +70,7 @@ def merge_variant_records(
     runner: sandbox_runner.workflow_sandbox_runner.WorkflowSandboxRunner | None = None,
     failure_threshold: int = 0,
     entropy_threshold: float = 2.0,
+    retriever: Retriever | None = None,
 ) -> list[Dict[str, Any]]:
     """Merge high-performing variants using :class:`MetaWorkflowPlanner`.
 
@@ -75,6 +80,8 @@ def merge_variant_records(
     """
 
     planner = planner or MetaWorkflowPlanner()
+    if retriever is None:
+        raise ValueError("merge_variant_records requires a Retriever")
     return planner.merge_high_performing_variants(
         records,
         workflows,
@@ -82,6 +89,7 @@ def merge_variant_records(
         runner=runner,
         failure_threshold=failure_threshold,
         entropy_threshold=entropy_threshold,
+        retriever=retriever,
     )
 
 


### PR DESCRIPTION
## Summary
- Require an initialized Retriever for workflow clustering and persist embeddings to the vector DB
- Use cached retriever queries with ROI-weighted similarities to form clusters
- Propagate Retriever requirement to variant merging utilities and documentation

## Testing
- `pytest` *(fails: 262 errors during collection)*
- `pytest tests/test_meta_workflow_planner.py::test_cluster_workflows_roi_weighting -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0fc431f60832ea54634307dbe0412