### PR TITLE
Add stop function and tests for self_modification_detector

### DIFF
--- a/self_modification_detector.py
+++ b/self_modification_detector.py
@@ -69,7 +69,10 @@ def _fetch_reference_hashes(url: str) -> Dict[str, str] | None:
     return None
 
 
-def detect_self_modification(reference_hashes: Dict[str, str], current_hashes: Dict[str, str]) -> List[str]:
+def detect_self_modification(
+    reference_hashes: Dict[str, str],
+    current_hashes: Dict[str, str],
+) -> List[str]:
     """Return list of files whose hashes differ from ``reference_hashes``."""
     changed: List[str] = []
     for filename, ref_hash in reference_hashes.items():
@@ -131,8 +134,20 @@ def monitor_self_integrity(interval_seconds: int = 10, reference_url: str | None
 
     global _MONITOR_THREAD
     if _MONITOR_THREAD is None or not _MONITOR_THREAD.is_alive():
+        _STOP_EVENT.clear()
         _MONITOR_THREAD = threading.Thread(target=_monitor, daemon=True)
         _MONITOR_THREAD.start()
+
+
+def stop_monitoring() -> None:
+    """Stop the integrity monitoring thread if running."""
+    global _MONITOR_THREAD
+    _STOP_EVENT.set()
+    if _MONITOR_THREAD is not None:
+        try:
+            _MONITOR_THREAD.join()
+        finally:
+            _MONITOR_THREAD = None
 
 
 __all__ = [
@@ -141,5 +156,6 @@ __all__ = [
     "load_reference_hashes",
     "detect_self_modification",
     "monitor_self_integrity",
+    "stop_monitoring",
     "trigger_lockdown",
 ]

--- a/tests/test_self_modification_detector.py
+++ b/tests/test_self_modification_detector.py
@@ -1,4 +1,6 @@
+import hashlib
 import types
+
 import menace.self_modification_detector as smd
 
 
@@ -17,6 +19,7 @@ def _run_once(monkeypatch, remote, current):
     class DummyEvent:
         def __init__(self):
             self.calls = 0
+
         def wait(self, _):
             self.calls += 1
             return self.calls > 1
@@ -27,9 +30,11 @@ def _run_once(monkeypatch, remote, current):
     class DummyThread:
         def __init__(self, target=None, daemon=None):
             self.target = target
+
         def start(self):
             if self.target:
                 self.target()
+
         def is_alive(self):
             return False
 
@@ -54,3 +59,69 @@ def test_save_reference_hashes_logs_warning(tmp_path, caplog):
     caplog.set_level("ERROR")
     smd.save_reference_hashes({"a": "1"}, str(path))
     assert "failed writing reference hashes" in caplog.text
+
+
+def test_generate_code_hashes(tmp_path):
+    root = tmp_path
+    (root / "a.py").write_text("print('a')", encoding="utf-8")
+    (root / "b.txt").write_text("nope", encoding="utf-8")
+    log_dir = root / "logs"
+    log_dir.mkdir()
+    (log_dir / "c.py").write_text("print('c')", encoding="utf-8")
+    hashes = smd.generate_code_hashes(str(root))
+    assert set(hashes) == {"a.py"}
+    assert hashes["a.py"] == hashlib.sha256(b"print('a')").hexdigest()
+
+
+def test_monitor_start_and_stop(monkeypatch):
+    class DummyEvent:
+        def __init__(self):
+            self.cleared = False
+            self.set_called = False
+
+        def wait(self, _):
+            return True
+
+        def clear(self):
+            self.cleared = True
+
+        def set(self):
+            self.set_called = True
+
+    event = DummyEvent()
+    monkeypatch.setattr(smd, "_STOP_EVENT", event)
+    monkeypatch.setattr(smd, "_REFERENCE_HASHES", {})
+    monkeypatch.setattr(smd, "generate_code_hashes", lambda d: {})
+    monkeypatch.setattr(smd, "load_reference_hashes", lambda p: {})
+    monkeypatch.setattr(smd, "save_reference_hashes", lambda d, p: None)
+    monkeypatch.setattr(smd, "detect_self_modification", lambda r, c: [])
+
+    class DummyThread:
+        def __init__(self, target=None, daemon=None):
+            self.target = target
+            self.join_called = False
+            self.alive = True
+
+        def start(self):
+            if self.target:
+                self.target()
+
+        def join(self):
+            self.join_called = True
+            self.alive = False
+
+        def is_alive(self):
+            return self.alive
+
+    monkeypatch.setattr(smd.threading, "Thread", DummyThread)
+    smd._MONITOR_THREAD = None
+
+    smd.monitor_self_integrity(interval_seconds=0)
+    thread = smd._MONITOR_THREAD
+    assert isinstance(thread, DummyThread)
+    assert event.cleared
+
+    smd.stop_monitoring()
+    assert event.set_called
+    assert thread.join_called
+    assert smd._MONITOR_THREAD is None


### PR DESCRIPTION
## Summary
- ensure integrity monitor imports logging, os, json and hashlib
- allow self-integrity monitoring to be stopped and restarted cleanly
- test code hash generation and monitoring lifecycle

## Testing
- `pre-commit run --files self_modification_detector.py tests/test_self_modification_detector.py`
- `pytest tests/test_self_modification_detector.py::test_generate_code_hashes tests/test_self_modification_detector.py::test_monitor_start_and_stop -q`


------
https://chatgpt.com/codex/tasks/task_e_68b17435dc38832ea49c9954ef8badb8