### PR TITLE
Persist ROI tag metadata for patch embeddings

### DIFF
--- a/tests/test_patch_logger_metadata.py
+++ b/tests/test_patch_logger_metadata.py
@@ -1,0 +1,58 @@
+import types
+
+from vector_service.patch_logger import PatchLogger
+
+
+class DummyVectorStore:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def add(self, kind, record_id, vector, *, origin_db=None, metadata=None):
+        self.calls.append(
+            {
+                "kind": kind,
+                "record_id": record_id,
+                "origin_db": origin_db,
+                "metadata": metadata or {},
+            }
+        )
+
+
+class DummyVectorService:
+    def __init__(self) -> None:
+        self.vector_store = DummyVectorStore()
+
+    def vectorise(self, kind, record):
+        return [0.0]
+
+    def vectorise_and_store(self, kind, record_id, record, *, origin_db=None, metadata=None):
+        vec = self.vectorise(kind, record)
+        self.vector_store.add(kind, record_id, vec, origin_db=origin_db, metadata=metadata)
+        return vec
+
+
+class DummyPatchDB:
+    def record_provenance(self, *a, **k):
+        pass
+
+    def log_ancestry(self, *a, **k):
+        pass
+
+    def log_contributors(self, *a, **k):
+        pass
+
+    def record_vector_metrics(self, *a, **k):
+        pass
+
+    def get(self, *a, **k):
+        return types.SimpleNamespace(description="some patch")
+
+
+def test_track_contributors_persists_roi_tag_in_metadata():
+    svc = DummyVectorService()
+    pdb = DummyPatchDB()
+    pl = PatchLogger(patch_db=pdb, vector_service=svc)
+    pl.track_contributors(["db:v1"], True, patch_id="1", roi_tag="high-ROI")
+    assert svc.vector_store.calls, "vector store should be called"
+    meta = svc.vector_store.calls[0]["metadata"]
+    assert meta.get("roi_tag") == "high-ROI"

--- a/vector_service/patch_logger.py
+++ b/vector_service/patch_logger.py
@@ -720,6 +720,7 @@ class PatchLogger:
                                 "diff": embed_diff or "",
                                 "summary": embed_summary or "",
                                 "enhancement_score": enhancement_score,
+                                "roi_tag": roi_tag_val.value,
                             }
                             svc = self.vector_service
                             if svc is None:

--- a/vector_service/retriever.py
+++ b/vector_service/retriever.py
@@ -206,6 +206,8 @@ class Retriever:
             if roi_tag is not None:
                 score = max(score - self.roi_tag_weights.get(str(roi_tag), 0.0), 0.0)
                 item["roi_tag"] = roi_tag
+                if isinstance(item.get("metadata"), dict):
+                    item["metadata"]["roi_tag"] = roi_tag
             item["score"] = score
             results.append(item)
         if filtered:
@@ -681,6 +683,8 @@ class PatchRetriever:
             roi_tag = md.get("roi_tag") if isinstance(md, dict) else None
             if roi_tag is not None:
                 score = max(score - self.roi_tag_weights.get(str(roi_tag), 0.0), 0.0)
+                if isinstance(md, dict):
+                    md["roi_tag"] = roi_tag
 
             item = {
                 "origin_db": origin,


### PR DESCRIPTION
## Summary
- include `roi_tag` in patch embedding metadata
- expose `roi_tag` during retrieval for analytics
- test that `PatchLogger` stores ROI tag metadata in vector store

## Testing
- `pytest tests/test_patch_logger_metadata.py tests/test_track_contributors_enhancement.py tests/test_weight_adjuster_roi_tag.py`

------
https://chatgpt.com/codex/tasks/task_e_68b2d43066d8832e8dd7d30e46023843