### PR TITLE
feat: improve optional dependency loading

### DIFF
--- a/self_improvement/utils.py
+++ b/self_improvement/utils.py
@@ -12,6 +12,8 @@ import time
 import asyncio
 import inspect
 import random
+import subprocess
+import sys
 from dataclasses import dataclass
 from typing import Any, Callable, Awaitable
 
@@ -19,21 +21,59 @@ from ..metrics_exporter import self_improvement_failure_total
 from ..sandbox_settings import SandboxSettings
 
 
-def _load_callable(module: str, attr: str) -> Callable[..., Any]:
-    """Dynamically import ``attr`` from ``module`` with logging.
+def _load_callable(
+    module: str,
+    attr: str,
+    _cache: dict[tuple[str, str], Callable[..., Any]] = {},
+    _diagnostics: dict[str, int] = {"cache_hits": 0, "cache_misses": 0, "install_attempts": 0},
+) -> Callable[..., Any]:
+    """Dynamically import ``attr`` from ``module`` with logging and caching.
 
-    When the dependency is missing a stub is returned. The stub carries a
-    structured error object and, depending on :class:`SandboxSettings`, may
-    attempt to lazily retry the import on first use.
+    Successful imports are cached for future lookups. When the dependency is
+    missing a stub is returned. The stub carries a structured error object and,
+    depending on :class:`SandboxSettings`, may attempt to lazily retry the
+    import on first use.  A best effort automatic installation is performed
+    before falling back to the stub and ``dependency_load_diagnostics`` keeps
+    track of cache statistics for monitoring.
     """
+
+    _load_callable.cache = _cache
+    _load_callable.diagnostics = _diagnostics
+    key = (module, attr)
+    if key in _cache:
+        _diagnostics["cache_hits"] += 1
+        return _cache[key]
+    _diagnostics["cache_misses"] += 1
 
     try:
         mod = importlib.import_module(module)
-        return getattr(mod, attr)
+        func = getattr(mod, attr)
+        _cache[key] = func
+        return func
     except (ImportError, AttributeError) as exc:  # pragma: no cover - best effort logging
         logger = logging.getLogger(__name__)
         logger.exception("missing dependency %s.%s", module, attr)
         self_improvement_failure_total.labels(reason="missing_dependency").inc()
+
+        settings = SandboxSettings()
+        installed = False
+        if not getattr(settings, "menace_offline_install", False):
+            pkg = module.split(".")[0]
+            _diagnostics["install_attempts"] += 1
+            try:  # pragma: no cover - network side effect
+                subprocess.check_call([sys.executable, "-m", "pip", "install", pkg])
+                installed = True
+            except Exception as install_exc:  # pragma: no cover - best effort logging
+                logger.warning("automatic install of %s failed: %s", pkg, install_exc)
+
+        if installed:
+            try:
+                mod = importlib.import_module(module)
+                func = getattr(mod, attr)
+                _cache[key] = func
+                return func
+            except Exception as exc2:  # pragma: no cover - best effort logging
+                exc = exc2
 
         @dataclass
         class MissingDependencyError:
@@ -42,11 +82,13 @@ def _load_callable(module: str, attr: str) -> Callable[..., Any]:
             exc: Exception
 
         error = MissingDependencyError(module, attr, exc)
-        settings = SandboxSettings()
+        guide = f"Install it via `pip install {module.split('.')[0]}` to use {attr}"
 
         if not getattr(settings, "retry_optional_dependencies", False):
             def _stub(*_args: Any, **_kwargs: Any) -> Any:
-                raise RuntimeError(f"{module} dependency is required for {attr}")
+                raise RuntimeError(
+                    f"{module} dependency is required for {attr}. {guide}"
+                )
 
             _stub.error = error
             return _stub
@@ -54,8 +96,8 @@ def _load_callable(module: str, attr: str) -> Callable[..., Any]:
         def _retry_stub(*args: Any, **kwargs: Any) -> Any:
             def _load_and_call() -> Any:
                 mod_inner = importlib.import_module(module)
-                func = getattr(mod_inner, attr)
-                return func(*args, **kwargs)
+                func_inner = getattr(mod_inner, attr)
+                return func_inner(*args, **kwargs)
 
             return _call_with_retries(
                 _load_and_call,


### PR DESCRIPTION
## Summary
- cache successfully imported callables and expose diagnostics
- attempt to install missing modules and provide clear guidance when unavailable
- add tests for caching and dependency installation flow

## Testing
- `pytest unit_tests/test_self_improvement_utils.py unit_tests/test_self_improvement_engine_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2a59c5d84832e9182095370fa0c81