### PR TITLE
Add configuration models for self-learning and self-test services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1981,6 +1981,33 @@ Install the extras with:
 pip install pandas psutil prometheus-client
 ```
 
+## Service Configuration
+
+### Self-Learning Service
+
+| Environment variable | Description | Default |
+| --- | --- | --- |
+| `SELF_LEARNING_PERSIST_EVENTS` | Optional path where the event bus persists state | unset |
+| `SELF_LEARNING_PERSIST_PROGRESS` | Optional path storing evaluation results on shutdown | unset |
+| `PRUNE_INTERVAL` | Number of new interactions before pruning GPT memory | `50` |
+
+### Self-Test Service
+
+| Environment variable | Description | Default |
+| --- | --- | --- |
+| `SELF_TEST_LOCK_FILE` | File used to serialise self-test runs | `sandbox_data/self_test.lock` |
+| `SELF_TEST_REPORT_DIR` | Directory used to store self-test reports | `sandbox_data/self_test_reports` |
+
+Example `.env` snippet for personal deployments:
+
+```env
+SELF_LEARNING_PERSIST_EVENTS=/var/menace/events.db
+SELF_LEARNING_PERSIST_PROGRESS=/var/menace/progress.json
+PRUNE_INTERVAL=100
+SELF_TEST_LOCK_FILE=/var/menace/self_test.lock
+SELF_TEST_REPORT_DIR=/var/menace/reports
+```
+
 ## Legal Notice
 
 See [LEGAL.md](LEGAL.md) for the full legal terms. In short, this project may

--- a/self_services_config.py
+++ b/self_services_config.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+"""Pydantic models for self-learning and self-test service configuration."""
+
+from pathlib import Path
+from typing import Any
+
+try:  # pragma: no cover - compatibility with pydantic v1/v2
+    from pydantic_settings import BaseSettings, SettingsConfigDict
+    PYDANTIC_V2 = True
+except Exception:  # pragma: no cover - fallback for pydantic<2
+    from pydantic import BaseSettings  # type: ignore
+    PYDANTIC_V2 = False
+    SettingsConfigDict = dict  # type: ignore[misc]
+from pydantic import Field
+try:  # pragma: no cover - compatibility shim
+    from pydantic import field_validator
+except Exception:  # pragma: no cover
+    from pydantic import validator as field_validator  # type: ignore
+
+
+class SelfLearningConfig(BaseSettings):
+    """Configuration for the self-learning service.
+
+    Values may be provided via environment variables.  Direct paths must point
+    to existing directories so the service can write its state without failing
+    later in the run.
+    """
+
+    persist_events: Path | None = Field(
+        default=None,
+        validation_alias="SELF_LEARNING_PERSIST_EVENTS",
+        description="Optional path where the event bus should persist state.",
+    )
+    persist_progress: Path | None = Field(
+        default=None,
+        validation_alias="SELF_LEARNING_PERSIST_PROGRESS",
+        description="Optional path for storing evaluation results on shutdown.",
+    )
+    prune_interval: int = Field(
+        default=50,
+        validation_alias="PRUNE_INTERVAL",
+        description="Number of new interactions before pruning GPT memory.",
+    )
+
+    @field_validator("prune_interval")
+    @classmethod
+    def _validate_prune_interval(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("prune_interval must be positive")
+        return v
+
+    @field_validator("persist_events", "persist_progress")
+    @classmethod
+    def _validate_parent_exists(cls, v: Path | None, info: Any) -> Path | None:
+        if v is not None and not v.parent.exists():
+            raise ValueError(
+                f"{info.field_name} directory does not exist: {v.parent}"
+            )
+        return v
+
+    model_config = SettingsConfigDict(env_prefix="", extra="ignore")
+    if not PYDANTIC_V2:  # pragma: no cover - pydantic v1 fallback
+        class Config:  # type: ignore[no-redef]
+            env_prefix = ""
+            extra = "ignore"
+
+
+class SelfTestConfig(BaseSettings):
+    """Configuration for the self-test service."""
+
+    lock_file: Path = Field(
+        default=Path("sandbox_data/self_test.lock"),
+        validation_alias="SELF_TEST_LOCK_FILE",
+        description="File used to serialise self-test runs.",
+    )
+    report_dir: Path = Field(
+        default=Path("sandbox_data/self_test_reports"),
+        validation_alias="SELF_TEST_REPORT_DIR",
+        description="Directory used to store self-test reports.",
+    )
+
+    @field_validator("lock_file")
+    @classmethod
+    def _validate_lock_parent(cls, v: Path) -> Path:
+        if not v.parent.exists():
+            raise ValueError(f"lock file directory does not exist: {v.parent}")
+        return v
+
+    @field_validator("report_dir")
+    @classmethod
+    def _validate_report_dir(cls, v: Path) -> Path:
+        if not v.exists():
+            raise ValueError(f"report_dir does not exist: {v}")
+        return v
+    model_config = SettingsConfigDict(env_prefix="", extra="ignore")
+    if not PYDANTIC_V2:  # pragma: no cover - pydantic v1 fallback
+        class Config:  # type: ignore[no-redef]
+            env_prefix = ""
+            extra = "ignore"
+
+
+__all__ = ["SelfLearningConfig", "SelfTestConfig"]

--- a/tests/test_self_services_config.py
+++ b/tests/test_self_services_config.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from self_services_config import SelfLearningConfig, SelfTestConfig
+
+
+def test_self_learning_config_defaults(tmp_path, monkeypatch):
+    events_dir = tmp_path / "events"
+    events_dir.mkdir()
+    progress_dir = tmp_path / "progress"
+    progress_dir.mkdir()
+    monkeypatch.setenv(
+        "SELF_LEARNING_PERSIST_EVENTS", str(events_dir / "bus.json")
+    )
+    monkeypatch.setenv(
+        "SELF_LEARNING_PERSIST_PROGRESS", str(progress_dir / "results.json")
+    )
+    cfg = SelfLearningConfig()
+    assert cfg.prune_interval == 50
+    assert cfg.persist_events == events_dir / "bus.json"
+    assert cfg.persist_progress == progress_dir / "results.json"
+
+
+def test_self_learning_config_invalid_prune_interval(monkeypatch):
+    monkeypatch.setenv("PRUNE_INTERVAL", "-1")
+    with pytest.raises(ValidationError):
+        SelfLearningConfig()
+
+
+def test_self_test_config_valid(tmp_path, monkeypatch):
+    lock_dir = tmp_path / "locks"
+    lock_dir.mkdir()
+    report_dir = tmp_path / "reports"
+    report_dir.mkdir()
+    monkeypatch.setenv("SELF_TEST_LOCK_FILE", str(lock_dir / "self.lock"))
+    monkeypatch.setenv("SELF_TEST_REPORT_DIR", str(report_dir))
+    cfg = SelfTestConfig()
+    assert cfg.lock_file == lock_dir / "self.lock"
+    assert cfg.report_dir == report_dir
+
+
+def test_self_test_config_missing_report_dir(tmp_path, monkeypatch):
+    lock_dir = tmp_path / "locks"
+    lock_dir.mkdir()
+    monkeypatch.setenv("SELF_TEST_LOCK_FILE", str(lock_dir / "self.lock"))
+    monkeypatch.setenv("SELF_TEST_REPORT_DIR", str(tmp_path / "missing"))
+    with pytest.raises(ValidationError):
+        SelfTestConfig()


### PR DESCRIPTION
## Summary
- add pydantic `SelfLearningConfig` and `SelfTestConfig` models with validation
- load configuration in self-learning and self-test services
- document env vars and example `.env` settings
- cover valid/invalid config scenarios with unit tests

## Testing
- `pre-commit run --files README.md self_learning_service.py self_test_service.py self_services_config.py tests/test_self_services_config.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest --noconftest tests/test_self_services_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b24ccc0be0832eab74bfed8ab54be9