### PR TITLE
Enhance generative stub provider with rule-based fallback and cache management

### DIFF
--- a/tests/test_environment_helpers.py
+++ b/tests/test_environment_helpers.py
@@ -20,6 +20,7 @@ if "pyroute2" not in sys.modules:
     pr2 = types.ModuleType("pyroute2")
     pr2.IPRoute = pr2.NSPopen = pr2.netns = object
     sys.modules["pyroute2"] = pr2
+sys.modules.pop("sandbox_runner", None)
 import sandbox_runner.environment as env  # noqa: E402
 
 
@@ -212,9 +213,9 @@ def test_generative_load_default(monkeypatch):
 
     called = {}
 
-    def dummy_pipeline(task, model):
+    def dummy_pipeline(task, **kwargs):
         called["task"] = task
-        called["model"] = model
+        called.update(kwargs)
 
         class Gen:
             pass
@@ -255,7 +256,7 @@ def test_generate_input_stubs_synthetic_fallback(monkeypatch, tmp_path):
         pass
 
     stubs = env.generate_input_stubs(1, target=target)
-    assert stubs == [{"a": 0}]
+    assert stubs == [{"a": 1}]
 
 
 def test_generate_input_stubs_history_db(monkeypatch, tmp_path):

--- a/tests/test_generative_stub_provider.py
+++ b/tests/test_generative_stub_provider.py
@@ -13,7 +13,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
-
+sys.modules.pop("sandbox_runner", None)
 import sandbox_runner.generative_stub_provider as gsp  # noqa: E402
 
 
@@ -99,7 +99,7 @@ def test_async_generate_returns_json(monkeypatch, tmp_path):
     assert result == [{"y": 2}]
 
 
-def test_deterministic_fallback(monkeypatch, tmp_path):
+def test_rule_based_fallback(monkeypatch, tmp_path):
     path = tmp_path / "cache.json"
     monkeypatch.setenv("SANDBOX_STUB_CACHE", str(path))
     gsp_mod = importlib.reload(gsp)
@@ -114,7 +114,7 @@ def test_deterministic_fallback(monkeypatch, tmp_path):
 
     ctx = {"strategy": "synthetic", "target": target}
     res = gsp_mod.generate_stubs([{}], ctx)
-    assert res == [{"a": 0, "b": 0.0, "c": False, "d": "", "e": None}]
+    assert res == [{"a": 1, "b": 1.0, "c": True, "d": "value", "e": None}]
 
 
 def test_generation_failure_propagates(monkeypatch, tmp_path):

--- a/tests/test_input_stub_generation.py
+++ b/tests/test_input_stub_generation.py
@@ -7,6 +7,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
+sys.modules.pop("sandbox_runner", None)
 
 import importlib  # noqa: E402
 import sandbox_runner.input_history_db as ih  # noqa: E402


### PR DESCRIPTION
## Summary
- Replace deterministic stub defaults with context-aware rule-based generation
- Add authenticated model loading, type-checked outputs, and retry/backoff helpers
- Persist stub cache atomically with LRU eviction to limit growth

## Testing
- `pre-commit run --files sandbox_runner/generative_stub_provider.py tests/test_environment_helpers.py tests/test_generative_stub_provider.py`
- `PYTHONPATH=. pytest tests/test_generative_stub_provider.py tests/test_environment_helpers.py tests/test_input_stub_generation.py` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b27971e648832ebd0088cb2c12d236