### PR TITLE
Enhance patch logging and ROI tracking

### DIFF
--- a/tests/test_patch_logger_metrics.py
+++ b/tests/test_patch_logger_metrics.py
@@ -95,6 +95,7 @@ class DummyPatchDB:
         tests_passed=None,
         enhancement_name=None,
         timestamp=None,
+        roi_deltas=None,
         diff=None,
         summary=None,
         outcome=None,
@@ -110,6 +111,7 @@ class DummyPatchDB:
             "tests_passed": tests_passed,
             "enhancement_name": enhancement_name,
             "timestamp": timestamp,
+            "roi_deltas": roi_deltas,
             "diff": diff,
             "summary": summary,
             "outcome": outcome,
@@ -206,6 +208,7 @@ def test_track_contributors_forwards_contribution_patch_db(monkeypatch):
     assert pdb.kwargs["tests_passed"] is True
     assert pdb.kwargs["enhancement_name"] == "feat"
     assert pdb.kwargs["timestamp"] == 123.0
+    assert pdb.kwargs["roi_deltas"] == {}
     assert pdb.kwargs["diff"] == "diff"
     assert pdb.kwargs["summary"] == "summary"
     assert pdb.kwargs["outcome"] == "failed"

--- a/tests/test_vector_service.py
+++ b/tests/test_vector_service.py
@@ -122,12 +122,13 @@ class DummyVectorMetricsDB:
 class DummyPatchDB:
     def __init__(self):
         self.called = False
-        self.args = None
+        self.kwargs = None
 
     def record_vector_metrics(
         self,
         session_id,
         pairs,
+        *,
         patch_id,
         contribution,
         win,
@@ -136,26 +137,28 @@ class DummyPatchDB:
         tests_passed=None,
         enhancement_name=None,
         timestamp=None,
+        roi_deltas=None,
         diff=None,
         summary=None,
         outcome=None,
     ):
         self.called = True
-        self.args = (
-            session_id,
-            pairs,
-            patch_id,
-            contribution,
-            win,
-            regret,
-            lines_changed,
-            tests_passed,
-            enhancement_name,
-            timestamp,
-            diff,
-            summary,
-            outcome,
-        )
+        self.kwargs = {
+            "session_id": session_id,
+            "pairs": pairs,
+            "patch_id": patch_id,
+            "contribution": contribution,
+            "win": win,
+            "regret": regret,
+            "lines_changed": lines_changed,
+            "tests_passed": tests_passed,
+            "enhancement_name": enhancement_name,
+            "timestamp": timestamp,
+            "roi_deltas": roi_deltas,
+            "diff": diff,
+            "summary": summary,
+            "outcome": outcome,
+        }
 
 
 def test_patch_logger_metrics_db_success():
@@ -178,7 +181,7 @@ def test_patch_logger_patch_db_success():
     pl = PatchLogger(patch_db=pdb)
     pl.track_contributors(["a:b"], True, patch_id="7", session_id="sid")
     assert pdb.called
-    assert pdb.args[2] == 7
+    assert pdb.kwargs["patch_id"] == 7
 
 
 def test_patch_logger_metrics_db_failure_ignored():


### PR DESCRIPTION
## Summary
- track contributor ROI deltas and forward patch metadata to PatchHistoryDB with detailed error handling
- persist per-patch ROI delta history and expose `get_patch_summary` for auditing
- update tests for new patch metrics flow

## Testing
- `pytest tests/test_patch_logger_metrics.py::test_track_contributors_forwards_contribution_patch_db -q`
- `pytest tests/test_vector_service.py::test_patch_logger_patch_db_success -q`
- `pytest tests/test_retrieval_redaction.py::test_retriever_redacts_and_logs -q`


------
https://chatgpt.com/codex/tasks/task_e_68b290ed9474832eafdd5cc01c51f409