### PR TITLE
Add PromptEngine docs and tests

### DIFF
--- a/docs/prompt_engine.md
+++ b/docs/prompt_engine.md
@@ -1,0 +1,41 @@
+# Prompt Engine
+
+The `prompt_engine` module assembles prompts from historical patch examples.
+It queries the retrieval layer for relevant patches, ranks the results and
+formats them into reusable snippets.
+
+## Usage
+
+```python
+from prompt_engine import PromptEngine
+
+prompt = PromptEngine.construct_prompt(
+    "Fix the failing parser",
+    retrieval_data="Related patches:",
+    retry_trace="Traceback: ValueError",
+    top_n=3,
+)
+print(prompt)
+```
+
+A successful lookup yields a prompt such as:
+
+```
+Given the following pattern...
+- Code summary: handle edge case
+  Diff summary: adjust parsing
+  Outcome: works (tests passed)
+
+Traceback: ValueError
+Please try a different approach.
+```
+
+## Configuration
+
+* `top_n` – number of patch examples to retrieve (default: `5`).
+* `DEFAULT_TEMPLATE` – fallback text when no snippets are available.
+* `CONFIDENCE_THRESHOLD` – minimum confidence before using the fallback
+  template.
+* `retrieval_data` – optional prefix containing external context.
+* `retry_trace` – when provided, the failure trace is appended to the prompt
+  to help retries.

--- a/unit_tests/test_prompt_engine.py
+++ b/unit_tests/test_prompt_engine.py
@@ -1,0 +1,46 @@
+import logging
+from prompt_engine import PromptEngine, DEFAULT_TEMPLATE
+
+
+def test_retrieval_snippets_included(monkeypatch):
+    records = [{"metadata": {
+        "summary": "fixed bug", 
+        "diff": "changed logic", 
+        "outcome": "works", 
+        "tests_passed": True
+    }}]
+    monkeypatch.setattr(PromptEngine, "_fetch_patches", staticmethod(lambda q, n: (records, 1.0)))
+    prompt = PromptEngine.construct_prompt("desc")
+    assert "Code summary: fixed bug" in prompt
+    assert "Diff summary: changed logic" in prompt
+    assert "Outcome: works (tests passed)" in prompt
+
+
+def test_orders_by_roi_and_timestamp(monkeypatch):
+    records = [
+        {"metadata": {"roi_delta": 0.1, "summary": "low", "tests_passed": True}},
+        {"metadata": {"roi_delta": 0.9, "summary": "high", "tests_passed": True}},
+        {"metadata": {"ts": 1, "summary": "old fail", "tests_passed": False}},
+        {"metadata": {"ts": 2, "summary": "new fail", "tests_passed": False}},
+    ]
+    monkeypatch.setattr(PromptEngine, "_fetch_patches", staticmethod(lambda q, n: (records, 1.0)))
+    prompt = PromptEngine.construct_prompt("desc")
+    assert prompt.index("Code summary: high") < prompt.index("Code summary: low")
+    assert prompt.index("Code summary: new fail") < prompt.index("Code summary: old fail")
+
+
+def test_fallback_on_low_confidence(monkeypatch, caplog):
+    monkeypatch.setattr(PromptEngine, "_fetch_patches", staticmethod(lambda q, n: ([], 0.0)))
+    with caplog.at_level(logging.INFO):
+        prompt = PromptEngine.construct_prompt("desc")
+    assert prompt == DEFAULT_TEMPLATE
+    assert "falling back" in caplog.text.lower()
+
+
+def test_retry_trace_included(monkeypatch):
+    records = [{"metadata": {"summary": "foo", "tests_passed": True}}]
+    monkeypatch.setattr(PromptEngine, "_fetch_patches", staticmethod(lambda q, n: (records, 1.0)))
+    trace = "Traceback: fail"
+    prompt = PromptEngine.construct_prompt("desc", retry_trace=trace)
+    assert trace in prompt
+    assert "Please try a different approach." in prompt


### PR DESCRIPTION
## Summary
- add unit tests for PromptEngine covering snippet inclusion, ranking, fallback template, and retry traces
- document PromptEngine usage and configuration options

## Testing
- `PYTHONPATH=. pytest unit_tests/test_prompt_engine.py -q > /tmp/pytest.log; tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b2e0479ebc832e9b49d7bfa64a7cd6