### PR TITLE
Log cache move failures

### DIFF
--- a/sandbox_runner/generative_stub_provider.py
+++ b/sandbox_runner/generative_stub_provider.py
@@ -472,8 +472,10 @@ async def async_generate_stubs(stubs: List[Dict[str, Any]], ctx: dict) -> List[D
             if cached is not None:
                 try:
                     _CACHE.move_to_end(key)
-                except Exception:
-                    logger.exception("failed to update cache LRU for key %s", key)
+                except Exception as exc:
+                    logger.warning(
+                        "failed to update cache LRU for key %s: %s", key, exc
+                    )
         if cached is not None:
             new_stubs.append(dict(cached))
             continue
@@ -544,8 +546,10 @@ async def async_generate_stubs(stubs: List[Dict[str, Any]], ctx: dict) -> List[D
                         _CACHE[key] = data
                         try:
                             _CACHE.move_to_end(key)
-                        except Exception:
-                            logger.exception("failed to update cache LRU for key %s", key)
+                        except Exception as exc:
+                            logger.warning(
+                                "failed to update cache LRU for key %s: %s", key, exc
+                            )
                         _cache_evict()
                     changed = True
                     new_stubs.append(dict(data))

--- a/unit_tests/test_generative_stub_cache.py
+++ b/unit_tests/test_generative_stub_cache.py
@@ -60,7 +60,7 @@ def test_move_to_end_logging(monkeypatch, caplog):
     monkeypatch.setattr(gsp, "_aload_generator", _fake_aload_generator)
 
     ctx = {"target": _dummy_func}
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.WARNING):
         result = asyncio.run(gsp.async_generate_stubs([{"a": 1}], ctx))
     assert result == [{"a": 1}]
     assert any("failed to update cache LRU" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- warn when `_CACHE.move_to_end` fails in `async_generate_stubs` and include the key
- adjust cache unit test to expect warning-level log

## Testing
- `pytest unit_tests/test_generative_stub_cache.py tests/test_generative_stub_provider.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2bc104388832ea6f135f8542877fe