### PR TITLE
feat: add retrieval fallback analytics

### DIFF
--- a/tests/test_prompt_engine_fallback.py
+++ b/tests/test_prompt_engine_fallback.py
@@ -25,7 +25,27 @@ def test_construct_prompt_fallback_on_low_confidence(monkeypatch, caplog):
         "_fetch_patches",
         staticmethod(lambda q, n: ([], 0.0)),
     )
+    monkeypatch.setattr(PromptEngine, "_static_prompt", staticmethod(lambda: DEFAULT_TEMPLATE))
+    events = []
+    monkeypatch.setattr("prompt_engine.audit_log_event", lambda e, d: events.append((e, d)))
     with caplog.at_level(logging.INFO):
         prompt = PromptEngine.construct_prompt("desc")
     assert prompt == DEFAULT_TEMPLATE
     assert "falling back" in caplog.text.lower()
+    assert events and events[0][0] == "prompt_engine_fallback"
+    assert events[0][1]["reason"] == "low_confidence"
+
+
+def test_construct_prompt_fallback_on_retrieval_error(monkeypatch, caplog):
+    def boom(q, n):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(PromptEngine, "_fetch_patches", staticmethod(boom))
+    monkeypatch.setattr(PromptEngine, "_static_prompt", staticmethod(lambda: DEFAULT_TEMPLATE))
+    events = []
+    monkeypatch.setattr("prompt_engine.audit_log_event", lambda e, d: events.append((e, d)))
+    with caplog.at_level(logging.ERROR):
+        prompt = PromptEngine.construct_prompt("desc")
+    assert prompt == DEFAULT_TEMPLATE
+    assert "boom" in caplog.text.lower()
+    assert events and events[0][1]["reason"] == "retrieval_error"


### PR DESCRIPTION
## Summary
- add configurable confidence threshold to `PromptEngine`
- fall back to static template when average snippet confidence is low or retrieval errors occur
- log fallback events for analytics

## Testing
- `pytest tests/test_prompt_engine_fallback.py -q`
- `pre-commit run --files prompt_engine.py tests/test_prompt_engine_fallback.py` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ea2b8498832eb880278a8997a6b3