### PR TITLE
docs: add sandbox self-improvement guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1301,6 +1301,46 @@ The Menace integrity model interprets tiers as follows:
 * ``critical`` – treated as integrity violations and usually block deployment
   until resolved or explicitly waived.
 
+### Sandbox self-improvement
+
+See [docs/sandbox_self_improvement.md](docs/sandbox_self_improvement.md) for a
+full walkthrough covering package requirements, environment variables, example
+workflows and troubleshooting tips.
+
+#### Required packages
+
+- `sandbox_runner`
+- `quick_fix_engine`
+
+#### Optional packages
+
+- `pandas`, `psutil` and `prometheus-client` for metrics dashboards and resource
+  statistics
+- `torch` for deep reinforcement learning modules
+
+#### Key environment variables
+
+- `SANDBOX_REPO_PATH` – path to the local sandbox repository clone
+- `SANDBOX_DATA_DIR` – directory where metrics and state files are written
+- `SANDBOX_ENV_PRESETS` – comma separated scenario preset files
+- `AUTO_TRAIN_INTERVAL`, `SYNERGY_TRAIN_INTERVAL`, `ADAPTIVE_ROI_RETRAIN_INTERVAL`
+  – control retraining frequency
+- `ENABLE_META_PLANNER` – require meta-planning support when set to ``true``
+
+#### Example workflow
+
+```bash
+SANDBOX_REPO_PATH=$(pwd) python sandbox_runner.py --runs 1
+```
+
+#### Troubleshooting
+
+- ``ModuleNotFoundError`` for `sandbox_runner` or `quick_fix_engine`: install
+  missing packages or rerun `./setup_env.sh`
+- ``RuntimeError: ffmpeg not found``: install `ffmpeg` and `tesseract` and
+  ensure they are on ``PATH``
+- Stale containers or overlays: ``python -m sandbox_runner.cli --cleanup``
+
 ### Safe mode, self-improvement intervals and metrics
 
 Run individual modules inside an isolated directory and block outbound
@@ -1329,19 +1369,6 @@ Self-improvement cycles retrain the synergy learner periodically. Set
 often weights are updated. ``ADAPTIVE_ROI_RETRAIN_INTERVAL`` controls ROI
 retraining frequency. Lower values shorten the feedback loop while higher ones
 reduce system load.
-
-#### Optional dependencies
-
-Some features rely on optional packages:
-
-- ``sandbox_runner`` and ``quick_fix_engine`` enable orphan integration and
-  helper patch generation.  Missing modules raise ``RuntimeError`` when those
-  features are invoked.
-- ``pandas``, ``psutil`` and ``prometheus-client`` power metrics dashboards and
-  detailed resource statistics.  If absent the sandbox logs a warning and
-  skips the related functionality.
-- ``torch`` enables deep reinforcement learners.  When not installed the engine
-  falls back to simpler strategies.
 
 #### Personal ``SandboxSettings`` example
 

--- a/docs/sandbox_self_improvement.md
+++ b/docs/sandbox_self_improvement.md
@@ -1,0 +1,62 @@
+# Sandbox Self-Improvement
+
+This guide outlines the packages, environment variables and common workflows needed
+to run self-improvement cycles inside the sandbox.
+
+## Required packages
+
+- Install core dependencies with `./setup_env.sh` or `pip install -r requirements.txt`.
+- `sandbox_runner` and `quick_fix_engine` provide the execution harness and patch
+generation.
+
+## Optional packages
+
+- `pandas`, `psutil` and `prometheus-client` enable dashboards and resource
+  metrics.
+- `torch` supplies deep reinforcement learning modules.
+
+## Environment variables
+
+- `SANDBOX_REPO_PATH` – path to the local sandbox repository clone.
+- `SANDBOX_DATA_DIR` – directory for metrics and state files.
+- `SANDBOX_ENV_PRESETS` – comma separated scenario preset files.
+- `AUTO_TRAIN_INTERVAL`, `SYNERGY_TRAIN_INTERVAL`,
+  `ADAPTIVE_ROI_RETRAIN_INTERVAL` – control retraining frequency.
+- `ENABLE_META_PLANNER` – require meta-planning support when set to `true`.
+
+## Example workflows
+
+### Run a single cycle from the CLI
+
+```bash
+SANDBOX_REPO_PATH=$(pwd) python sandbox_runner.py --runs 1
+```
+
+### Trigger a cycle programmatically
+
+```python
+from self_improvement import SelfImprovementEngine
+from model_automation_pipeline import ModelAutomationPipeline
+
+engine = SelfImprovementEngine(bot_name="alpha",
+                               pipeline=ModelAutomationPipeline())
+engine.run_cycle()
+```
+
+## Troubleshooting
+
+### Missing dependencies
+
+- `ModuleNotFoundError: sandbox_runner` or `quick_fix_engine` – run
+  `./setup_env.sh` or install the packages manually.
+- `RuntimeError: ffmpeg not found` – install `ffmpeg` and `tesseract` and
+  ensure they are on `PATH`.
+
+### Common runtime errors
+
+- Stale containers or overlays: `python -m sandbox_runner.cli --cleanup`.
+- Planner required but unavailable: set `ENABLE_META_PLANNER=0` to disable
+  meta-planning.
+
+For configuration details see
+[`sandbox_self_improvement_configuration.md`](sandbox_self_improvement_configuration.md).


### PR DESCRIPTION
## Summary
- document sandbox self-improvement prerequisites in README
- add dedicated guide covering packages, env vars, example workflows, and troubleshooting

## Testing
- `pytest tests/integration/test_full_self_improvement_cycle.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2f0afb6dc832ea5d030851a919b7c