### PR TITLE
handle missing self-model bootstrap

### DIFF
--- a/self_improvement_engine.py
+++ b/self_improvement_engine.py
@@ -544,10 +544,25 @@ def _update_alignment_baseline(settings: SandboxSettings | None = None) -> None:
     except Exception:
         logger.exception("alignment baseline update failed")
 
-try:  # pragma: no cover - optional dependency
+try:  # optional dependency
     from .self_model_bootstrap import bootstrap
-except Exception:  # pragma: no cover - fallback for tests
-    bootstrap = lambda: 0  # type: ignore
+except Exception as exc:
+    def bootstrap(*_a: object, **_k: object) -> int:  # type: ignore
+        """Bootstrap the system model.
+
+        This helper requires :mod:`self_model_bootstrap`.  When that module
+        cannot be imported a descriptive :class:`RuntimeError` is raised to
+        alert the caller that bootstrapping is unavailable.
+
+        Returns
+        -------
+        int
+            Identifier of the bootstrapped model.
+        """
+
+        raise RuntimeError(
+            "self_model_bootstrap module is required for bootstrapping"
+        ) from exc
 from .research_aggregator_bot import (
     ResearchAggregatorBot,
     ResearchItem,

--- a/tests/test_self_model_bootstrap_availability.py
+++ b/tests/test_self_model_bootstrap_availability.py
@@ -1,0 +1,90 @@
+import types
+import sys
+import builtins
+import pytest
+
+
+def test_self_model_bootstrap_returns_identifier(monkeypatch):
+    # Stub dependent modules before import
+    dep_mod = types.ModuleType("menace.deployment_bot")
+
+    class DummyDeploymentBot:
+        def _record_workflows(self, *a, **k):
+            return []
+
+        def _update_bot_records(self, *a, **k):
+            return {}
+
+        def _record_code_templates(self, *a, **k):
+            return None
+    dep_mod.DeploymentBot = DummyDeploymentBot
+    monkeypatch.setitem(sys.modules, "menace.deployment_bot", dep_mod)
+
+    err_mod = types.ModuleType("menace.error_bot")
+
+    class DummyErrorBot:
+        def __init__(self, *a, **k):
+            return None
+
+        def record_runtime_error(self, *a, **k):
+            return None
+
+        def monitor(self):
+            return None
+    err_mod.ErrorBot = DummyErrorBot
+    monkeypatch.setitem(sys.modules, "menace.error_bot", err_mod)
+
+    data_mod = types.ModuleType("menace.data_bot")
+
+    class DummyDB:
+        def fetch(self, _):
+            return types.SimpleNamespace(empty=True)
+
+    class DummyDataBot:
+        def __init__(self, *a, **k):
+            self.db = DummyDB()
+
+        def collect(self, *a, **k):
+            return None
+    data_mod.DataBot = DummyDataBot
+    data_mod.MetricsDB = object  # placeholder
+    monkeypatch.setitem(sys.modules, "menace.data_bot", data_mod)
+
+    cap_mod = types.ModuleType("menace.capital_management_bot")
+
+    class DummyCapital:
+        def update_rois(self):
+            return None
+    cap_mod.CapitalManagementBot = DummyCapital
+    monkeypatch.setitem(sys.modules, "menace.capital_management_bot", cap_mod)
+
+    dbm_mod = types.ModuleType("menace.database_manager")
+    dbm_mod.add_model = lambda *a, **k: 7
+    dbm_mod.update_model = lambda *a, **k: None
+    dbm_mod.DB_PATH = ""
+    monkeypatch.setitem(sys.modules, "menace.database_manager", dbm_mod)
+
+    import menace.self_model_bootstrap as smb
+    monkeypatch.setattr(smb.Path, "glob", lambda self, pattern: [])
+    assert smb.bootstrap() == 7
+
+
+def test_bootstrap_missing_module_raises(monkeypatch):
+    orig_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "menace.self_model_bootstrap":
+            raise ModuleNotFoundError("missing")
+        return orig_import(name, globals, locals, fromlist, level)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    code = (
+        "try:\n"
+        "    from menace.self_model_bootstrap import bootstrap\n"
+        "except Exception:\n"
+        "    def bootstrap(*_a, **_k) -> int:\n"
+        "        raise RuntimeError('self_model_bootstrap module is required for bootstrapping')\n"
+    )
+    mod = types.ModuleType("tmp")
+    exec(code, mod.__dict__)
+    with pytest.raises(RuntimeError, match="self_model_bootstrap module is required"):
+        mod.bootstrap()


### PR DESCRIPTION
## Summary
- raise RuntimeError when `self_model_bootstrap` cannot be imported
- add regression tests for bootstrap routine availability

## Testing
- `pre-commit run --files self_improvement_engine.py tests/test_self_model_bootstrap_availability.py`
- `pytest tests/test_self_model_bootstrap_availability.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1af23d4d0832e9583b5270ad6b9df