### PR TITLE
feat: incorporate synergy into pipeline scoring

### DIFF
--- a/docs/meta_workflow_planner.md
+++ b/docs/meta_workflow_planner.md
@@ -48,7 +48,9 @@ provided `Retriever`, while `compose_pipeline` iteratively blends embedding simi
 `WorkflowSynergyComparator` scores and recent ROI trends to choose the next
 step.  The default formula is
 ``(similarity * similarity_weight + synergy * synergy_weight) * (1 + ROI * roi_weight)``
-giving callers independent control over similarity, synergy and ROI.
+giving callers independent control over similarity, synergy and ROI.  Setting
+`synergy_weight` to `0` ignores structural synergy and ranks steps purely by
+similarity and ROI.
 
 ## Sandbox simulation
 


### PR DESCRIPTION
## Summary
- compute synergy scores via `WorkflowSynergyComparator` inside `compose_pipeline`
- blend similarity, synergy, and ROI using documented formula
- document new scoring behavior and add synergy weight test

## Testing
- `python -m pytest tests/test_meta_workflow_planner.py::test_compose_pipeline_chaining tests/test_meta_workflow_planner.py::test_compose_pipeline_roi_weighting tests/test_meta_workflow_planner.py::test_compose_pipeline_synergy_weighting -q`
- `pre-commit run --files meta_workflow_planner.py docs/meta_workflow_planner.md tests/test_meta_workflow_planner.py`


------
https://chatgpt.com/codex/tasks/task_e_68b16abebde8832e911590ec134b3dfa