### PR TITLE
Log stat failures for absolute paths

### DIFF
--- a/sandbox_runner/workflow_sandbox_runner.py
+++ b/sandbox_runner/workflow_sandbox_runner.py
@@ -604,7 +604,7 @@ class WorkflowSandboxRunner:
                     try:
                         return original_stat(raw, *a, **kw)
                     except Exception:
-                        logger.exception('unexpected error')
+                        logger.exception("os.stat failed for absolute path %s", raw)
                 current = os.stat
                 try:
                     os.stat = original_stat

--- a/tests/integration/test_workflow_sandbox_runner_error_logging.py
+++ b/tests/integration/test_workflow_sandbox_runner_error_logging.py
@@ -1,5 +1,8 @@
 import logging
 import os
+
+import pytest
+
 from sandbox_runner.workflow_sandbox_runner import WorkflowSandboxRunner
 
 
@@ -10,8 +13,6 @@ def test_run_logs_stat_error(caplog):
         os.stat("/definitely/missing/path")
 
     with caplog.at_level(logging.ERROR):
-        try:
+        with pytest.raises(FileNotFoundError):
             runner.run(wf)
-        except Exception:
-            pass
-    assert any("unexpected error" in r.message for r in caplog.records)
+    assert any("/definitely/missing/path" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- log `os.stat` failures for absolute paths in the sandbox runner
- test that missing absolute paths emit logged errors

## Testing
- `pytest tests/integration/test_workflow_sandbox_runner_error_logging.py::test_run_logs_stat_error -q`
- `pytest tests/test_workflow_sandbox_runner_isolation.py::test_fs_mocks_for_new_wrappers -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2cd050734832e82f04e9d45439d21