### PR TITLE
Add outcome metadata to patch history records

### DIFF
--- a/code_database.py
+++ b/code_database.py
@@ -994,6 +994,7 @@ class PatchRecord:
     trigger: str | None = None
     diff: str | None = None
     summary: str | None = None
+    outcome: str | None = None
 
     def __post_init__(self) -> None:
         assert self.filename, "filename cannot be empty"
@@ -1056,6 +1057,7 @@ class PatchHistoryDB:
                 trigger TEXT,
                 diff TEXT,
                 summary TEXT,
+                outcome TEXT,
                 lines_changed INTEGER DEFAULT 0,
                 tests_passed INTEGER DEFAULT 0,
                 enhancement_name TEXT,
@@ -1152,6 +1154,7 @@ class PatchHistoryDB:
             "trigger": "ALTER TABLE patch_history ADD COLUMN trigger TEXT",
             "diff": "ALTER TABLE patch_history ADD COLUMN diff TEXT",
             "summary": "ALTER TABLE patch_history ADD COLUMN summary TEXT",
+            "outcome": "ALTER TABLE patch_history ADD COLUMN outcome TEXT",
             "lines_changed": "ALTER TABLE patch_history ADD COLUMN lines_changed INTEGER DEFAULT 0",
             "tests_passed": "ALTER TABLE patch_history ADD COLUMN tests_passed INTEGER DEFAULT 0",
             "enhancement_name": "ALTER TABLE patch_history ADD COLUMN enhancement_name TEXT",
@@ -1366,7 +1369,7 @@ class PatchHistoryDB:
                     pass
 
             cur = conn.execute(
-                "INSERT INTO patch_history(filename, description, roi_before, roi_after, errors_before, errors_after, roi_delta, complexity_before, complexity_after, complexity_delta, entropy_before, entropy_after, entropy_delta, predicted_roi, predicted_errors, reverted, trending_topic, ts, code_id, code_hash, source_bot, version, parent_patch_id, reason, trigger, diff, summary) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                "INSERT INTO patch_history(filename, description, roi_before, roi_after, errors_before, errors_after, roi_delta, complexity_before, complexity_after, complexity_delta, entropy_before, entropy_after, entropy_delta, predicted_roi, predicted_errors, reverted, trending_topic, ts, code_id, code_hash, source_bot, version, parent_patch_id, reason, trigger, diff, summary, outcome) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
                 (
                     rec.filename,
                     rec.description,
@@ -1395,6 +1398,7 @@ class PatchHistoryDB:
                     rec.trigger,
                     rec.diff,
                     rec.summary,
+                    rec.outcome,
                 ),
             )
 
@@ -1435,7 +1439,7 @@ class PatchHistoryDB:
 
         def op(conn: sqlite3.Connection) -> PatchRecord | None:
             row = conn.execute(
-                "SELECT filename, description, roi_before, roi_after, errors_before, errors_after, roi_delta, complexity_before, complexity_after, complexity_delta, entropy_before, entropy_after, entropy_delta, predicted_roi, predicted_errors, reverted, trending_topic, ts, code_id, code_hash, source_bot, version, parent_patch_id, reason, trigger, diff, summary FROM patch_history WHERE id=?",
+                "SELECT filename, description, roi_before, roi_after, errors_before, errors_after, roi_delta, complexity_before, complexity_after, complexity_delta, entropy_before, entropy_after, entropy_delta, predicted_roi, predicted_errors, reverted, trending_topic, ts, code_id, code_hash, source_bot, version, parent_patch_id, reason, trigger, diff, summary, outcome FROM patch_history WHERE id=?",
                 (patch_id,),
             ).fetchone()
             return PatchRecord(*row) if row else None
@@ -1446,7 +1450,7 @@ class PatchHistoryDB:
         """Return the highest ROI patches."""
         with self._connect() as conn:
             cur = conn.execute(
-                "SELECT filename, description, roi_before, roi_after, errors_before, errors_after, roi_delta, complexity_before, complexity_after, complexity_delta, entropy_before, entropy_after, entropy_delta, predicted_roi, predicted_errors, reverted, trending_topic, ts, code_id, code_hash, source_bot, version, parent_patch_id, reason, trigger, diff, summary FROM patch_history ORDER BY roi_delta DESC LIMIT ?",
+                "SELECT filename, description, roi_before, roi_after, errors_before, errors_after, roi_delta, complexity_before, complexity_after, complexity_delta, entropy_before, entropy_after, entropy_delta, predicted_roi, predicted_errors, reverted, trending_topic, ts, code_id, code_hash, source_bot, version, parent_patch_id, reason, trigger, diff, summary, outcome FROM patch_history ORDER BY roi_delta DESC LIMIT ?",
                 (limit,),
             )
             rows = cur.fetchall()
@@ -1482,6 +1486,7 @@ class PatchHistoryDB:
         timestamp: float | None = None,
         diff: str | None = None,
         summary: str | None = None,
+        outcome: str | None = None,
     ) -> None:
         """Update :class:`VectorMetricsDB` rows for *session_id* and *vectors*."""
 
@@ -1502,7 +1507,7 @@ class PatchHistoryDB:
         try:
             conn = self.router.get_connection("patch_history")
             conn.execute(
-                "UPDATE patch_history SET lines_changed=?, tests_passed=?, enhancement_name=?, timestamp=?, diff=COALESCE(?, diff), summary=COALESCE(?, summary) WHERE id=?",
+                "UPDATE patch_history SET lines_changed=?, tests_passed=?, enhancement_name=?, timestamp=?, diff=COALESCE(?, diff), summary=COALESCE(?, summary), outcome=COALESCE(?, outcome) WHERE id=?",
                 (
                     lines_changed,
                     None if tests_passed is None else int(bool(tests_passed)),
@@ -1510,6 +1515,7 @@ class PatchHistoryDB:
                     timestamp,
                     diff,
                     summary,
+                    outcome,
                     patch_id,
                 ),
             )
@@ -1803,7 +1809,7 @@ class PatchHistoryDB:
             base = (
                 "SELECT filename, description, roi_before, roi_after, errors_before, errors_after, "
                 "roi_delta, complexity_before, complexity_after, complexity_delta, entropy_before, entropy_after, entropy_delta, predicted_roi, "
-                "predicted_errors, reverted, trending_topic, ts, code_id, code_hash, source_bot, version, parent_patch_id, reason, trigger, diff, summary FROM patch_history"
+                "predicted_errors, reverted, trending_topic, ts, code_id, code_hash, source_bot, version, parent_patch_id, reason, trigger, diff, summary, outcome FROM patch_history"
             )
             clauses: List[str] = []
             params: List[Any] = []
@@ -1838,7 +1844,7 @@ class PatchHistoryDB:
 
         def op(conn: sqlite3.Connection) -> List[PatchRecord]:
             rows = conn.execute(
-                "SELECT filename, description, roi_before, roi_after, errors_before, errors_after, roi_delta, complexity_before, complexity_after, complexity_delta, entropy_before, entropy_after, entropy_delta, predicted_roi, predicted_errors, reverted, trending_topic, ts, code_id, code_hash, source_bot, version, parent_patch_id, reason, trigger, diff, summary FROM patch_history WHERE description LIKE ? COLLATE NOCASE OR filename LIKE ? COLLATE NOCASE",
+                "SELECT filename, description, roi_before, roi_after, errors_before, errors_after, roi_delta, complexity_before, complexity_after, complexity_delta, entropy_before, entropy_after, entropy_delta, predicted_roi, predicted_errors, reverted, trending_topic, ts, code_id, code_hash, source_bot, version, parent_patch_id, reason, trigger, diff, summary, outcome FROM patch_history WHERE description LIKE ? COLLATE NOCASE OR filename LIKE ? COLLATE NOCASE",
                 (pattern, pattern),
             ).fetchall()
             patches = [PatchRecord(*row) for row in rows]
@@ -1852,7 +1858,7 @@ class PatchHistoryDB:
 
         def op(conn: sqlite3.Connection) -> List[PatchRecord]:
             rows = conn.execute(
-                "SELECT filename, description, roi_before, roi_after, errors_before, errors_after, roi_delta, complexity_before, complexity_after, complexity_delta, entropy_before, entropy_after, entropy_delta, predicted_roi, predicted_errors, reverted, trending_topic, ts, code_id, code_hash, source_bot, version, parent_patch_id, reason, trigger, diff, summary FROM patch_history WHERE ts BETWEEN ? AND ?",
+                "SELECT filename, description, roi_before, roi_after, errors_before, errors_after, roi_delta, complexity_before, complexity_after, complexity_delta, entropy_before, entropy_after, entropy_delta, predicted_roi, predicted_errors, reverted, trending_topic, ts, code_id, code_hash, source_bot, version, parent_patch_id, reason, trigger, diff, summary, outcome FROM patch_history WHERE ts BETWEEN ? AND ?",
                 (start.isoformat(), end.isoformat()),
             ).fetchall()
             patches = [PatchRecord(*row) for row in rows]
@@ -1873,7 +1879,7 @@ class PatchHistoryDB:
 
         def op(conn: sqlite3.Connection) -> List[PatchRecord]:
             rows = conn.execute(
-                "SELECT filename, description, roi_before, roi_after, errors_before, errors_after, roi_delta, complexity_before, complexity_after, complexity_delta, entropy_before, entropy_after, entropy_delta, predicted_roi, predicted_errors, reverted, trending_topic, ts, code_id, code_hash, source_bot, version, parent_patch_id, reason, trigger, diff, summary FROM patch_history WHERE code_hash=?",
+                "SELECT filename, description, roi_before, roi_after, errors_before, errors_after, roi_delta, complexity_before, complexity_after, complexity_delta, entropy_before, entropy_after, entropy_delta, predicted_roi, predicted_errors, reverted, trending_topic, ts, code_id, code_hash, source_bot, version, parent_patch_id, reason, trigger, diff, summary, outcome FROM patch_history WHERE code_hash=?",
                 (code_hash,),
             ).fetchall()
             patches = [PatchRecord(*row) for row in rows]
@@ -1893,7 +1899,7 @@ class PatchHistoryDB:
             base = (
                 "SELECT id, filename, description, roi_before, roi_after, errors_before, errors_after, "
                 "roi_delta, complexity_before, complexity_after, complexity_delta, entropy_before, entropy_after, entropy_delta, "
-                "predicted_roi, predicted_errors, reverted, trending_topic, ts, code_id, code_hash, source_bot, version, parent_patch_id, reason, trigger, diff, summary FROM patch_history ORDER BY id DESC"
+                "predicted_roi, predicted_errors, reverted, trending_topic, ts, code_id, code_hash, source_bot, version, parent_patch_id, reason, trigger, diff, summary, outcome FROM patch_history ORDER BY id DESC"
             )
             rows = conn.execute(base + (" LIMIT ?" if limit is not None else ""),
                                  (() if limit is None else (limit,))).fetchall()
@@ -1915,7 +1921,8 @@ class PatchHistoryDB:
 
         def op(conn: sqlite3.Connection) -> List[tuple[int, PatchRecord]]:
             query = (
-                "SELECT id, filename, description, roi_before, roi_after, errors_before, errors_after, roi_delta, complexity_before, complexity_after, complexity_delta, entropy_before, entropy_after, entropy_delta, predicted_roi, predicted_errors, reverted, trending_topic, ts, code_id, code_hash, source_bot, version, parent_patch_id, reason, trigger, diff, summary FROM patch_history"
+                "SELECT id, filename, description, roi_before, roi_after, errors_before, errors_after, roi_delta, complexity_before, complexity_after, complexity_delta, entropy_before, entropy_after, entropy_delta, predicted_roi, predicted_errors, reverted, trending_topic, ts, code_id, code_hash, source_bot, version, parent_patch_id, reason, trigger, diff, summary, outcome FROM patch_history"
+            )
             if index_hint:
                 query += f" INDEXED BY {index_hint}"
             query += " WHERE description LIKE ? COLLATE NOCASE OR filename LIKE ? COLLATE NOCASE"
@@ -1939,12 +1946,12 @@ class PatchHistoryDB:
             if ":" in vector:
                 origin, vid = vector.split(":", 1)
                 rows = conn.execute(
-                    "SELECT h.id, h.filename, h.description, h.roi_before, h.roi_after, h.errors_before, h.errors_after, h.roi_delta, h.complexity_before, h.complexity_after, h.complexity_delta, h.entropy_before, h.entropy_after, h.entropy_delta, h.predicted_roi, h.predicted_errors, h.reverted, h.trending_topic, h.ts, h.code_id, h.code_hash, h.source_bot, h.version, h.parent_patch_id, h.reason, h.trigger, h.diff, h.summary FROM patch_provenance p JOIN patch_history h ON h.id=p.patch_id WHERE p.origin=? AND p.vector_id=?",
+                    "SELECT h.id, h.filename, h.description, h.roi_before, h.roi_after, h.errors_before, h.errors_after, h.roi_delta, h.complexity_before, h.complexity_after, h.complexity_delta, h.entropy_before, h.entropy_after, h.entropy_delta, h.predicted_roi, h.predicted_errors, h.reverted, h.trending_topic, h.ts, h.code_id, h.code_hash, h.source_bot, h.version, h.parent_patch_id, h.reason, h.trigger, h.diff, h.summary, h.outcome FROM patch_provenance p JOIN patch_history h ON h.id=p.patch_id WHERE p.origin=? AND p.vector_id=?",
                     (origin, vid),
                 ).fetchall()
             else:
                 rows = conn.execute(
-                    "SELECT h.id, h.filename, h.description, h.roi_before, h.roi_after, h.errors_before, h.errors_after, h.roi_delta, h.complexity_before, h.complexity_after, h.complexity_delta, h.entropy_before, h.entropy_after, h.entropy_delta, h.predicted_roi, h.predicted_errors, h.reverted, h.trending_topic, h.ts, h.code_id, h.code_hash, h.source_bot, h.version, h.parent_patch_id, h.reason, h.trigger, h.diff, h.summary FROM patch_provenance p JOIN patch_history h ON h.id=p.patch_id WHERE p.vector_id=?",
+                    "SELECT h.id, h.filename, h.description, h.roi_before, h.roi_after, h.errors_before, h.errors_after, h.roi_delta, h.complexity_before, h.complexity_after, h.complexity_delta, h.entropy_before, h.entropy_after, h.entropy_delta, h.predicted_roi, h.predicted_errors, h.reverted, h.trending_topic, h.ts, h.code_id, h.code_hash, h.source_bot, h.version, h.parent_patch_id, h.reason, h.trigger, h.diff, h.summary, h.outcome FROM patch_provenance p JOIN patch_history h ON h.id=p.patch_id WHERE p.vector_id=?",
                     (vector,),
                 ).fetchall()
             return [(row[0], PatchRecord(*row[1:])) for row in rows]


### PR DESCRIPTION
## Summary
- track patch diff, summary and outcome in PatchRecord
- migrate `patch_history` table to include new outcome column
- update SQL queries and vector metrics recording with outcome field

## Testing
- `pytest` *(fails: KeyboardInterrupt, 206 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b27f00e10c832e8c8e256d4b72238b