### PR TITLE
refactor: remove auto installs and add dependency check

### DIFF
--- a/startup_checks.py
+++ b/startup_checks.py
@@ -62,6 +62,20 @@ def validate_dependencies(modules: Iterable[str] = OPTIONAL_LIBS) -> list[str]:
     return missing
 
 
+def verify_optional_dependencies(modules: Iterable[str] | None = None) -> list[str]:
+    """Return list of optional modules specific to the sandbox that are missing."""
+
+    modules = list(modules) if modules is not None else ["quick_fix_engine"]
+    missing: list[str] = []
+    for mod in modules:
+        try:
+            importlib.import_module(mod)
+        except Exception:
+            logger.warning("optional dependency %s is missing", mod)
+            missing.append(mod)
+    return missing
+
+
 def _parse_requirement(req: str) -> str:
     """Return the package name portion of a dependency string."""
     name = req.split(";")[0].strip()
@@ -145,6 +159,7 @@ def run_startup_checks(pyproject_path: Path | None = None) -> None:
     missing_optional = validate_dependencies()
     if missing_optional:
         _install_packages(missing_optional)
+    verify_optional_dependencies()
     missing = verify_project_dependencies(pyproject_path or PYPROJECT_PATH)
     mode = os.getenv("MENACE_MODE", "test").lower()
     if missing:
@@ -182,4 +197,5 @@ __all__ = [
     "verify_critical_libs",
     "verify_project_dependencies",
     "dependencies_from_pyproject",
+    "verify_optional_dependencies",
 ]

--- a/unit_tests/test_self_improvement_engine_utils.py
+++ b/unit_tests/test_self_improvement_engine_utils.py
@@ -1,5 +1,4 @@
 import ast
-import ast
 import importlib
 import logging
 import time
@@ -11,8 +10,6 @@ import asyncio
 import random
 import inspect
 from dataclasses import dataclass
-import subprocess
-import sys
 import threading
 from functools import lru_cache
 
@@ -57,8 +54,6 @@ def _load_utils():
         "self_improvement_failure_total": counter,
         "SandboxSettings": _StubSettings,
         "dataclass": dataclass,
-        "subprocess": subprocess,
-        "sys": sys,
         "threading": threading,
         "lru_cache": lru_cache,
     }
@@ -68,13 +63,10 @@ def _load_utils():
 
 def test_missing_dependency_returns_stub():
     utils = _load_utils()
-    with patch("subprocess.run") as sp, patch(
-        "importlib.import_module", side_effect=ModuleNotFoundError
-    ):
+    with patch("importlib.import_module", side_effect=ModuleNotFoundError):
         fn = utils["_load_callable"]("mod", "attr")
         with pytest.raises(RuntimeError):
             fn()
-    sp.assert_not_called()
 
 
 def test_retry_succeeds_after_transient_failure():
@@ -104,9 +96,7 @@ def test_load_callable_retry_when_enabled():
             raise ModuleNotFoundError
         return types.SimpleNamespace(attr=lambda: "ok")
 
-    with patch("subprocess.run", side_effect=Exception), patch(
-        "importlib.import_module", side_effect=side_effect
-    ):
+    with patch("importlib.import_module", side_effect=side_effect):
         utils["SandboxSettings"] = lambda: types.SimpleNamespace(
             retry_optional_dependencies=True,
             sandbox_retry_delay=0,


### PR DESCRIPTION
## Summary
- raise explicit runtime errors for missing optional dependencies instead of auto-installing
- add `verify_optional_dependencies` preflight check executed during startup
- update tests for new dependency handling

## Testing
- `pytest unit_tests/test_self_improvement_utils.py unit_tests/test_self_improvement_engine_utils.py tests/test_startup_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_68b2f93370d8832e98fd50e6798e23d7