### PR TITLE
Improve SynergyExporter error handling and health reporting

### DIFF
--- a/tests/stress/test_autonomous_extended_run.py
+++ b/tests/stress/test_autonomous_extended_run.py
@@ -143,7 +143,7 @@ def test_autonomous_extended_run(monkeypatch, tmp_path: Path) -> None:
     health_url = f"http://localhost:{exporter.health_port}/health"
     data = urllib.request.urlopen(health_url).read().decode()
     info = json.loads(data)
-    assert info.get("status") == "ok"
+    assert info.get("healthy") is True
 
     roi_file = tmp_path / "roi_history.json"
     roi_data = json.loads(roi_file.read_text())

--- a/tests/stress/test_autonomous_long_run.py
+++ b/tests/stress/test_autonomous_long_run.py
@@ -104,7 +104,7 @@ def test_autonomous_long_run(monkeypatch, tmp_path: Path) -> None:
     health_url = f"http://localhost:{exporter.health_port}/health"
     data = urllib.request.urlopen(health_url).read().decode()
     info = json.loads(data)
-    assert info.get("status") == "ok"
+    assert info.get("healthy") is True
 
     roi_file = tmp_path / "roi_history.json"
     roi_data = json.loads(roi_file.read_text())

--- a/tests/test_synergy_exporter_health.py
+++ b/tests/test_synergy_exporter_health.py
@@ -51,10 +51,12 @@ def test_health_endpoint_returns_json(tmp_path: Path) -> None:
             time.sleep(0.05)
         assert metrics.get("synergy_roi") == 0.42
 
-        health = urllib.request.urlopen(f"http://localhost:{exp.health_port}/health").read().decode()
+        health = urllib.request.urlopen(
+            f"http://localhost:{exp.health_port}/health"
+        ).read().decode()
         info = json.loads(health)
-        assert info["status"] == "ok"
-        assert isinstance(info.get("updated"), float)
+        assert info["healthy"] is True
+        assert isinstance(info.get("last_update"), float)
     finally:
         exp.stop()
         me.stop_metrics_server()

--- a/tests/test_synergy_exporter_values.py
+++ b/tests/test_synergy_exporter_values.py
@@ -54,10 +54,12 @@ def test_metrics_and_health_update(tmp_path: Path) -> None:
         assert metrics.get("synergy_roi") == 0.1
         assert metrics.get("security_score") == 50
 
-        health = urllib.request.urlopen(f"http://localhost:{exp.health_port}/health").read().decode()
+        health = urllib.request.urlopen(
+            f"http://localhost:{exp.health_port}/health"
+        ).read().decode()
         info = json.loads(health)
-        assert info["status"] == "ok"
-        first_ts = info.get("updated")
+        assert info["healthy"] is True
+        first_ts = info.get("last_update")
         assert isinstance(first_ts, float)
 
         conn = db_mod.connect(hist_file)
@@ -76,10 +78,12 @@ def test_metrics_and_health_update(tmp_path: Path) -> None:
         assert metrics.get("synergy_roi") == 0.2
         assert metrics.get("security_score") == 60
 
-        health2 = urllib.request.urlopen(f"http://localhost:{exp.health_port}/health").read().decode()
+        health2 = urllib.request.urlopen(
+            f"http://localhost:{exp.health_port}/health"
+        ).read().decode()
         info2 = json.loads(health2)
-        assert info2["status"] == "ok"
-        second_ts = info2.get("updated")
+        assert info2["healthy"] is True
+        second_ts = info2.get("last_update")
         assert isinstance(second_ts, float)
         assert second_ts >= first_ts
     finally:


### PR DESCRIPTION
## Summary
- handle SQLite and JSON failures explicitly and add retry/backoff logic for gauges
- expose exporter health and last update time via `/health`
- update tests for new health payload and robustness

## Testing
- `pytest tests/test_synergy_exporter.py tests/test_synergy_exporter_values.py tests/test_synergy_exporter_health.py tests/test_synergy_history_export.py tests/stress/test_autonomous_long_run.py tests/stress/test_autonomous_extended_run.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b141c55814832e89d502ee7558a0b8