### PR TITLE
Log radar tracking failures with module context

### DIFF
--- a/sandbox_runner/cycle.py
+++ b/sandbox_runner/cycle.py
@@ -139,9 +139,8 @@ def _async_track_usage(module: str, impact: float | None = None) -> None:
                 return
             except Exception:  # pragma: no cover - network/IO errors
                 logger.exception(
-                    "relevancy radar usage tracking failed for %s (attempt %d)",
-                    module,
-                    attempt + 1,
+                    "relevancy radar usage tracking failed",
+                    extra=log_record(module=module, attempt=attempt + 1),
                 )
                 # small delay before retrying to avoid hot looping
                 time.sleep(0.1)
@@ -149,7 +148,10 @@ def _async_track_usage(module: str, impact: float | None = None) -> None:
     try:
         threading.Thread(target=_track, daemon=True).start()
     except Exception:  # pragma: no cover - thread creation failures
-        logger.exception("failed to start usage tracking thread")
+        logger.exception(
+            "failed to start usage tracking thread",
+            extra=log_record(module=module),
+        )
         raise
 
 

--- a/unit_tests/test_async_track_usage_logging.py
+++ b/unit_tests/test_async_track_usage_logging.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import ast
+import types
+
+
+class DummyLogger:
+    def __init__(self):
+        self.records = []
+
+    def exception(self, msg, *args, **kwargs):
+        self.records.append((msg % args if args else msg, kwargs.get("extra")))
+
+
+def _load_async_track_usage():
+    src = Path("sandbox_runner/cycle.py").read_text()
+    tree = ast.parse(src)
+    func = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "_async_track_usage")
+    module = ast.Module([func], type_ignores=[])
+    module = ast.fix_missing_locations(module)
+    ns: dict[str, object] = {}
+
+    class DummyThread:
+        def __init__(self, target, daemon=True):
+            self.target = target
+            self.daemon = daemon
+
+        def start(self):
+            self.target()
+
+    ns.update(
+        {
+            "_ENABLE_RELEVANCY_RADAR": True,
+            "_radar_track_usage": lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")),
+            "record_output_impact": lambda *a, **k: None,
+            "logger": DummyLogger(),
+            "threading": types.SimpleNamespace(Thread=DummyThread),
+            "time": types.SimpleNamespace(sleep=lambda *a, **k: None),
+            "log_record": lambda **kw: kw,
+        }
+    )
+
+    exec(compile(module, "<ast>", "exec"), ns)
+    return ns["_async_track_usage"], ns["logger"]
+
+
+def test_async_track_usage_logs_failure():
+    fn, logger = _load_async_track_usage()
+    fn("test.mod", 1.0)
+    assert len(logger.records) == 3
+    assert all(r[1].get("module") == "test.mod" for r in logger.records)
+    assert [r[1].get("attempt") for r in logger.records] == [1, 2, 3]


### PR DESCRIPTION
## Summary
- log exceptions from `_radar_track_usage` and thread creation with module identifiers
- add unit test for `_async_track_usage` to ensure failing tracker logs attempts

## Testing
- `pytest unit_tests/test_async_track_usage_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2c023b400832e8d06ea34ffa92f63