### PR TITLE
refactor: add dependency-injected prompt engine

### DIFF
--- a/tests/test_prompt_engine_fallback.py
+++ b/tests/test_prompt_engine_fallback.py
@@ -1,35 +1,44 @@
+from typing import Any, Dict, List, Tuple
 import logging
+
 from prompt_engine import PromptEngine, DEFAULT_TEMPLATE
 
 
-def test_construct_prompt_orders_by_roi_and_timestamp(monkeypatch):
+class DummyRetriever:
+    def __init__(self, records: List[Dict[str, Any]], boom: bool = False):
+        self.records = records
+        self.boom = boom
+
+    def search(self, query: str, top_k: int):
+        if self.boom:
+            raise RuntimeError("boom")
+        return self.records[:top_k]
+
+
+def _record(score: float, **meta: Any) -> Dict[str, Any]:
+    return {"score": score, "metadata": meta}
+
+
+def test_construct_prompt_orders_by_roi_and_timestamp():
     records = [
-        {"metadata": {"roi_delta": 0.1, "summary": "low", "tests_passed": True}},
-        {"metadata": {"roi_delta": 0.9, "summary": "high", "tests_passed": True}},
-        {"metadata": {"ts": 1, "summary": "old fail", "tests_passed": False}},
-        {"metadata": {"ts": 2, "summary": "new fail", "tests_passed": False}},
+        _record(1.0, roi_delta=0.1, summary="low", tests_passed=True),
+        _record(1.0, roi_delta=0.9, summary="high", tests_passed=True),
+        _record(1.0, ts=1, summary="old fail", tests_passed=False),
+        _record(1.0, ts=2, summary="new fail", tests_passed=False),
     ]
-
-    def fake_fetch(q, n):
-        return records, 0.9
-
-    monkeypatch.setattr(PromptEngine, "_fetch_patches", staticmethod(fake_fetch))
-    prompt = PromptEngine.construct_prompt("desc")
+    engine = PromptEngine(retriever=DummyRetriever(records))
+    prompt = engine.build_prompt("desc")
     assert prompt.index("Code summary: high") < prompt.index("Code summary: low")
     assert prompt.index("Code summary: new fail") < prompt.index("Code summary: old fail")
 
 
 def test_construct_prompt_fallback_on_low_confidence(monkeypatch, caplog):
-    monkeypatch.setattr(
-        PromptEngine,
-        "_fetch_patches",
-        staticmethod(lambda q, n: ([], 0.0)),
-    )
-    monkeypatch.setattr(PromptEngine, "_static_prompt", staticmethod(lambda: DEFAULT_TEMPLATE))
-    events = []
+    engine = PromptEngine(retriever=DummyRetriever([]))
+    monkeypatch.setattr(engine, "_static_prompt", lambda: DEFAULT_TEMPLATE)
+    events: List[Tuple[str, Dict[str, Any]]] = []
     monkeypatch.setattr("prompt_engine.audit_log_event", lambda e, d: events.append((e, d)))
     with caplog.at_level(logging.INFO):
-        prompt = PromptEngine.construct_prompt("desc")
+        prompt = engine.build_prompt("desc")
     assert prompt == DEFAULT_TEMPLATE
     assert "falling back" in caplog.text.lower()
     assert events and events[0][0] == "prompt_engine_fallback"
@@ -37,15 +46,12 @@ def test_construct_prompt_fallback_on_low_confidence(monkeypatch, caplog):
 
 
 def test_construct_prompt_fallback_on_retrieval_error(monkeypatch, caplog):
-    def boom(q, n):
-        raise RuntimeError("boom")
-
-    monkeypatch.setattr(PromptEngine, "_fetch_patches", staticmethod(boom))
-    monkeypatch.setattr(PromptEngine, "_static_prompt", staticmethod(lambda: DEFAULT_TEMPLATE))
-    events = []
+    engine = PromptEngine(retriever=DummyRetriever([], boom=True))
+    monkeypatch.setattr(engine, "_static_prompt", lambda: DEFAULT_TEMPLATE)
+    events: List[Tuple[str, Dict[str, Any]]] = []
     monkeypatch.setattr("prompt_engine.audit_log_event", lambda e, d: events.append((e, d)))
     with caplog.at_level(logging.ERROR):
-        prompt = PromptEngine.construct_prompt("desc")
+        prompt = engine.build_prompt("desc")
     assert prompt == DEFAULT_TEMPLATE
     assert "boom" in caplog.text.lower()
     assert events and events[0][1]["reason"] == "retrieval_error"

--- a/unit_tests/test_prompt_engine.py
+++ b/unit_tests/test_prompt_engine.py
@@ -1,46 +1,63 @@
-import logging
 from prompt_engine import PromptEngine, DEFAULT_TEMPLATE
+from typing import Any, Dict, List
+import logging
 
 
-def test_retrieval_snippets_included(monkeypatch):
-    records = [{"metadata": {
-        "summary": "fixed bug",
-        "diff": "changed logic",
-        "outcome": "works",
-        "tests_passed": True,
-    }}]
-    monkeypatch.setattr(PromptEngine, "_fetch_patches", staticmethod(lambda q, n: (records, 1.0)))
-    prompt = PromptEngine.construct_prompt("desc")
+class DummyRetriever:
+    def __init__(self, records):
+        self.records = records
+
+    def search(self, query, top_k):
+        return self.records[:top_k]
+
+
+def _record(score: float, **meta: Any) -> Dict[str, Any]:
+    return {"score": score, "metadata": meta}
+
+
+def test_retrieval_snippets_included():
+    records = [
+        _record(
+            1.0,
+            summary="fixed bug",
+            diff="changed logic",
+            outcome="works",
+            tests_passed=True,
+        )
+    ]
+    engine = PromptEngine(retriever=DummyRetriever(records))
+    prompt = engine.build_prompt("desc")
     assert "Code summary: fixed bug" in prompt
     assert "Diff summary: changed logic" in prompt
     assert "Outcome: works (tests passed)" in prompt
 
 
-def test_orders_by_roi_and_timestamp(monkeypatch):
+def test_orders_by_roi_and_timestamp():
     records = [
-        {"metadata": {"roi_delta": 0.1, "summary": "low", "tests_passed": True}},
-        {"metadata": {"roi_delta": 0.9, "summary": "high", "tests_passed": True}},
-        {"metadata": {"ts": 1, "summary": "old fail", "tests_passed": False}},
-        {"metadata": {"ts": 2, "summary": "new fail", "tests_passed": False}},
+        _record(1.0, roi_delta=0.1, summary="low", tests_passed=True),
+        _record(1.0, roi_delta=0.9, summary="high", tests_passed=True),
+        _record(1.0, ts=1, summary="old fail", tests_passed=False),
+        _record(1.0, ts=2, summary="new fail", tests_passed=False),
     ]
-    monkeypatch.setattr(PromptEngine, "_fetch_patches", staticmethod(lambda q, n: (records, 1.0)))
-    prompt = PromptEngine.construct_prompt("desc")
+    engine = PromptEngine(retriever=DummyRetriever(records))
+    prompt = engine.build_prompt("desc")
     assert prompt.index("Code summary: high") < prompt.index("Code summary: low")
     assert prompt.index("Code summary: new fail") < prompt.index("Code summary: old fail")
 
 
-def test_fallback_on_low_confidence(monkeypatch, caplog):
-    monkeypatch.setattr(PromptEngine, "_fetch_patches", staticmethod(lambda q, n: ([], 0.0)))
+def test_fallback_on_low_confidence(caplog):
+    records: List[Dict[str, Any]] = []
+    engine = PromptEngine(retriever=DummyRetriever(records))
     with caplog.at_level(logging.INFO):
-        prompt = PromptEngine.construct_prompt("desc")
+        prompt = engine.build_prompt("desc")
     assert prompt == DEFAULT_TEMPLATE
     assert "falling back" in caplog.text.lower()
 
 
-def test_retry_trace_included(monkeypatch):
-    records = [{"metadata": {"summary": "foo", "tests_passed": True}}]
-    monkeypatch.setattr(PromptEngine, "_fetch_patches", staticmethod(lambda q, n: (records, 1.0)))
+def test_retry_trace_included():
+    records = [_record(1.0, summary="foo", tests_passed=True)]
+    engine = PromptEngine(retriever=DummyRetriever(records))
     trace = "Traceback: fail"
-    prompt = PromptEngine.construct_prompt("desc", retry_trace=trace)
+    prompt = engine.build_prompt("desc", retry_info=trace)
     expected = f"Previous attempt failed with {trace}; seek alternative solution."
     assert expected in prompt


### PR DESCRIPTION
## Summary
- refactor prompt engine to accept retriever/context builder dependencies
- expose build_prompt and build_snippets for snippet orchestration
- update tests to exercise new prompt engine behaviour

## Testing
- `pre-commit run --files prompt_engine.py tests/test_prompt_engine_fallback.py tests/test_prompt_engine_vector_service.py unit_tests/test_prompt_engine.py`
- `pytest tests/test_prompt_engine_fallback.py tests/test_prompt_engine_vector_service.py unit_tests/test_prompt_engine.py tests/test_self_coding_engine_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2ec21b8a8832ea5e58af07c418399