### PR TITLE
Add similarity-threshold clustering fallback for meta workflow planner

### DIFF
--- a/docs/meta_workflow_planner.md
+++ b/docs/meta_workflow_planner.md
@@ -43,8 +43,12 @@ pipeline = planner.compose_pipeline("A", workflows, length=3)
 ```
 
 `cluster_workflows` encodes each specification, persists the embedding and
-groups workflows using ROI‑weighted cosine similarity and DBSCAN via the
-provided `Retriever`, while `compose_pipeline` iteratively blends embedding similarity,
+groups workflows using ROI‑weighted cosine similarity.  When
+[scikit‑learn](https://scikit-learn.org) is available the normalised distance
+matrix is clustered with DBSCAN via the provided `Retriever`.  Without
+scikit‑learn a simple similarity‑threshold fallback groups connected workflows
+so the planner remains functional in lightweight environments.  In both cases
+`compose_pipeline` iteratively blends embedding similarity,
 `WorkflowSynergyComparator` scores and recent ROI trends to choose the next
 step.  The default formula is
 ``(similarity * similarity_weight + synergy * synergy_weight) * (1 + ROI * roi_weight)``


### PR DESCRIPTION
## Summary
- Allow `cluster_workflows` to operate without scikit-learn by grouping workflows via a simple similarity threshold when DBSCAN isn't available
- Document the fallback behavior in planner docs
- Test clustering logic with and without scikit-learn

## Testing
- `pytest tests/test_meta_workflow_planner.py::test_cluster_workflows_roi_weighting -q`
- `pre-commit run --files meta_workflow_planner.py docs/meta_workflow_planner.md tests/test_meta_workflow_planner.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b171903624832e82c809d5c2956547