### PR TITLE
Add configurable RL strategy dataclasses and serialization

### DIFF
--- a/tests/test_rl_strategies.py
+++ b/tests/test_rl_strategies.py
@@ -29,3 +29,31 @@ def test_actor_critic_update():
     strat.update(table, (0,), 1, 1.0, (1,), 0.5, 0.5)
     assert table[(0,)][1] == pytest.approx(0.5)
     assert strat.state_values[(0,)] == pytest.approx(0.5)
+
+
+def test_dimension_validation():
+    cfg = sip.QLearningConfig(state_dim=2, action_dim=2)
+    strat = sip.QLearningStrategy(cfg)
+    with pytest.raises(ValueError):
+        strat.update({}, (0,), 1, 1.0, None, 0.5, 0.5)
+    with pytest.raises(ValueError):
+        strat.update({}, (0, 0), 3, 1.0, None, 0.5, 0.5)
+
+
+def test_policy_serialization_roundtrip():
+    cfg = sip.QLearningConfig(state_dim=1, action_dim=2)
+    policy = sip.SelfImprovementPolicy(strategy=sip.QLearningStrategy(cfg))
+    policy.update((0,), 1.0)
+    data = policy.to_json()
+    restored = sip.SelfImprovementPolicy.from_json(data)
+    assert restored.score((0,)) == pytest.approx(policy.score((0,)))
+
+
+def test_dqn_training_example():
+    if sip.torch is None:
+        pytest.skip("torch not available")
+    cfg = sip.DQNConfig(state_dim=2, action_dim=2, hidden_dim=8, batch_size=1, capacity=10)
+    strat = sip.DQNStrategy(cfg)
+    table: dict = {}
+    q = strat.update(table, (0, 0), 1, 1.0, (0, 1), 0.5, 0.9)
+    assert isinstance(q, float)


### PR DESCRIPTION
## Summary
- add dataclass-based configs for Q-learning, actor-critic and DQN strategies with dimension validation
- add JSON serialization/deserialization helpers for `SelfImprovementPolicy`
- extend RL strategy tests with dimension mismatch checks, round-trip serialization and DQN toy training

## Testing
- `pre-commit run --files self_improvement_policy.py tests/test_rl_strategies.py`
- `pytest tests/test_rl_strategies.py`


------
https://chatgpt.com/codex/tasks/task_e_68b180fac91c832eaa7804d61b2cb729