### PR TITLE
Check for numeric backend at import time

### DIFF
--- a/README.md
+++ b/README.md
@@ -792,9 +792,11 @@ libcst
 kafka-python
 pyspark
 stable-baselines3
-torch
+torch or numpy
 sentry-sdk
 ```
+
+At least one numeric backend (PyTorch or NumPy) must be installed.
 
 For convenience, a `setup_env.sh` script installs dependencies and pytest. To
 prepare a fresh environment for running the test suite in one step run:

--- a/menace/__init__.py
+++ b/menace/__init__.py
@@ -7,6 +7,8 @@ import os
 # Allow importing modules from repository root using ``menace`` prefix.
 __path__.append(os.path.dirname(os.path.dirname(__file__)))
 
+from .numeric_backend import NUMERIC_BACKEND
+
 # Default flag used by modules expecting it
 RAISE_ERRORS = False
 
@@ -16,4 +18,4 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - optional dependency
     MenaceDB = None  # type: ignore
 
-__all__ = ["RAISE_ERRORS", "MenaceDB"]
+__all__ = ["RAISE_ERRORS", "MenaceDB", "NUMERIC_BACKEND"]

--- a/numeric_backend.py
+++ b/numeric_backend.py
@@ -1,0 +1,23 @@
+"""Determine which numeric backend is available.
+
+This module checks at import time whether either PyTorch or NumPy is
+installed.  It exposes :data:`NUMERIC_BACKEND` indicating the detected
+backend and raises :class:`ImportError` if neither is present.
+"""
+
+from __future__ import annotations
+
+try:  # pragma: no cover - heavy optional import
+    import torch  # type: ignore
+    NUMERIC_BACKEND = "torch"
+except Exception:  # pragma: no cover - torch missing
+    try:
+        import numpy as np  # type: ignore  # noqa: F401
+        NUMERIC_BACKEND = "numpy"
+    except Exception:  # pragma: no cover - no supported backend
+        raise ImportError(
+            "Menace requires either PyTorch or NumPy; install one of them to "
+            "provide a numeric backend"
+        )
+
+__all__ = ["NUMERIC_BACKEND"]

--- a/tests/test_numeric_backend.py
+++ b/tests/test_numeric_backend.py
@@ -1,0 +1,35 @@
+import importlib
+import sys
+import builtins
+
+import pytest
+
+
+def _reload_backend(monkeypatch, missing):
+    """Reload menace.numeric_backend with selected modules missing."""
+    for mod in ["menace.numeric_backend", "numeric_backend", "menace"]:
+        sys.modules.pop(mod, None)
+    orig_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name in missing:
+            raise ImportError(f"mocked missing module: {name}")
+        return orig_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    return importlib.import_module("menace.numeric_backend")
+
+
+def test_backend_detects_present():
+    import menace.numeric_backend as nb
+    assert nb.NUMERIC_BACKEND in {"torch", "numpy"}
+
+
+def test_backend_falls_back_to_numpy(monkeypatch):
+    nb = _reload_backend(monkeypatch, {"torch"})
+    assert nb.NUMERIC_BACKEND == "numpy"
+
+
+def test_backend_missing_raises(monkeypatch):
+    with pytest.raises(ImportError):
+        _reload_backend(monkeypatch, {"torch", "numpy"})


### PR DESCRIPTION
## Summary
- ensure package import fails if neither PyTorch nor NumPy is installed
- document numeric backend requirement in README
- add tests covering backend detection and fallback to NumPy

## Testing
- `pytest tests/test_numeric_backend.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1c8326ff8832eac21bfc25276ddcd