### PR TITLE
feat: add cross-platform sandbox lock

### DIFF
--- a/fcntl_compat.py
+++ b/fcntl_compat.py
@@ -2,6 +2,7 @@ import os
 
 if os.name == "nt":
     import msvcrt
+    import errno
 
     LOCK_EX = 0x1
     LOCK_SH = 0x2
@@ -18,5 +19,30 @@ if os.name == "nt":
         else:
             mode = msvcrt.LK_UNLCK
         msvcrt.locking(fd, mode, 1)
+
+    def ioctl(fd: int, op: int, arg: int = 0, mutate_flag: bool = True) -> int:
+        """Basic ``ioctl`` compatibility wrapper for Windows.
+
+        The sandbox only relies on ``ioctl`` for file locking behaviour on
+        Unix platforms. Windows does not offer a direct equivalent so we
+        approximate the locking semantics using :mod:`msvcrt` and simply
+        perform a no-op for unsupported operations.  The function returns ``0``
+        to mimic the ``fcntl.ioctl`` return value.
+
+        Parameters mirror :func:`fcntl.ioctl` but are largely ignored on
+        Windows. Unsupported operations raise :class:`OSError` with
+        ``errno.ENOSYS``.
+        """
+
+        if op in (LOCK_EX, LOCK_SH):
+            # ``arg`` is unused; we always lock a single byte similar to
+            # ``flock`` above.
+            mode = msvcrt.LK_LOCK if op == LOCK_EX else msvcrt.LK_RLCK
+            msvcrt.locking(fd, mode, 1)
+            return 0
+        if op == LOCK_UN:
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            return 0
+        raise OSError(errno.ENOSYS, "ioctl operation not supported on Windows")
 else:
-    from fcntl import flock, LOCK_EX, LOCK_SH, LOCK_NB, LOCK_UN
+    from fcntl import flock, ioctl, LOCK_EX, LOCK_SH, LOCK_NB, LOCK_UN

--- a/menace_visual_agent_2.py
+++ b/menace_visual_agent_2.py
@@ -24,9 +24,11 @@ import secrets
 import tempfile
 from contextlib import suppress
 try:
-    from .lock_utils import _ContextFileLock, is_lock_stale, Timeout
+    from .lock_utils import SandboxLock, is_lock_stale, Timeout
+    _ContextFileLock = SandboxLock  # backward compatibility
 except ImportError:  # pragma: no cover - allow running as script
-    from lock_utils import _ContextFileLock, is_lock_stale, Timeout
+    from lock_utils import SandboxLock, is_lock_stale, Timeout
+    _ContextFileLock = SandboxLock
 import json
 from pathlib import Path
 import atexit
@@ -142,7 +144,7 @@ except Exception:  # pragma: no cover - fs errors
     logger.exception("failed to remove stale lock %s", GLOBAL_LOCK_PATH)
 
 # File-based lock preventing multiple agent instances
-_global_lock = _ContextFileLock(GLOBAL_LOCK_PATH)
+_global_lock = SandboxLock(GLOBAL_LOCK_PATH)
 INSTANCE_LOCK_PATH = os.getenv(
     "VISUAL_AGENT_INSTANCE_LOCK",
     os.path.join(tempfile.gettempdir(), "visual_agent.lock.tmp"),

--- a/visual_agent_client.py
+++ b/visual_agent_client.py
@@ -20,7 +20,10 @@ from . import metrics_exporter
 
 from .audit_logger import log_event
 
-from .lock_utils import _ContextFileLock, LOCK_TIMEOUT
+from .lock_utils import SandboxLock, LOCK_TIMEOUT
+
+# Backwards compatibility for tests importing the old name
+_ContextFileLock = SandboxLock
 try:
     import requests  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
@@ -70,7 +73,7 @@ GLOBAL_LOCK_PATH = os.getenv(
     "VISUAL_AGENT_LOCK_FILE",
     os.path.join(tempfile.gettempdir(), "visual_agent.lock"),
 )
-_global_lock = _ContextFileLock(GLOBAL_LOCK_PATH)
+_global_lock = SandboxLock(GLOBAL_LOCK_PATH)
 
 
 class VisualAgentClient:


### PR DESCRIPTION
## Summary
- add fcntl compatibility layer with basic ioctl implementation
- introduce SandboxLock abstraction for unified cross-platform locking
- apply SandboxLock in visual agent components and sandbox environment

## Testing
- `python -m pytest tests/test_dummy_lock_recovery.py`
- `python -m pytest tests/test_lock_files.py` *(fails: subprocess timeout / RecursionError)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b8885abc832e8a9527509eea1a40