### PR TITLE
docs: describe safe mode and sandbox settings

### DIFF
--- a/docs/sandbox_settings.md
+++ b/docs/sandbox_settings.md
@@ -55,3 +55,26 @@ settings = load_sandbox_settings("docs/sandbox_config.sample.yaml")
 
 See [`sandbox_config.sample.yaml`](sandbox_config.sample.yaml) for a complete
 example configuration file.
+
+## Personal configuration examples
+
+Override defaults via constructor arguments or environment variables when
+tailoring the sandbox for personal deployments:
+
+```python
+from sandbox_settings import SandboxSettings
+
+settings = SandboxSettings(
+    sandbox_repo_path="/home/alice/menace_sandbox",
+    sandbox_data_dir="/home/alice/.menace",
+    synergy_train_interval=20,
+)
+```
+
+```env
+SANDBOX_REPO_PATH=/home/alice/menace_sandbox
+SANDBOX_DATA_DIR=/home/alice/.menace
+SYNERGY_TRAIN_INTERVAL=20
+```
+
+Any field listed above can be overridden in the same manner.


### PR DESCRIPTION
## Summary
- document running modules in sandbox safe mode, tuning self-improvement intervals, interpreting metrics, and handling optional dependencies
- add personal SandboxSettings examples

## Testing
- `pre-commit run --files README.md docs/sandbox_settings.md`

------
https://chatgpt.com/codex/tasks/task_e_68b27856ebe4832ea045d9b87a1d121f