### PR TITLE
Convert self-learning coordination to async with state persistence

### DIFF
--- a/tests/test_curriculum_builder.py
+++ b/tests/test_curriculum_builder.py
@@ -6,15 +6,19 @@ sys.modules.setdefault("pulp", types.ModuleType("pulp"))
 sys.modules.setdefault("pandas", types.ModuleType("pandas"))
 sqlalchemy_mod = types.ModuleType("sqlalchemy")
 engine_mod = types.ModuleType("sqlalchemy.engine")
+
+
 class DummyEngine:
     pass
+
+
 engine_mod.Engine = DummyEngine
 sqlalchemy_mod.engine = engine_mod
 sys.modules.setdefault("sqlalchemy", sqlalchemy_mod)
 sys.modules.setdefault("sqlalchemy.engine", engine_mod)
 sys.modules.setdefault("prometheus_client", types.ModuleType("prometheus_client"))
 
-from menace.unified_event_bus import UnifiedEventBus
+from menace.unified_event_bus import UnifiedEventBus  # noqa: E402
 
 # Stub optional modules used by ErrorBot
 
@@ -23,6 +27,29 @@ stub_err.ErrorBot = object
 stub_err.ErrorDB = object
 sys.modules.setdefault("menace.error_bot", stub_err)
 
+# Stub MetricsDB to avoid heavy imports
+stub_db = types.ModuleType("menace.data_bot")
+
+
+class MetricsDB:  # noqa: D401 - simple stub
+    def __init__(self, *a, **k):
+        pass
+
+    def log_training_stat(self, *a, **k):
+        pass
+
+
+stub_db.MetricsDB = MetricsDB
+sys.modules.setdefault("menace.data_bot", stub_db)
+
+# Stub learning engine modules to avoid heavy imports
+ule = types.ModuleType("menace.unified_learning_engine")
+ule.UnifiedLearningEngine = object
+sys.modules.setdefault("menace.unified_learning_engine", ule)
+ale = types.ModuleType("menace.action_learning_engine")
+ale.ActionLearningEngine = object
+sys.modules.setdefault("menace.action_learning_engine", ale)
+
 jinja_mod = types.ModuleType("jinja2")
 jinja_mod.Template = type("T", (), {"render": lambda self, *a, **k: ""})
 sys.modules.setdefault("jinja2", jinja_mod)
@@ -30,8 +57,9 @@ yaml_mod = types.ModuleType("yaml")
 yaml_mod.safe_load = lambda *a, **k: {}
 sys.modules.setdefault("yaml", yaml_mod)
 
-from menace.curriculum_builder import CurriculumBuilder
-from menace.self_learning_coordinator import SelfLearningCoordinator
+from menace.curriculum_builder import CurriculumBuilder  # noqa: E402
+from menace.self_learning_coordinator import SelfLearningCoordinator  # noqa: E402
+import asyncio  # noqa: E402
 
 for mod in [
     "networkx",
@@ -43,6 +71,7 @@ for mod in [
 ]:
     sys.modules.pop(mod, None)
 
+
 class DummyEngine:
     def __init__(self):
         self.records = []
@@ -50,6 +79,7 @@ class DummyEngine:
     def partial_train(self, rec):
         self.records.append(rec)
         return True
+
 
 class DummyErrorBot:
     def __init__(self, summary):
@@ -70,5 +100,6 @@ def test_curriculum_generation_triggers_training(tmp_path):
     coord = SelfLearningCoordinator(bus, learning_engine=engine, curriculum_builder=builder)
     coord.start()
     builder.publish()
+    bus._loop.run_until_complete(asyncio.sleep(0.1))
     assert engine.records
     assert engine.records[0].actions == "io"


### PR DESCRIPTION
## Summary
- convert SelfLearningCoordinator handlers to async and subscribe via `subscribe_async`
- add persistent state for training counts and last evaluation time, reloading intervals from SandboxSettings at runtime
- update tests for new async behavior and state reloads

## Testing
- `pre-commit run --files self_learning_coordinator.py tests/test_self_learning_coordinator.py tests/test_curriculum_builder.py unit_tests/test_self_learning_coordinator.py`
- `pytest tests/test_self_learning_coordinator.py tests/test_curriculum_builder.py unit_tests/test_self_learning_coordinator.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2853e76c8832ea947d48528097a74