### PR TITLE
Use global DB router

### DIFF
--- a/bot_database.py
+++ b/bot_database.py
@@ -23,7 +23,7 @@ except Exception:  # pragma: no cover - optional dependency
     MenaceDB = None  # type: ignore
     warnings.warn("MenaceDB unavailable, Menace integration disabled.")
 
-from db_router import GLOBAL_ROUTER as router, SHARED_TABLES, queue_insert
+from db_router import GLOBAL_ROUTER, SHARED_TABLES, queue_insert
 from .scope_utils import Scope, build_scope_clause, apply_scope
 from db_dedup import insert_if_unique, ensure_content_hash_column
 
@@ -139,9 +139,9 @@ class BotDB(EmbeddableDBMixin):
         vector_index_path: Path | str = "bot_embeddings.index",
         embedding_version: int = 1,
     ) -> None:
-        if not router:
+        if GLOBAL_ROUTER is None:
             raise RuntimeError("Database router is not initialised")
-        self.router = router
+        self.router = GLOBAL_ROUTER
         self.conn = self.router.get_connection("bots")
         self.event_bus = event_bus
         self.menace_db = menace_db

--- a/database_manager.py
+++ b/database_manager.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
-from db_router import GLOBAL_ROUTER as router
+from db_router import GLOBAL_ROUTER
 
 from typing import TYPE_CHECKING
 
@@ -72,9 +72,9 @@ def get_connection(
     """
 
     if conn is None:
-        if not router:
+        if GLOBAL_ROUTER is None:
             raise RuntimeError("Database router is not initialised")
-        with router.get_connection("models") as conn:
+        with GLOBAL_ROUTER.get_connection("models") as conn:
             try:
                 yield conn
                 conn.commit()

--- a/menace_memory_manager.py
+++ b/menace_memory_manager.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Callable, Iterable, List, Optional, Sequence, Any
 import logging
 
-from db_router import GLOBAL_ROUTER as router
+from db_router import GLOBAL_ROUTER
 
 try:
     from sklearn.cluster import KMeans  # type: ignore
@@ -130,9 +130,9 @@ class MenaceMemoryManager(GPTMemoryInterface):
         summary_interval: int = 50,
     ) -> None:
         # allow connections to be shared across threads
-        if not router:
+        if GLOBAL_ROUTER is None:
             raise RuntimeError("Database router is not initialised")
-        with router.get_connection("memory") as conn:
+        with GLOBAL_ROUTER.get_connection("memory") as conn:
             self.conn = conn
         self.subscribers: List[Callable[[MemoryEntry], None]] = []
         self.event_bus = event_bus

--- a/offer_testing_bot.py
+++ b/offer_testing_bot.py
@@ -7,9 +7,10 @@ from dataclasses import dataclass
 import dataclasses
 from datetime import datetime
 from typing import Any, List, Dict, Optional
+from pathlib import Path
 import logging
 
-from db_router import GLOBAL_ROUTER as router
+from db_router import GLOBAL_ROUTER
 
 from .unified_event_bus import UnifiedEventBus
 from .menace_memory_manager import MenaceMemoryManager, MemoryEntry
@@ -46,12 +47,17 @@ class OfferInteraction:
 class OfferDB:
     """SQLite-backed store for offers and interactions."""
 
-    def __init__(self, *, event_bus: Optional[UnifiedEventBus] = None) -> None:
+    def __init__(
+        self,
+        path: Path | str | None = None,
+        *,
+        event_bus: Optional[UnifiedEventBus] = None,
+    ) -> None:
         # allow the connection to be used across threads since OfferTestingBot
         # may be accessed from a thread pool in ``ModelAutomationPipeline``
-        if not router:
+        if GLOBAL_ROUTER is None:
             raise RuntimeError("Database router is not initialised")
-        with router.get_connection("variants") as conn:
+        with GLOBAL_ROUTER.get_connection("variants") as conn:
             self.conn = conn
         self.event_bus = event_bus
         self.conn.execute(

--- a/unified_event_bus.py
+++ b/unified_event_bus.py
@@ -23,7 +23,7 @@ import json
 import time
 import logging
 
-from db_router import GLOBAL_ROUTER as router
+from db_router import GLOBAL_ROUTER
 
 from .automated_reviewer import AutomatedReviewer
 from .resilience import CircuitBreaker, CircuitOpenError, retry_with_backoff
@@ -97,9 +97,9 @@ class UnifiedEventBus:
                 self._network = None
         if persist_path:
             # allow event persistence from multiple threads
-            if not router:
+            if GLOBAL_ROUTER is None:
                 raise RuntimeError("Database router is not initialised")
-            self._persist = router.get_connection("events")
+            self._persist = GLOBAL_ROUTER.get_connection("events")
             self._persist.execute(
                 "CREATE TABLE IF NOT EXISTS events(ts REAL, topic TEXT, payload TEXT)"
             )

--- a/violation_logger.py
+++ b/violation_logger.py
@@ -11,7 +11,7 @@ from threading import Thread
 from typing import Any, List, Dict, Optional
 
 from .retry_utils import publish_with_retry
-from db_router import GLOBAL_ROUTER as router
+from db_router import GLOBAL_ROUTER
 import sqlite3
 
 try:  # optional dependency
@@ -49,9 +49,9 @@ def _ensure_log_dir() -> None:
 
 def _alignment_conn() -> sqlite3.Connection:
     """Return a connection for alignment warnings."""
-    if not router:
+    if GLOBAL_ROUTER is None:
         raise RuntimeError("Database router is not initialised")
-    return router.get_connection("errors")
+    return GLOBAL_ROUTER.get_connection("errors")
 
 
 def persist_alignment_warning(record: Dict[str, Any]) -> None:
@@ -108,7 +108,7 @@ def load_persisted_alignment_warnings(
 
     if limit <= 0:
         return []
-    if not router and not os.path.exists(ALIGNMENT_DB_PATH):
+    if GLOBAL_ROUTER is None and not os.path.exists(ALIGNMENT_DB_PATH):
         return []
     conn = _alignment_conn()
     query = (


### PR DESCRIPTION
## Summary
- remove router placeholder imports and rely on GLOBAL_ROUTER
- require GLOBAL_ROUTER initialization when persisting events or opening DB connections
- allow OfferDB to accept a path while still using the global router

## Testing
- `MENACE_LIGHT_IMPORTS=1 pytest tests/test_violation_logger.py::test_log_and_load -q`
- `MENACE_LIGHT_IMPORTS=1 pytest tests/test_unified_event_bus.py::test_callback_error_logged_and_collected -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1bd8f6804832e8918952a0de69a09