### PR TITLE
Log cache update errors in orphan discovery

### DIFF
--- a/sandbox_runner/orphan_discovery.py
+++ b/sandbox_runner/orphan_discovery.py
@@ -845,6 +845,6 @@ def discover_recursive_orphans(
         append_orphan_cache(repo, entries)
         append_orphan_classifications(repo, class_entries)
     except Exception:  # pragma: no cover - best effort
-        pass
+        logger.exception("failed to update orphan cache for %s", repo)
 
     return result

--- a/tests/test_orphan_cache_logging.py
+++ b/tests/test_orphan_cache_logging.py
@@ -1,0 +1,15 @@
+import logging
+import sandbox_runner.orphan_discovery as od
+
+
+def test_cache_update_logs_error(tmp_path, monkeypatch, caplog):
+    (tmp_path / "a.py").write_text("x = 1\n")
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(od, "append_orphan_cache", boom)
+    monkeypatch.setattr(od, "append_orphan_classifications", lambda *a, **k: None)
+    caplog.set_level(logging.ERROR, logger=od.__name__)
+    od.discover_recursive_orphans(str(tmp_path))
+    assert "failed to update orphan cache" in caplog.text


### PR DESCRIPTION
## Summary
- log failures when updating orphan discovery cache
- test that cache write failures are logged

## Testing
- `pytest tests/test_orphan_cache_logging.py::test_cache_update_logs_error -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2de1c14b4832ebc45554122c6cd9b