### PR TITLE
feat: enhance self-test stubs with type-aware values

### DIFF
--- a/tests/test_pytest_stub_signatures.py
+++ b/tests/test_pytest_stub_signatures.py
@@ -44,6 +44,15 @@ sys.modules.setdefault(
     "error_logger", types.SimpleNamespace(ErrorLogger=lambda *a, **k: None)
 )
 sys.modules.setdefault("menace.error_logger", sys.modules["error_logger"])
+sys.modules.setdefault("sandbox_runner", types.ModuleType("sandbox_runner"))
+od = types.SimpleNamespace(
+    append_orphan_cache=lambda *a, **k: None,
+    append_orphan_classifications=lambda *a, **k: None,
+    prune_orphan_cache=lambda *a, **k: None,
+    load_orphan_cache=lambda *a, **k: {},
+)
+sys.modules.setdefault("sandbox_runner.orphan_discovery", od)
+sys.modules.setdefault("orphan_discovery", od)
 
 
 class _Gauge:

--- a/tests/test_pytest_stub_typed_values.py
+++ b/tests/test_pytest_stub_typed_values.py
@@ -1,0 +1,71 @@
+import runpy
+import sys
+import os
+
+from tests.test_pytest_stub_signatures import load_self_test_service
+
+os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
+
+sts = load_self_test_service()
+
+
+def test_stub_handles_typed_annotations(tmp_path, monkeypatch):
+    mod_code = (
+        "from dataclasses import dataclass\n"
+        "from enum import Enum\n\n"
+        "@dataclass\n"
+        "class Point:\n"
+        "    x: int\n"
+        "    y: int\n\n"
+        "class Colour(Enum):\n"
+        "    RED = 1\n"
+        "    BLUE = 2\n\n"
+        "called = []\n\n"
+        "def handle(pt: Point, colour: Colour, nums: list[int], mapping: dict[str, int]):\n"
+        "    called.append((pt, colour, nums, mapping))\n\n"
+        "def needs_custom(a: int):\n"
+        "    called.append(a)\n\n"
+        "class C:\n"
+        "    def __init__(self, colour: Colour, pts: list[Point]):\n"
+        "        called.append((colour, pts))\n"
+    )
+
+    mod_path = tmp_path / "typed_mod.py"
+    mod_path.write_text(mod_code, encoding="utf-8")
+
+    hook_mod = tmp_path / "hook_mod.py"
+    hook_mod.write_text(
+        "def gen(p):\n    if p.name == 'a':\n        return 42\n",
+        encoding="utf-8",
+    )
+
+    sys.path.insert(0, str(tmp_path))
+    monkeypatch.setenv("SANDBOX_REPO_PATH", str(tmp_path))
+
+    svc = sts.SelfTestService(fixture_hook="hook_mod:gen")
+    stub_path = svc._generate_pytest_stub(str(mod_path))
+    ns = runpy.run_path(stub_path)
+    ns["test_stub"]()
+
+    mod = sys.modules["typed_mod"]
+
+    c_colour, pts = mod.called[0]
+    assert isinstance(c_colour, mod.Colour)
+    assert isinstance(pts, list) and isinstance(pts[0], mod.Point)
+
+    pt, colour, nums, mapping = mod.called[1]
+    assert isinstance(pt, mod.Point)
+    assert isinstance(colour, mod.Colour)
+    assert isinstance(nums, list) and isinstance(nums[0], int)
+    assert isinstance(mapping, dict) and isinstance(next(iter(mapping)), str)
+
+    assert mod.called[2] == 42
+
+    stub_dir = stub_path.parent
+    stub_path.unlink()
+    stub_dir.rmdir()
+    stub_dir.parent.rmdir()
+    stub_dir.parent.parent.rmdir()
+    sys.path.remove(str(tmp_path))
+    sys.modules.pop("typed_mod", None)
+    sys.modules.pop("hook_mod", None)


### PR DESCRIPTION
## Summary
- generate stub arguments based on type hints, including dataclasses, enums, and typed collections
- allow optional fixture hook to supply domain-specific values
- add regression tests for stub generation

## Testing
- `pytest tests/test_pytest_stub_signatures.py tests/test_pytest_stub_typed_values.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b25a092af4832ea4df9937ea187f4f