### PR TITLE
Include retry trace guidance for retries

### DIFF
--- a/docs/prompt_engine.md
+++ b/docs/prompt_engine.md
@@ -11,7 +11,6 @@ from prompt_engine import PromptEngine
 
 prompt = PromptEngine.construct_prompt(
     "Fix the failing parser",
-    retrieval_data="Related patches:",
     retry_trace="Traceback: ValueError",
     top_n=3,
 )
@@ -25,9 +24,7 @@ Given the following pattern...
 - Code summary: handle edge case
   Diff summary: adjust parsing
   Outcome: works (tests passed)
-
-Traceback: ValueError
-Please try a different approach.
+Previous attempt failed with Traceback: ValueError; seek alternative solution.
 ```
 
 ## Configuration
@@ -36,6 +33,5 @@ Please try a different approach.
 * `DEFAULT_TEMPLATE` – fallback text when no snippets are available.
 * `CONFIDENCE_THRESHOLD` – minimum confidence before using the fallback
   template.
-* `retrieval_data` – optional prefix containing external context.
-* `retry_trace` – when provided, the failure trace is appended to the prompt
-  to help retries.
+* `retry_trace` – when provided, the prompt includes:
+  `Previous attempt failed with <trace>; seek alternative solution.`

--- a/prompt_engine.py
+++ b/prompt_engine.py
@@ -150,8 +150,9 @@ class PromptEngine:
                 lines.extend(self._format_record(meta))
                 lines.append("")
         if retry_trace:
-            lines.append(retry_trace)
-            lines.append("Please try a different approach.")
+            lines.append(
+                f"Previous attempt failed with {retry_trace}; seek alternative solution."
+            )
         return "\n".join(line for line in lines if line)
 
     # Backwards compatibility -------------------------------------------------

--- a/unit_tests/test_prompt_engine.py
+++ b/unit_tests/test_prompt_engine.py
@@ -4,10 +4,10 @@ from prompt_engine import PromptEngine, DEFAULT_TEMPLATE
 
 def test_retrieval_snippets_included(monkeypatch):
     records = [{"metadata": {
-        "summary": "fixed bug", 
-        "diff": "changed logic", 
-        "outcome": "works", 
-        "tests_passed": True
+        "summary": "fixed bug",
+        "diff": "changed logic",
+        "outcome": "works",
+        "tests_passed": True,
     }}]
     monkeypatch.setattr(PromptEngine, "_fetch_patches", staticmethod(lambda q, n: (records, 1.0)))
     prompt = PromptEngine.construct_prompt("desc")
@@ -42,5 +42,5 @@ def test_retry_trace_included(monkeypatch):
     monkeypatch.setattr(PromptEngine, "_fetch_patches", staticmethod(lambda q, n: (records, 1.0)))
     trace = "Traceback: fail"
     prompt = PromptEngine.construct_prompt("desc", retry_trace=trace)
-    assert trace in prompt
-    assert "Please try a different approach." in prompt
+    expected = f"Previous attempt failed with {trace}; seek alternative solution."
+    assert expected in prompt


### PR DESCRIPTION
## Summary
- Teach `PromptEngine` to add a retry section: "Previous attempt failed with …; seek alternative solution."
- Pull failure traces from analyzer logs or stored state in `SelfCodingEngine` before LLM retries
- Document new retry behavior and extend unit test coverage

## Testing
- `pre-commit run --files prompt_engine.py self_coding_engine.py unit_tests/test_prompt_engine.py`
- `PYTHONPATH=. pytest unit_tests/test_prompt_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2e8461ab0832ea7415aee95c6d7a5