### PR TITLE
centralise sandbox configuration paths and thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,6 +965,15 @@ missing. Notable defaults include:
 - `SANDBOX_ROI_TOLERANCE=0.01`
 - `SANDBOX_CYCLES=5`
 - `SANDBOX_DATA_DIR=sandbox_data`
+- `PRUNE_INTERVAL=50`
+- `SELF_LEARNING_EVAL_INTERVAL=0`
+- `SELF_LEARNING_SUMMARY_INTERVAL=0`
+- `SELF_TEST_LOCK_FILE=sandbox_data/self_test.lock`
+- `SELF_TEST_REPORT_DIR=sandbox_data/self_test_reports`
+- `SYNERGY_WEIGHTS_PATH=sandbox_data/synergy_weights.json`
+- `ALIGNMENT_FLAGS_PATH=sandbox_data/alignment_flags.jsonl`
+- `MODULE_SYNERGY_GRAPH_PATH=sandbox_data/module_synergy_graph.json`
+- `RELEVANCY_METRICS_DB_PATH=sandbox_data/relevancy_metrics.db`
 - `RUN_CYCLES=0`
 - `RUN_UNTIL=`
  - `METRICS_PORT=8001`  # same as `--metrics-port`

--- a/self_improvement/__init__.py
+++ b/self_improvement/__init__.py
@@ -1121,7 +1121,7 @@ class SelfImprovementEngine:
             "linear": getattr(settings, "growth_multiplier_linear", 2.0),
             "marginal": getattr(settings, "growth_multiplier_marginal", 1.0),
         }
-        default_path = Path(settings.sandbox_data_dir) / "synergy_weights.json"
+        default_path = Path(settings.synergy_weights_path)
         self.synergy_weights_path = (
             Path(synergy_weights_path)
             if synergy_weights_path is not None
@@ -2390,8 +2390,7 @@ class SelfImprovementEngine:
                 except Exception:
                     self.logger.exception("alignment event publish failed")
             try:
-                path = Path("sandbox_data") / "alignment_flags.jsonl"
-                path.parent.mkdir(parents=True, exist_ok=True)
+                path = Path(settings.alignment_flags_path)
                 with path.open("a", encoding="utf-8") as fh:
                     fh.write(json.dumps(record) + "\n")
             except Exception:
@@ -3720,7 +3719,9 @@ class SelfImprovementEngine:
                 from module_synergy_grapher import ModuleSynergyGrapher
 
                 grapher = ModuleSynergyGrapher(root=repo)
-                graph_path = repo / "sandbox_data" / "module_synergy_graph.json"
+                graph_path = Path(settings.module_synergy_graph_path)
+                if not graph_path.is_absolute():
+                    graph_path = repo / graph_path
                 try:
                     grapher.load(graph_path)
                 except Exception:
@@ -3735,7 +3736,9 @@ class SelfImprovementEngine:
             if clusterer is None:
                 from intent_clusterer import IntentClusterer
 
-                data_dir = repo / "sandbox_data"
+                data_dir = Path(settings.sandbox_data_dir)
+                if not data_dir.is_absolute():
+                    data_dir = repo / data_dir
                 clusterer = IntentClusterer(
                     local_db_path=data_dir / "intent.db",
                     shared_db_path=data_dir / "intent.db",
@@ -5720,9 +5723,9 @@ class SelfImprovementEngine:
         except Exception:
             self.logger.exception("relevancy evaluation failed")
         try:
-            metrics_db = (
-                Path(__file__).resolve().parent / "sandbox_data" / "relevancy_metrics.db"
-            )
+            metrics_db = Path(settings.relevancy_metrics_db_path)
+            if not metrics_db.is_absolute():
+                metrics_db = _repo_path() / metrics_db
             scan_flags = radar_scan(metrics_db)
             if scan_flags:
                 flags.update(scan_flags)

--- a/self_learning_service.py
+++ b/self_learning_service.py
@@ -8,6 +8,8 @@ import logging
 from typing import Optional
 from threading import Event, Thread
 
+from sandbox_settings import SandboxSettings
+
 from .unified_event_bus import UnifiedEventBus
 from .neuroplasticity import PathwayDB
 from .menace_memory_manager import MenaceMemoryManager
@@ -20,11 +22,7 @@ from .self_learning_coordinator import SelfLearningCoordinator
 from .local_knowledge_module import init_local_knowledge
 
 logger = logging.getLogger(__name__)
-
-# Default number of interactions added to GPT memory before a compaction is
-# triggered.  This value can be overridden at runtime via the ``prune_interval``
-# parameter or the ``PRUNE_INTERVAL`` environment variable.
-DEFAULT_PRUNE_INTERVAL = 50
+settings = SandboxSettings()
 
 
 def main(
@@ -72,13 +70,9 @@ def main(
     )
     coord.start()
 
-    # Determine the effective prune interval from argument or environment.
+    # Determine the effective prune interval from argument or settings.
     if prune_interval is None:
-        env_value = os.getenv("PRUNE_INTERVAL", str(DEFAULT_PRUNE_INTERVAL))
-        try:
-            prune_interval = int(env_value)
-        except ValueError as exc:  # pragma: no cover - validation
-            raise ValueError("prune_interval must be an integer") from exc
+        prune_interval = int(getattr(settings, "prune_interval", 50))
     if prune_interval <= 0:
         raise ValueError("prune_interval must be positive")
 


### PR DESCRIPTION
## Summary
- add configurable paths and thresholds to `SandboxSettings`
- wire self-learning and self-test services to new settings
- document environment overrides for new options

## Testing
- `pre-commit run --files sandbox_settings.py self_learning_service.py self_learning_coordinator.py self_test_service.py self_improvement/__init__.py README.md`
- `pytest tests/test_self_learning_coordinator.py unit_tests/test_self_learning_coordinator.py unit_tests/test_self_improvement_engine_utils.py -q`
- `pytest tests/test_self_learning_coordinator.py tests/test_self_test_service_async.py unit_tests/test_self_learning_coordinator.py unit_tests/test_self_improvement_engine_utils.py -q` *(fails: ImportError: cannot import name 'RAISE_ERRORS' from 'menace')*


------
https://chatgpt.com/codex/tasks/task_e_68b2428d696c832eacdeaba32b80b003