### PR TITLE
feat: inject summariser and cache patch summaries

### DIFF
--- a/config.py
+++ b/config.py
@@ -206,6 +206,10 @@ class ContextBuilderConfig(BaseModel):
             " if set to False or the dependency is missing, a regex approximation is used."
         ),
     )
+    max_diff_lines: int = Field(
+        200,
+        description="Truncate diffs to this many lines before summarisation",
+    )
     similarity_metric: str = Field(
         "cosine",
         description="Similarity metric for patch examples. Options: cosine or inner_product",

--- a/tests/test_context_builder_cache.py
+++ b/tests/test_context_builder_cache.py
@@ -1,0 +1,66 @@
+from vector_service import ContextBuilder
+
+class DummyPatchSafety:
+    def __init__(self):
+        self.max_alert_severity = 1.0
+        self.max_alerts = 5
+        self.license_denylist = set()
+    def evaluate(self, *_, **__):
+        return True, 0.0, {}
+
+
+def test_context_respects_max_tokens():
+    class DummyRetriever:
+        def search(self, query, top_k=5, **_):
+            text = "word " * 100
+            return [
+                {
+                    "origin_db": "error",
+                    "record_id": 1,
+                    "score": 1.0,
+                    "metadata": {"id": 1, "message": text, "frequency": 1},
+                }
+            ]
+
+    builder = ContextBuilder(
+        retriever=DummyRetriever(),
+        patch_safety=DummyPatchSafety(),
+        max_tokens=20,
+    )
+    _, stats = builder.build_context("q", return_stats=True)
+    assert stats["tokens"] <= 20
+
+
+def test_summary_cached():
+    calls = {"count": 0}
+
+    def summarise(text: str) -> str:
+        calls["count"] += 1
+        return text[:10]
+
+    class DummyRetriever:
+        def search(self, query, top_k=5, **_):
+            meta = {
+                "id": 1,
+                "summary": "a" * 50,
+                "diff": "line1\nline2\nline3",
+                "patch_id": 42,
+            }
+            return [
+                {
+                    "origin_db": "patch",
+                    "record_id": 1,
+                    "score": 1.0,
+                    "metadata": meta,
+                }
+            ]
+
+    builder = ContextBuilder(
+        retriever=DummyRetriever(),
+        summariser=summarise,
+        patch_safety=DummyPatchSafety(),
+    )
+    builder.build_context("q")
+    first_calls = calls["count"]
+    builder.build_context("q")
+    assert calls["count"] == first_calls


### PR DESCRIPTION
## Summary
- allow ContextBuilder to accept pluggable summariser and cache patch summaries
- truncate large diffs and require tiktoken for precise token counts
- add tests for token budget handling and summary caching

## Testing
- `pytest tests/test_context_builder_cache.py -q`
- `pytest tests/test_context_builder.py tests/test_context_builder_cache.py -q` *(fails: No module named 'sandbox_runner.workflow_sandbox_runner')*


------
https://chatgpt.com/codex/tasks/task_e_68b2983e88e8832e89ea31e031eb7513