### PR TITLE
feat: support async retries

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -182,6 +182,16 @@ class SandboxSettings(BaseSettings):
         env="SANDBOX_RETRY_DELAY",
         description="Initial delay between restart attempts in seconds.",
     )
+    sandbox_retry_backoff_multiplier: float = Field(
+        1.0,
+        env="SANDBOX_RETRY_BACKOFF_MULTIPLIER",
+        description="Multiplier applied to the base delay for each retry attempt.",
+    )
+    sandbox_retry_jitter: float = Field(
+        0.0,
+        env="SANDBOX_RETRY_JITTER",
+        description="Maximum jitter in seconds added to retry delays.",
+    )
     sandbox_max_retries: int | None = Field(
         None,
         env="SANDBOX_MAX_RETRIES",

--- a/unit_tests/test_self_improvement_engine_utils.py
+++ b/unit_tests/test_self_improvement_engine_utils.py
@@ -41,6 +41,8 @@ def _load_utils():
             self.sandbox_retry_delay = 0
             self.sandbox_max_retries = 0
             self.menace_offline_install = False
+            self.sandbox_retry_backoff_multiplier = 1.0
+            self.sandbox_retry_jitter = 0.0
 
     ns = {
         "importlib": importlib,
@@ -147,3 +149,28 @@ def test_async_retry_and_backoff_features():
     )
     assert attempts["count"] == 2
     assert sleeps == [1.5]
+
+
+def test_async_context_uses_asyncio_sleep():
+    utils = _load_utils()
+    sleeps: list[float] = []
+
+    async def fake_sleep(t: float) -> None:
+        sleeps.append(t)
+
+    utils["asyncio"].sleep = fake_sleep
+    attempts = {"count": 0}
+
+    async def flaky_async():
+        attempts["count"] += 1
+        if attempts["count"] < 2:
+            raise ValueError("boom")
+        return "ok"
+
+    async def runner():
+        return await utils["_call_with_retries"](flaky_async, retries=2, delay=1)
+
+    result = asyncio.run(runner())
+    assert result == "ok"
+    assert attempts["count"] == 2
+    assert sleeps == [1]


### PR DESCRIPTION
## Summary
- handle async callables and event loops in `_call_with_retries`
- expose retry backoff and jitter in `SandboxSettings`
- test async retry paths

## Testing
- `pytest unit_tests/test_self_improvement_utils.py unit_tests/test_self_improvement_engine_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68b2e93fef74832ead041e639f0d2ae9