### PR TITLE
Use SandboxSettings for SelfCodingScheduler defaults

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -358,6 +358,21 @@ class SandboxSettings(BaseSettings):
         env="ADAPTIVE_ROI_PRIORITIZATION",
         description="Prioritize improvements using AdaptiveROI classifications.",
     )
+    self_coding_interval: int = Field(
+        300,
+        env="SELF_CODING_INTERVAL",
+        description="Seconds between self-coding checks.",
+    )
+    self_coding_roi_drop: float = Field(
+        -0.1,
+        env="SELF_CODING_ROI_DROP",
+        description="ROI drop triggering self-coding.",
+    )
+    self_coding_error_increase: float = Field(
+        1.0,
+        env="SELF_CODING_ERROR_INCREASE",
+        description="Error increase triggering self-coding.",
+    )
     roi_growth_weighting: bool = Field(
         True,
         env="ROI_GROWTH_WEIGHTING",

--- a/tests/test_self_coding_scheduler.py
+++ b/tests/test_self_coding_scheduler.py
@@ -55,6 +55,7 @@ sys.modules.setdefault("git", types.ModuleType("git"))
 
 import menace.self_coding_scheduler as sched_mod
 from menace.self_coding_scheduler import SelfCodingScheduler
+from menace.sandbox_settings import SandboxSettings
 
 
 class DummyManager:
@@ -87,3 +88,34 @@ def test_patch_failure_logged(monkeypatch):
     with pytest.raises(SystemExit):
         sched._loop()
     assert calls and "self-coding loop failed" in calls[0]
+
+
+def test_settings_provide_defaults():
+    mgr = DummyManager()
+    data_bot = types.SimpleNamespace(roi=lambda b: 0.0, db=types.SimpleNamespace(fetch=lambda l: []))
+    cfg = SandboxSettings(
+        self_coding_interval=123,
+        self_coding_roi_drop=-0.5,
+        self_coding_error_increase=2.5,
+    )
+    sched = SelfCodingScheduler(mgr, data_bot, settings=cfg)
+    assert (sched.interval, sched.roi_drop, sched.error_increase) == (123, -0.5, 2.5)
+
+
+def test_constructor_overrides_settings():
+    mgr = DummyManager()
+    data_bot = types.SimpleNamespace(roi=lambda b: 0.0, db=types.SimpleNamespace(fetch=lambda l: []))
+    cfg = SandboxSettings(
+        self_coding_interval=123,
+        self_coding_roi_drop=-0.5,
+        self_coding_error_increase=2.5,
+    )
+    sched = SelfCodingScheduler(
+        mgr,
+        data_bot,
+        interval=5,
+        roi_drop=-0.2,
+        error_increase=1.1,
+        settings=cfg,
+    )
+    assert (sched.interval, sched.roi_drop, sched.error_increase) == (5, -0.2, 1.1)


### PR DESCRIPTION
## Summary
- Load SelfCodingScheduler thresholds from SandboxSettings with optional overrides
- Add self_coding_* options to SandboxSettings
- Test and document config driven defaults

## Testing
- `pytest tests/test_self_coding_scheduler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1d56f3d4c832e93cd20c54c4c6b2a