### PR TITLE
feat: record patch outcome details

### DIFF
--- a/tests/integration/test_cognition_layer_feedback.py
+++ b/tests/integration/test_cognition_layer_feedback.py
@@ -19,6 +19,7 @@ class DummyROITracker:
 
     def update_db_metrics(self, metrics):  # pragma: no cover - interface only
         self.last_update = metrics
+
     def update(self, *_args, **_kwargs):  # pragma: no cover - interface stub
         return None
 
@@ -43,6 +44,13 @@ class DummyPatchLogger:
         contribution=None,
         retrieval_metadata=None,
         risk_callback=None,
+        lines_changed=None,
+        tests_passed=None,
+        enhancement_name=None,
+        timestamp=None,
+        diff=None,
+        summary=None,
+        outcome=None,
     ):
         if risk_callback is not None:
             risk_callback(self.risk_scores)

--- a/tests/test_cognition_layer.py
+++ b/tests/test_cognition_layer.py
@@ -1,4 +1,3 @@
-import types
 import pytest
 import time
 
@@ -118,6 +117,9 @@ class DummyPatchLogger:
         tests_passed=None,
         enhancement_name=None,
         timestamp=None,
+        diff=None,
+        summary=None,
+        outcome=None,
     ):
         self.calls.append(
             {
@@ -131,6 +133,9 @@ class DummyPatchLogger:
                 "tests_passed": tests_passed,
                 "enhancement_name": enhancement_name,
                 "timestamp": timestamp,
+                "diff": diff,
+                "summary": summary,
+                "outcome": outcome,
             }
         )
         origin_totals = {}
@@ -218,8 +223,8 @@ def test_query_and_record_patch_outcome_updates_metrics_and_ranking():
     assert ranker.rank_calls == 1
 
     rows = metrics.conn.execute(
-        "SELECT session_id, vector_id, contribution, win, regret, tokens, wall_time_ms, prompt_tokens, age FROM vector_metrics"
-        " WHERE event_type='retrieval' AND session_id=?",
+        "SELECT session_id, vector_id, contribution, win, regret, tokens, wall_time_ms, "
+        "prompt_tokens, age FROM vector_metrics WHERE event_type='retrieval' AND session_id=?",
         (sid,),
     ).fetchall()
     assert len(rows) >= 2
@@ -355,6 +360,13 @@ def test_build_context_and_feedback_updates_weights(monkeypatch):
             session_id="",
             contribution=None,
             retrieval_metadata=None,
+            lines_changed=None,
+            tests_passed=None,
+            enhancement_name=None,
+            timestamp=None,
+            diff=None,
+            summary=None,
+            outcome=None,
         ):
             super().track_contributors(
                 vector_ids,
@@ -363,6 +375,13 @@ def test_build_context_and_feedback_updates_weights(monkeypatch):
                 session_id=session_id,
                 contribution=contribution,
                 retrieval_metadata=retrieval_metadata,
+                lines_changed=lines_changed,
+                tests_passed=tests_passed,
+                enhancement_name=enhancement_name,
+                timestamp=timestamp,
+                diff=diff,
+                summary=summary,
+                outcome=outcome,
             )
             if not result:
                 scores = {}
@@ -381,7 +400,8 @@ def test_build_context_and_feedback_updates_weights(monkeypatch):
         roi_tracker=tracker,
     )
 
-    import sys, types
+    import sys
+    import types
 
     sys.modules.setdefault("roi_tracker", types.SimpleNamespace(ROITracker=DummyROITracker))
 

--- a/tests/test_cognition_layer_async.py
+++ b/tests/test_cognition_layer_async.py
@@ -5,7 +5,16 @@ from vector_service.cognition_layer import CognitionLayer
 
 
 class DummyContextBuilder:
-    def build_context(self, prompt, *, top_k=5, include_vectors=False, session_id="", return_stats=False, return_metadata=False):
+    def build_context(
+        self,
+        prompt,
+        *,
+        top_k=5,
+        include_vectors=False,
+        session_id="",
+        return_stats=False,
+        return_metadata=False,
+    ):
         vectors = [(prompt, "v1", 0.5)]
         stats = {"tokens": 1, "wall_time_ms": 1.0, "prompt_tokens": len(prompt.split())}
         meta = {
@@ -34,7 +43,16 @@ class DummyContextBuilder:
             return "ctx", stats
         return "ctx"
 
-    async def build_async(self, prompt, *, top_k=5, include_vectors=False, session_id="", return_stats=False, return_metadata=False):
+    async def build_async(
+        self,
+        prompt,
+        *,
+        top_k=5,
+        include_vectors=False,
+        session_id="",
+        return_stats=False,
+        return_metadata=False,
+    ):
         await asyncio.sleep(0.05)
         return self.build_context(
             prompt,
@@ -68,6 +86,9 @@ class DummyPatchLogger:
         tests_passed=None,
         enhancement_name=None,
         timestamp=None,
+        diff=None,
+        summary=None,
+        outcome=None,
     ):
         await asyncio.sleep(0.05)
         self.sessions.append(
@@ -103,6 +124,7 @@ def test_concurrent_async_usage():
     )
 
     start = time.time()
+
     async def runner():
         return await asyncio.gather(
             _run_session(layer, "a"),

--- a/tests/test_cognition_layer_feedback.py
+++ b/tests/test_cognition_layer_feedback.py
@@ -123,6 +123,13 @@ class DummyPatchLogger:
         session_id="",
         contribution=None,
         retrieval_metadata=None,
+        lines_changed=None,
+        tests_passed=None,
+        enhancement_name=None,
+        timestamp=None,
+        diff=None,
+        summary=None,
+        outcome=None,
     ):
         self.calls.append(
             {
@@ -132,6 +139,13 @@ class DummyPatchLogger:
                 "session_id": session_id,
                 "contribution": contribution,
                 "retrieval_metadata": retrieval_metadata,
+                "lines_changed": lines_changed,
+                "tests_passed": tests_passed,
+                "enhancement_name": enhancement_name,
+                "timestamp": timestamp,
+                "diff": diff,
+                "summary": summary,
+                "outcome": outcome,
             }
         )
         origin_totals = {}

--- a/tests/test_record_patch_outcome_impl.py
+++ b/tests/test_record_patch_outcome_impl.py
@@ -63,6 +63,13 @@ class DualPatchLogger:
         session_id="",
         contribution=None,
         retrieval_metadata=None,
+        lines_changed=None,
+        tests_passed=None,
+        enhancement_name=None,
+        timestamp=None,
+        diff=None,
+        summary=None,
+        outcome=None,
     ):
         self.sync_calls.append(
             {
@@ -72,6 +79,13 @@ class DualPatchLogger:
                 "session_id": session_id,
                 "contribution": contribution,
                 "retrieval_metadata": retrieval_metadata,
+                "lines_changed": lines_changed,
+                "tests_passed": tests_passed,
+                "enhancement_name": enhancement_name,
+                "timestamp": timestamp,
+                "diff": diff,
+                "summary": summary,
+                "outcome": outcome,
             }
         )
         return {}
@@ -85,6 +99,13 @@ class DualPatchLogger:
         session_id="",
         contribution=None,
         retrieval_metadata=None,
+        lines_changed=None,
+        tests_passed=None,
+        enhancement_name=None,
+        timestamp=None,
+        diff=None,
+        summary=None,
+        outcome=None,
     ):
         self.async_calls.append(
             {
@@ -94,6 +115,13 @@ class DualPatchLogger:
                 "session_id": session_id,
                 "contribution": contribution,
                 "retrieval_metadata": retrieval_metadata,
+                "lines_changed": lines_changed,
+                "tests_passed": tests_passed,
+                "enhancement_name": enhancement_name,
+                "timestamp": timestamp,
+                "diff": diff,
+                "summary": summary,
+                "outcome": outcome,
             }
         )
         return {}

--- a/tests/test_vector_service.py
+++ b/tests/test_vector_service.py
@@ -138,6 +138,7 @@ class DummyPatchDB:
         timestamp=None,
         diff=None,
         summary=None,
+        outcome=None,
     ):
         self.called = True
         self.args = (
@@ -153,6 +154,7 @@ class DummyPatchDB:
             timestamp,
             diff,
             summary,
+            outcome,
         )
 
 

--- a/vector_service/patch_logger.py
+++ b/vector_service/patch_logger.py
@@ -215,6 +215,7 @@ class PatchLogger:
         timestamp: float | None = None,
         diff: str | None = None,
         summary: str | None = None,
+        outcome: str | None = None,
     ) -> dict[str, float]:
         """Log patch outcome for vectors contributing to a patch.
 
@@ -366,6 +367,7 @@ class PatchLogger:
                             timestamp=timestamp,
                             diff=diff,
                             summary=summary,
+                            outcome=outcome,
                         )
                     except Exception:
                         logger.exception("patch_db.record_vector_metrics failed")
@@ -636,7 +638,7 @@ class PatchLogger:
                 logger.exception(
                     "UnifiedEventBus patch_logger outcome publish failed"
                 )
-        summary = {
+        summary_payload = {
             "patch_id": patch_id,
             "result": result,
             "roi_deltas": dict(roi_deltas),
@@ -644,15 +646,19 @@ class PatchLogger:
             "tests_passed": tests_passed,
             "enhancement_name": enhancement_name,
             "timestamp": timestamp,
+            "diff": diff,
+            "summary": summary,
+            "outcome": outcome,
+            "errors": errors,
         }
         if self.event_bus is not None:
             try:
-                self.event_bus.publish("patch:summary", summary)
+                self.event_bus.publish("patch:summary", summary_payload)
             except Exception:
                 logger.exception("event bus patch summary publish failed")
         elif UnifiedEventBus is not None:
             try:
-                UnifiedEventBus().publish("patch:summary", summary)
+                UnifiedEventBus().publish("patch:summary", summary_payload)
             except Exception:
                 logger.exception("UnifiedEventBus patch summary publish failed")
 
@@ -682,6 +688,7 @@ class PatchLogger:
         timestamp: float | None = None,
         diff: str | None = None,
         summary: str | None = None,
+        outcome: str | None = None,
     ) -> dict[str, float]:
         """Asynchronous wrapper for :meth:`track_contributors`."""
 
@@ -701,6 +708,7 @@ class PatchLogger:
             timestamp=timestamp,
             diff=diff,
             summary=summary,
+            outcome=outcome,
         )
 
 


### PR DESCRIPTION
## Summary
- add optional `outcome` parameter to PatchLogger APIs
- persist diff, summary, outcome, errors, and test results in patch summaries
- extend tests for new patch history fields

## Testing
- `pre-commit run --files vector_service/patch_logger.py tests/integration/test_cognition_layer_feedback.py tests/test_cognition_layer.py tests/test_cognition_layer_async.py tests/test_cognition_layer_feedback.py tests/test_patch_logger_metrics.py tests/test_record_patch_outcome_impl.py tests/test_vector_service.py`
- `pytest tests/test_patch_logger_metrics.py tests/test_cognition_layer_async.py tests/test_cognition_layer_feedback.py tests/integration/test_cognition_layer_feedback.py tests/test_record_patch_outcome_impl.py`
- `pytest` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_68b280ced2e0832e909df35640a80e1d