### PR TITLE
Add ROI tagging for patch tracking

### DIFF
--- a/tests/test_patch_logger_metrics.py
+++ b/tests/test_patch_logger_metrics.py
@@ -470,19 +470,20 @@ def test_track_contributors_persists_errors_and_results(monkeypatch):
         lines_changed=2,
         tests_passed=True,
         retrieval_metadata={"error": {"msg": "boom"}},
+        roi_tag="low-ROI",
     )
     assert pdb.kwargs["errors"] == [{"msg": "boom"}]
     assert pdb.kwargs["context_tokens"] == 0
     assert pdb.kwargs["patch_difficulty"] == 2
     assert pdb.kwargs["error_trace_count"] == 1
-    assert pdb.kwargs.get("roi_tag") is None
+    assert pdb.kwargs.get("roi_tag") == "low-ROI"
     assert vm.summary_calls and vm.summary_calls[0]["errors"] == [{"msg": "boom"}]
     assert vm.summary_calls[0]["tests_passed"] is True
     assert vm.summary_calls[0]["lines_changed"] == 2
     assert vm.summary_calls[0]["context_tokens"] == 0
     assert vm.summary_calls[0]["patch_difficulty"] == 2
     assert vm.summary_calls[0]["error_trace_count"] == 1
-    assert vm.summary_calls[0]["roi_tag"] is None
+    assert vm.summary_calls[0]["roi_tag"] == "low-ROI"
     assert ("inc", "", 1.0) in fail_gauge.calls
     assert ("inc", "passed", 1.0) in test_gauge.calls
     assert res.tests_passed is True

--- a/tests/test_vector_service_api.py
+++ b/tests/test_vector_service_api.py
@@ -61,16 +61,22 @@ def test_build_context_error(monkeypatch):
 def test_track_contributors_success(monkeypatch):
     called = {}
 
-    def fake_track(ids, result, patch_id="", session_id=""):
-        called['args'] = (ids, result, patch_id, session_id)
+    def fake_track(ids, result, patch_id="", session_id="", **kwargs):
+        called['args'] = (ids, result, patch_id, session_id, kwargs.get("roi_tag"))
 
     monkeypatch.setattr(api, "_patch_logger", types.SimpleNamespace(track_contributors=fake_track))
     resp = client.post(
         "/track-contributors",
-        json={"vector_ids": ["a"], "result": True, "patch_id": "p", "session_id": "s"},
+        json={
+            "vector_ids": ["a"],
+            "result": True,
+            "patch_id": "p",
+            "session_id": "s",
+            "roi_tag": "success",
+        },
     )
     assert resp.status_code == 200
-    assert called['args'] == (["a"], True, "p", "s")
+    assert called['args'] == (["a"], True, "p", "s", "success")
 
 
 def test_track_contributors_error(monkeypatch):


### PR DESCRIPTION
## Summary
- add typed `roi_tag` parameter to PatchLogger and record in metrics
- forward `roi_tag` through API for manual reviewer override
- log patch summaries with ROI tagging for legacy metrics backends

## Testing
- `pytest tests/test_patch_logger_metrics.py::test_track_contributors_persists_errors_and_results tests/test_vector_service_api.py::test_track_contributors_success -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2b5cd6a98832e88262d15e380162b