### PR TITLE
Add comprehensive patch metric and retrieval tests

### DIFF
--- a/tests/test_patch_metric_migrations.py
+++ b/tests/test_patch_metric_migrations.py
@@ -1,0 +1,38 @@
+
+import sys
+from pathlib import Path
+import sqlite3
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.modules.setdefault("data_bot", types.SimpleNamespace(MetricsDB=object))
+
+from menace_sandbox.vector_metrics_db import VectorMetricsDB
+from menace_sandbox.code_database import PatchHistoryDB
+
+
+def test_vector_metrics_db_migration(tmp_path):
+    db_path = tmp_path / "vm_old.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE patch_metrics(patch_id TEXT)")
+    conn.commit()
+    conn.close()
+
+    db = VectorMetricsDB(db_path)
+    cols = {c[1] for c in db.conn.execute("PRAGMA table_info(patch_metrics)").fetchall()}
+    required = {"patch_difficulty", "time_to_completion", "error_trace_count", "effort_estimate", "enhancement_score"}
+    assert required <= cols
+
+
+def test_patch_history_db_migration(tmp_path):
+    db_path = tmp_path / "ph_old.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE patch_history(id INTEGER PRIMARY KEY, filename TEXT, description TEXT, ts REAL)")
+    conn.commit()
+    conn.close()
+
+    db = PatchHistoryDB(db_path)
+    conn = db.router.get_connection("patch_history")
+    cols = {c[1] for c in conn.execute("PRAGMA table_info(patch_history)").fetchall()}
+    required = {"patch_difficulty", "time_to_completion", "error_trace_count", "effort_estimate", "enhancement_score"}
+    assert required <= cols

--- a/tests/test_patch_metrics_persistence.py
+++ b/tests/test_patch_metrics_persistence.py
@@ -1,0 +1,128 @@
+
+import sys
+from pathlib import Path
+import types
+import sqlite3
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from vector_service.patch_logger import PatchLogger
+from vector_metrics_db import VectorMetricsDB
+
+
+class SimplePatchDB:
+    def __init__(self, path):
+        self.conn = sqlite3.connect(path)
+        self.conn.execute(
+            "CREATE TABLE patch_history(id INTEGER PRIMARY KEY, patch_difficulty INTEGER, time_to_completion REAL, error_trace_count INTEGER, effort_estimate REAL, enhancement_score REAL)"
+        )
+
+    def add(self):
+        cur = self.conn.execute("INSERT INTO patch_history DEFAULT VALUES")
+        self.conn.commit()
+        return cur.lastrowid
+
+    def record_provenance(self, *a, **k):
+        pass
+
+    def log_ancestry(self, *a, **k):
+        pass
+
+    def log_contributors(self, *a, **k):
+        pass
+
+    def get(self, *a, **k):
+        return None
+
+    def record_vector_metrics(
+        self,
+        session_id,
+        vectors,
+        *,
+        patch_id,
+        contribution,
+        win,
+        regret,
+        lines_changed=None,
+        tests_passed=None,
+        context_tokens=None,
+        patch_difficulty=None,
+        effort_estimate=None,
+        enhancement_name=None,
+        timestamp=None,
+        start_time=None,
+        time_to_completion=None,
+        roi_deltas=None,
+        diff=None,
+        summary=None,
+        outcome=None,
+        errors=None,
+        error_trace_count=None,
+        roi_tag=None,
+        enhancement_score=None,
+    ):
+        self.conn.execute(
+            "UPDATE patch_history SET patch_difficulty=?, time_to_completion=?, error_trace_count=?, effort_estimate=?, enhancement_score=? WHERE id=?",
+            (
+                patch_difficulty,
+                time_to_completion,
+                error_trace_count,
+                effort_estimate,
+                enhancement_score,
+                patch_id,
+            ),
+        )
+        self.conn.commit()
+
+
+def _dummy_patch_safety():
+    return types.SimpleNamespace(
+        evaluate=lambda *a, **k: (True, 0.0, {}),
+        record_failure=lambda *a, **k: None,
+        threshold=0.0,
+        max_alert_severity=1.0,
+        max_alerts=5,
+        license_denylist=set(),
+    )
+
+
+def test_patch_logger_persists_metrics(tmp_path):
+    vm_path = tmp_path / "vm.db"
+    ph_path = tmp_path / "ph.db"
+    vmdb = VectorMetricsDB(vm_path)
+    patch_db = SimplePatchDB(ph_path)
+    patch_id = patch_db.add()
+
+    pl = PatchLogger(patch_db=patch_db, vector_metrics=vmdb)
+    pl.patch_safety = _dummy_patch_safety()
+
+    meta = {"patch:1": {"prompt_tokens": 3}}
+    pl.track_contributors(
+        ["patch:1"],
+        True,
+        patch_id=str(patch_id),
+        session_id="s",
+        retrieval_metadata=meta,
+        lines_changed=2,
+        tests_passed=True,
+        start_time=1.0,
+        timestamp=4.0,
+        error_summary="err",
+        effort_estimate=2.0,
+    )
+
+    expected_score = 5 + 2.0 + 1 - 1 - 3
+
+    vm_row = vmdb.conn.execute(
+        "SELECT patch_difficulty, time_to_completion, error_trace_count, effort_estimate, enhancement_score FROM patch_metrics WHERE patch_id=?",
+        (str(patch_id),),
+    ).fetchone()
+    assert vm_row == (5, 3.0, 1, 2.0, pytest.approx(expected_score))
+
+    ph_row = patch_db.conn.execute(
+        "SELECT patch_difficulty, time_to_completion, error_trace_count, effort_estimate, enhancement_score FROM patch_history WHERE id=?",
+        (patch_id,),
+    ).fetchone()
+    assert ph_row == (5, 3.0, 1, 2.0, pytest.approx(expected_score))

--- a/tests/test_weight_adjuster.py
+++ b/tests/test_weight_adjuster.py
@@ -1,0 +1,25 @@
+import pytest
+
+from vector_metrics_db import VectorMetricsDB
+from weight_adjuster import WeightAdjuster
+
+
+def test_weight_adjuster_updates_weights(tmp_path):
+    db = VectorMetricsDB(tmp_path / "vm.db")
+    adj = WeightAdjuster(vector_metrics=db, success_delta=0.2, failure_delta=0.1)
+    vectors = [("patch", "v1", 0.0)]
+
+    adj.adjust(vectors, True)
+    assert db.get_vector_weight("patch:v1") == pytest.approx(0.2)
+
+    adj.adjust(vectors, False)
+    assert db.get_vector_weight("patch:v1") == pytest.approx(0.1)
+
+
+def test_weight_adjuster_negative_roi(tmp_path):
+    db = VectorMetricsDB(tmp_path / "vm2.db")
+    adj = WeightAdjuster(vector_metrics=db, success_delta=0.2, failure_delta=0.1)
+    vectors = [("patch", "v1", 0.0)]
+
+    adj.adjust(vectors, True, roi_deltas={"patch": -1.0})
+    assert db.get_vector_weight("patch:v1") == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- verify PatchLogger computes and persists patch difficulty, completion time, error traces, effort estimate and enhancement score
- add migration tests for patch and vector metric tables
- add WeightAdjuster regression tests and ensure retriever prioritizes high enhancement score patches

## Testing
- `pytest tests/test_patch_metrics_persistence.py tests/test_patch_metric_migrations.py tests/test_weight_adjuster.py tests/test_patch_retriever_metrics.py::test_similarity_switching tests/test_patch_retriever_metrics.py::test_search_top_n_accuracy tests/test_patch_retriever_metrics.py::test_enhancement_score_boost tests/test_patch_retriever_metrics.py::test_prioritizes_enhancement_score_on_tie -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2b0271e74832eb029eac1a452bc7d