### PR TITLE
feat: persist configurable synergy weights

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -453,6 +453,24 @@ class SandboxSettings(BaseSettings):
         env="SYNERGY_WEIGHTS_PATH",
         description="Persisted synergy weight JSON file.",
     )
+    synergy_weight_file: str = Field(
+        "sandbox_data/synergy_weights.json",
+        env="SYNERGY_WEIGHT_FILE",
+        description="File storing persisted synergy weights between runs.",
+    )
+    default_synergy_weights: dict[str, float] = Field(
+        default_factory=lambda: {
+            "roi": 1.0,
+            "efficiency": 1.0,
+            "resilience": 1.0,
+            "antifragility": 1.0,
+            "reliability": 1.0,
+            "maintainability": 1.0,
+            "throughput": 1.0,
+        },
+        env="DEFAULT_SYNERGY_WEIGHTS",
+        description="Fallback synergy weights used when no persisted file is found.",
+    )
     alignment_flags_path: str = Field(
         "sandbox_data/alignment_flags.jsonl",
         env="ALIGNMENT_FLAGS_PATH",


### PR DESCRIPTION
## Summary
- allow setting synergy_weight_file and default_synergy_weights via SandboxSettings
- load synergy weights from configured file in self_improvement and fall back to defaults
- persist updated synergy weights atomically for reuse across runs

## Testing
- `pytest menace_sandbox/tests/test_atomic_file_writes.py::test_atomic_write_no_corruption -q` *(fails: AttributeError: module 'sandbox_runner.environment' has no attribute '_write_active_containers')*


------
https://chatgpt.com/codex/tasks/task_e_68b2f54d7d3c832ebd257f61d852d618