### PR TITLE
feat: add configurable suggestion sources

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -260,6 +260,25 @@ class SandboxSettings(BaseSettings):
             if isinstance(v, str):
                 return [s.strip() for s in v.split(",") if s.strip()]
             return v
+    suggestion_sources: list[str] = Field(
+        default_factory=lambda: ["cache", "knowledge", "heuristic"],
+        env="SANDBOX_SUGGESTION_SOURCES",
+        description=(
+            "Comma-separated suggestion source order for offline patch hints."
+        ),
+    )
+    if PYDANTIC_V2:
+        @field_validator("suggestion_sources", mode="before")
+        def _split_suggestion_sources(cls, v: Any) -> Any:
+            if isinstance(v, str):
+                return [s.strip() for s in v.split(",") if s.strip()]
+            return v
+    else:  # pragma: no cover - pydantic<2
+        @field_validator("suggestion_sources", pre=True)
+        def _split_suggestion_sources(cls, v: Any) -> Any:  # type: ignore[override]
+            if isinstance(v, str):
+                return [s.strip() for s in v.split(",") if s.strip()]
+            return v
     meta_planning_interval: int = Field(
         10,
         env="META_PLANNING_INTERVAL",


### PR DESCRIPTION
## Summary
- replace hardcoded suggestion fallback with knowledge/heuristic pipeline
- add SandboxSettings.suggestion_sources for tuning suggestion sources

## Testing
- `pre-commit run --files sandbox_runner/cycle.py sandbox_settings.py`
- `pytest tests/test_offline_suggestions.py unit_tests/test_settings_env_overrides.py` *(fails: No module named 'sandbox_runner.cycle')*


------
https://chatgpt.com/codex/tasks/task_e_68b2aba21134832eb285e92248ee6090