### PR TITLE
feat: boost patch ranking with enhancement score

### DIFF
--- a/docs/vector_service.md
+++ b/docs/vector_service.md
@@ -72,6 +72,10 @@ context, meta = builder.build_context("fix failing tests", return_metadata=True)
 `context` contains the compact summaries while `meta` mirrors the structure with
 the additional `win_rate`, `regret_rate` and `flags` details for each entry.
 
+When patch examples are retrieved, ranking combines vector similarity with the
+`enhancement_score` pulled from `PatchHistoryDB`.  The relative influence of the
+score can be tuned via ``ContextBuilderConfig.enhancement_weight``.
+
 ## PatchLogger
 
 ```python

--- a/vector_service/README.md
+++ b/vector_service/README.md
@@ -47,6 +47,11 @@ examples = search_patches("fix bug", top_k=3)
 The returned list contains ``origin_db``, ``record_id`` and ``score`` fields
 similar to results from ``Retriever.search``.
 
+When available, the retriever looks up each patch's ``enhancement_score`` in
+``PatchHistoryDB`` and boosts the similarity score.  The balance between
+similarity and enhancement can be tuned with
+``ContextBuilderConfig.enhancement_weight``.
+
 ## Adding new modalities
 
 The vector service dynamically discovers vectorisers.  Any module placed under


### PR DESCRIPTION
## Summary
- factor in `enhancement_score` when ranking patches in PatchRetriever and ContextBuilder
- allow tuning similarity vs enhancement weighting with `enhancement_weight`
- document new patch ranking behaviour

## Testing
- `pytest tests/test_patch_retriever_metrics.py tests/test_patch_examples_retrieval.py`

------
https://chatgpt.com/codex/tasks/task_e_68b2bbae97ac832ea8511b09690ce75e