### PR TITLE
Make entropy threshold configurable

### DIFF
--- a/docs/sandbox_config.sample.yaml
+++ b/docs/sandbox_config.sample.yaml
@@ -1,4 +1,4 @@
-meta_entropy_threshold: null
+meta_entropy_threshold: 0.2
 roi:
   threshold: null
   confidence: null

--- a/docs/sandbox_settings.md
+++ b/docs/sandbox_settings.md
@@ -18,7 +18,7 @@ settings = load_sandbox_settings("docs/sandbox_config.sample.yaml")
 - `meta_mutation_rate`: `1.0`
 - `meta_roi_weight`: `1.0`
 - `meta_domain_penalty`: `1.0`
-- `meta_entropy_threshold`: `null`
+- `meta_entropy_threshold`: `0.2`
 
 ## ROI defaults
 - `threshold`: `null`

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -291,9 +291,12 @@ class SandboxSettings(BaseSettings):
         description="Penalty for domain transitions in meta planning.",
     )
     meta_entropy_threshold: float | None = Field(
-        None,
+        0.2,
         env="META_ENTROPY_THRESHOLD",
-        description="Maximum allowed workflow entropy when recording improvements.",
+        description=(
+            "Maximum allowed workflow entropy when recording improvements."
+            " Defaults to 0.2 when unset."
+        ),
     )
     workflows_db: str = Field(
         "workflows.db",

--- a/tests/integration/test_full_self_improvement_cycle.py
+++ b/tests/integration/test_full_self_improvement_cycle.py
@@ -34,6 +34,8 @@ def _load_meta_planning():
         "Any": Any,
         "Callable": Callable,
         "Mapping": Mapping,
+        "DEFAULT_ENTROPY_THRESHOLD": 0.2,
+        "load_sandbox_settings": lambda: None,
     }
     exec(compile(module, "<ast>", "exec"), ns)
     return ns
@@ -103,7 +105,7 @@ def test_full_self_improvement_cycle(monkeypatch):
                 warning=lambda *a, **k: None, exception=lambda *a, **k: None
             ),
             "log_record": lambda **kw: kw,
-            "SandboxSettings": lambda: types.SimpleNamespace(
+            "load_sandbox_settings": lambda: types.SimpleNamespace(
                 meta_mutation_rate=None,
                 meta_roi_weight=None,
                 meta_domain_penalty=None,

--- a/tests/test_meta_planning_entropy.py
+++ b/tests/test_meta_planning_entropy.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 from pathlib import Path
 import ast
+import pytest
+from typing import Any, Mapping
 
 
 src_path = Path(__file__).resolve().parents[1] / "self_improvement" / "meta_planning.py"
@@ -8,9 +10,9 @@ tree = ast.parse(src_path.read_text(), filename=str(src_path))
 ns: dict[str, object] = {}
 ns["SandboxSettings"] = object
 ns["WorkflowStabilityDB"] = object
-from typing import Any, Mapping
 ns["Any"] = Any
 ns["Mapping"] = Mapping
+ns["DEFAULT_ENTROPY_THRESHOLD"] = 0.2
 for node in tree.body:
     if isinstance(node, ast.FunctionDef) and node.name in {
         "_get_entropy_threshold",
@@ -23,20 +25,21 @@ _get_entropy_threshold = ns["_get_entropy_threshold"]
 _should_encode = ns["_should_encode"]
 
 
-def test_threshold_from_settings_overrides_history():
-    settings = SimpleNamespace(meta_entropy_threshold=0.1)
-    db = SimpleNamespace(data={"a": {"entropy": 0.5}})
-    assert _get_entropy_threshold(settings, db) == 0.1
-
-
-def test_threshold_derived_from_history_when_not_set():
-    settings = SimpleNamespace(meta_entropy_threshold=None)
-    db = SimpleNamespace(data={"a": {"entropy": 0.1}, "b": {"entropy": 0.4}})
-    assert _get_entropy_threshold(settings, db) == 0.4
+@pytest.mark.parametrize(
+    "cfg_value, db_data, expected",
+    [
+        (0.1, {"a": {"entropy": 0.5}}, 0.1),
+        (None, {"a": {"entropy": 0.1}, "b": {"entropy": 0.4}}, 0.4),
+        (None, {}, 0.2),
+    ],
+)
+def test_get_entropy_threshold(cfg_value, db_data, expected):
+    settings = SimpleNamespace(meta_entropy_threshold=cfg_value)
+    db = SimpleNamespace(data=db_data)
+    assert _get_entropy_threshold(settings, db) == expected
 
 
 def test_should_encode_respects_threshold():
     record = {"roi_gain": 0.2, "entropy": 0.25}
     assert _should_encode(record, entropy_threshold=0.3)
     assert not _should_encode(record, entropy_threshold=0.2)
-


### PR DESCRIPTION
## Summary
- derive meta entropy threshold from sandbox settings with 0.2 default
- document meta_entropy_threshold in settings and sample config
- parameterize entropy threshold in meta-planning tests

## Testing
- `python -m pre_commit run --files self_improvement/meta_planning.py sandbox_settings.py docs/sandbox_config.sample.yaml docs/sandbox_settings.md tests/test_meta_planning_entropy.py unit_tests/test_meta_planning.py tests/integration/test_full_self_improvement_cycle.py`
- `pytest tests/test_meta_planning_entropy.py unit_tests/test_meta_planning.py tests/integration/test_full_self_improvement_cycle.py`

------
https://chatgpt.com/codex/tasks/task_e_68b29836c3e4832e86fdc28ccd8f4cbb