### PR TITLE
Enable safe-mode toggling and rollback controls

### DIFF
--- a/tests/test_auto_escalation_manager.py
+++ b/tests/test_auto_escalation_manager.py
@@ -1,3 +1,4 @@
+ # flake8: noqa
 import os
 import sys
 import types
@@ -94,12 +95,13 @@ def test_self_service_override_enables_safe(tmp_path, monkeypatch):
 
     roi = FakeROI()
 
+    monkeypatch.delenv("MENACE_SAFE", raising=False)
     metrics = db.MetricsDB(tmp_path / "m.db")
     metrics.add(db.MetricRecord(bot="b", cpu=1.0, memory=1.0, response_time=0.1, disk_io=1.0, net_io=1.0, errors=10))
 
     svc = so.SelfServiceOverride(roi, metrics)
     svc.adjust()
-    assert os.environ.get("MENACE_SAFE") is None
+    assert os.environ.get("MENACE_SAFE") == "1"
 
 
 def test_publish_retry_and_log(monkeypatch, caplog):
@@ -141,6 +143,7 @@ def test_auto_rollback_service(tmp_path, monkeypatch):
 
     roi = FakeROI()
 
+    monkeypatch.delenv("MENACE_SAFE", raising=False)
     metrics = db.MetricsDB(tmp_path / "m.db")
     metrics.add(db.MetricRecord(bot="b", cpu=1.0, memory=1.0, response_time=0.1, disk_io=1.0, net_io=1.0, errors=10))
     metrics.log_eval("system", "avg_energy_score", 0.2)
@@ -156,5 +159,4 @@ def test_auto_rollback_service(tmp_path, monkeypatch):
     svc = so.AutoRollbackService(roi, metrics)
     svc.adjust()
     assert calls and calls[0][0] == "git"
-    assert os.environ.get("MENACE_SAFE") is None
-
+    assert os.environ.get("MENACE_SAFE") == "1"

--- a/tests/test_self_service_override.py
+++ b/tests/test_self_service_override.py
@@ -1,53 +1,128 @@
+# flake8: noqa
 import os
+import sys
+import types
 import time
-import threading
+import subprocess
+
+os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
+pkg = types.ModuleType("menace")
+pkg.__path__ = [os.getcwd()]
+sys.modules.setdefault("menace", pkg)
 
 import menace.self_service_override as so
 import menace.resource_allocation_optimizer as rao
 import menace.data_bot as db
 
 
-def test_run_continuous_invokes_adjust(tmp_path, monkeypatch):
+class DummyDF(list):
+    @property
+    def iloc(self):
+        class ILoc:
+            def __init__(self, rows):
+                self._rows = rows
+
+            def __getitem__(self, idx):
+                return self._rows[idx]
+
+        return ILoc(self)
+
+
+class FlatROI:
+    def history(self, limit=2):
+        return DummyDF(
+            [{"revenue": 100.0, "api_cost": 0.0}, {"revenue": 100.0, "api_cost": 0.0}]
+        )
+
+
+class DroppingROI:
+    def history(self, limit=2):
+        return DummyDF(
+            [{"revenue": 50.0, "api_cost": 0.0}, {"revenue": 100.0, "api_cost": 0.0}]
+        )
+
+
+def test_run_continuous_invokes_adjust_and_stop(tmp_path, monkeypatch):
     roi = rao.ROIDB(tmp_path / "r.db")
     metrics = db.MetricsDB(tmp_path / "m.db")
     svc = so.SelfServiceOverride(roi, metrics)
 
     calls = []
     monkeypatch.setattr(svc, "adjust", lambda: calls.append(True))
-    stop = threading.Event()
-    thread = svc.run_continuous(interval=0.01, stop_event=stop)
+    thread = svc.run_continuous(interval=0.01)
     time.sleep(0.03)
-    stop.set()
+    svc.stop()
     thread.join(timeout=0.1)
     assert calls
 
 
-def test_adjust_triggers_audit(tmp_path, monkeypatch):
-    class DummyDF(list):
-        @property
-        def iloc(self):
-            class ILoc:
-                def __init__(self, rows):
-                    self._rows = rows
-
-                def __getitem__(self, idx):
-                    return self._rows[idx]
-
-            return ILoc(self)
-
-    class FakeROI:
-        def history(self, limit=2):
-            return DummyDF(
-                [
-                    {"revenue": 50.0, "api_cost": 0.0},
-                    {"revenue": 100.0, "api_cost": 0.0},
-                ]
-            )
-
-    roi = FakeROI()
+def test_adjust_enables_safe_on_roi_drop(tmp_path, monkeypatch):
+    monkeypatch.delenv("MENACE_SAFE", raising=False)
+    roi = DroppingROI()
     metrics = db.MetricsDB(tmp_path / "m.db")
-    metrics.add(db.MetricRecord(bot="b", cpu=0.0, memory=0.0, response_time=0.0, disk_io=0.0, net_io=0.0, errors=10))
-
+    metrics.add(
+        db.MetricRecord(
+            bot="b",
+            cpu=0.0,
+            memory=0.0,
+            response_time=0.0,
+            disk_io=0.0,
+            net_io=0.0,
+            errors=0,
+        )
+    )
     svc = so.SelfServiceOverride(roi, metrics)
     svc.adjust()
-    assert os.environ.get("MENACE_SAFE") is None
+    assert os.environ.get("MENACE_SAFE") == "1"
+
+
+def test_adjust_enables_safe_on_error_rate(tmp_path, monkeypatch):
+    monkeypatch.delenv("MENACE_SAFE", raising=False)
+    roi = FlatROI()
+    metrics = db.MetricsDB(tmp_path / "m.db")
+    metrics.add(
+        db.MetricRecord(
+            bot="b",
+            cpu=0.0,
+            memory=0.0,
+            response_time=0.0,
+            disk_io=0.0,
+            net_io=0.0,
+            errors=10,
+        )
+    )
+    svc = so.SelfServiceOverride(roi, metrics)
+    svc.adjust()
+    assert os.environ.get("MENACE_SAFE") == "1"
+
+
+def test_auto_rollback_service_triggers_revert(tmp_path, monkeypatch):
+    monkeypatch.delenv("MENACE_SAFE", raising=False)
+
+    roi = DroppingROI()
+    metrics = db.MetricsDB(tmp_path / "m.db")
+    metrics.add(
+        db.MetricRecord(
+            bot="b",
+            cpu=0.0,
+            memory=0.0,
+            response_time=0.0,
+            disk_io=0.0,
+            net_io=0.0,
+            errors=10,
+        )
+    )
+    metrics.log_eval("system", "avg_energy_score", 0.2)
+
+    called = []
+
+    def fake_revert(cmd, check=True, stdout=None, stderr=None):
+        called.append(cmd)
+        return None
+
+    monkeypatch.setattr(subprocess, "run", fake_revert)
+
+    svc = so.AutoRollbackService(roi, metrics)
+    svc.adjust()
+    assert called and called[0][0] == "git"
+    assert os.environ.get("MENACE_SAFE") == "1"


### PR DESCRIPTION
## Summary
- activate safe mode when ROI drop or error thresholds are exceeded
- allow clean shutdown of SelfServiceOverride threads
- add environment-driven thresholds and rollback unit tests

## Testing
- `pre-commit run --files self_service_override.py tests/test_self_service_override.py tests/test_auto_escalation_manager.py`
- `MENACE_LIGHT_IMPORTS=1 pytest tests/test_self_service_override.py tests/test_auto_escalation_manager.py` *(fails: ImportError: attempted relative import with no known parent package and heavy deps)*

------
https://chatgpt.com/codex/tasks/task_e_68b175dedb90832e8023eee328d5cda2