### PR TITLE
Add token-aware patch compression for prompts

### DIFF
--- a/tests/test_prompt_engine_vector_service.py
+++ b/tests/test_prompt_engine_vector_service.py
@@ -40,6 +40,7 @@ def test_prompt_engine_retrieves_top_n_snippets(monkeypatch, tmp_path):
     pr = _setup_store(monkeypatch, tmp_path, patches, [1.0, 0.0])
     engine = PromptEngine(retriever=pr, top_n=2)
     prompt = engine.build_prompt("goal")
+    assert "Successful example:" in prompt
     assert "Code summary: A1" in prompt
     assert "Code summary: A2" in prompt
     assert "A3" not in prompt

--- a/unit_tests/test_prompt_engine.py
+++ b/unit_tests/test_prompt_engine.py
@@ -28,6 +28,7 @@ def test_retrieval_snippets_included():
     ]
     engine = PromptEngine(retriever=DummyRetriever(records))
     prompt = engine.build_prompt("desc")
+    assert "Successful example:" in prompt
     assert "Code summary: fixed bug" in prompt
     assert "Diff summary: changed logic" in prompt
     assert "Outcome: works (tests passed)" in prompt


### PR DESCRIPTION
## Summary
- Compress patch metadata into concise snippets using ContextBuilder token counting
- Include code, diff, and test log in prompt snippets grouped by success/failure
- Add regression tests for new headings in prompt output

## Testing
- `pytest unit_tests/test_prompt_engine.py tests/test_prompt_engine_vector_service.py`
- `pytest` *(fails: FileNotFoundError: 'docker', 290 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f074dd78832e8c68bce0532389bc