### PR TITLE
feat: make meta planner entropy threshold configurable

### DIFF
--- a/docs/sandbox_config.sample.yaml
+++ b/docs/sandbox_config.sample.yaml
@@ -1,3 +1,4 @@
+meta_entropy_threshold: null
 roi:
   threshold: null
   confidence: null

--- a/docs/sandbox_settings.md
+++ b/docs/sandbox_settings.md
@@ -10,6 +10,9 @@ from sandbox_settings import load_sandbox_settings
 settings = load_sandbox_settings("docs/sandbox_config.sample.yaml")
 ```
 
+## Meta planning defaults
+- `meta_entropy_threshold`: `null`
+
 ## ROI defaults
 - `threshold`: `null`
 - `confidence`: `null`

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -212,6 +212,11 @@ class SandboxSettings(BaseSettings):
         env="META_DOMAIN_PENALTY",
         description="Penalty for domain transitions in meta planning.",
     )
+    meta_entropy_threshold: float | None = Field(
+        None,
+        env="META_ENTROPY_THRESHOLD",
+        description="Maximum allowed workflow entropy when recording improvements.",
+    )
     workflows_db: str = Field(
         "workflows.db",
         env="WORKFLOWS_DB",
@@ -363,6 +368,14 @@ class SandboxSettings(BaseSettings):
     def _validate_exploration_temperature(cls, v: float) -> float:
         if v <= 0:
             raise ValueError("exploration_temperature must be positive")
+        return v
+
+    @field_validator("meta_entropy_threshold")
+    def _validate_meta_entropy_threshold(
+        cls, v: float | None
+    ) -> float | None:
+        if v is not None and not 0 <= v <= 1:
+            raise ValueError("meta_entropy_threshold must be between 0 and 1")
         return v
 
     @field_validator("meta_planning_interval", "meta_planning_period")

--- a/tests/test_meta_planning_entropy.py
+++ b/tests/test_meta_planning_entropy.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+from pathlib import Path
+import ast
+
+
+src_path = Path(__file__).resolve().parents[1] / "self_improvement" / "meta_planning.py"
+tree = ast.parse(src_path.read_text(), filename=str(src_path))
+ns: dict[str, object] = {}
+ns["SandboxSettings"] = object
+ns["WorkflowStabilityDB"] = object
+from typing import Any, Mapping
+ns["Any"] = Any
+ns["Mapping"] = Mapping
+for node in tree.body:
+    if isinstance(node, ast.FunctionDef) and node.name in {
+        "_get_entropy_threshold",
+        "_should_encode",
+    }:
+        mod = ast.Module([node], type_ignores=[])
+        exec(compile(mod, str(src_path), "exec"), ns)
+
+_get_entropy_threshold = ns["_get_entropy_threshold"]
+_should_encode = ns["_should_encode"]
+
+
+def test_threshold_from_settings_overrides_history():
+    settings = SimpleNamespace(meta_entropy_threshold=0.1)
+    db = SimpleNamespace(data={"a": {"entropy": 0.5}})
+    assert _get_entropy_threshold(settings, db) == 0.1
+
+
+def test_threshold_derived_from_history_when_not_set():
+    settings = SimpleNamespace(meta_entropy_threshold=None)
+    db = SimpleNamespace(data={"a": {"entropy": 0.1}, "b": {"entropy": 0.4}})
+    assert _get_entropy_threshold(settings, db) == 0.4
+
+
+def test_should_encode_respects_threshold():
+    record = {"roi_gain": 0.2, "entropy": 0.25}
+    assert _should_encode(record, entropy_threshold=0.3)
+    assert not _should_encode(record, entropy_threshold=0.2)
+


### PR DESCRIPTION
## Summary
- allow meta planner to read entropy threshold from settings or historical data
- document new `meta_entropy_threshold` config
- validate threshold and test planner behaviour across different values

## Testing
- `pytest tests/test_meta_planning_entropy.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2561114ac832ea335d71fe6270b9c