### PR TITLE
Improve rule-based stub generation

### DIFF
--- a/tests/integration/test_stub_generation.py
+++ b/tests/integration/test_stub_generation.py
@@ -15,5 +15,7 @@ def test_rule_based_stub_generation(monkeypatch):
     monkeypatch.setattr(gsp, "_aload_generator", fake_aload_generator)
     gsp._CACHE.clear()
 
-    stubs = gsp.generate_stubs([{}], {"target": sample_func})
-    assert stubs == [{"name": "example", "count": 1, "active": True}]
+    stubs = gsp.generate_stubs([{}], {"target": sample_func})[0]
+    assert gsp._type_matches(stubs["name"], str)
+    assert gsp._type_matches(stubs["count"], int)
+    assert gsp._type_matches(stubs["active"], bool)

--- a/tests/test_environment_helpers.py
+++ b/tests/test_environment_helpers.py
@@ -259,7 +259,7 @@ def test_generate_input_stubs_synthetic_fallback(monkeypatch, tmp_path):
         pass
 
     stubs = env.generate_input_stubs(1, target=target)
-    assert stubs == [{"a": 1}]
+    assert gsp._type_matches(stubs[0]["a"], int)
 
 
 def test_generate_input_stubs_history_db(monkeypatch, tmp_path):

--- a/tests/test_generative_stub_provider.py
+++ b/tests/test_generative_stub_provider.py
@@ -114,8 +114,12 @@ def test_rule_based_fallback(monkeypatch, tmp_path):
         pass
 
     ctx = {"strategy": "synthetic", "target": target}
-    res = gsp_mod.generate_stubs([{}], ctx)
-    assert res == [{"a": 1, "b": 1.0, "c": True, "d": "value", "e": None}]
+    res = gsp_mod.generate_stubs([{}], ctx)[0]
+    assert gsp_mod._type_matches(res["a"], int)
+    assert gsp_mod._type_matches(res["b"], float)
+    assert gsp_mod._type_matches(res["c"], bool)
+    assert gsp_mod._type_matches(res["d"], str)
+    assert res["e"] is None
 
 
 def test_generation_failure_propagates(monkeypatch, tmp_path):

--- a/tests/test_rule_based_stub_complex.py
+++ b/tests/test_rule_based_stub_complex.py
@@ -1,0 +1,51 @@
+import sandbox_runner.generative_stub_provider as gsp
+
+
+def _disable_generation(monkeypatch):
+    async def _noop():
+        return None
+
+    monkeypatch.setattr(gsp, "_aload_generator", _noop)
+    gsp._CACHE.clear()
+
+
+class Config:
+    def __init__(self, name: str, thresholds: dict[str, list[int]]):
+        self.name = name
+        self.thresholds = thresholds
+
+
+def complex_func(configs: list[Config], mapping: dict[str, tuple[int, float]]) -> None:
+    """Function with nested and custom class annotations."""
+
+
+def test_custom_class_and_nested(monkeypatch):
+    _disable_generation(monkeypatch)
+    stub = gsp.generate_stubs([{}], {"target": complex_func})[0]
+    assert isinstance(stub["configs"], list)
+    assert len(stub["configs"]) == 1
+    cfg = stub["configs"][0]
+    assert isinstance(cfg, Config)
+    assert isinstance(cfg.name, str)
+    assert isinstance(cfg.thresholds, dict)
+    for k, v in cfg.thresholds.items():
+        assert isinstance(k, str)
+        assert isinstance(v, list)
+        assert all(isinstance(i, int) for i in v)
+    mapping = stub["mapping"]
+    assert isinstance(mapping, dict)
+    for k, v in mapping.items():
+        assert isinstance(k, str)
+        assert isinstance(v, tuple) and len(v) == 2
+        assert isinstance(v[0], int)
+        assert isinstance(v[1], float)
+
+
+def test_defaults_used(monkeypatch):
+    _disable_generation(monkeypatch)
+
+    def with_defaults(a: int = 5, flag: bool = False, name: str = "x") -> None:
+        pass
+
+    stub = gsp.generate_stubs([{}], {"target": with_defaults})[0]
+    assert stub == {"a": 5, "flag": False, "name": "x"}


### PR DESCRIPTION
## Summary
- enhance rule-based stub generation with name-aware defaults and default value handling
- expand tests to cover complex annotations and custom classes
- update existing tests for new stub generation semantics

## Testing
- `pre-commit run --files sandbox_runner/generative_stub_provider.py tests/integration/test_stub_generation.py tests/test_environment_helpers.py tests/test_generative_stub_provider.py tests/test_rule_based_stub_complex.py`
- `pytest tests/test_rule_based_stub_types.py::test_nested_and_dataclass tests/test_rule_based_stub_complex.py tests/test_generative_stub_provider.py tests/integration/test_stub_generation.py tests/test_environment_helpers.py::test_generate_input_stubs_synthetic_fallback`


------
https://chatgpt.com/codex/tasks/task_e_68b2cf727158832eb5bc48035a2b398b