### PR TITLE
feat: store patch diffs and summaries

### DIFF
--- a/tests/test_patch_logger_metrics.py
+++ b/tests/test_patch_logger_metrics.py
@@ -95,6 +95,8 @@ class DummyPatchDB:
         tests_passed=None,
         enhancement_name=None,
         timestamp=None,
+        diff=None,
+        summary=None,
     ):
         self.kwargs = {
             "session_id": session_id,
@@ -107,6 +109,8 @@ class DummyPatchDB:
             "tests_passed": tests_passed,
             "enhancement_name": enhancement_name,
             "timestamp": timestamp,
+            "diff": diff,
+            "summary": summary,
         }
 
 

--- a/tests/test_vector_service.py
+++ b/tests/test_vector_service.py
@@ -136,6 +136,8 @@ class DummyPatchDB:
         tests_passed=None,
         enhancement_name=None,
         timestamp=None,
+        diff=None,
+        summary=None,
     ):
         self.called = True
         self.args = (
@@ -149,6 +151,8 @@ class DummyPatchDB:
             tests_passed,
             enhancement_name,
             timestamp,
+            diff,
+            summary,
         )
 
 

--- a/vector_service/patch_logger.py
+++ b/vector_service/patch_logger.py
@@ -213,6 +213,8 @@ class PatchLogger:
         tests_passed: bool | None = None,
         enhancement_name: str | None = None,
         timestamp: float | None = None,
+        diff: str | None = None,
+        summary: str | None = None,
     ) -> dict[str, float]:
         """Log patch outcome for vectors contributing to a patch.
 
@@ -259,7 +261,11 @@ class PatchLogger:
                     except Exception:
                         logger.exception("Failed to record failure metadata")
                 if similarity >= self.patch_safety.threshold:
-                    payload = {"vector": key, "score": similarity, "threshold": self.patch_safety.threshold}
+                    payload = {
+                        "vector": key,
+                        "score": similarity,
+                        "threshold": self.patch_safety.threshold,
+                    }
                     bus = self.event_bus
                     if bus is None and UnifiedEventBus is not None:
                         try:
@@ -358,6 +364,8 @@ class PatchLogger:
                             tests_passed=tests_passed,
                             enhancement_name=enhancement_name,
                             timestamp=timestamp,
+                            diff=diff,
+                            summary=summary,
                         )
                     except Exception:
                         logger.exception("patch_db.record_vector_metrics failed")
@@ -601,7 +609,8 @@ class PatchLogger:
         try:
             conn = router.get_connection("risk_summaries")
             conn.execute(
-                "CREATE TABLE IF NOT EXISTS risk_summaries(ts REAL, patch_id TEXT, origin TEXT, risk REAL)"
+                "CREATE TABLE IF NOT EXISTS risk_summaries("
+                "ts REAL, patch_id TEXT, origin TEXT, risk REAL)"
             )
             ts = time.time()
             for origin, risk in origin_similarity.items():
@@ -671,6 +680,8 @@ class PatchLogger:
         tests_passed: bool | None = None,
         enhancement_name: str | None = None,
         timestamp: float | None = None,
+        diff: str | None = None,
+        summary: str | None = None,
     ) -> dict[str, float]:
         """Asynchronous wrapper for :meth:`track_contributors`."""
 
@@ -688,8 +699,9 @@ class PatchLogger:
             tests_passed=tests_passed,
             enhancement_name=enhancement_name,
             timestamp=timestamp,
+            diff=diff,
+            summary=summary,
         )
 
 
 __all__ = ["PatchLogger"]
-

--- a/vector_service_api.py
+++ b/vector_service_api.py
@@ -25,6 +25,7 @@ from vector_service import (
     PatchLogger,
     Retriever,
     VectorServiceError,
+    FallbackResult,
 )
 from roi_tracker import ROITracker
 from analytics.ranker_scheduler import start_scheduler_from_env
@@ -189,6 +190,8 @@ class TrackRequest(BaseModel):
     result: bool
     patch_id: str | None = ""
     session_id: str = ""
+    diff: str | None = None
+    summary: str | None = None
 
 
 @app.post("/track-contributors")
@@ -201,6 +204,8 @@ def track_contributors(req: TrackRequest) -> Any:
             req.result,
             patch_id=req.patch_id or "",
             session_id=req.session_id,
+            diff=req.diff,
+            summary=req.summary,
         )
     except VectorServiceError as exc:  # pragma: no cover - defensive
         raise HTTPException(status_code=500, detail=str(exc))


### PR DESCRIPTION
## Summary
- record diff and summary metadata for patches
- propagate diff and summary through patch logging API
- expose diff and summary in patch history queries

## Testing
- `pre-commit run --files code_database.py vector_service/patch_logger.py vector_service_api.py tests/test_patch_logger_metrics.py tests/test_vector_service.py`
- `pytest -q` *(fails: 287 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68b277114dd8832ea9349d0d74efa441