### PR TITLE
Use SandboxSettings for recovery config and label restart metrics

### DIFF
--- a/metrics_exporter.py
+++ b/metrics_exporter.py
@@ -678,7 +678,9 @@ isolated_modules_integrated_total = Gauge(
     "Total number of isolated modules successfully integrated",
 )
 sandbox_restart_total = Gauge(
-    "sandbox_restart_total", "Total number of sandbox restarts"
+    "sandbox_restart_total",
+    "Total number of sandbox restarts",
+    labelnames=["service", "reason"],
 )
 sandbox_last_failure_ts = Gauge(
     "sandbox_last_failure_ts", "Timestamp of last sandbox failure"

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -177,6 +177,26 @@ class SandboxSettings(BaseSettings):
         env="SANDBOX_CENTRAL_LOGGING",
         description="Enable centralised logging output.",
     )
+    sandbox_retry_delay: float = Field(
+        1.0,
+        env="SANDBOX_RETRY_DELAY",
+        description="Initial delay between restart attempts in seconds.",
+    )
+    sandbox_max_retries: int | None = Field(
+        None,
+        env="SANDBOX_MAX_RETRIES",
+        description="Maximum number of restart attempts before giving up.",
+    )
+    sandbox_circuit_max_failures: int = Field(
+        5,
+        env="SANDBOX_CIRCUIT_MAX_FAILURES",
+        description="Consecutive failures allowed before opening the circuit breaker.",
+    )
+    sandbox_circuit_reset_timeout: float = Field(
+        60.0,
+        env="SANDBOX_CIRCUIT_RESET_TIMEOUT",
+        description="Time in seconds before a tripped circuit resets.",
+    )
     openai_api_key: str | None = Field(
         None, env="OPENAI_API_KEY", description="API key for OpenAI access."
     )


### PR DESCRIPTION
## Summary
- Read retry delays, retry counts, and circuit breaker thresholds from `SandboxSettings`
- Record restart metrics with service and reason labels via `metrics_exporter`
- Expose new sandbox recovery options in settings

## Testing
- `pytest tests/test_sandbox_recovery_manager.py -q`
- `pytest unit_tests/test_settings_env_overrides.py -q` *(fails: ImportError: attempted relative import with no known parent package)*


------
https://chatgpt.com/codex/tasks/task_e_68b292c2cc54832eb475e5ff3399aefa