### PR TITLE
feat: record patch metadata

### DIFF
--- a/tests/test_vector_service.py
+++ b/tests/test_vector_service.py
@@ -124,9 +124,32 @@ class DummyPatchDB:
         self.called = False
         self.args = None
 
-    def record_vector_metrics(self, session_id, pairs, patch_id, contribution, win, regret):
+    def record_vector_metrics(
+        self,
+        session_id,
+        pairs,
+        patch_id,
+        contribution,
+        win,
+        regret,
+        lines_changed=None,
+        tests_passed=None,
+        enhancement_name=None,
+        timestamp=None,
+    ):
         self.called = True
-        self.args = (session_id, pairs, patch_id, contribution, win, regret)
+        self.args = (
+            session_id,
+            pairs,
+            patch_id,
+            contribution,
+            win,
+            regret,
+            lines_changed,
+            tests_passed,
+            enhancement_name,
+            timestamp,
+        )
 
 
 def test_patch_logger_metrics_db_success():

--- a/vector_service/cognition_layer.py
+++ b/vector_service/cognition_layer.py
@@ -676,6 +676,10 @@ class CognitionLayer:
         *,
         patch_id: str = "",
         contribution: float | None = None,
+        lines_changed: int | None = None,
+        tests_passed: bool | None = None,
+        enhancement_name: str | None = None,
+        timestamp: float | None = None,
         async_mode: bool = False,
     ) -> None:
         """Shared implementation for patch outcome recording."""
@@ -729,6 +733,10 @@ class CognitionLayer:
             "session_id": session_id,
             "contribution": contribution,
             "retrieval_metadata": meta,
+            "lines_changed": lines_changed,
+            "tests_passed": tests_passed,
+            "enhancement_name": enhancement_name,
+            "timestamp": timestamp,
         }
         import inspect
 
@@ -920,6 +928,10 @@ class CognitionLayer:
         *,
         patch_id: str = "",
         contribution: float | None = None,
+        lines_changed: int | None = None,
+        tests_passed: bool | None = None,
+        enhancement_name: str | None = None,
+        timestamp: float | None = None,
     ) -> None:
         """Forward patch outcome to :class:`PatchLogger`."""
 
@@ -929,6 +941,10 @@ class CognitionLayer:
                 success,
                 patch_id=patch_id,
                 contribution=contribution,
+                lines_changed=lines_changed,
+                tests_passed=tests_passed,
+                enhancement_name=enhancement_name,
+                timestamp=timestamp,
                 async_mode=False,
             )
         )
@@ -941,6 +957,10 @@ class CognitionLayer:
         *,
         patch_id: str = "",
         contribution: float | None = None,
+        lines_changed: int | None = None,
+        tests_passed: bool | None = None,
+        enhancement_name: str | None = None,
+        timestamp: float | None = None,
     ) -> None:
         """Asynchronous wrapper for :meth:`record_patch_outcome`."""
 
@@ -949,6 +969,10 @@ class CognitionLayer:
             success,
             patch_id=patch_id,
             contribution=contribution,
+            lines_changed=lines_changed,
+            tests_passed=tests_passed,
+            enhancement_name=enhancement_name,
+            timestamp=timestamp,
             async_mode=True,
         )
 


### PR DESCRIPTION
## Summary
- track patch metadata like line deltas and test outcomes
- persist new metrics to patch history with migration
- emit patch summary events with ROI deltas

## Testing
- `pytest tests/test_patch_logger_metrics.py`
- `pytest tests/test_patch_logger_failure_record.py`
- `pytest tests/test_patch_logger_lessons.py`
- `pytest tests/test_patch_logger_origin_penalty.py`
- `pytest tests/test_patch_logger_scheduler_integration.py`
- `pytest tests/test_cognition_layer_async.py`
- `pytest tests/test_cognition_layer.py` *(fails: assertion errors and closed DB)*

------
https://chatgpt.com/codex/tasks/task_e_68b26ff18c24832eb7c367fe66b17cae