### PR TITLE
Include diff and summary in patch embeddings

### DIFF
--- a/embeddable_db_mixin.py
+++ b/embeddable_db_mixin.py
@@ -57,6 +57,7 @@ try:
         embedding_wall_time_seconds as _EMBED_WALL_LAST,
         embedding_store_latency_seconds as _EMBED_STORE_LAST,
     )
+    from .data_bot import MetricsDB
 except Exception:  # pragma: no cover - fallback to absolute imports
     from vector_metrics_db import VectorMetricsDB  # type: ignore
     from embedding_stats_db import EmbeddingStatsDB  # type: ignore
@@ -68,6 +69,7 @@ except Exception:  # pragma: no cover - fallback to absolute imports
         embedding_wall_time_seconds as _EMBED_WALL_LAST,
         embedding_store_latency_seconds as _EMBED_STORE_LAST,
     )
+    from data_bot import MetricsDB  # type: ignore
 
 logger = logging.getLogger(__name__)
 
@@ -357,6 +359,7 @@ class EmbeddableDBMixin:
             "kind": kind,
             "source_id": source_id,
             "redacted": True,
+            "record": record,
         }
         self._rebuild_index()
         save_start = perf_counter()

--- a/tests/test_patch_vectorizer.py
+++ b/tests/test_patch_vectorizer.py
@@ -1,0 +1,87 @@
+import importlib
+import sys
+from pathlib import Path
+import types
+
+from db_router import DBRouter
+
+# Ensure relative imports resolve and stub heavy dependencies
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+# Provide a minimal ``code_database`` with ``PatchHistoryDB`` for the vectorizer
+code_db_mod = types.ModuleType("code_database")
+
+
+class PatchHistoryDB:  # noqa: D401 - minimal stub
+    """Simple stand-in storing path and returning SQLite connection."""
+
+    def __init__(self, path):
+        self.path = Path(path)
+        self.router = DBRouter("patch_history", str(self.path), str(self.path))
+
+
+code_db_mod.PatchHistoryDB = PatchHistoryDB
+sys.modules.setdefault("code_database", code_db_mod)
+sys.modules.setdefault("menace_sandbox.code_database", code_db_mod)
+
+# Stub ``data_bot`` with minimal ``MetricsDB`` implementation
+data_bot_mod = types.ModuleType("data_bot")
+
+
+class MetricsDB:  # noqa: D401 - simple stub
+    """Stub metrics DB used for staleness logging."""
+
+    def log_embedding_staleness(self, origin, rid, age):  # pragma: no cover - stub
+        pass
+
+
+data_bot_mod.MetricsDB = MetricsDB
+sys.modules.setdefault("data_bot", data_bot_mod)
+sys.modules.setdefault("menace_sandbox.data_bot", data_bot_mod)
+
+# Finally, expose ``embeddable_db_mixin`` for direct import by vectorizers
+sys.modules.setdefault(
+    "embeddable_db_mixin",  # noqa: E402
+    importlib.import_module("menace_sandbox.embeddable_db_mixin"),
+)
+
+from vector_service.patch_vectorizer import PatchVectorizer  # noqa: E402
+from code_database import PatchHistoryDB  # noqa: E402
+
+
+def test_patch_vectorizer_embeds_diff_and_summary(tmp_path, monkeypatch):
+    db_path = tmp_path / "patch_history.db"
+    phdb = PatchHistoryDB(db_path)
+    conn = phdb.router.get_connection("patch_history")
+    conn.execute(
+        "CREATE TABLE patch_history ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "description TEXT, diff TEXT, summary TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO patch_history (description, diff, summary) VALUES (?, ?, ?)",
+        ("desc text", "diff text", "summary text"),
+    )
+    conn.commit()
+
+    pv = PatchVectorizer(path=db_path, index_path=tmp_path / "patch.index")
+
+    captured = {}
+
+    def fake_encode(self, text: str):
+        captured["text"] = text
+        return [float(len(text))]
+
+    monkeypatch.setattr(PatchVectorizer, "encode_text", fake_encode, raising=False)
+
+    pv.backfill_embeddings()
+
+    assert "diff text" in captured["text"]
+    assert "summary text" in captured["text"]
+
+    meta = pv._metadata.get("1")
+    assert meta and meta["record"]["diff"] == "diff text"
+    assert meta["record"]["summary"] == "summary text"
+
+    expected = "\n".join(["desc text", "diff text", "summary text"])
+    assert pv.get_vector(1) == [float(len(expected))]

--- a/vector_service/patch_vectorizer.py
+++ b/vector_service/patch_vectorizer.py
@@ -52,9 +52,15 @@ class PatchVectorizer(EmbeddableDBMixin):
     vector = transform
 
     def iter_records(self) -> Iterator[Tuple[int, Dict[str, Any], str]]:
-        cur = self.conn.execute("SELECT id, description FROM patch_history")
-        for pid, desc in cur.fetchall():
-            yield pid, {"description": desc}, "patch"
+        cur = self.conn.execute(
+            "SELECT id, description, diff, summary FROM patch_history"
+        )
+        for pid, desc, diff, summary in cur.fetchall():
+            yield pid, {
+                "description": desc,
+                "diff": diff,
+                "summary": summary,
+            }, "patch"
 
 
 __all__ = ["PatchVectorizer"]


### PR DESCRIPTION
## Summary
- embed patch diffs and summaries alongside descriptions for patch history records
- persist original record metadata when adding embeddings
- test that patch vectorizer composes description, diff, and summary into embedding input

## Testing
- `pre-commit run --files embeddable_db_mixin.py vector_service/patch_vectorizer.py tests/test_patch_vectorizer.py`
- `pytest tests/test_patch_vectorizer.py`


------
https://chatgpt.com/codex/tasks/task_e_68b279d0c24c832e902054b836018ec8