### PR TITLE
feat: async relevancy telemetry tracking

### DIFF
--- a/tests/test_async_track_usage_events.py
+++ b/tests/test_async_track_usage_events.py
@@ -1,0 +1,40 @@
+import importlib.util
+import sys
+import types
+import time
+from pathlib import Path
+
+
+def test_async_track_usage_emits(monkeypatch):
+    pkg = types.ModuleType("sandbox_runner")
+    pkg.__path__ = []  # ensure submodules cannot be resolved
+    monkeypatch.setitem(sys.modules, "sandbox_runner", pkg)
+
+    events: list[tuple[str, str, float]] = []
+
+    def track_usage(module: str, impact: float) -> None:
+        events.append(("track", module, impact))
+
+    def record_output_impact(module: str, impact: float) -> None:
+        events.append(("impact", module, impact))
+
+    rr = types.ModuleType("relevancy_radar")
+    rr.track_usage = track_usage
+    rr.record_output_impact = record_output_impact
+    monkeypatch.setitem(sys.modules, "relevancy_radar", rr)
+
+    path = Path(__file__).resolve().parent.parent / "sandbox_runner" / "meta_logger.py"
+    spec = importlib.util.spec_from_file_location("sandbox_runner.meta_logger", path)
+    mod = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "sandbox_runner.meta_logger", mod)
+    spec.loader.exec_module(mod)
+
+    mod._async_track_usage("foo", 1.0)
+
+    for _ in range(100):  # wait for background thread
+        if len(events) >= 2:
+            break
+        time.sleep(0.01)
+
+    assert ("track", "foo", 1.0) in events
+    assert ("impact", "foo", 1.0) in events

--- a/tests/test_async_track_usage_warning.py
+++ b/tests/test_async_track_usage_warning.py
@@ -9,12 +9,13 @@ def test_async_track_usage_warns_once(monkeypatch, caplog):
     monkeypatch.delenv("SANDBOX_SUPPRESS_TELEMETRY_WARNING", raising=False)
     pkg = types.ModuleType("sandbox_runner")
     pkg.__path__ = []  # empty so submodules cannot be resolved
-    sys.modules["sandbox_runner"] = pkg
+    monkeypatch.setitem(sys.modules, "sandbox_runner", pkg)
+    monkeypatch.setitem(sys.modules, "relevancy_radar", types.ModuleType("relevancy_radar"))
 
     path = Path(__file__).resolve().parent.parent / "sandbox_runner" / "meta_logger.py"
     spec = importlib.util.spec_from_file_location("sandbox_runner.meta_logger", path)
     mod = importlib.util.module_from_spec(spec)
-    sys.modules["sandbox_runner.meta_logger"] = mod
+    monkeypatch.setitem(sys.modules, "sandbox_runner.meta_logger", mod)
     with caplog.at_level(logging.WARNING):
         spec.loader.exec_module(mod)
         mod._async_track_usage("a")


### PR DESCRIPTION
## Summary
- add async fallback for relevancy radar usage tracking
- log telemetry exceptions and spawn thread or task
- test module usage events tracking

## Testing
- `pre-commit run --files sandbox_runner/meta_logger.py tests/test_async_track_usage_events.py tests/test_async_track_usage_warning.py`
- `pytest tests/test_async_track_usage_events.py tests/test_async_track_usage_warning.py`
- `pytest tests/test_relevancy_output_impact.py` *(fails: ModuleNotFoundError: No module named 'sandbox_runner.cycle')*


------
https://chatgpt.com/codex/tasks/task_e_68b295f29064832ea38e3cadb56f8bcf