### PR TITLE
feat: use sandbox runner metrics for chain validation

### DIFF
--- a/tests/test_meta_workflow_planner_failures.py
+++ b/tests/test_meta_workflow_planner_failures.py
@@ -143,16 +143,16 @@ def test_validate_chain_multi_run_aggregation(tmp_path, monkeypatch):
     assert record is not None
     assert record["roi_gain"] == pytest.approx(2.0)
     assert record["roi_var"] == pytest.approx(2 / 3)
-    assert record["failures"] == pytest.approx(1 / 3)
-    assert record["failures_var"] == pytest.approx(2 / 9)
+    assert record["failures"] == pytest.approx(1 / 6)
+    assert record["failures_var"] == pytest.approx(1 / 18)
 
     chain_id = "a->b"
     db_rec = roi_db.fetch_results(chain_id)[0]
     agg = db_rec.module_deltas["__aggregate__"]
     assert agg["roi_gain_var"] == pytest.approx(2 / 3)
-    assert agg["failures_mean"] == pytest.approx(1 / 3)
+    assert agg["failures_mean"] == pytest.approx(1 / 6)
     stable = stability_db.data[chain_id]
     assert stable["roi"] == pytest.approx(2.0)
     assert stable["roi_var"] == pytest.approx(2 / 3)
-    assert stable["failures"] == pytest.approx(1 / 3)
-    assert stable["failures_var"] == pytest.approx(2 / 9)
+    assert stable["failures"] == pytest.approx(1 / 6)
+    assert stable["failures_var"] == pytest.approx(1 / 18)


### PR DESCRIPTION
## Summary
- compute failure rate, ROI and entropy using WorkflowSandboxRunner and average across multiple runs
- log aggregated metrics and failure rates to ROI/stability databases and cluster map
- update multi-run aggregation test to expect averaged failure rate

## Testing
- `pre-commit run --files meta_workflow_planner.py tests/test_meta_workflow_planner_failures.py`
- `pytest tests/test_meta_workflow_planner_failures.py tests/test_meta_workflow_planner_core.py`


------
https://chatgpt.com/codex/tasks/task_e_68b139f2b5e8832eb7d91c6c94da9694