### PR TITLE
feat: fallback to static templates on low confidence

### DIFF
--- a/tests/test_prompt_engine_fallback.py
+++ b/tests/test_prompt_engine_fallback.py
@@ -1,5 +1,6 @@
-from typing import Any, Dict, List, Tuple
+import json
 import logging
+from typing import Any, Dict, List, Tuple
 
 from prompt_engine import PromptEngine, DEFAULT_TEMPLATE
 from vector_service.roi_tags import RoiTag
@@ -56,3 +57,15 @@ def test_construct_prompt_fallback_on_retrieval_error(monkeypatch, caplog):
     assert prompt == DEFAULT_TEMPLATE
     assert "boom" in caplog.text.lower()
     assert events and events[0][1]["reason"] == "retrieval_error"
+
+
+def test_static_prompt_uses_config(tmp_path):
+    data = {"templates": {"a": ["A1", "A2"], "b": ["B1"]}}
+    cfg = tmp_path / "prompts.json"
+    cfg.write_text(json.dumps(data))
+    engine = PromptEngine(
+        retriever=DummyRetriever([]),
+        template_path=cfg,
+        template_sections=["a"],
+    )
+    assert engine._static_prompt() == "A1\nA2"


### PR DESCRIPTION
## Summary
- compute prompt confidence from retrieval scores
- load fallback templates from config when retrieval is weak or empty
- support custom template sections via config

## Testing
- `pre-commit run --files prompt_engine.py tests/test_prompt_engine_fallback.py`
- `pytest tests/test_prompt_engine_fallback.py tests/test_prompt_engine_vector_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2f322d1ac832eb6e367aa8994cdb6