### PR TITLE
Add self-improvement and sandbox runner tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,8 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    env:
+      MENACE_SAFE: "1"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -47,6 +49,8 @@ jobs:
 
   workflow-policy-integration:
     runs-on: ubuntu-latest
+    env:
+      MENACE_SAFE: "1"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -60,6 +64,8 @@ jobs:
   stress-tests:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.stress == 'true'
     runs-on: ubuntu-latest
+    env:
+      MENACE_SAFE: "1"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/tests/integration/test_full_self_improvement_cycle.py
+++ b/tests/integration/test_full_self_improvement_cycle.py
@@ -1,0 +1,136 @@
+import ast
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _load_meta_planning():
+    src = (ROOT / "self_improvement" / "meta_planning.py").read_text()
+    tree = ast.parse(src)
+    wanted = {"_get_entropy_threshold", "_should_encode", "self_improvement_cycle"}
+    nodes = [
+        n
+        for n in tree.body
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name in wanted
+    ]
+    future = ast.ImportFrom(
+        module="__future__", names=[ast.alias("annotations", None)], level=0
+    )
+    module = ast.Module([future] + nodes, type_ignores=[])
+    module = ast.fix_missing_locations(module)
+    ns = {
+        "asyncio": asyncio,
+        "PLANNER_INTERVAL": 0.0,
+        "SandboxSettings": object,
+        "WorkflowStabilityDB": object,
+        "Any": Any,
+        "Callable": Callable,
+        "Mapping": Mapping,
+    }
+    exec(compile(module, "<ast>", "exec"), ns)
+    return ns
+
+
+# Dynamically load WorkflowSandboxRunner without importing the full package
+package_path = ROOT / "sandbox_runner"
+package = types.ModuleType("sandbox_runner")
+package.__path__ = [str(package_path)]
+sys.modules["sandbox_runner"] = package
+spec = importlib.util.spec_from_file_location(
+    "sandbox_runner.workflow_sandbox_runner", package_path / "workflow_sandbox_runner.py"
+)
+wsr = importlib.util.module_from_spec(spec)
+assert spec.loader
+sys.modules[spec.name] = wsr
+spec.loader.exec_module(wsr)
+WorkflowSandboxRunner = wsr.WorkflowSandboxRunner
+
+
+def test_full_self_improvement_cycle(monkeypatch):
+    meta = _load_meta_planning()
+
+    class DummyROI:
+        def __init__(self):
+            self.logged = []
+
+        def log_result(self, **kw):
+            self.logged.append(kw)
+
+    class DummyStability:
+        def __init__(self):
+            self.recorded = []
+            self.data = {}
+
+        def record_metrics(self, wf, roi, failures, entropy, roi_delta=None):
+            self.recorded.append((wf, roi, entropy))
+
+    planner_instances: list[object] = []
+
+    class DummyPlanner:
+        def __init__(self):
+            self.roi_db = DummyROI()
+            self.stability_db = DummyStability()
+            self.cluster_map = {}
+            planner_instances.append(self)
+
+        def discover_and_persist(self, workflows):
+            return [
+                {"chain": ["wf"], "roi_gain": 0.5, "failures": 0, "entropy": 0.0}
+            ]
+
+    class DummyBus:
+        def __init__(self):
+            self.events: list[tuple[str, dict]] = []
+
+        def publish(self, topic: str, payload: dict):
+            self.events.append((topic, payload))
+
+    bus = DummyBus()
+    global_db = DummyStability()
+
+    meta.update(
+        {
+            "MetaWorkflowPlanner": DummyPlanner,
+            "get_logger": lambda name: types.SimpleNamespace(
+                warning=lambda *a, **k: None, exception=lambda *a, **k: None
+            ),
+            "log_record": lambda **kw: kw,
+            "SandboxSettings": lambda: types.SimpleNamespace(
+                meta_mutation_rate=None,
+                meta_roi_weight=None,
+                meta_domain_penalty=None,
+                meta_entropy_threshold=None,
+            ),
+            "STABLE_WORKFLOWS": global_db,
+        }
+    )
+
+    # Step 1: execute a workflow inside the sandbox
+    runner = WorkflowSandboxRunner()
+
+    def wf():
+        return "ok"
+
+    metrics = runner.run([wf], safe_mode=True)
+    assert metrics.crash_count == 0
+
+    # Step 2: run a single iteration of the self-improvement cycle
+    async def run_cycle():
+        await meta["self_improvement_cycle"]({"wf": wf}, interval=0.0, event_bus=bus)
+
+    with pytest.raises(asyncio.TimeoutError):
+        asyncio.run(asyncio.wait_for(run_cycle(), timeout=0.01))
+
+    planner = planner_instances[0]
+    assert planner.roi_db.logged
+    assert planner.stability_db.recorded
+    assert global_db.recorded
+    assert bus.events

--- a/unit_tests/test_meta_planning.py
+++ b/unit_tests/test_meta_planning.py
@@ -1,0 +1,90 @@
+import ast
+import asyncio
+import types
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+
+def _load_meta_planning():
+    src = Path("self_improvement/meta_planning.py").read_text()
+    tree = ast.parse(src)
+    wanted = {"_get_entropy_threshold", "_should_encode", "self_improvement_cycle"}
+    nodes = [
+        n
+        for n in tree.body
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name in wanted
+    ]
+    future = ast.ImportFrom(
+        module="__future__", names=[ast.alias("annotations", None)], level=0
+    )
+    module = ast.Module([future] + nodes, type_ignores=[])
+    module = ast.fix_missing_locations(module)
+    ns = {
+        "asyncio": asyncio,
+        "PLANNER_INTERVAL": 0.0,
+        "SandboxSettings": object,
+        "WorkflowStabilityDB": object,
+        "Any": Any,
+        "Callable": Callable,
+        "Mapping": Mapping,
+    }
+    exec(compile(module, "<ast>", "exec"), ns)
+    return ns
+
+
+def test_entropy_threshold_from_settings():
+    meta = _load_meta_planning()
+
+    class Cfg:
+        meta_entropy_threshold = 0.7
+
+    class DB:
+        data = {}
+
+    assert meta["_get_entropy_threshold"](Cfg(), DB()) == 0.7
+
+
+def test_entropy_threshold_falls_back_to_db():
+    meta = _load_meta_planning()
+
+    class Cfg:
+        meta_entropy_threshold = None
+
+    class DB:
+        data = {"a": {"entropy": 0.2}, "b": {"entropy": -0.5}}
+
+    assert meta["_get_entropy_threshold"](Cfg(), DB()) == 0.5
+
+
+def test_should_encode_requires_positive_roi_and_low_entropy():
+    meta = _load_meta_planning()
+    should_encode = meta["_should_encode"]
+
+    assert should_encode({"roi_gain": 0.1, "entropy": 0.1}, entropy_threshold=0.2)
+    assert not should_encode({"roi_gain": 0.0, "entropy": 0.1}, entropy_threshold=0.2)
+    assert not should_encode({"roi_gain": 0.1, "entropy": 0.3}, entropy_threshold=0.2)
+
+
+def test_cycle_logs_when_planner_missing():
+    meta = _load_meta_planning()
+
+    messages: list[str] = []
+    meta.update(
+        {
+            "MetaWorkflowPlanner": None,
+            "get_logger": lambda name: types.SimpleNamespace(
+                warning=lambda msg: messages.append(msg)
+            ),
+            "log_record": lambda **kw: kw,
+            "SandboxSettings": lambda: types.SimpleNamespace(
+                meta_mutation_rate=None,
+                meta_roi_weight=None,
+                meta_domain_penalty=None,
+                meta_entropy_threshold=0.2,
+            ),
+            "STABLE_WORKFLOWS": types.SimpleNamespace(),
+        }
+    )
+
+    asyncio.run(meta["self_improvement_cycle"]({}))
+    assert any("MetaWorkflowPlanner unavailable" in m for m in messages)

--- a/unit_tests/test_self_improvement_utils.py
+++ b/unit_tests/test_self_improvement_utils.py
@@ -1,0 +1,64 @@
+import ast
+import importlib
+import logging
+import time
+import types
+from pathlib import Path
+from typing import Any, Callable
+from unittest.mock import patch
+
+import pytest
+
+
+def _load_utils():
+    src = Path("self_improvement/utils.py").read_text()
+    tree = ast.parse(src)
+    wanted = {"_load_callable", "_call_with_retries"}
+    nodes = [n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name in wanted]
+    module = ast.Module(nodes, type_ignores=[])
+
+    class Counter:
+        def __init__(self) -> None:
+            self.count = 0
+
+        def labels(self, **kw):  # pragma: no cover - simple stub
+            return types.SimpleNamespace(inc=lambda: setattr(self, "count", self.count + 1))
+
+    counter = Counter()
+    ns = {
+        "importlib": importlib,
+        "logging": logging,
+        "time": time,
+        "Callable": Callable,
+        "Any": Any,
+        "self_improvement_failure_total": counter,
+    }
+    exec(compile(module, "<ast>", "exec"), ns)
+    return ns, counter
+
+
+def test_load_callable_success():
+    utils, counter = _load_utils()
+    fn = utils["_load_callable"]("math", "sqrt")
+    assert fn(4) == 2
+    assert counter.count == 0
+
+
+def test_load_callable_missing_increments_metric():
+    utils, counter = _load_utils()
+    with patch("importlib.import_module", side_effect=ImportError):
+        with pytest.raises(RuntimeError):
+            utils["_load_callable"]("missing", "attr")
+    assert counter.count == 1
+
+
+def test_call_with_retries_records_failure():
+    utils, counter = _load_utils()
+    utils["time"].sleep = lambda *a, **k: None
+
+    def always_fail():
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        utils["_call_with_retries"](always_fail, retries=2)
+    assert counter.count == 1

--- a/unit_tests/test_workflow_sandbox_runner_resolve.py
+++ b/unit_tests/test_workflow_sandbox_runner_resolve.py
@@ -1,0 +1,41 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+package_path = ROOT / "sandbox_runner"
+package = types.ModuleType("sandbox_runner")
+package.__path__ = [str(package_path)]
+sys.modules["sandbox_runner"] = package
+
+spec = importlib.util.spec_from_file_location(
+    "sandbox_runner.workflow_sandbox_runner", package_path / "workflow_sandbox_runner.py"
+)
+wsr = importlib.util.module_from_spec(spec)
+assert spec.loader
+sys.modules[spec.name] = wsr
+spec.loader.exec_module(wsr)
+WorkflowSandboxRunner = wsr.WorkflowSandboxRunner
+
+
+def test_resolve_inside(tmp_path):
+    runner = WorkflowSandboxRunner()
+    resolved = runner._resolve(tmp_path, "foo.txt")
+    assert resolved == (tmp_path / "foo.txt").resolve()
+
+
+def test_resolve_absolute_path(tmp_path):
+    runner = WorkflowSandboxRunner()
+    inside = (tmp_path / "bar.txt").resolve()
+    resolved = runner._resolve(tmp_path, inside)
+    assert resolved == inside
+
+
+def test_resolve_prevents_escape(tmp_path):
+    runner = WorkflowSandboxRunner()
+    with pytest.raises(RuntimeError):
+        runner._resolve(tmp_path, "../escape.txt")


### PR DESCRIPTION
## Summary
- add unit tests for meta planning entropy checks and planner fallback
- cover self-improvement utilities and sandbox path resolution
- include integration test exercising self-improvement cycle and sandbox runner
- run CI with MENACE_SAFE enabled

## Testing
- `pre-commit run --files .github/workflows/tests.yml unit_tests/test_meta_planning.py unit_tests/test_self_improvement_utils.py unit_tests/test_workflow_sandbox_runner_resolve.py tests/integration/test_full_self_improvement_cycle.py`
- `pytest unit_tests/test_meta_planning.py unit_tests/test_self_improvement_utils.py unit_tests/test_workflow_sandbox_runner_resolve.py tests/integration/test_full_self_improvement_cycle.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2752cc814832e8384b17c91c12b7d