### PR TITLE
Ensure sandbox import tracking is temporary

### DIFF
--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -49,7 +49,7 @@ from typing import (
     get_args,
     TYPE_CHECKING,
 )
-from contextlib import asynccontextmanager, suppress
+from contextlib import asynccontextmanager, contextmanager, suppress
 from filelock import FileLock
 from dataclasses import dataclass, asdict
 
@@ -129,7 +129,16 @@ def _tracking_import(
     return mod
 
 
-builtins.__import__ = _tracking_import
+@contextmanager
+def _patched_imports() -> Iterable[None]:
+    """Temporarily install import tracker."""
+
+    previous = builtins.__import__
+    builtins.__import__ = _tracking_import
+    try:
+        yield
+    finally:
+        builtins.__import__ = previous
 
 logger = get_logger(__name__)
 

--- a/sandbox_runner/workflow_sandbox_runner.py
+++ b/sandbox_runner/workflow_sandbox_runner.py
@@ -189,8 +189,16 @@ class WorkflowSandboxRunner:
 
         proc = psutil.Process() if psutil else None
 
+        try:
+            from .environment import _patched_imports
+        except Exception:  # pragma: no cover - fallback when environment unavailable
+            @contextlib.contextmanager
+            def _patched_imports():
+                yield
+
         with tempfile.TemporaryDirectory() as tmp, contextlib.ExitStack() as stack:
             root = pathlib.Path(tmp).resolve()
+            stack.enter_context(_patched_imports())
 
             funcs = [workflow] if callable(workflow) else list(workflow)
 

--- a/tests/test_import_tracking.py
+++ b/tests/test_import_tracking.py
@@ -1,0 +1,56 @@
+import builtins
+import contextlib
+import sys
+import types
+
+import pytest
+
+from tests.test_workflow_sandbox_runner import WorkflowSandboxRunner
+
+
+def _make_stub_env(tracker):
+    env = types.ModuleType("sandbox_runner.environment")
+
+    @contextlib.contextmanager
+    def _patched_imports():
+        prev = builtins.__import__
+        builtins.__import__ = tracker
+        try:
+            yield
+        finally:
+            builtins.__import__ = prev
+
+    env._patched_imports = _patched_imports
+    return env
+
+
+def test_import_tracker_restores_builtins():
+    original = builtins.__import__
+
+    def tracker(name, globals=None, locals=None, fromlist=(), level=0):
+        return original(name, globals, locals, fromlist, level)
+
+    sys.modules["sandbox_runner.environment"] = _make_stub_env(tracker)
+
+    runner = WorkflowSandboxRunner()
+    runner.run(lambda: None)
+
+    assert builtins.__import__ is original
+
+
+def test_import_tracker_restores_on_exception():
+    original = builtins.__import__
+
+    def tracker(name, globals=None, locals=None, fromlist=(), level=0):
+        return original(name, globals, locals, fromlist, level)
+
+    sys.modules["sandbox_runner.environment"] = _make_stub_env(tracker)
+
+    runner = WorkflowSandboxRunner()
+
+    with pytest.raises(RuntimeError):
+        def fail():
+            raise RuntimeError("boom")
+        runner.run(fail)
+
+    assert builtins.__import__ is original


### PR DESCRIPTION
## Summary
- use context manager to temporarily replace `__import__` during sandbox runs
- restore global import hook even when workflow execution raises
- add tests proving no lingering import hook side effects

## Testing
- `pre-commit run --files tests/test_import_tracking.py` *(fails: `pre-commit run --files sandbox_runner/environment.py` due to existing lint errors)*
- `pytest tests/test_import_tracking.py`
- `pytest tests/test_workflow_sandbox_runner_isolation.py::test_files_confined_to_temp_dir`

------
https://chatgpt.com/codex/tasks/task_e_68b1925244e8832ebc0fdb9934b914dd