### PR TITLE
Add retryable stub for optional dependency loading

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -197,6 +197,11 @@ class SandboxSettings(BaseSettings):
         env="SANDBOX_CIRCUIT_RESET_TIMEOUT",
         description="Time in seconds before a tripped circuit resets.",
     )
+    retry_optional_dependencies: bool = Field(
+        False,
+        env="RETRY_OPTIONAL_DEPENDENCIES",
+        description="Retry loading optional modules instead of using a stub.",
+    )
     openai_api_key: str | None = Field(
         None, env="OPENAI_API_KEY", description="API key for OpenAI access."
     )

--- a/unit_tests/test_self_improvement_engine_utils.py
+++ b/unit_tests/test_self_improvement_engine_utils.py
@@ -9,6 +9,7 @@ import types
 import asyncio
 import random
 import inspect
+from dataclasses import dataclass
 
 import pytest
 
@@ -20,6 +21,13 @@ def _load_utils():
     nodes = [n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name in wanted]
     module = ast.Module(nodes, type_ignores=[])
     counter = types.SimpleNamespace(labels=lambda **k: types.SimpleNamespace(inc=lambda: None))
+
+    class _StubSettings:
+        def __init__(self) -> None:
+            self.retry_optional_dependencies = False
+            self.sandbox_retry_delay = 0
+            self.sandbox_max_retries = 0
+
     ns = {
         "importlib": importlib,
         "logging": logging,
@@ -31,16 +39,19 @@ def _load_utils():
         "Any": Any,
         "Awaitable": Awaitable,
         "self_improvement_failure_total": counter,
+        "SandboxSettings": _StubSettings,
+        "dataclass": dataclass,
     }
     exec(compile(module, "<ast>", "exec"), ns)
     return ns
 
 
-def test_missing_dependency_raises_runtime_error():
+def test_missing_dependency_returns_stub():
     utils = _load_utils()
     with patch("importlib.import_module", side_effect=ModuleNotFoundError):
+        fn = utils["_load_callable"]("mod", "attr")
         with pytest.raises(RuntimeError):
-            utils["_load_callable"]("mod", "attr")
+            fn()
 
 
 def test_retry_succeeds_after_transient_failure():
@@ -56,6 +67,28 @@ def test_retry_succeeds_after_transient_failure():
 
     assert utils["_call_with_retries"](flaky, retries=3) == "ok"
     assert attempts["count"] == 2
+
+
+def test_load_callable_retry_when_enabled():
+    utils = _load_utils()
+    utils["time"].sleep = lambda *a, **k: None
+
+    attempts = {"count": 0}
+
+    def side_effect(name):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise ModuleNotFoundError
+        return types.SimpleNamespace(attr=lambda: "ok")
+
+    with patch("importlib.import_module", side_effect=side_effect):
+        utils["SandboxSettings"] = lambda: types.SimpleNamespace(
+            retry_optional_dependencies=True,
+            sandbox_retry_delay=0,
+            sandbox_max_retries=3,
+        )
+        fn = utils["_load_callable"]("mod", "attr")
+        assert fn() == "ok"
 
 
 def test_retry_fails_after_all_attempts():
@@ -90,4 +123,3 @@ def test_async_retry_and_backoff_features():
     )
     assert attempts["count"] == 2
     assert sleeps == [1.5]
-


### PR DESCRIPTION
## Summary
- return stub with structured error when optional modules missing in `_load_callable`
- add `retry_optional_dependencies` setting to control retry/backoff
- test missing and delayed dependencies in self-improvement utils

## Testing
- `pre-commit run --files self_improvement/utils.py sandbox_settings.py unit_tests/test_self_improvement_utils.py unit_tests/test_self_improvement_engine_utils.py`
- `pytest unit_tests/test_self_improvement_utils.py unit_tests/test_self_improvement_engine_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68b29c1b582c832e99160ac223620d03