### PR TITLE
feat: add entry-point stub provider loading

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -210,6 +210,31 @@ class SandboxSettings(BaseSettings):
         env="SANDBOX_STUB_RETRY_MAX",
         description="Maximum delay for exponential backoff in seconds.",
     )
+    stub_providers: list[str] | None = Field(
+        None,
+        env="SANDBOX_STUB_PROVIDERS",
+        description=(
+            "Comma-separated stub provider names to enable. When unset, all "
+            "discovered providers are used."
+        ),
+    )
+    disabled_stub_providers: list[str] = Field(
+        default_factory=list,
+        env="SANDBOX_DISABLED_STUB_PROVIDERS",
+        description="Comma-separated stub provider names to disable.",
+    )
+    if PYDANTIC_V2:
+        @field_validator("stub_providers", "disabled_stub_providers", mode="before")
+        def _split_stub_providers(cls, v: Any) -> Any:
+            if isinstance(v, str):
+                return [s.strip() for s in v.split(",") if s.strip()]
+            return v
+    else:  # pragma: no cover - pydantic<2
+        @field_validator("stub_providers", "disabled_stub_providers", pre=True)
+        def _split_stub_providers(cls, v: Any) -> Any:  # type: ignore[override]
+            if isinstance(v, str):
+                return [s.strip() for s in v.split(",") if s.strip()]
+            return v
     meta_planning_interval: int = Field(
         10,
         env="META_PLANNING_INTERVAL",

--- a/tests/test_stub_providers.py
+++ b/tests/test_stub_providers.py
@@ -1,0 +1,81 @@
+import sys
+from pathlib import Path
+
+import importlib.metadata as metadata
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import os
+os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
+sys.modules.pop("sandbox_runner", None)
+
+import sandbox_runner.stub_providers as sp
+from sandbox_settings import SandboxSettings
+
+
+def test_discover_stub_providers_settings(monkeypatch):
+    def prov_a(stubs, ctx):
+        return stubs + [{"a": 1}]
+
+    def prov_b(stubs, ctx):
+        return stubs + [{"b": 2}]
+
+    class EP:
+        def __init__(self, name, func):
+            self.name = name
+            self._func = func
+
+        def load(self):  # pragma: no cover - trivial
+            return self._func
+
+    def fake_entry_points(*, group):
+        if group == sp.STUB_PROVIDER_GROUP:
+            return [EP("a", prov_a), EP("b", prov_b)]
+        return []
+
+    monkeypatch.setattr(metadata, "entry_points", fake_entry_points)
+
+    settings = SandboxSettings(stub_providers=["a"])
+    providers = sp.discover_stub_providers(settings)
+    assert providers == [prov_a]
+
+    settings = SandboxSettings(disabled_stub_providers=["a"])
+    providers = sp.discover_stub_providers(settings)
+    assert providers == [prov_b]
+
+
+def test_invalid_and_failing_providers(monkeypatch):
+    def good(stubs, ctx):
+        return stubs
+
+    def bad(stubs):  # missing ctx argument
+        return stubs
+
+    class GoodEP:
+        name = "good"
+
+        def load(self):  # pragma: no cover - trivial
+            return good
+
+    class BadEP:
+        name = "bad"
+
+        def load(self):  # pragma: no cover - trivial
+            return bad
+
+    class FailEP:
+        name = "fail"
+
+        def load(self):  # pragma: no cover - trivial
+            raise RuntimeError("boom")
+
+    def fake_entry_points(*, group):
+        if group == sp.STUB_PROVIDER_GROUP:
+            return [GoodEP(), BadEP(), FailEP()]
+        return []
+
+    monkeypatch.setattr(metadata, "entry_points", fake_entry_points)
+    providers = sp.discover_stub_providers()
+    assert providers == [good]


### PR DESCRIPTION
## Summary
- load stub providers via entry-point namespace and validate signatures
- add settings to enable or disable stub provider plugins
- cover entry-point discovery with tests

## Testing
- `python -m pre_commit run --files sandbox_runner/stub_providers.py sandbox_settings.py tests/test_stub_providers.py`
- `pytest tests/test_stub_providers.py tests/test_input_stub_generation.py`


------
https://chatgpt.com/codex/tasks/task_e_68b28b45faa4832e82fcf3c0770e35fd