### PR TITLE
Improve stub provider retries and caching

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -177,6 +177,26 @@ class SandboxSettings(BaseSettings):
         env="SANDBOX_CENTRAL_LOGGING",
         description="Enable centralised logging output.",
     )
+    stub_timeout: float = Field(
+        10.0,
+        env="SANDBOX_STUB_TIMEOUT",
+        description="Timeout for stub generation in seconds.",
+    )
+    stub_retries: int = Field(
+        2,
+        env="SANDBOX_STUB_RETRIES",
+        description="Retry attempts for stub generation.",
+    )
+    stub_retry_base: float = Field(
+        0.5,
+        env="SANDBOX_STUB_RETRY_BASE",
+        description="Initial delay for exponential backoff in seconds.",
+    )
+    stub_retry_max: float = Field(
+        30.0,
+        env="SANDBOX_STUB_RETRY_MAX",
+        description="Maximum delay for exponential backoff in seconds.",
+    )
     meta_planning_interval: int = Field(
         10,
         env="META_PLANNING_INTERVAL",


### PR DESCRIPTION
## Summary
- validate stub generation settings and warn on bad values
- add jittered exponential backoff and configurable retry options
- ensure background cache writes are shielded and awaited during shutdown

## Testing
- `pytest --noconftest tests/test_generative_stub_provider.py::test_generate_stubs_cache -q`
- `pytest --noconftest tests/test_generative_stub_provider.py::test_call_with_retry_backoff -q` *(fails: async def functions are not natively supported)*
- `pytest --noconftest tests/test_generative_stub_provider.py::test_cache_persist_after_failure -q`


------
https://chatgpt.com/codex/tasks/task_e_68b26da78dc4832eb4ce00e930f181b6