### PR TITLE
feat: add enhancement score utility

### DIFF
--- a/config/enhancement_score.yaml
+++ b/config/enhancement_score.yaml
@@ -1,0 +1,6 @@
+difficulty: 1.0
+time_to_completion: -0.5
+tests_passed: 2.0
+tests_failed: -1.0
+error_traces: -1.5
+effort_estimate: 0.5

--- a/enhancement_score.py
+++ b/enhancement_score.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+"""Utility to compute a numeric enhancement score.
+
+The score is a weighted sum of several metrics that describe the effort and
+quality of an enhancement.  Weights are loaded from
+``config/enhancement_score.yaml`` so they can be tuned without code changes.
+"""
+
+from dataclasses import dataclass
+import os
+import yaml
+
+
+@dataclass
+class EnhancementMetrics:
+    """Metrics describing a code enhancement."""
+
+    lines_changed: int
+    context_tokens: int
+    time_to_completion: float
+    tests_passed: int
+    tests_failed: int
+    error_traces: int
+    effort_estimate: float
+
+
+@dataclass
+class EnhancementScoreWeights:
+    """Weighting factors applied to :class:`EnhancementMetrics`."""
+
+    difficulty: float = 1.0
+    time_to_completion: float = 1.0
+    tests_passed: float = 1.0
+    tests_failed: float = -1.0
+    error_traces: float = -1.0
+    effort_estimate: float = 1.0
+
+
+_DEFAULT_CONFIG_PATH = os.path.join(
+    os.path.dirname(__file__), "config", "enhancement_score.yaml"
+)
+
+
+def load_weights(path: str | None = None) -> EnhancementScoreWeights:
+    """Load weighting factors from ``path``.
+
+    If ``path`` is omitted, ``config/enhancement_score.yaml`` relative to the
+    repository root is used. Missing entries default to the values in
+    :class:`EnhancementScoreWeights`.
+    """
+
+    cfg_path = path or _DEFAULT_CONFIG_PATH
+    try:
+        with open(cfg_path, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    except FileNotFoundError:
+        data = {}
+    weights = EnhancementScoreWeights()
+    for field in weights.__dataclass_fields__:  # type: ignore[attr-defined]
+        if isinstance(data.get(field), (int, float)):
+            setattr(weights, field, float(data[field]))
+    return weights
+
+
+def compute_enhancement_score(
+    metrics: EnhancementMetrics, weights: EnhancementScoreWeights | None = None
+) -> float:
+    """Return a weighted enhancement score for ``metrics``.
+
+    ``lines_changed`` and ``context_tokens`` are combined as a difficulty
+    component before weighting. ``tests_failed`` and ``error_traces`` reduce the
+    overall score when their weights are negative.
+    """
+
+    w = weights or load_weights()
+    difficulty = metrics.lines_changed + metrics.context_tokens
+    score = (
+        difficulty * w.difficulty
+        + metrics.time_to_completion * w.time_to_completion
+        + metrics.tests_passed * w.tests_passed
+        + metrics.tests_failed * w.tests_failed
+        + metrics.error_traces * w.error_traces
+        + metrics.effort_estimate * w.effort_estimate
+    )
+    return float(score)
+
+
+__all__ = [
+    "EnhancementMetrics",
+    "EnhancementScoreWeights",
+    "load_weights",
+    "compute_enhancement_score",
+]


### PR DESCRIPTION
## Summary
- add enhancement_score module to compute weighted enhancement scores
- load tuning weights from new config file

## Testing
- `pre-commit run --files enhancement_score.py config/enhancement_score.yaml`
- `pytest enhancement_score.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2c0ae2dbc832eb6417b2fb19e095c