### PR TITLE
Support multi-domain workflow transitions

### DIFF
--- a/tests/test_find_synergy_chain.py
+++ b/tests/test_find_synergy_chain.py
@@ -45,7 +45,9 @@ def test_find_synergy_chain_prefers_reinforced(tmp_path, monkeypatch):
     monkeypatch.setattr(mwp, "WorkflowStabilityDB", None)
     monkeypatch.setattr(mwp, "CodeDB", None)
     monkeypatch.setattr(mwp.MetaWorkflowPlanner, "_load_cluster_map", lambda self: None)
-    monkeypatch.setattr(mwp.MetaWorkflowPlanner, "_workflow_domain", lambda self, wid: (0, "d"))
+    monkeypatch.setattr(
+        mwp.MetaWorkflowPlanner, "_workflow_domain", lambda self, wid: ([0], ["d"])
+    )
     monkeypatch.setattr(mwp.MetaWorkflowPlanner, "transition_probabilities", lambda self: {})
 
     chain = mwp.find_synergy_chain("a", length=2, cluster_map={})


### PR DESCRIPTION
## Summary
- Allow workflows to expose multiple domain tags
- Encode workflows using multi-hot domain vectors and consider all domain transition pairs when planning
- Track and test multi-domain pipeline transition statistics

## Testing
- `pytest tests/test_meta_workflow_planner_transitions.py tests/test_meta_workflow_planner.py::test_domain_transition_vector tests/test_find_synergy_chain.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b16d6197d4832e96ed05c8161e2627