### PR TITLE
Track context token usage for patches

### DIFF
--- a/code_database.py
+++ b/code_database.py
@@ -1060,6 +1060,8 @@ class PatchHistoryDB:
                 outcome TEXT,
                 lines_changed INTEGER DEFAULT 0,
                 tests_passed INTEGER DEFAULT 0,
+                context_tokens INTEGER DEFAULT 0,
+                patch_difficulty INTEGER DEFAULT 0,
                 enhancement_name TEXT,
                 timestamp REAL,
                 roi_deltas TEXT,
@@ -1159,6 +1161,8 @@ class PatchHistoryDB:
             "outcome": "ALTER TABLE patch_history ADD COLUMN outcome TEXT",
             "lines_changed": "ALTER TABLE patch_history ADD COLUMN lines_changed INTEGER DEFAULT 0",
             "tests_passed": "ALTER TABLE patch_history ADD COLUMN tests_passed INTEGER DEFAULT 0",
+            "context_tokens": "ALTER TABLE patch_history ADD COLUMN context_tokens INTEGER DEFAULT 0",
+            "patch_difficulty": "ALTER TABLE patch_history ADD COLUMN patch_difficulty INTEGER DEFAULT 0",
             "enhancement_name": "ALTER TABLE patch_history ADD COLUMN enhancement_name TEXT",
             "timestamp": "ALTER TABLE patch_history ADD COLUMN timestamp REAL",
             "roi_deltas": "ALTER TABLE patch_history ADD COLUMN roi_deltas TEXT",
@@ -1486,6 +1490,8 @@ class PatchHistoryDB:
         regret: bool,
         lines_changed: int | None = None,
         tests_passed: bool | None = None,
+        context_tokens: int | None = None,
+        patch_difficulty: int | None = None,
         enhancement_name: str | None = None,
         timestamp: float | None = None,
         roi_deltas: Mapping[str, float] | None = None,
@@ -1525,10 +1531,12 @@ class PatchHistoryDB:
                 except Exception:
                     logger.exception("failed to serialise errors")
             conn.execute(
-                "UPDATE patch_history SET lines_changed=?, tests_passed=?, enhancement_name=?, timestamp=?, diff=COALESCE(?, diff), summary=COALESCE(?, summary), outcome=COALESCE(?, outcome), roi_deltas=COALESCE(?, roi_deltas), errors=COALESCE(?, errors) WHERE id=?",
+                "UPDATE patch_history SET lines_changed=?, tests_passed=?, context_tokens=?, patch_difficulty=?, enhancement_name=?, timestamp=?, diff=COALESCE(?, diff), summary=COALESCE(?, summary), outcome=COALESCE(?, outcome), roi_deltas=COALESCE(?, roi_deltas), errors=COALESCE(?, errors) WHERE id=?",
                 (
                     lines_changed,
                     None if tests_passed is None else int(bool(tests_passed)),
+                    context_tokens,
+                    patch_difficulty,
                     enhancement_name,
                     timestamp,
                     diff,
@@ -1550,6 +1558,8 @@ class PatchHistoryDB:
                     errors=errors,
                     tests_passed=tests_passed,
                     lines_changed=lines_changed,
+                    context_tokens=context_tokens,
+                    patch_difficulty=patch_difficulty,
                 )
             except Exception:
                 logger.exception("vector metrics patch summary failed")

--- a/tests/test_vector_service.py
+++ b/tests/test_vector_service.py
@@ -135,6 +135,8 @@ class DummyPatchDB:
         regret,
         lines_changed=None,
         tests_passed=None,
+        context_tokens=None,
+        patch_difficulty=None,
         enhancement_name=None,
         timestamp=None,
         roi_deltas=None,
@@ -153,6 +155,8 @@ class DummyPatchDB:
             "regret": regret,
             "lines_changed": lines_changed,
             "tests_passed": tests_passed,
+            "context_tokens": context_tokens,
+            "patch_difficulty": patch_difficulty,
             "enhancement_name": enhancement_name,
             "timestamp": timestamp,
             "roi_deltas": roi_deltas,
@@ -184,6 +188,8 @@ def test_patch_logger_patch_db_success():
     pl.track_contributors(["a:b"], True, patch_id="7", session_id="sid")
     assert pdb.called
     assert pdb.kwargs["patch_id"] == 7
+    assert pdb.kwargs["context_tokens"] == 0
+    assert pdb.kwargs["patch_difficulty"] == 0
 
 
 def test_patch_logger_metrics_db_failure_ignored():


### PR DESCRIPTION
## Summary
- capture context token counts from retrieval metadata and compute patch difficulty
- persist context tokens and patch difficulty in patch history and patch metrics tables
- include new metrics in patch summary events

## Testing
- `pytest tests/test_patch_logger_metrics.py::test_track_contributors_forwards_contribution_patch_db tests/test_patch_logger_metrics.py::test_track_contributors_emits_summary_event tests/test_patch_logger_metrics.py::test_track_contributors_persists_errors_and_results tests/test_vector_service.py::test_patch_logger_patch_db_success tests/test_vector_service.py::test_patch_logger_vector_metrics_db_success tests/test_retrieval_redaction.py::test_retriever_redacts_and_logs -q`
- `pytest tests/test_self_improvement_engine.py::test_policy_state_with_patch_metrics -q` *(failed: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68b29e3e6cd0832e9a8a39fcb53467c9