### PR TITLE
Publish canonical sandbox profiles and strengthen module profile suggestions

### DIFF
--- a/environment_generator.py
+++ b/environment_generator.py
@@ -144,6 +144,14 @@ CANONICAL_PROFILES: List[str] = [
     "concurrency_spike",
 ]
 
+# Export a subset of public attributes for consumers.
+__all__ = [
+    "CANONICAL_PROFILES",
+    "suggest_profiles_for_module",
+    "generate_canonical_presets",
+    "generate_combined_presets",
+]
+
 # legacy aliases mapping to canonical scenario names
 _PROFILE_ALIASES = {
     "high_latency": "high_latency_api",
@@ -167,6 +175,8 @@ _KEYWORD_PROFILE_MAP: Dict[str, List[str]] = {
     "common": CANONICAL_PROFILES,
     "misc": CANONICAL_PROFILES,
     "shared": CANONICAL_PROFILES,
+    "base": CANONICAL_PROFILES,
+    "core": CANONICAL_PROFILES,
 }
 
 
@@ -217,16 +227,15 @@ def suggest_profiles_for_module(module_name: str) -> List[str]:
         if key and key in name:
             profiles.extend(profs)
 
-    if not profiles:
-        return list(CANONICAL_PROFILES)
-
     seen: set[str] = set()
     unique: List[str] = []
     for prof in profiles:
         if prof not in seen:
             unique.append(prof)
             seen.add(prof)
-    return unique
+
+    # If no keywords matched, fall back to the canonical set to keep coverage high.
+    return unique or list(CANONICAL_PROFILES)
 
 # probability of injecting a random profile when none specified
 _PROFILE_PROB = 0.3


### PR DESCRIPTION
## Summary
- Export `CANONICAL_PROFILES` for reuse and include key helpers in `__all__`
- Map generic module keywords to the canonical profile set
- Return canonical profiles when no keyword matches while deduplicating results

## Testing
- `pytest tests/test_environment_generator.py::test_generate_presets_count_and_keys tests/test_environment_generator.py::test_generate_presets_profiles -q`

------
https://chatgpt.com/codex/tasks/task_e_689946569f04832e859f0a3c9c7a4519