### PR TITLE
Log ROI delta errors

### DIFF
--- a/workflow_chain_suggester.py
+++ b/workflow_chain_suggester.py
@@ -172,8 +172,9 @@ class WorkflowChainSuggester:
                 return float(trends[-1].get("roi_gain", 0.0)) - float(
                     trends[-2].get("roi_gain", 0.0)
                 )
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("ROI delta fetch failed for %s: %s", workflow_id, exc)
+            return 0.0
         return 0.0
 
     def _entropy(self, chain: Sequence[str]) -> float:


### PR DESCRIPTION
## Summary
- log ROI delta fetch failures in `workflow_chain_suggester._roi_delta`
- add regression test ensuring failures are logged and default value is returned

## Testing
- `pytest tests/test_workflow_chain_suggester.py::test_roi_delta_logs_and_defaults -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68b164654d68832ebb62fb5a672c83aa