### PR TITLE
Add dependency checks with import guards and fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1965,6 +1965,22 @@ python -m vector_metrics_analytics --weight-summary
 
 Use `--db` to point at an alternative `vector_metrics.db` file.
 
+### Dependencies
+
+Some features rely on optional third‑party libraries. Missing packages trigger
+warnings and degrade functionality gracefully.
+
+- `pandas` – enables DataFrame operations in performance assessment and metrics
+  queries.
+- `psutil` – provides detailed CPU, memory and I/O statistics for the data bot.
+- `prometheus-client` – exposes collected metrics via a Prometheus endpoint.
+
+Install the extras with:
+
+```bash
+pip install pandas psutil prometheus-client
+```
+
 ## Legal Notice
 
 See [LEGAL.md](LEGAL.md) for the full legal terms. In short, this project may

--- a/data_bot.py
+++ b/data_bot.py
@@ -25,16 +25,25 @@ try:
     import psutil  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
     psutil = None  # type: ignore
+    logging.getLogger(__name__).warning(
+        "psutil is not installed; install with 'pip install psutil' to capture system metrics"
+    )
 
 try:
     import pandas as pd  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
     pd = None  # type: ignore
+    logging.getLogger(__name__).warning(
+        "pandas is not installed; install with 'pip install pandas' for DataFrame support"
+    )
 
 try:
     from prometheus_client import CollectorRegistry, Gauge  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
     CollectorRegistry = Gauge = None  # type: ignore
+    logging.getLogger(__name__).warning(
+        "prometheus_client is not installed; install with 'pip install prometheus-client' for Prometheus metrics"
+    )
 
 try:  # pragma: no cover - optional dependency
     from .vector_metrics_db import VectorMetricsDB

--- a/unit_tests/test_dependency_fallbacks.py
+++ b/unit_tests/test_dependency_fallbacks.py
@@ -1,0 +1,70 @@
+import importlib
+import logging
+import sys
+import types
+from pathlib import Path
+
+
+def _reload(name, missing):
+    for m in missing:
+        sys.modules.pop(m, None)
+        sys.modules[m] = None
+    sys.modules.pop(name, None)
+    parent = Path(__file__).resolve().parent.parent
+    if str(parent) not in sys.path:
+        sys.path.insert(0, str(parent))
+    return importlib.import_module(name)
+
+def test_data_bot_missing_dependencies(monkeypatch, caplog):
+    with caplog.at_level(logging.WARNING):
+        mod = _reload(
+            "menace_sandbox.data_bot", ["pandas", "psutil", "prometheus_client"]
+        )
+    assert mod.pd is None and mod.psutil is None
+    assert any("pandas" in rec.message for rec in caplog.records)
+    assert any("psutil" in rec.message for rec in caplog.records)
+    mdb = mod.MetricsDB.__new__(mod.MetricsDB)
+    mdb.router = types.SimpleNamespace(menace_id="x")
+
+    class _Cur:
+        description = [(c,) for c in [
+            "bot","cpu","memory","response_time","disk_io","net_io","errors",
+            "revenue","expense","security_score","safety_rating","adaptability",
+            "antifragility","shannon_entropy","efficiency","flexibility","gpu_usage",
+            "projected_lucrativity","profitability","patch_complexity","patch_entropy",
+            "energy_consumption","resilience","network_latency","throughput","risk_index",
+            "maintainability","code_quality","ts"
+        ]]
+
+        def fetchall(self):
+            return []
+
+    class _Conn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, *_):
+            return _Cur()
+
+    mdb._connect = lambda: _Conn()
+    result = mdb.fetch(limit=1)
+    assert result == []
+
+def test_performance_bot_fallback(monkeypatch, caplog):
+    with caplog.at_level(logging.WARNING):
+        mod = _reload("menace_sandbox.performance_assessment_bot", ["pandas"])
+    assert any("pandas" in rec.message for rec in caplog.records)
+
+    class DummyDB:
+        def fetch(self, limit):
+            return [{
+                "bot": "b1", "cpu": 10.0, "memory": 10.0,
+                "response_time": 1.0, "errors": 0,
+            }]
+
+    bot = mod.PerformanceAssessmentBot(metrics_db=DummyDB())
+    score = bot.self_assess("b1")
+    assert isinstance(score, float)


### PR DESCRIPTION
## Summary
- warn and gracefully degrade when pandas, psutil, or prometheus-client are missing
- handle missing pandas in PerformanceAssessmentBot by using dict-based fallback
- document optional dependencies in README
- test import guards and fallback behavior

## Testing
- `pytest unit_tests/test_dependency_fallbacks.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b247ce58f4832eacbfeca0265d43cc