### PR TITLE
Handle empty workflows gracefully

### DIFF
--- a/meta_workflow_planner.py
+++ b/meta_workflow_planner.py
@@ -651,10 +651,12 @@ class MetaWorkflowPlanner:
             elif isinstance(meta, Iterable):
                 labels.extend(str(m).lower() for m in meta if m)
 
-        labels = [l for i, l in enumerate(labels) if l and l not in labels[:i]]
+        labels = [lbl for i, lbl in enumerate(labels) if lbl and lbl not in labels[:i]]
         if not labels:
             return [], []
-        indices = [_get_index(l, self.domain_index, self.max_domains) for l in labels]
+        indices = [
+            _get_index(lbl, self.domain_index, self.max_domains) for lbl in labels
+        ]
         return indices, labels
 
     # ------------------------------------------------------------------
@@ -938,6 +940,9 @@ class MetaWorkflowPlanner:
             if not callable(fn):
                 return None
             funcs.append(fn)
+
+        if not funcs:
+            return None
 
         if runner is None:
             try:
@@ -2333,9 +2338,15 @@ class MetaWorkflowPlanner:
                         prev_ent = float(entry.get("last_entropy", entropy))
                         entry["last_entropy"] = entropy
                         delta_e = entropy - prev_ent
-                    entry["delta_roi"] += (delta_r - entry.get("delta_roi", 0.0)) / entry["count"]
-                    entry["delta_failures"] += (delta_f - entry.get("delta_failures", 0.0)) / entry["count"]
-                    entry["delta_entropy"] += (delta_e - entry.get("delta_entropy", 0.0)) / entry["count"]
+                    entry["delta_roi"] += (
+                        delta_r - entry.get("delta_roi", 0.0)
+                    ) / entry["count"]
+                    entry["delta_failures"] += (
+                        delta_f - entry.get("delta_failures", 0.0)
+                    ) / entry["count"]
+                    entry["delta_entropy"] += (
+                        delta_e - entry.get("delta_entropy", 0.0)
+                    ) / entry["count"]
 
         if save:
             self._save_cluster_map()

--- a/tests/test_meta_workflow_planner_transitions.py
+++ b/tests/test_meta_workflow_planner_transitions.py
@@ -156,3 +156,14 @@ def test_validate_chain_recursive_execution(monkeypatch):
     assert record is not None
     assert record["roi_gain"] == pytest.approx(1.0)
     assert record["failures"] == pytest.approx(1 / 3)
+
+
+def test_validate_chain_skips_empty_chain():
+    planner = MetaWorkflowPlanner()
+
+    class DummyRunner:
+        def run(self, *_a, **_kw):  # pragma: no cover - should not be called
+            raise AssertionError("runner.run should not be invoked")
+
+    record = planner._validate_chain([], {}, runner=DummyRunner(), runs=1)
+    assert record is None

--- a/tests/test_workflow_sandbox_runner.py
+++ b/tests/test_workflow_sandbox_runner.py
@@ -36,6 +36,7 @@ assert spec.loader
 sys.modules[spec.name] = wsr
 spec.loader.exec_module(wsr)
 WorkflowSandboxRunner = wsr.WorkflowSandboxRunner
+EmptyWorkflowError = wsr.EmptyWorkflowError
 
 from tests.fixtures.workflow_modules import mod_a  # noqa: E402
 
@@ -44,6 +45,12 @@ from tests.fixtures.workflow_modules import mod_a  # noqa: E402
 def _no_psutil(monkeypatch):
     """Ensure psutil is absent so tests don't depend on it."""
     monkeypatch.setattr(wsr, "psutil", None, raising=False)
+
+
+def test_empty_workflow_errors():
+    runner = WorkflowSandboxRunner()
+    with pytest.raises(EmptyWorkflowError):
+        runner.run([])
 
 
 def test_files_confined_to_temp_dir(monkeypatch):


### PR DESCRIPTION
## Summary
- raise `EmptyWorkflowError` when the sandbox runner receives no steps
- skip validation runs for empty workflow chains in the meta workflow planner
- add regression tests for empty workflow handling

## Testing
- `pre-commit run --files sandbox_runner/workflow_sandbox_runner.py meta_workflow_planner.py tests/test_workflow_sandbox_runner.py tests/test_meta_workflow_planner_transitions.py`
- `pytest tests/test_workflow_sandbox_runner.py::test_empty_workflow_errors tests/test_meta_workflow_planner_transitions.py::test_validate_chain_skips_empty_chain -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2aeb41030832ea9b76d5aeb00e657