### PR TITLE
Warn when relevancy radar missing

### DIFF
--- a/sandbox_runner/meta_logger.py
+++ b/sandbox_runner/meta_logger.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Sequence
 import json
 import math
+import os
 
 from logging_utils import get_logger, log_record
 from audit_trail import AuditTrail
@@ -16,8 +17,15 @@ except Exception:  # pragma: no cover - optional
 try:  # avoid heavy dependency during light imports
     from .cycle import _async_track_usage
 except Exception:  # pragma: no cover - best effort stub
+    _SUPPRESS_TELEMETRY_WARNING = os.getenv("SANDBOX_SUPPRESS_TELEMETRY_WARNING") == "1"
+
     def _async_track_usage(*_a, **_k) -> None:  # type: ignore
-        pass
+        if _SUPPRESS_TELEMETRY_WARNING or getattr(_async_track_usage, "_warned", False):
+            return
+        logger.warning(
+            "relevancy radar unavailable; telemetry tracking disabled"
+        )
+        _async_track_usage._warned = True  # type: ignore
 
 logger = get_logger(__name__)
 

--- a/tests/test_async_track_usage_warning.py
+++ b/tests/test_async_track_usage_warning.py
@@ -1,0 +1,23 @@
+import importlib.util
+import types
+import sys
+import logging
+from pathlib import Path
+
+
+def test_async_track_usage_warns_once(monkeypatch, caplog):
+    monkeypatch.delenv("SANDBOX_SUPPRESS_TELEMETRY_WARNING", raising=False)
+    pkg = types.ModuleType("sandbox_runner")
+    pkg.__path__ = []  # empty so submodules cannot be resolved
+    sys.modules["sandbox_runner"] = pkg
+
+    path = Path(__file__).resolve().parent.parent / "sandbox_runner" / "meta_logger.py"
+    spec = importlib.util.spec_from_file_location("sandbox_runner.meta_logger", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["sandbox_runner.meta_logger"] = mod
+    with caplog.at_level(logging.WARNING):
+        spec.loader.exec_module(mod)
+        mod._async_track_usage("a")
+        mod._async_track_usage("b")
+    warns = [r for r in caplog.records if "relevancy radar unavailable" in r.message]
+    assert len(warns) == 1


### PR DESCRIPTION
## Summary
- warn when relevancy radar unavailable instead of silent stub
- allow disabling telemetry warning via `SANDBOX_SUPPRESS_TELEMETRY_WARNING`
- test that warning emitted once when radar dependency is missing

## Testing
- `pytest tests/test_async_track_usage_warning.py -q`
- `pytest tests/test_sandbox_meta_logger.py -q` *(fails: module 'sandbox_runner' has no attribute '_SandboxMetaLogger')*


------
https://chatgpt.com/codex/tasks/task_e_68b2706c091c832eb0d066b8b6778fca