### PR TITLE
Add fallback meta planner and configuration flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - Adaptive energy score guiding resource allocation ([docs/energy_score.md](docs/energy_score.md))
 - Central Menace orchestrator coordinating all stages and hierarchical oversight
 - Self improvement engine automatically runs the workflow on the Menace model when metrics degrade
+- Optional meta planner integrates structural evolution; set `ENABLE_META_PLANNER=true` to require its presence
 - ROI foresight with `ForesightTracker.predict_roi_collapse`, projecting trends,
   classifying risk (Stable, Slow decay, Volatile, Immediate collapse risk) and
   flagging brittle workflows. Baseline curves live in

--- a/docs/sandbox_config.sample.yaml
+++ b/docs/sandbox_config.sample.yaml
@@ -1,4 +1,5 @@
 meta_entropy_threshold: 0.2
+enable_meta_planner: false
 roi:
   threshold: null
   confidence: null

--- a/docs/sandbox_settings.md
+++ b/docs/sandbox_settings.md
@@ -14,6 +14,7 @@ settings = load_sandbox_settings("docs/sandbox_config.sample.yaml")
 - `meta_planning_interval`: `10`
 - `meta_planning_period`: `3600`
 - `meta_planning_loop`: `False`
+- `enable_meta_planner`: `False` – fail if the optional MetaWorkflowPlanner is missing
 - `meta_improvement_threshold`: `0.01`
 - `meta_mutation_rate`: `1.0`
 - `meta_roi_weight`: `1.0`

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -275,6 +275,11 @@ class SandboxSettings(BaseSettings):
         env="META_PLANNING_LOOP",
         description="Run meta planning continuously in its own loop.",
     )
+    enable_meta_planner: bool = Field(
+        False,
+        env="ENABLE_META_PLANNER",
+        description="Fail fast if MetaWorkflowPlanner is unavailable.",
+    )
     meta_improvement_threshold: float = Field(
         0.01,
         env="META_IMPROVEMENT_THRESHOLD",


### PR DESCRIPTION
## Summary
- provide `_FallbackPlanner` when `MetaWorkflowPlanner` isn't installed
- support `ENABLE_META_PLANNER` flag to require the planner and fail fast
- document meta planner requirement and configuration
- test fallback and failure code paths

## Testing
- `pre-commit run --files self_improvement/meta_planning.py sandbox_settings.py docs/sandbox_settings.md docs/sandbox_config.sample.yaml README.md unit_tests/test_meta_planning.py`
- `pytest unit_tests/test_meta_planning.py tests/test_meta_planning_entropy.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2a05c6b40832e9cbf2d30ac572d22