### PR TITLE
Propagate enhancement metrics to WeightAdjuster

### DIFF
--- a/tests/test_vector_service_weight_adjuster.py
+++ b/tests/test_vector_service_weight_adjuster.py
@@ -13,9 +13,9 @@ def test_adjust_updates_weights(tmp_path):
         vector_success_delta=0.2,
         vector_failure_delta=0.1,
     )
-    adj.adjust([("db", "v1", 0.5)], 0.8, RoiTag.HIGH_ROI)
+    adj.adjust([("db", "v1", 0.8, RoiTag.HIGH_ROI)])
     assert vm.get_db_weights()["db"] == pytest.approx(0.16)
-    assert vm.get_vector_weight("db:v1") == pytest.approx(0.08)
+    assert vm.get_vector_weight("db:v1") == pytest.approx(0.16)
 
 
 def test_adjust_decreases_on_failure(tmp_path):
@@ -29,7 +29,7 @@ def test_adjust_decreases_on_failure(tmp_path):
         vector_success_delta=0.2,
         vector_failure_delta=0.1,
     )
-    adj.adjust([("db", "v1", 1.0)], 0.8, RoiTag.LOW_ROI)
+    adj.adjust([("db", "v1", 0.8, RoiTag.LOW_ROI)])
     assert vm.get_db_weights()["db"] == pytest.approx(0.42)
     assert vm.get_vector_weight("db:v1") == pytest.approx(0.42)
 

--- a/tests/test_weight_adjuster.py
+++ b/tests/test_weight_adjuster.py
@@ -1,7 +1,9 @@
+import types
 import pytest
 
 from vector_metrics_db import VectorMetricsDB
 from vector_service.weight_adjuster import WeightAdjuster, RoiTag
+from vector_service.patch_logger import PatchLogger
 
 
 def test_weight_adjuster_updates_weights(tmp_path):
@@ -13,12 +15,12 @@ def test_weight_adjuster_updates_weights(tmp_path):
         vector_success_delta=0.2,
         vector_failure_delta=0.1,
     )
-    vectors = [("patch", "v1", 0.0)]
+    vectors = [("patch", "v1", 1.0, RoiTag.SUCCESS)]
 
-    adj.adjust(vectors, 1.0, RoiTag.SUCCESS, tests_passed=True)
+    adj.adjust(vectors, tests_passed=True)
     assert db.get_vector_weight("patch:v1") == pytest.approx(0.2)
 
-    adj.adjust(vectors, 1.0, RoiTag.LOW_ROI, tests_passed=True)
+    adj.adjust([("patch", "v1", 1.0, RoiTag.LOW_ROI)], tests_passed=True)
     assert db.get_vector_weight("patch:v1") == pytest.approx(0.1)
 
 
@@ -31,16 +33,64 @@ def test_weight_adjuster_scales_by_quality(tmp_path):
         vector_success_delta=0.2,
         vector_failure_delta=0.1,
     )
-    vectors = [("patch", "v1", 1.0)]
+    vectors = [("patch", "v1", 1.0, RoiTag.SUCCESS)]
 
-    adj.adjust(vectors, 1.0, RoiTag.SUCCESS, tests_passed=True)
+    adj.adjust(vectors, tests_passed=True)
     base = db.get_vector_weight("patch:v1")
 
     adj.adjust(
         vectors,
-        1.0,
-        RoiTag.SUCCESS,
         tests_passed=False,
         error_trace_count=2,
     )
     assert db.get_vector_weight("patch:v1") == pytest.approx(base - (0.1 / 3))
+
+
+def test_track_contributors_updates_vector_weights(tmp_path):
+    db = VectorMetricsDB(tmp_path / "vm3.db")
+    adj = WeightAdjuster(
+        vector_metrics=db,
+        db_success_delta=0.2,
+        db_failure_delta=0.1,
+        vector_success_delta=0.2,
+        vector_failure_delta=0.1,
+    )
+    ps = types.SimpleNamespace(
+        evaluate=lambda *a, **k: (True, 0.0, {}),
+        record_failure=lambda *a, **k: None,
+        threshold=0.0,
+        max_alert_severity=1.0,
+        max_alerts=5,
+        license_denylist=set(),
+    )
+    pl = PatchLogger(vector_metrics=db, patch_safety=ps, weight_adjuster=adj)
+
+    pl.track_contributors(["db:v1", "db:v2"], True, lines_changed=1)
+
+    assert db.get_vector_weight("db:v1") == pytest.approx(0.2)
+    assert db.get_vector_weight("db:v2") == pytest.approx(0.2)
+
+
+def test_track_contributors_negative_roi_decreases_weight(tmp_path):
+    db = VectorMetricsDB(tmp_path / "vm4.db")
+    adj = WeightAdjuster(
+        vector_metrics=db,
+        db_success_delta=0.2,
+        db_failure_delta=0.1,
+        vector_success_delta=0.2,
+        vector_failure_delta=0.1,
+    )
+    ps = types.SimpleNamespace(
+        evaluate=lambda *a, **k: (True, 0.0, {}),
+        record_failure=lambda *a, **k: None,
+        threshold=0.0,
+        max_alert_severity=1.0,
+        max_alerts=5,
+        license_denylist=set(),
+    )
+    pl = PatchLogger(vector_metrics=db, patch_safety=ps, weight_adjuster=adj)
+
+    pl.track_contributors(["db:v1"], True, lines_changed=1)
+    pl.track_contributors(["db:v1"], True, lines_changed=1, roi_tag=RoiTag.LOW_ROI)
+
+    assert db.get_vector_weight("db:v1") == pytest.approx(0.1)

--- a/tests/test_weight_adjuster_roi_tag.py
+++ b/tests/test_weight_adjuster_roi_tag.py
@@ -1,5 +1,7 @@
 import pytest
 
+import pytest
+
 from vector_service.weight_adjuster import WeightAdjuster, RoiTag
 
 
@@ -31,9 +33,9 @@ def test_roi_tag_positive_overrides_score():
         vector_success_delta=0.2,
         vector_failure_delta=0.2,
     )
-    adj.adjust([("db", "v1", 0.5)], 0.1, RoiTag.SUCCESS)
+    adj.adjust([("db", "v1", 0.1, RoiTag.SUCCESS)])
     assert vm.weights["db"] == pytest.approx(1.02)
-    assert vm.vector_weights["db:v1"] == pytest.approx(0.01)
+    assert vm.vector_weights["db:v1"] == pytest.approx(0.02)
 
 
 def test_roi_tag_negative_overrides_score():
@@ -45,6 +47,6 @@ def test_roi_tag_negative_overrides_score():
         vector_success_delta=0.2,
         vector_failure_delta=0.2,
     )
-    adj.adjust([("db", "v1", 0.5)], 0.9, RoiTag.BUG_INTRODUCED)
+    adj.adjust([("db", "v1", 0.9, RoiTag.BUG_INTRODUCED)])
     assert vm.weights["db"] == pytest.approx(0.82)
     assert vm.vector_weights["db:v1"] == pytest.approx(0.0)

--- a/vector_service/patch_logger.py
+++ b/vector_service/patch_logger.py
@@ -947,10 +947,12 @@ class PatchLogger:
 
         if self.weight_adjuster is not None:
             try:
+                vector_details = [
+                    (o, vid, enhancement_score, roi_tag_val.value)
+                    for o, vid, _ in detailed
+                ]
                 self.weight_adjuster.adjust(
-                    detailed,
-                    enhancement_score,
-                    roi_tag_val.value,
+                    vector_details,
                     error_trace_count=error_trace_count,
                     tests_passed=tests_passed,
                 )


### PR DESCRIPTION
## Summary
- Pass `(origin, vector_id, enhancement_score, roi_tag)` tuples from `PatchLogger.track_contributors` to `WeightAdjuster`
- Extend `WeightAdjuster.adjust` to accept per-vector details and persist individual vector weight updates via `VectorMetricsDB`
- Add tests ensuring per-vector weight updates and negative ROI handling

## Testing
- `pytest tests/test_weight_adjuster.py tests/test_weight_adjuster_roi_tag.py tests/test_vector_service_weight_adjuster.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2cd022e70832eac14a7b52498d610