### PR TITLE
feat: enhance generative stub provider

### DIFF
--- a/sandbox_runner/generative_stub_provider.py
+++ b/sandbox_runner/generative_stub_provider.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Stub provider using a language model via ``transformers``."""
 
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Callable, Awaitable
 import asyncio
 import inspect
 import json
@@ -12,6 +12,7 @@ import re
 from pathlib import Path
 from collections import Counter
 import atexit
+import importlib
 
 from .input_history_db import InputHistoryDB
 
@@ -21,20 +22,66 @@ _STUB_CACHE_PATH = Path(
     os.getenv("SANDBOX_STUB_CACHE", str(ROOT / "sandbox_data" / "stub_cache.json"))
 )
 
-try:
-    from transformers import pipeline
-except Exception:  # pragma: no cover - optional dependency
-    pipeline = None  # type: ignore
 
-try:
-    import openai  # type: ignore
-except Exception:  # pragma: no cover - optional dependency
-    openai = None  # type: ignore
+# Optional dependencies loaded lazily
+pipeline = None  # type: ignore
+openai = None  # type: ignore
 
 logger = logging.getLogger(__name__)
 
 _GENERATOR = None
 _CACHE: Dict[Tuple[str, str], Dict[str, Any]] = {}
+
+_SAVE_TASKS: set[asyncio.Task[None]] = set()
+
+
+def _feature_enabled(name: str) -> bool:
+    """Return True if feature flag *name* is truthy."""
+    val = os.getenv(name, "").lower()
+    return val in {"1", "true", "yes"}
+
+
+_RATE_LIMIT = asyncio.Semaphore(int(os.getenv("SANDBOX_STUB_MAX_CONCURRENCY", "1")))
+_GEN_TIMEOUT = float(os.getenv("SANDBOX_STUB_TIMEOUT", "10"))
+_GEN_RETRIES = int(os.getenv("SANDBOX_STUB_RETRIES", "2"))
+
+
+async def _call_with_retry(func: Callable[[], Awaitable[Any]]) -> Any:
+    """Invoke *func* with retry, timeout and rate limiting."""
+    for attempt in range(_GEN_RETRIES):
+        try:
+            async with _RATE_LIMIT:
+                return await asyncio.wait_for(func(), timeout=_GEN_TIMEOUT)
+        except Exception:
+            if attempt == _GEN_RETRIES - 1:
+                raise
+            await asyncio.sleep(0.5 * (attempt + 1))
+
+
+def _deterministic_stub(stub: Dict[str, Any], func: Any | None) -> Dict[str, Any]:
+    """Fill missing fields in *stub* using simple deterministic defaults."""
+    if func is None:
+        return dict(stub)
+    try:
+        sig = inspect.signature(func)
+    except Exception:
+        return dict(stub)
+    result: Dict[str, Any] = {}
+    for name, param in sig.parameters.items():
+        ann = param.annotation
+        if ann in (int, "int"):
+            val: Any = 0
+        elif ann in (float, "float"):
+            val = 0.0
+        elif ann in (bool, "bool"):
+            val = False
+        elif ann in (str, "str"):
+            val = ""
+        else:
+            val = None
+        result[name] = val
+    result.update(stub)
+    return result
 
 
 def _load_cache() -> Dict[Tuple[str, str], Dict[str, Any]]:
@@ -53,6 +100,11 @@ def _load_cache() -> Dict[Tuple[str, str], Dict[str, Any]]:
                 return cache
     except Exception:
         logger.exception("failed to load stub cache")
+        try:
+            backup = _STUB_CACHE_PATH.with_suffix(".corrupt")
+            _STUB_CACHE_PATH.replace(backup)
+        except Exception:
+            logger.exception("failed to back up corrupt cache")
     return {}
 
 
@@ -60,8 +112,10 @@ def _save_cache() -> None:
     try:
         _STUB_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
         data = {f"{k[0]}::{k[1]}": v for k, v in _CACHE.items()}
-        with open(_STUB_CACHE_PATH, "w", encoding="utf-8") as fh:
+        tmp = _STUB_CACHE_PATH.with_suffix(".tmp")
+        with open(tmp, "w", encoding="utf-8") as fh:
             json.dump(data, fh)
+        tmp.replace(_STUB_CACHE_PATH)
     except Exception:
         logger.exception("failed to save stub cache")
 
@@ -74,6 +128,20 @@ async def _aload_cache() -> Dict[Tuple[str, str], Dict[str, Any]]:
 async def _asave_cache() -> None:
     """Asynchronously persist stub cache to disk."""
     await asyncio.to_thread(_save_cache)
+
+
+def _schedule_cache_persist() -> None:
+    """Persist the cache in the background."""
+
+    async def _runner() -> None:
+        try:
+            await _asave_cache()
+        except Exception:
+            logger.exception("failed to save stub cache")
+
+    task = asyncio.create_task(_runner())
+    _SAVE_TASKS.add(task)
+    task.add_done_callback(lambda t: _SAVE_TASKS.discard(t))
 
 
 # load persistent cache at import time
@@ -115,15 +183,35 @@ async def _aload_generator():
         return _GENERATOR
     model = os.getenv("SANDBOX_STUB_MODEL")
 
-    if model == "openai" and os.getenv("OPENAI_API_KEY"):
-        if openai is None:
+    if model == "openai":
+        if not _feature_enabled("SANDBOX_ENABLE_OPENAI"):
+            logger.error("openai support disabled; set SANDBOX_ENABLE_OPENAI=1")
+            return None
+        if not os.getenv("OPENAI_API_KEY"):
+            logger.error("OPENAI_API_KEY missing for openai usage")
+            return None
+        try:
+            global openai
+            if openai is None:
+                openai = importlib.import_module("openai")  # type: ignore
+        except Exception:
             logger.error("openai library unavailable")
             return None
         openai.api_key = os.getenv("OPENAI_API_KEY")
         _GENERATOR = openai
         return _GENERATOR
 
-    if pipeline is None:
+    if not _feature_enabled("SANDBOX_ENABLE_TRANSFORMERS"):
+        logger.error("transformers support disabled; set SANDBOX_ENABLE_TRANSFORMERS=1")
+        return None
+
+    try:
+        global pipeline
+        if pipeline is None:
+            transformers = importlib.import_module("transformers")
+            pipeline = transformers.pipeline  # type: ignore[attr-defined]
+    except Exception:
+        logger.error("transformers library unavailable")
         return None
 
     candidates = ["gpt2-large", "distilgpt2"] if model is None else [model]
@@ -189,19 +277,18 @@ async def async_generate_stubs(stubs: List[Dict[str, Any]], ctx: dict) -> List[D
         return stubs
 
     gen = await _aload_generator()
-    use_openai = False
-    if gen is openai:
-        use_openai = True
-    elif gen is None and os.getenv("SANDBOX_STUB_MODEL") == "openai" and os.getenv("OPENAI_API_KEY") and openai:
-        openai.api_key = os.getenv("OPENAI_API_KEY")
-        gen = openai
-        use_openai = True
+    use_openai = gen is openai
     if gen is None:
-        return stubs
+        func = ctx.get("target")
+        base = stubs or [{}]
+        return [_deterministic_stub(s, func) for s in base]
 
     template: str = ctx.get(
         "prompt_template",
-        "Create a JSON object for '{name}' using arguments with example values: {args}. Return only the JSON object.",
+        (
+            "Create a JSON object for '{name}' using arguments with example values: {args}. "
+            "Return only the JSON object."
+        ),
     )
     temperature = ctx.get("temperature")
     top_p = ctx.get("top_p")
@@ -226,7 +313,7 @@ async def async_generate_stubs(stubs: List[Dict[str, Any]], ctx: dict) -> List[D
         if top_p is not None:
             gen_kwargs["top_p"] = top_p
 
-        try:
+        async def _invoke() -> str:
             if use_openai:
                 comp_kwargs = {
                     "model": os.getenv("OPENAI_STUB_COMPLETION_MODEL", "text-davinci-003"),
@@ -238,20 +325,22 @@ async def async_generate_stubs(stubs: List[Dict[str, Any]], ctx: dict) -> List[D
                 if top_p is not None:
                     comp_kwargs["top_p"] = top_p
                 result = await asyncio.to_thread(gen.Completion.create, **comp_kwargs)
-                text = result["choices"][0]["text"]  # type: ignore
-            elif use_stream and hasattr(gen, "stream"):
+                return result["choices"][0]["text"]  # type: ignore
+            if use_stream and hasattr(gen, "stream"):
                 stream_res = gen.stream(prompt, **gen_kwargs)
                 if inspect.isasyncgen(stream_res):
                     parts = [p async for p in stream_res]
                 else:
                     parts = list(stream_res)
-                text = "".join(parts)
+                return "".join(parts)
+            if inspect.iscoroutinefunction(getattr(gen, "__call__", gen)):
+                result = await gen(prompt, **gen_kwargs)
             else:
-                if inspect.iscoroutinefunction(getattr(gen, "__call__", gen)):
-                    result = await gen(prompt, **gen_kwargs)
-                else:
-                    result = await asyncio.to_thread(gen, prompt, **gen_kwargs)
-                text = result[0].get("generated_text", "")
+                result = await asyncio.to_thread(gen, prompt, **gen_kwargs)
+            return result[0].get("generated_text", "")
+
+        try:
+            text = await _call_with_retry(_invoke)
             match = re.search(r"{.*}", text, flags=re.S)
             if match:
                 data = json.loads(match.group(0))
@@ -273,37 +362,26 @@ async def async_generate_stubs(stubs: List[Dict[str, Any]], ctx: dict) -> List[D
                             ]
                         except Exception:
                             params = []
-                    valid = True
                     for p_name in params:
                         if p_name not in data:
-                            valid = False
-                            break
+                            raise ValueError("missing field")
                         if (
                             p_name in stub
                             and stub[p_name] is not None
                             and not isinstance(data[p_name], type(stub[p_name]))
                         ):
-                            valid = False
-                            break
-                    if valid:
-                        _CACHE[key] = data
-                        changed = True
-                        new_stubs.append(dict(data))
-                        continue
-                    logger.warning(
-                        "invalid stub generated for %s", name
-                    )
-        except Exception:  # pragma: no cover - generation failures
+                            raise ValueError("type mismatch")
+                    _CACHE[key] = data
+                    changed = True
+                    new_stubs.append(dict(data))
+                    continue
+            raise ValueError("invalid generation output")
+        except Exception as exc:  # pragma: no cover - generation failures
             logger.exception("stub generation failed")
-        _CACHE[key] = stub
-        changed = True
-        new_stubs.append(dict(stub))
+            raise RuntimeError("stub generation failed") from exc
 
     if changed:
-        try:
-            await _asave_cache()
-        except Exception:
-            logger.exception("failed to save stub cache")
+        _schedule_cache_persist()
 
     return new_stubs
 

--- a/tests/test_input_stub_generation.py
+++ b/tests/test_input_stub_generation.py
@@ -1,9 +1,16 @@
 import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
 
-import importlib
-import sandbox_runner.input_history_db as ih
-import sandbox_runner.environment as env
+import importlib  # noqa: E402
+import sandbox_runner.input_history_db as ih  # noqa: E402
+import sandbox_runner.environment as env  # noqa: E402
 
 
 def test_aggregate_history_stubs(tmp_path, monkeypatch):
@@ -28,7 +35,8 @@ def test_generate_input_stubs_use_history(monkeypatch, tmp_path):
     monkeypatch.setenv("SANDBOX_INPUT_HISTORY", str(db_path))
     importlib.reload(env)
     expected = env.aggregate_history_stubs()
-    import sandbox_runner.generative_stub_provider as gsp
+    import sandbox_runner.generative_stub_provider as gsp  # noqa: E402
+
     def fail(*a, **k):
         raise RuntimeError("boom")
     monkeypatch.setattr(gsp, "generate_stubs", fail)


### PR DESCRIPTION
## Summary
- add feature-flagged language-model support with retries, timeouts and rate limiting
- persist stub cache concurrently with corruption recovery
- fall back to deterministic stubs when generators unavailable

## Testing
- `pre-commit run --files sandbox_runner/generative_stub_provider.py tests/test_generative_stub_provider.py tests/test_environment_helpers.py tests/test_input_stub_generation.py`
- `PYTHONPATH=/workspace/menace_sandbox:/workspace pytest tests/test_generative_stub_provider.py tests/test_environment_helpers.py tests/test_input_stub_generation.py -q` *(fails: No module named 'sandbox_runner.generative_stub_provider')*


------
https://chatgpt.com/codex/tasks/task_e_68b1951686b4832e92e1c07050219e2d