### PR TITLE
Add enhancement score and ROI tag tests

### DIFF
--- a/tests/integration/test_retriever_enhancement_ordering.py
+++ b/tests/integration/test_retriever_enhancement_ordering.py
@@ -1,0 +1,27 @@
+import types
+
+from vector_service.retriever import PatchRetriever
+
+
+class DummyStore:
+    def __init__(self, vectors, meta):
+        self.vectors = vectors
+        self.ids = [str(i) for i in range(len(vectors))]
+        self.meta = meta
+
+    def query(self, vector, top_k=5):
+        return [(vid, 0.0) for vid in self.ids[:top_k]]
+
+
+def test_enhancement_score_affects_ordering():
+    vectors = [[1.0, 0.0], [1.0, 0.0]]
+    meta = [
+        {"origin_db": "patch", "metadata": {"text": "a", "enhancement_score": 0.0}},
+        {"origin_db": "patch", "metadata": {"text": "b", "enhancement_score": 1.0}},
+    ]
+    store = DummyStore(vectors, meta)
+    vec_service = types.SimpleNamespace(vectorise=lambda kind, record: [1.0, 0.0])
+    pr = PatchRetriever(store=store, vector_service=vec_service, enhancement_weight=1.0)
+    results = pr.search("query", top_k=2)
+    ids = [r["record_id"] for r in results]
+    assert ids == ["1", "0"]

--- a/tests/test_track_contributors_enhancement.py
+++ b/tests/test_track_contributors_enhancement.py
@@ -1,0 +1,97 @@
+import types
+
+import pytest
+
+from vector_service.patch_logger import PatchLogger, compute_enhancement_score
+
+
+class DummyPatchDB:
+    def __init__(self):
+        self.kwargs = None
+
+    def record_vector_metrics(
+        self,
+        session_id,
+        pairs,
+        patch_id,
+        contribution,
+        win,
+        regret,
+        lines_changed,
+        tests_passed,
+        context_tokens,
+        patch_difficulty,
+        effort_estimate,
+        enhancement_name,
+        start_time,
+        time_to_completion,
+        timestamp,
+        errors,
+        error_trace_count,
+        roi_tag,
+        diff,
+        summary,
+        outcome,
+        roi_deltas,
+        enhancement_score,
+    ):
+        self.kwargs = {
+            "roi_tag": roi_tag,
+            "enhancement_score": enhancement_score,
+        }
+
+    # The following methods are invoked by PatchLogger but are not
+    # relevant for this test; they simply satisfy the interface.
+    def record_provenance(self, *a, **k):  # pragma: no cover - interface stub
+        pass
+
+    def log_ancestry(self, *a, **k):  # pragma: no cover - interface stub
+        pass
+
+    def log_contributors(self, *a, **k):  # pragma: no cover - interface stub
+        pass
+
+    def get(self, patch_id):  # pragma: no cover - not used
+        return None
+
+
+class DummyVectorMetrics:
+    def __init__(self):
+        self.kwargs = None
+
+    def record_patch_summary(self, *args, **kwargs):
+        self.kwargs = kwargs
+
+    def update_outcome(self, *a, **k):  # pragma: no cover - interface stub
+        pass
+
+    def record_patch_ancestry(self, *a, **k):  # pragma: no cover - interface stub
+        pass
+
+
+def test_track_contributors_enhancement_score_and_roi_tag():
+    pdb = DummyPatchDB()
+    vm = DummyVectorMetrics()
+    pl = PatchLogger(
+        patch_db=pdb,
+        vector_metrics=vm,
+        weight_adjuster=types.SimpleNamespace(adjust=lambda *a, **k: None),
+    )
+    res = pl.track_contributors(
+        ["db:v1"],
+        True,
+        patch_id="1",
+        session_id="s",
+        lines_changed=10,
+        tests_passed=True,
+        start_time=0.0,
+        timestamp=30.0,
+        roi_tag="high-ROI",
+        effort_estimate=5.0,
+    )
+    expected = compute_enhancement_score(10, 0, 30.0, True, 0, 5.0)
+    assert res.enhancement_score == pytest.approx(expected)
+    assert pdb.kwargs["roi_tag"] == "high-ROI"
+    assert vm.kwargs["roi_tag"] == "high-ROI"
+    assert pdb.kwargs["enhancement_score"] == pytest.approx(expected)
+    assert vm.kwargs["enhancement_score"] == pytest.approx(expected)

--- a/tests/test_weight_adjuster_roi_tag.py
+++ b/tests/test_weight_adjuster_roi_tag.py
@@ -1,0 +1,30 @@
+import pytest
+
+from vector_service.weight_adjuster import WeightAdjuster
+
+
+class DummyVectorMetrics:
+    def __init__(self):
+        self.weights = {}
+
+    def update_db_weight(self, origin, delta):
+        weight = self.weights.get(origin, 1.0) + delta
+        self.weights[origin] = weight
+        return weight
+
+    def log_ranker_update(self, origin, delta, weight):  # pragma: no cover - optional
+        self.last = (origin, delta, weight)
+
+
+def test_roi_tag_positive_overrides_score():
+    vm = DummyVectorMetrics()
+    adj = WeightAdjuster(vector_metrics=vm, success_delta=0.2, failure_delta=0.2)
+    adj.adjust(["db:v1"], 0.1, "pass")
+    assert vm.weights["db"] == pytest.approx(1.02)
+
+
+def test_roi_tag_negative_overrides_score():
+    vm = DummyVectorMetrics()
+    adj = WeightAdjuster(vector_metrics=vm, success_delta=0.2, failure_delta=0.2)
+    adj.adjust(["db:v1"], 0.9, "bug")
+    assert vm.weights["db"] == pytest.approx(0.82)


### PR DESCRIPTION
## Summary
- test PatchLogger.track_contributors computes enhancement score and stores ROI tags
- check WeightAdjuster uses roi_tag to adjust weights up or down
- integration test that PatchRetriever ordering honors enhancement score

## Testing
- `pytest tests/test_track_contributors_enhancement.py -q`
- `pytest tests/test_weight_adjuster_roi_tag.py -q`
- `pytest tests/integration/test_retriever_enhancement_ordering.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2bd890f70832e84de0d04c1a0e221