### PR TITLE
Log warnings for invalid cycle env vars

### DIFF
--- a/sandbox_runner/cli.py
+++ b/sandbox_runner/cli.py
@@ -806,14 +806,22 @@ def full_autonomous_run(
         try:
             roi_cycles = int(env_val)
         except Exception:
-            pass
+            logger.warning(
+                "invalid ROI_CYCLES %r, using %s",
+                env_val,
+                roi_cycles,
+            )
     synergy_cycles = getattr(args, "synergy_cycles", 3)
     env_val = os.getenv("SYNERGY_CYCLES")
     if env_val is not None:
         try:
             synergy_cycles = int(env_val)
         except Exception:
-            pass
+            logger.warning(
+                "invalid SYNERGY_CYCLES %r, using %s",
+                env_val,
+                synergy_cycles,
+            )
     if synergy_threshold_window is None:
         synergy_threshold_window = synergy_cycles
     if synergy_threshold_weight is None:


### PR DESCRIPTION
## Summary
- log and default invalid ROI_CYCLES and SYNERGY_CYCLES values
- test that bad cycle env vars warn without crashing

## Testing
- `pre-commit run --files sandbox_runner/cli.py tests/test_run_autonomous_env_vars.py` *(fails: flake8 existing issues in sandbox_runner/cli.py)*
- `pre-commit run --files tests/test_run_autonomous_env_vars.py`
- `pytest tests/test_run_autonomous_env_vars.py::test_invalid_roi_cycles_warns tests/test_run_autonomous_env_vars.py::test_invalid_synergy_cycles_warns -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2d6025b68832e8d5b4fcdce2f4366