### PR TITLE
Refactor self test container handling and scheduling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -61,6 +61,8 @@ colorama==0.4.6
     # via radon
 contourpy==1.3.2
     # via matplotlib
+croniter==6.0.0
+    # via menace (pyproject.toml)
 cryptography==45.0.5
     # via menace (pyproject.toml)
 cycler==0.12.1

--- a/tests/test_self_test_service_cleanup.py
+++ b/tests/test_self_test_service_cleanup.py
@@ -55,6 +55,10 @@ sys.modules.setdefault("pydantic.dataclasses", pydantic_dc)
 def load_self_test_service():
     if 'menace' in sys.modules:
         del sys.modules['menace']
+    sys.modules.setdefault('data_bot', types.SimpleNamespace(DataBot=object))
+    sys.modules.setdefault('error_bot', types.SimpleNamespace(ErrorDB=object))
+    sys.modules.setdefault('error_logger', types.SimpleNamespace(ErrorLogger=object))
+    sys.modules.setdefault('knowledge_graph', types.SimpleNamespace(KnowledgeGraph=object))
     pkg = types.ModuleType('menace')
     pkg.__path__ = [str(ROOT)]
     pkg.__spec__ = importlib.machinery.ModuleSpec('menace', loader=None, is_package=True)

--- a/tests/test_self_test_service_lock_stress.py
+++ b/tests/test_self_test_service_lock_stress.py
@@ -52,6 +52,10 @@ sys.modules.setdefault("orphan_discovery", orphan_stub)
 def load_self_test_service():
     if "menace" in sys.modules:
         del sys.modules["menace"]
+    sys.modules.setdefault('data_bot', types.SimpleNamespace(DataBot=object))
+    sys.modules.setdefault('error_bot', types.SimpleNamespace(ErrorDB=object))
+    sys.modules.setdefault('error_logger', types.SimpleNamespace(ErrorLogger=object))
+    sys.modules.setdefault('knowledge_graph', types.SimpleNamespace(KnowledgeGraph=object))
     pkg = types.ModuleType("menace")
     pkg.__path__ = [str(ROOT)]
     pkg.__spec__ = importlib.machinery.ModuleSpec("menace", loader=None, is_package=True)
@@ -67,7 +71,6 @@ def load_self_test_service():
 
 sts = load_self_test_service()
 SelfTestService = sts.SelfTestService
-_container_lock = sts._container_lock
 
 
 def test_cleanup_lock_stress(monkeypatch):
@@ -126,4 +129,5 @@ def test_cleanup_lock_stress(monkeypatch):
     asyncio.run(run())
     assert max_concurrent == 1
     assert calls == 3
-    assert not _container_lock.locked()
+    assert not svc1._container_lock.locked()
+    assert not svc2._container_lock.locked()

--- a/tests/test_self_test_service_locking.py
+++ b/tests/test_self_test_service_locking.py
@@ -58,6 +58,10 @@ ROOT = Path(__file__).resolve().parents[1]
 def load_self_test_service():
     if 'menace' in sys.modules:
         del sys.modules['menace']
+    sys.modules.setdefault('data_bot', types.SimpleNamespace(DataBot=object))
+    sys.modules.setdefault('error_bot', types.SimpleNamespace(ErrorDB=object))
+    sys.modules.setdefault('error_logger', types.SimpleNamespace(ErrorLogger=object))
+    sys.modules.setdefault('knowledge_graph', types.SimpleNamespace(KnowledgeGraph=object))
     pkg = types.ModuleType('menace')
     pkg.__path__ = [str(ROOT)]
     pkg.__spec__ = importlib.machinery.ModuleSpec('menace', loader=None, is_package=True)
@@ -136,7 +140,8 @@ def test_container_locking(monkeypatch):
         await asyncio.gather(run_svc(svc1), run_svc(svc2))
 
     asyncio.run(main())
-    assert not sts._container_lock.locked()
+    assert not svc1._container_lock.locked()
+    assert not svc2._container_lock.locked()
 
 
 def test_container_retries(monkeypatch):


### PR DESCRIPTION
## Summary
- manage self-test containers with per-service locks and tracked IDs
- support cron-style scheduling and improved container timeout logging
- add croniter dependency and adjust tests for new locking semantics

## Testing
- `pytest tests/test_self_test_service_locking.py tests/test_self_test_service_lock_release.py tests/test_self_test_service_lock_stress.py tests/test_self_test_service_cleanup.py` *(fails: ImportError: cannot import name 'RAISE_ERRORS')*

------
https://chatgpt.com/codex/tasks/task_e_68b28fb8c2dc832e8826e352d959b7e4