### PR TITLE
Load scoring config from SandboxSettings

### DIFF
--- a/tests/test_self_debugger_sandbox.py
+++ b/tests/test_self_debugger_sandbox.py
@@ -255,6 +255,14 @@ class DummyTrail:
         self.records.append(msg)
 
 
+def test_score_config_from_env(monkeypatch):
+    monkeypatch.setenv("SCORE_THRESHOLD", "0.8")
+    monkeypatch.setenv("SCORE_WEIGHTS", "[0.1,0.2,0.3,0.4,0.5,0.6]")
+    dbg = sds.SelfDebuggerSandbox(DummyTelem(), DummyEngine())
+    assert dbg.score_threshold == 0.8
+    assert dbg.score_weights == (0.1, 0.2, 0.3, 0.4, 0.5, 0.6)
+
+
 def test_sandbox_failing_patch(monkeypatch, tmp_path):
     engine = DummyEngine()
     dbg = sds.SelfDebuggerSandbox(DummyTelem(), engine)


### PR DESCRIPTION
## Summary
- allow SelfDebuggerSandbox to read score threshold and weights from SandboxSettings/environment
- validate score configuration with Pydantic schema fields
- add regression test for environment-based scoring config

## Testing
- `pytest tests/test_self_debugger_sandbox.py::test_score_config_from_env -q`
- `pytest tests/test_self_debugger_scoring.py::test_z_score_prefers_better_patch -q` *(fails: KeyboardInterrupt after ~30s)*


------
https://chatgpt.com/codex/tasks/task_e_68b1bb5b08d8832e8710784cb9f05b94