### PR TITLE
feat: rank retriever results by ROI and recency

### DIFF
--- a/tests/test_prompt_engine_fallback.py
+++ b/tests/test_prompt_engine_fallback.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Tuple
 import logging
 
 from prompt_engine import PromptEngine, DEFAULT_TEMPLATE
+from vector_service.roi_tags import RoiTag
 
 
 class DummyRetriever:
@@ -21,8 +22,8 @@ def _record(score: float, **meta: Any) -> Dict[str, Any]:
 
 def test_construct_prompt_orders_by_roi_and_timestamp():
     records = [
-        _record(1.0, roi_delta=0.1, summary="low", tests_passed=True),
-        _record(1.0, roi_delta=0.9, summary="high", tests_passed=True),
+        _record(1.0, roi_tag=RoiTag.LOW_ROI.value, summary="low", tests_passed=True),
+        _record(1.0, roi_tag=RoiTag.HIGH_ROI.value, summary="high", tests_passed=True),
         _record(1.0, ts=1, summary="old fail", tests_passed=False),
         _record(1.0, ts=2, summary="new fail", tests_passed=False),
     ]

--- a/tests/test_prompt_engine_vector_service.py
+++ b/tests/test_prompt_engine_vector_service.py
@@ -4,6 +4,7 @@ from prompt_engine import PromptEngine, DEFAULT_TEMPLATE
 import vector_service.vectorizer as vz
 from vector_service.retriever import PatchRetriever
 from vector_service.vector_store import AnnoyVectorStore
+from vector_service.roi_tags import RoiTag
 
 
 def _setup_store(monkeypatch, tmp_path, patches, query_vec):
@@ -46,8 +47,8 @@ def test_prompt_engine_retrieves_top_n_snippets(monkeypatch, tmp_path):
 
 def test_prompt_engine_orders_by_roi_and_recency(monkeypatch, tmp_path):
     patches = [
-        ("1", [1.0, 0.0], {"summary": "low", "tests_passed": True, "roi_delta": 0.1}),
-        ("2", [1.0, 0.0], {"summary": "high", "tests_passed": True, "roi_delta": 0.9}),
+        ("1", [1.0, 0.0], {"summary": "low", "tests_passed": True, "roi_tag": RoiTag.LOW_ROI.value}),
+        ("2", [1.0, 0.0], {"summary": "high", "tests_passed": True, "roi_tag": RoiTag.HIGH_ROI.value}),
         ("3", [1.0, 0.0], {"summary": "old fail", "tests_passed": False, "ts": 1}),
         ("4", [1.0, 0.0], {"summary": "new fail", "tests_passed": False, "ts": 2}),
     ]

--- a/unit_tests/test_prompt_engine.py
+++ b/unit_tests/test_prompt_engine.py
@@ -1,4 +1,5 @@
 from prompt_engine import PromptEngine, DEFAULT_TEMPLATE
+from vector_service.roi_tags import RoiTag
 from typing import Any, Dict, List
 import logging
 
@@ -34,8 +35,8 @@ def test_retrieval_snippets_included():
 
 def test_orders_by_roi_and_timestamp():
     records = [
-        _record(1.0, roi_delta=0.1, summary="low", tests_passed=True),
-        _record(1.0, roi_delta=0.9, summary="high", tests_passed=True),
+        _record(1.0, roi_tag=RoiTag.LOW_ROI.value, summary="low", tests_passed=True),
+        _record(1.0, roi_tag=RoiTag.HIGH_ROI.value, summary="high", tests_passed=True),
         _record(1.0, ts=1, summary="old fail", tests_passed=False),
         _record(1.0, ts=2, summary="new fail", tests_passed=False),
     ]


### PR DESCRIPTION
## Summary
- call Retriever.search with task description and rank patches using ROI tags and timestamps
- expose configurable top-N and weighting for ROI and recency
- include ROI tag metadata in snippet compression and output

## Testing
- `pytest unit_tests/test_prompt_engine.py tests/test_prompt_engine_vector_service.py tests/test_prompt_engine_fallback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2ee659024832eb478983f3416049b