### PR TITLE
feat: make sandbox repo configurable

### DIFF
--- a/sandbox_runner.py
+++ b/sandbox_runner.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 """Execute Menace patches in a controlled sandbox environment.
 
 The module initialises :data:`GLOBAL_ROUTER` early via :func:`init_db_router`
-so that subsequent imports can perform database operations safely.
+so that subsequent imports can perform database operations safely. Repository
+location and related settings are provided by :mod:`sandbox_runner.config`,
+which reads ``SANDBOX_REPO_URL`` and ``SANDBOX_REPO_PATH`` from environment
+variables or a ``SandboxSettings`` instance.
 """
 
 import importlib.util
@@ -281,7 +284,7 @@ _local_knowledge_refresh_counter = 0
 
 ROOT = Path(__file__).resolve().parent
 
-from sandbox_runner.config import SANDBOX_REPO_URL, SANDBOX_REPO_PATH
+import sandbox_runner.config as sandbox_config
 
 _TPL_PATH = Path(
     os.getenv("GPT_SECTION_TEMPLATE", ROOT / "templates" / "gpt_section_prompt.j2")
@@ -776,7 +779,7 @@ def _sandbox_init(preset: Dict[str, Any], args: argparse.Namespace) -> SandboxCo
 
     tmp = tempfile.mkdtemp(prefix="menace_sandbox_")
     logger.info("sandbox temporary directory", extra=log_record(path=tmp))
-    repo = SANDBOX_REPO_PATH
+    repo = sandbox_config.get_sandbox_repo_path()
     orig_cwd = Path.cwd()
 
     data_dir = Path(

--- a/sandbox_runner/config.py
+++ b/sandbox_runner/config.py
@@ -1,13 +1,68 @@
-"""Configuration for sandbox runner."""
+"""Configuration helpers for sandbox runners.
 
+This module determines where the sandbox repository lives.  Values are read
+from the :envvar:`SANDBOX_REPO_URL` and :envvar:`SANDBOX_REPO_PATH`
+environment variables or from a ``SandboxSettings`` instance when supplied.
+If neither source provides a value sensible defaults are used that point to
+the current checkout of the Menace sandbox repository.
+"""
+
+from __future__ import annotations
+
+import os
 from pathlib import Path
+from typing import Any
 
-# Remote repository used by the visual agent service
-SANDBOX_REPO_URL = "https://github.com/Demi-urge/menace_sandbox"
+DEFAULT_REPO_URL = "https://github.com/Demi-urge/menace_sandbox"
+DEFAULT_REPO_PATH = Path(__file__).resolve().parents[1]
 
-# Local checkout path of ``SANDBOX_REPO_URL``. The sandbox runner assumes this
-# repository already exists and will operate directly on it instead of cloning
-# a fresh copy for each run.
-SANDBOX_REPO_PATH = Path(__file__).resolve().parents[1]
+
+def get_sandbox_repo_url(settings: Any | None = None) -> str:
+    """Return the sandbox repository URL.
+
+    Parameters
+    ----------
+    settings:
+        Optional ``SandboxSettings`` providing a ``sandbox_repo_url`` attribute.
+
+    The function first checks ``settings`` then the ``SANDBOX_REPO_URL``
+    environment variable before falling back to ``DEFAULT_REPO_URL``.
+    """
+
+    if settings and getattr(settings, "sandbox_repo_url", None):
+        return str(getattr(settings, "sandbox_repo_url"))
+    return os.getenv("SANDBOX_REPO_URL", DEFAULT_REPO_URL)
+
+
+def get_sandbox_repo_path(settings: Any | None = None) -> Path:
+    """Return the local sandbox repository path.
+
+    Parameters
+    ----------
+    settings:
+        Optional ``SandboxSettings`` providing a ``sandbox_repo_path`` attribute.
+
+    ``settings`` takes precedence over the ``SANDBOX_REPO_PATH`` environment
+    variable.  When neither is specified, ``DEFAULT_REPO_PATH`` is used.
+    """
+
+    if settings and getattr(settings, "sandbox_repo_path", None):
+        return Path(getattr(settings, "sandbox_repo_path")).resolve()
+    return Path(os.getenv("SANDBOX_REPO_PATH", DEFAULT_REPO_PATH)).resolve()
+
+
+# Backwards compatible constants evaluated at import time
+SANDBOX_REPO_URL = get_sandbox_repo_url()
+SANDBOX_REPO_PATH = get_sandbox_repo_path()
+
+
+__all__ = [
+    "DEFAULT_REPO_URL",
+    "DEFAULT_REPO_PATH",
+    "get_sandbox_repo_url",
+    "get_sandbox_repo_path",
+    "SANDBOX_REPO_URL",
+    "SANDBOX_REPO_PATH",
+]
 
 

--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -1,3 +1,11 @@
+"""Runtime helpers for sandbox execution.
+
+The sandbox repository location is resolved via :mod:`sandbox_runner.config`,
+which consults the ``SANDBOX_REPO_URL`` and ``SANDBOX_REPO_PATH`` environment
+variables or a ``SandboxSettings`` instance.  When unset, defaults point to the
+current repository checkout.
+"""
+
 from __future__ import annotations
 
 import ast
@@ -173,7 +181,7 @@ except ImportError:  # pragma: no cover - optional dependency
 
 _FAKER = Faker() if Faker is not None else None
 
-from .config import SANDBOX_REPO_URL, SANDBOX_REPO_PATH
+from . import config as sandbox_config
 from .input_history_db import InputHistoryDB
 from collections import Counter
 try:
@@ -6431,7 +6439,7 @@ def simulate_full_environment(preset: Dict[str, Any]) -> "ROITracker":
     tmp_dir = tempfile.mkdtemp(prefix="full_env_")
     diagnostics: Dict[str, str] = {}
     try:
-        repo_path = SANDBOX_REPO_PATH
+        repo_path = sandbox_config.get_sandbox_repo_path()
         data_dir = Path(tmp_dir) / "data"
         env = os.environ.copy()
         env.update({k: str(v) for k, v in preset.items()})


### PR DESCRIPTION
## Summary
- make sandbox repository URL/path configurable via env vars or settings
- pull sandbox repo info through helper functions for dynamic access
- document SANDBOX_REPO_URL and SANDBOX_REPO_PATH options across modules

## Testing
- `pytest unit_tests/test_settings_env_overrides.py` *(fails: ImportError: attempted relative import with no known parent package)*
- `pytest unit_tests/test_workflow_sandbox_runner.py::test_safe_mode_blocks_network_access`


------
https://chatgpt.com/codex/tasks/task_e_68b2ba64a29c832e949474a3313f6871