### PR TITLE
feat: track code metrics with radon

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     ,"fastapi"
     ,"pydantic"
     ,"pydantic-settings"
+    ,"radon"
     ,"redis"
     ,"sentence-transformers"
     ,"hdbscan"

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,6 +57,8 @@ cloudpickle==3.1.1
     # via
     #   gymnasium
     #   stable-baselines3
+colorama==0.4.6
+    # via radon
 contourpy==1.3.2
     # via matplotlib
 cryptography==45.0.5
@@ -160,6 +162,8 @@ libcst==1.8.2
     # via menace (pyproject.toml)
 mako==1.3.10
     # via alembic
+mando==0.7.1
+    # via radon
 markupsafe==3.0.2
     # via
     #   flask
@@ -343,6 +347,8 @@ pyyaml==6.0.2
     #   libcst
     #   transformers
 pyzmq==27.0.0
+    # via menace (pyproject.toml)
+radon==6.0.1
     # via menace (pyproject.toml)
 rapidfuzz==3.13.0
     # via levenshtein

--- a/self_improvement/metrics.py
+++ b/self_improvement/metrics.py
@@ -1,62 +1,140 @@
 """Metrics helpers for the self-improvement package."""
 from __future__ import annotations
 
+import argparse
 import ast
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Dict, Iterable
+
+import yaml
+
+try:  # pragma: no cover - radon is an optional dependency
+    from radon.complexity import cc_visit
+    from radon.metrics import mi_visit
+except Exception:  # pragma: no cover
+    cc_visit = mi_visit = None
 
 from ..sandbox_settings import SandboxSettings
 
 
-def _update_alignment_baseline(settings: SandboxSettings | None = None) -> None:
-    """Write current test counts and complexity scores to baseline metrics file."""
+def _collect_metrics(files: Iterable[Path], repo: Path) -> tuple[Dict[str, Dict[str, float]], int, float, int]:
+    """Return per-file metrics, total complexity, avg maintainability and tests."""
+
+    per_file: Dict[str, Dict[str, float]] = {}
+    total_complexity = 0
+    mi_total = 0.0
+    mi_count = 0
+    test_count = 0
+
+    for file in files:
+        rel = file.relative_to(repo).as_posix()
+        name = file.name
+        if rel.startswith("tests") or name.startswith("test_") or name.endswith("_test.py"):
+            test_count += 1
+        try:
+            code = file.read_text(encoding="utf-8")
+        except Exception:
+            continue
+
+        file_complexity = 0
+        file_mi = 0.0
+
+        if cc_visit and mi_visit:
+            try:
+                blocks = cc_visit(code)
+                file_complexity = int(sum(b.complexity for b in blocks))
+                file_mi = float(mi_visit(code, False))
+            except Exception:
+                pass
+        else:  # fallback to AST-based estimation
+            try:
+                tree = ast.parse(code)
+                for node in ast.walk(tree):
+                    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        score = 1
+                        for sub in ast.walk(node):
+                            if isinstance(
+                                sub,
+                                (
+                                    ast.If,
+                                    ast.For,
+                                    ast.While,
+                                    ast.Try,
+                                    ast.With,
+                                    ast.BoolOp,
+                                    ast.IfExp,
+                                ),
+                            ):
+                                score += 1
+                        file_complexity += score
+                file_mi = 100.0
+            except Exception:
+                pass
+
+        per_file[rel] = {"complexity": file_complexity, "maintainability": file_mi}
+        total_complexity += file_complexity
+        mi_total += file_mi
+        mi_count += 1
+
+    avg_mi = mi_total / mi_count if mi_count else 0.0
+    return per_file, total_complexity, avg_mi, test_count
+
+
+def get_alignment_metrics(settings: SandboxSettings | None = None) -> Dict[str, Any]:
+    """Return stored baseline metrics if available."""
+
     try:
         settings = settings or SandboxSettings()
         path_str = getattr(settings, "alignment_baseline_metrics_path", "")
         if not path_str:
-            return
-        repo = Path(SandboxSettings().sandbox_repo_path)
-        test_count = 0
-        total_complexity = 0
-        for file in repo.rglob("*.py"):
-            rel = file.relative_to(repo)
-            name = rel.name
-            rel_posix = rel.as_posix()
-            if (
-                rel_posix.startswith("tests")
-                or name.startswith("test_")
-                or name.endswith("_test.py")
-            ):
-                test_count += 1
-            try:
-                code = file.read_text(encoding="utf-8")
-                tree = ast.parse(code)
-            except Exception:
-                continue
-            for node in ast.walk(tree):
-                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                    score = 1
-                    for sub in ast.walk(node):
-                        if isinstance(
-                            sub,
-                            (
-                                ast.If,
-                                ast.For,
-                                ast.While,
-                                ast.Try,
-                                ast.With,
-                                ast.BoolOp,
-                                ast.IfExp,
-                            ),
-                        ):
-                            score += 1
-                    total_complexity += score
-        Path(path_str).write_text(
-            f"tests={test_count}\ncomplexity={total_complexity}\n",
-            encoding="utf-8",
-        )
+            return {}
+        return yaml.safe_load(Path(path_str).read_text()) or {}
     except Exception:  # pragma: no cover - best effort
-        return
+        return {}
 
 
-__all__ = ["_update_alignment_baseline"]
+def _update_alignment_baseline(settings: SandboxSettings | None = None) -> Dict[str, Any]:
+    """Compute and persist current code metrics to the baseline file."""
+
+    try:
+        settings = settings or SandboxSettings()
+        path_str = getattr(settings, "alignment_baseline_metrics_path", "")
+        if not path_str:
+            return {}
+        repo = Path(SandboxSettings().sandbox_repo_path)
+        per_file, total_complexity, avg_mi, test_count = _collect_metrics(
+            repo.rglob("*.py"), repo
+        )
+        data: Dict[str, Any] = {
+            "tests": test_count,
+            "complexity": total_complexity,
+            "maintainability": avg_mi,
+            "files": per_file,
+        }
+        Path(path_str).write_text(yaml.safe_dump(data), encoding="utf-8")
+        return data
+    except Exception:  # pragma: no cover - best effort
+        return {}
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    """CLI entry point for updating or displaying baseline metrics."""
+
+    parser = argparse.ArgumentParser(description="Self-improvement metrics utilities")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("update", help="Recalculate and store baseline metrics")
+    sub.add_parser("show", help="Display stored baseline metrics")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.cmd == "update":
+        metrics = _update_alignment_baseline()
+        print(yaml.safe_dump(metrics))
+    elif args.cmd == "show":
+        print(yaml.safe_dump(get_alignment_metrics()))
+
+
+__all__ = ["_update_alignment_baseline", "get_alignment_metrics", "main"]
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()


### PR DESCRIPTION
## Summary
- integrate radon to record cyclomatic complexity and maintainability
- persist per-file code metrics and expose CLI helpers
- add radon dependency and expand baseline tests

## Testing
- `pytest tests/test_alignment_baseline_update.py tests/test_metric_improvement_alignment_warning.py::test_metric_improvement_still_warns -q`

------
https://chatgpt.com/codex/tasks/task_e_68b25c44b68c832e88e5e698eb6900a4