### PR TITLE
feat: recompute enhancement scores

### DIFF
--- a/enhancement_score_backfill.py
+++ b/enhancement_score_backfill.py
@@ -1,0 +1,55 @@
+"""CLI to backfill enhancement scores for existing patches."""
+
+from __future__ import annotations
+
+import logging
+from enhancement_score import EnhancementMetrics
+from vector_service.patch_logger import PatchLogger
+from vector_metrics_db import VectorMetricsDB
+from code_database import PatchHistoryDB
+
+
+def backfill() -> None:
+    pdb = PatchHistoryDB()
+    vm = VectorMetricsDB()
+    logger = PatchLogger(patch_db=pdb, vector_metrics=vm)
+    conn = pdb.router.get_connection("patch_history")
+    cur = conn.execute(
+        "SELECT id, lines_changed, context_tokens, time_to_completion, "
+        "tests_passed, error_trace_count, effort_estimate, roi_tag FROM patch_history"
+    )
+    for (
+        patch_id,
+        lines_changed,
+        context_tokens,
+        time_to_completion,
+        tests_passed,
+        error_trace_count,
+        effort_estimate,
+        roi_tag,
+    ) in cur.fetchall():
+        metrics = EnhancementMetrics(
+            lines_changed=lines_changed or 0,
+            context_tokens=context_tokens or 0,
+            time_to_completion=time_to_completion or 0.0,
+            tests_passed=1 if tests_passed else 0,
+            tests_failed=0 if tests_passed else 1 if tests_passed is not None else 0,
+            error_traces=error_trace_count or 0,
+            effort_estimate=effort_estimate or 0.0,
+        )
+        try:
+            logger.recompute_enhancement_score(
+                patch_id,
+                metrics,
+                roi_tag=roi_tag,
+                error_trace_count=error_trace_count,
+            )
+        except Exception:  # pragma: no cover - best effort logging
+            logging.getLogger(__name__).exception(
+                "failed to backfill enhancement score for patch %s", patch_id
+            )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    backfill()

--- a/tests/test_track_contributors_enhancement.py
+++ b/tests/test_track_contributors_enhancement.py
@@ -105,3 +105,22 @@ def test_track_contributors_enhancement_score_and_roi_tag():
     assert vm.kwargs["roi_tag"] == "low-ROI"
     assert pdb.kwargs["enhancement_score"] == pytest.approx(expected)
     assert vm.kwargs["enhancement_score"] == pytest.approx(expected)
+
+
+def test_recompute_enhancement_score_updates_metrics():
+    vm = DummyVectorMetrics()
+    pl = PatchLogger(patch_db=None, vector_metrics=vm)
+    metrics = EnhancementMetrics(
+        lines_changed=5,
+        context_tokens=3,
+        time_to_completion=2.0,
+        tests_passed=1,
+        tests_failed=0,
+        error_traces=0,
+        effort_estimate=1.0,
+    )
+    score = pl.recompute_enhancement_score("42", metrics, roi_tag="high-ROI")
+    expected = compute_enhancement_score(metrics)
+    assert score == pytest.approx(expected)
+    assert vm.kwargs["enhancement_score"] == pytest.approx(expected)
+    assert vm.kwargs["roi_tag"] == "high-ROI"


### PR DESCRIPTION
## Summary
- add helper to recompute patch enhancement scores and persist metrics
- load latest enhancement score in PatchRetriever from VectorMetricsDB
- add CLI to backfill enhancement scores for existing patches

## Testing
- `pytest tests/test_track_contributors_enhancement.py tests/test_patch_retriever_metrics.py tests/test_patch_logger_metrics.py tests/test_patch_metrics_persistence.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2c7b93aa4832e8a80e74bce1f8a10