### PR TITLE
feat: add qdrant and chroma vector store backends

### DIFF
--- a/tests/test_shared_vector_interface.py
+++ b/tests/test_shared_vector_interface.py
@@ -56,6 +56,24 @@ def test_gpt_memory_routes_through_vector_service():
             return [self._Vec([0.25]) for _ in texts]
 
     svc = SharedVectorService(DummyEmbedder(), vector_store=store)
+
+    # ``gpt_memory`` depends on modules with package-relative imports which are
+    # not available in the test environment.  Provide lightweight stubs so the
+    # import succeeds without pulling in the heavy dependencies.
+    import sys
+    sys.modules.setdefault(
+        "data_bot",
+        types.SimpleNamespace(MetricsDB=object),
+    )
+    sys.modules.setdefault(
+        "scope_utils",
+        types.SimpleNamespace(
+            Scope=object,
+            build_scope_clause=lambda *a, **k: "",
+            apply_scope=lambda *a, **k: None,
+        ),
+    )
+
     from gpt_memory import GPTMemoryManager
     mem = GPTMemoryManager(db_path=':memory:', vector_service=svc)
     mem.log_interaction('hi','there')

--- a/tests/test_vector_store_qdrant_chroma.py
+++ b/tests/test_vector_store_qdrant_chroma.py
@@ -1,0 +1,28 @@
+import pytest
+import vector_service.vector_store as vs
+
+
+@pytest.mark.parametrize(
+    "backend,cls,mod_name",
+    [
+        ("qdrant", vs.QdrantVectorStore, "qdrant_client"),
+        ("chroma", vs.ChromaVectorStore, "chromadb"),
+    ],
+)
+def test_vector_store_roundtrip(tmp_path, backend, cls, mod_name):
+    pytest.importorskip(mod_name)
+    store_path = tmp_path / backend
+    store = vs.create_vector_store(3, store_path, backend=backend)
+    assert isinstance(store, cls)
+    store.add("test", "1", [0.0, 0.0, 1.0])
+    res = store.query([0.0, 0.0, 1.0], top_k=1)
+    assert res and res[0][0] == "1"
+    # ensure data persists via load
+    if hasattr(store, "client"):
+        try:
+            store.client.close()
+        except Exception:
+            pass
+    store2 = cls(dim=3, path=store_path)
+    res2 = store2.query([0.0, 0.0, 1.0], top_k=1)
+    assert res2 and res2[0][0] == "1"


### PR DESCRIPTION
## Summary
- support Qdrant and Chroma vector stores alongside Faiss and Annoy
- choose vector store backend via configuration
- add tests for new backends and gpt_memory integration

## Testing
- `pytest -q tests/test_shared_vector_interface.py tests/test_vector_store_qdrant_chroma.py`
- `pytest -q tests/test_vector_store_backend.py`


------
https://chatgpt.com/codex/tasks/task_e_68b28bd841d0832ebbb51053c02dafce