### PR TITLE
feat: add nested sandbox settings with validation

### DIFF
--- a/docs/sandbox_config.sample.yaml
+++ b/docs/sandbox_config.sample.yaml
@@ -1,0 +1,44 @@
+roi:
+  threshold: null
+  confidence: null
+  ema_alpha: 0.1
+  compounding_weight: 1.0
+  min_integration_roi: 0.0
+  entropy_threshold: null
+  entropy_plateau_threshold: null
+  entropy_plateau_consecutive: null
+  entropy_ceiling_threshold: null
+  entropy_ceiling_consecutive: null
+synergy:
+  threshold: null
+  confidence: null
+  threshold_window: null
+  threshold_weight: null
+  ma_window: null
+  stationarity_confidence: null
+  std_threshold: null
+  variance_confidence: null
+  weight_roi: 1.0
+  weight_efficiency: 1.0
+  weight_resilience: 1.0
+  weight_antifragility: 1.0
+  weight_reliability: 1.0
+  weight_maintainability: 1.0
+  weight_throughput: 1.0
+  weights_lr: 0.1
+  train_interval: 10
+  replay_size: 100
+alignment:
+  enable_flagger: true
+  warning_threshold: 0.5
+  failure_threshold: 0.9
+  improvement_warning_threshold: 0.5
+  improvement_failure_threshold: 0.9
+  baseline_metrics_path: sandbox_metrics.yaml
+  rules:
+    max_complexity_score: 10
+    max_comment_density_drop: 0.1
+    allowed_network_calls: 0
+    comment_density_severity: 2
+    network_call_severity: 3
+    rule_modules: []

--- a/docs/sandbox_settings.md
+++ b/docs/sandbox_settings.md
@@ -1,0 +1,54 @@
+# Sandbox Settings
+
+`SandboxSettings` provides configuration for sandbox runners. Settings are
+loaded from environment variables, an optional `.env` file, and may be
+version-controlled by supplying a YAML or JSON configuration file via
+`load_sandbox_settings()`.
+
+```python
+from sandbox_settings import load_sandbox_settings
+settings = load_sandbox_settings("docs/sandbox_config.sample.yaml")
+```
+
+## ROI defaults
+- `threshold`: `null`
+- `confidence`: `null`
+- `ema_alpha`: `0.1`
+- `compounding_weight`: `1.0`
+- `min_integration_roi`: `0.0`
+- `entropy_threshold`: `null`
+- `entropy_plateau_threshold`: `null`
+- `entropy_plateau_consecutive`: `null`
+- `entropy_ceiling_threshold`: `null`
+- `entropy_ceiling_consecutive`: `null`
+
+## Synergy defaults
+- `threshold`: `null`
+- `confidence`: `null`
+- `threshold_window`: `null`
+- `threshold_weight`: `null`
+- `ma_window`: `null`
+- `stationarity_confidence`: `null`
+- `std_threshold`: `null`
+- `variance_confidence`: `null`
+- `weight_roi`: `1.0`
+- `weight_efficiency`: `1.0`
+- `weight_resilience`: `1.0`
+- `weight_antifragility`: `1.0`
+- `weight_reliability`: `1.0`
+- `weight_maintainability`: `1.0`
+- `weight_throughput`: `1.0`
+- `weights_lr`: `0.1`
+- `train_interval`: `10`
+- `replay_size`: `100`
+
+## Alignment defaults
+- `enable_flagger`: `True`
+- `warning_threshold`: `0.5`
+- `failure_threshold`: `0.9`
+- `improvement_warning_threshold`: `0.5`
+- `improvement_failure_threshold`: `0.9`
+- `baseline_metrics_path`: `sandbox_metrics.yaml`
+
+See [`sandbox_config.sample.yaml`](sandbox_config.sample.yaml) for a complete
+example configuration file.


### PR DESCRIPTION
## Summary
- load sandbox settings from optional YAML/JSON files and .env
- add ROI, Synergy, and Alignment nested models with range validators
- document defaults and provide sample configuration file

## Testing
- `pre-commit run --files sandbox_settings.py docs/sandbox_config.sample.yaml docs/sandbox_settings.md`

------
https://chatgpt.com/codex/tasks/task_e_68b18aea784c832e8003bbf99c11129c