### PR TITLE
Handle missing and negative transition probabilities

### DIFF
--- a/meta_workflow_planner.py
+++ b/meta_workflow_planner.py
@@ -765,11 +765,14 @@ class MetaWorkflowPlanner:
                 if prev_domain >= 0 and cand_domain >= 0:
                     prob = trans_probs.get((prev_domain, cand_domain))
                     if prob is None:
-                        pass
-                    elif prob > 0:
-                        score *= 1.0 + prob
+                        logger.debug(
+                            "no transition stats for domains %s -> %s",
+                            prev_domain,
+                            cand_domain,
+                        )
+                        score *= 1.0
                     else:
-                        score *= 0.8
+                        score *= 1.0 + prob
 
                 if score > best_score:
                     best_id = wid


### PR DESCRIPTION
## Summary
- log and neutralize missing domain transition stats
- scale penalties for negative transition probabilities
- add tests for missing and negative transition cases in compose_pipeline

## Testing
- `python - <<'PY'
import types, sys, pytest
# stub torch and submodules
torch = types.ModuleType('torch')
nn = types.ModuleType('torch.nn')
att = types.ModuleType('torch.nn.attention')
flex = types.ModuleType('torch.nn.attention.flex_attention')
setattr(torch, 'nn', nn)
sys.modules['torch'] = torch
sys.modules['torch.nn'] = nn
sys.modules['torch.nn.attention'] = att
sys.modules['torch.nn.attention.flex_attention'] = flex
sys.modules['torch._dynamo'] = types.ModuleType('torch._dynamo')
# stub transformers
transformers = types.ModuleType('transformers')
transformers.AutoModel = object
transformers.AutoTokenizer = object
sys.modules['transformers'] = transformers

# run pytest
raise SystemExit(pytest.main(['tests/test_meta_workflow_planner.py::test_compose_pipeline_transition_matrix','tests/test_meta_workflow_planner.py::test_compose_pipeline_missing_transition','tests/test_meta_workflow_planner.py::test_compose_pipeline_negative_transition','-q']))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b15fab68ec832eb155c08e4ee10e66