### PR TITLE
Harden sandbox safe mode and export resource metrics

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -37,6 +37,16 @@ class SandboxSettings(BaseSettings):
     menace_env_file: str = Field(".env", env="MENACE_ENV_FILE")
     sandbox_data_dir: str = Field("sandbox_data", env="SANDBOX_DATA_DIR")
     sandbox_env_presets: str | None = Field(None, env="SANDBOX_ENV_PRESETS")
+    default_module_timeout: float | None = Field(
+        None,
+        env="SANDBOX_TIMEOUT",
+        description="Default per-module execution timeout in seconds.",
+    )
+    default_memory_limit: int | None = Field(
+        None,
+        env="SANDBOX_MEMORY_LIMIT",
+        description="Default per-module RSS memory limit in bytes.",
+    )
     auto_include_isolated: bool = Field(
         True,
         env="SANDBOX_AUTO_INCLUDE_ISOLATED",

--- a/tests/test_sandbox_escape_attempts.py
+++ b/tests/test_sandbox_escape_attempts.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from sandbox_runner.workflow_sandbox_runner import WorkflowSandboxRunner
+
+
+def test_unmocked_network_raises_runtimeerror():
+    def step():
+        import urllib.request
+
+        urllib.request.urlopen("http://example.com")
+
+    runner = WorkflowSandboxRunner()
+    metrics = runner.run([step], safe_mode=True)
+    assert metrics.crash_count == 1
+    assert "network access disabled" in (metrics.modules[0].exception or "")
+
+
+def test_absolute_path_write_raises_runtimeerror(tmp_path):
+    outside = Path("/tmp/outside_escape.txt")
+
+    def step():
+        outside.write_text("data")
+
+    runner = WorkflowSandboxRunner()
+    metrics = runner.run([step], safe_mode=True)
+    assert metrics.crash_count == 1
+    assert "file write disabled" in (metrics.modules[0].exception or "")
+    assert not outside.exists()


### PR DESCRIPTION
## Summary
- block outbound network in safe mode unless URL-specific mocks are supplied
- expose per-module CPU and memory gauges via metrics_exporter
- allow sandbox defaults for timeout and memory limit via `SandboxSettings`
- add tests covering sandbox escape attempts

## Testing
- `pre-commit run --files sandbox_runner/workflow_sandbox_runner.py sandbox_settings.py tests/test_workflow_sandbox_runner.py tests/test_sandbox_escape_attempts.py`
- `pytest tests/test_workflow_sandbox_runner.py tests/test_sandbox_escape_attempts.py`


------
https://chatgpt.com/codex/tasks/task_e_68b188e78d7c832e94691f2ac622521d