### PR TITLE
feat: make training intervals configurable

### DIFF
--- a/docs/autonomous_sandbox.md
+++ b/docs/autonomous_sandbox.md
@@ -649,6 +649,9 @@ persisted to `sandbox_data/metrics.db` for later inspection.
 - `SANDBOX_PRESET_RL_STRATEGY` – reinforcement learning algorithm
 - `SANDBOX_ADAPTIVE_AGENT_PATH` – path to the adaptive RL agent state
 - `SANDBOX_ADAPTIVE_AGENT_STRATEGY` – algorithm for the adaptive agent
+- `ADAPTIVE_ROI_TRAIN_INTERVAL` – seconds between scheduled adaptive ROI training
+- `ADAPTIVE_ROI_RETRAIN_INTERVAL` – cycles between adaptive ROI model retraining
+- `SELF_IMPROVEMENT_BACKUP_COUNT` – number of rotated backups to keep for self-improvement data
 
 ### Recursion environment variables
 

--- a/sandbox_runner/cycle.py
+++ b/sandbox_runner/cycle.py
@@ -79,10 +79,6 @@ logger = get_logger(__name__)
 from analytics import adaptive_roi_model
 from adaptive_roi_predictor import load_training_data
 
-ADAPTIVE_ROI_RETRAIN_INTERVAL = int(
-    os.getenv("ADAPTIVE_ROI_RETRAIN_INTERVAL", "20")
-)
-
 from metrics_exporter import (
     orphan_modules_reintroduced_total,
     orphan_modules_tested_total,
@@ -684,6 +680,8 @@ def _sandbox_cycle_runner(
             record_error(exc)
 
     tuner = ResourceTuner()
+    settings = getattr(ctx, "settings", SandboxSettings())
+    retrain_interval = getattr(settings, "adaptive_roi_retrain_interval", 20)
 
     low_roi_streak = 0
     resilience_history: list[float] = []
@@ -1918,7 +1916,7 @@ def _sandbox_cycle_runner(
         except Exception:
             logger.exception("relevancy radar flagging failed")
 
-        if (idx + 1) % ADAPTIVE_ROI_RETRAIN_INTERVAL == 0:
+        if (idx + 1) % retrain_interval == 0:
             logger.info(
                 "adaptive roi model retrain", extra=log_record(cycle=idx)
             )

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -657,6 +657,16 @@ class SandboxSettings(BaseSettings):
             raise ValueError(f"{info.field_name} must be a positive integer")
         return v
 
+    @field_validator(
+        "adaptive_roi_retrain_interval",
+        "adaptive_roi_train_interval",
+        "backup_rotation_count",
+    )
+    def _validate_positive_training(cls, v: int, info: Any) -> int:
+        if v <= 0:
+            raise ValueError(f"{info.field_name} must be a positive integer")
+        return v
+
     @field_validator("weight_update_interval", "test_run_timeout")
     def _validate_positive_float(cls, v: float, info: Any) -> float:
         if v <= 0:
@@ -906,6 +916,21 @@ class SandboxSettings(BaseSettings):
     synergy_weights_lr: float = Field(0.1, env="SYNERGY_WEIGHTS_LR")
     synergy_train_interval: int = Field(10, env="SYNERGY_TRAIN_INTERVAL")
     synergy_replay_size: int = Field(100, env="SYNERGY_REPLAY_SIZE")
+    adaptive_roi_retrain_interval: int = Field(
+        20,
+        env="ADAPTIVE_ROI_RETRAIN_INTERVAL",
+        description="Cycles between adaptive ROI model retraining.",
+    )
+    adaptive_roi_train_interval: int = Field(
+        3600,
+        env="ADAPTIVE_ROI_TRAIN_INTERVAL",
+        description="Seconds between scheduled adaptive ROI predictor training.",
+    )
+    backup_rotation_count: int = Field(
+        3,
+        env="SELF_IMPROVEMENT_BACKUP_COUNT",
+        description="Number of rotated backups to keep for self-improvement data.",
+    )
     scenario_metric_thresholds: dict[str, float] = Field(
         default_factory=lambda: {
             "schema_mismatch_rate": 0.1,


### PR DESCRIPTION
## Summary
- expose adaptive ROI training and retraining intervals in SandboxSettings
- load backup rotation count from SandboxSettings and use configurable defaults
- document new adaptive ROI and backup settings

## Testing
- `make mypy`
- `pytest tests/test_self_improvement_cycle_regression.py tests/test_self_improvement_error_handling.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2fb4dea4c832e9364855992d275a8