### PR TITLE
feat: extend light-import ForesightTracker

### DIFF
--- a/sandbox_runner.py
+++ b/sandbox_runner.py
@@ -172,23 +172,58 @@ try:  # optional system metrics
 except Exception:  # pragma: no cover - psutil not installed
     psutil = None
 if os.getenv("MENACE_LIGHT_IMPORTS"):
+    from collections import deque
+    from numbers import Number
+    from typing import Deque, Dict, Mapping
+
     class ForesightTracker:  # type: ignore[no-redef]
+        """Minimal in-repo fallback used when heavy imports are disabled."""
+
         def __init__(
             self,
             window: int = 10,
             volatility_threshold: float = 1.0,
             N: int | None = None,
-        ) -> None:  # pragma: no cover - stub
+        ) -> None:
             if N is not None:
                 window = N
             self.max_cycles = window
+            self.volatility_threshold = volatility_threshold
+            self.history: Dict[str, Deque[dict[str, float | str]]] = {}
 
         @property
-        def window(self) -> int:  # pragma: no cover - stub
-            return getattr(self, "max_cycles", 0)
+        def window(self) -> int:
+            """Legacy alias returning the configured history window."""
 
-        def to_dict(self) -> dict:  # pragma: no cover - stub
-            return {}
+            return self.max_cycles
+
+        def record_cycle_metrics(
+            self,
+            workflow_id: str,
+            metrics: Mapping[str, float],
+            **extra_metrics: float | str,
+        ) -> None:
+            """Store ``metrics`` for ``workflow_id`` respecting the window size."""
+
+            entry = {k: float(v) for k, v in metrics.items()}
+            for key, value in extra_metrics.items():
+                entry[key] = float(value) if isinstance(value, Number) else value
+            queue = self.history.setdefault(
+                workflow_id, deque(maxlen=self.max_cycles)
+            )
+            queue.append(entry)
+
+        def to_dict(self) -> dict:
+            """Return a JSON-serialisable representation of tracked data."""
+
+            return {
+                "window": self.max_cycles,
+                "volatility_threshold": self.volatility_threshold,
+                "history": {
+                    wf_id: [dict(entry) for entry in list(entries)]
+                    for wf_id, entries in self.history.items()
+                },
+            }
 
         @classmethod
         def from_dict(
@@ -197,8 +232,26 @@ if os.getenv("MENACE_LIGHT_IMPORTS"):
             window: int | None = None,
             volatility_threshold: float | None = None,
             N: int | None = None,
-        ) -> "ForesightTracker":  # pragma: no cover - stub
-            return cls(window=window or N or 10)
+        ) -> "ForesightTracker":
+            if window is not None:
+                N = window
+            if N is None:
+                N = int(data.get("window", data.get("N", 10)))
+            if volatility_threshold is None:
+                volatility_threshold = float(data.get("volatility_threshold", 1.0))
+            tracker = cls(window=N, volatility_threshold=volatility_threshold)
+            raw_history = data.get("history", {})
+            for wf_id, entries in raw_history.items():
+                queue: Deque[dict[str, float | str]] = deque(maxlen=tracker.max_cycles)
+                for entry in list(entries)[-tracker.max_cycles:]:
+                    queue.append(
+                        {
+                            k: (float(v) if isinstance(v, Number) else v)
+                            for k, v in entry.items()
+                        }
+                    )
+                tracker.history[wf_id] = queue
+            return tracker
 else:  # pragma: no cover - import when not in light mode
     from foresight_tracker import ForesightTracker
 from relevancy_metrics_db import RelevancyMetricsDB

--- a/tests/test_fallback_foresight_tracker.py
+++ b/tests/test_fallback_foresight_tracker.py
@@ -1,0 +1,55 @@
+import os
+import re
+import textwrap
+from pathlib import Path
+
+from menace_sandbox.foresight_tracker import ForesightTracker as FullTracker
+
+
+def _prepare_light_import_env(monkeypatch, tmp_path):
+    """Create dummy system binaries and import the light ForesightTracker."""
+
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    for name in ["ffmpeg", "tesseract", "qemu-system-x86_64"]:
+        path = bindir / name
+        path.write_text("#!/bin/sh\n")
+        path.chmod(0o755)
+    monkeypatch.setenv("PATH", str(bindir) + os.pathsep + os.environ.get("PATH", ""))
+    monkeypatch.setenv("MENACE_LIGHT_IMPORTS", "1")
+    path = Path(__file__).resolve().parents[1] / "sandbox_runner.py"
+    source = path.read_text()
+    match = re.search(
+        r"if os\.getenv\(\"MENACE_LIGHT_IMPORTS\"\):\n(?P<body>.+?)else:",
+        source,
+        re.DOTALL,
+    )
+    assert match is not None
+    code = textwrap.dedent(match.group("body"))
+    namespace: dict[str, object] = {}
+    exec(code, namespace)
+    return namespace["ForesightTracker"]
+
+
+def test_full_tracker_window_property():
+    tracker = FullTracker(max_cycles=5)
+    assert tracker.window == 5
+
+
+def test_light_import_tracker_roundtrip(monkeypatch, tmp_path):
+    Fallback = _prepare_light_import_env(monkeypatch, tmp_path)
+
+    tracker = Fallback(window=2)
+    tracker.record_cycle_metrics("wf", {"m": 1})
+    tracker.record_cycle_metrics("wf", {"m": 2})
+
+    data = tracker.to_dict()
+    assert data["window"] == 2
+    assert [e["m"] for e in data["history"]["wf"]] == [1.0, 2.0]
+
+    loaded_full = FullTracker.from_dict(data, max_cycles=2)
+    assert [e["m"] for e in loaded_full.history["wf"]] == [1.0, 2.0]
+
+    loaded_fallback = Fallback.from_dict(loaded_full.to_dict(), window=2)
+    assert [e["m"] for e in loaded_fallback.history["wf"]] == [1.0, 2.0]
+


### PR DESCRIPTION
## Summary
- track windowed metrics in sandbox_runner's ForesightTracker fallback
- add serialization helpers and compatibility with full tracker
- test light-import fallback and existing tracker behavior

## Testing
- `pytest tests/test_fallback_foresight_tracker.py tests/test_sandbox_runner_history.py tests/test_foresight_tracker.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1c35460b4832e9dbbcf7eece74abc