### PR TITLE
log missing container ids during cleanup

### DIFF
--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -2962,6 +2962,11 @@ def _cleanup_pools() -> None:
                             stderr=subprocess.DEVNULL,
                             check=False,
                         )
+                    else:
+                        try:
+                            logger.warning("encountered empty container id during prune")
+                        except Exception:
+                            logger.exception('unexpected error')
             else:
                 try:
                     stderr = (proc.stderr or "").strip()


### PR DESCRIPTION
## Summary
- log warning when docker ps outputs empty container ID during cleanup

## Testing
- `pytest sandbox_runner -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2e5b0cad8832e9586af07c8ad2e52