### PR TITLE
feat: add retry trace to prompt builder

### DIFF
--- a/docs/prompt_engine.md
+++ b/docs/prompt_engine.md
@@ -24,9 +24,9 @@ Given the following pattern...
 - Code summary: handle edge case
   Diff summary: adjust parsing
   Outcome: works (tests passed)
-Previous attempt failed with:
+Previous failure:
 Traceback: ValueError
-Try a different approach.
+Please attempt a different solution.
 ```
 
 ## Configuration
@@ -38,7 +38,7 @@ Try a different approach.
 * `retry_trace` – when provided, the prompt includes:
 
   ```
-  Previous attempt failed with:
+  Previous failure:
   <trace>
-  Try a different approach.
+  Please attempt a different solution.
   ```

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -324,7 +324,7 @@ class SelfCodingEngine:
             description,
             context="\n".join([p for p in (context.strip(), repo_layout) if p]),
             retrieval_context=retrieval_context or "",
-            retry_info=retry_trace,
+            retry_trace=retry_trace,
         )
         if VA_PROMPT_TEMPLATE:
             try:
@@ -424,7 +424,7 @@ class SelfCodingEngine:
                 description,
                 context="\n".join([p for p in (context, repo_layout) if p]),
                 retrieval_context=retrieval_context,
-                retry_info=retry_trace,
+                retry_trace=retry_trace,
             )
         except Exception as exc:
             self._last_retry_trace = str(exc)

--- a/tests/test_build_visual_agent_prompt.py
+++ b/tests/test_build_visual_agent_prompt.py
@@ -125,12 +125,14 @@ import menace.self_coding_engine as sce  # noqa: E402
 def test_build_visual_agent_prompt_basic(monkeypatch):
     captured: dict[str, str | None] = {}
 
-    def fake_build_prompt(self, description, *, context="", retrieval_context="", retry_info=None):
+    def fake_build_prompt(
+        self, description, *, context="", retrieval_context="", retry_trace=None
+    ):
         captured.update(
             description=description,
             context=context,
             retrieval_context=retrieval_context,
-            retry_info=retry_info,
+            retry_trace=retry_trace,
         )
         return "PROMPT"
 
@@ -142,7 +144,7 @@ def test_build_visual_agent_prompt_basic(monkeypatch):
     assert captured["description"] == "print hello"
     assert "def hello()" in captured["context"]
     assert captured["retrieval_context"] == ""
-    assert captured["retry_info"] is None
+    assert captured["retry_trace"] is None
 
 
 def test_build_visual_agent_prompt_env(monkeypatch, tmp_path):
@@ -167,7 +169,9 @@ def test_build_visual_agent_prompt_layout(monkeypatch):
     importlib.reload(sce)
     captured = {}
 
-    def fake_build_prompt(self, description, *, context="", retrieval_context="", retry_info=None):
+    def fake_build_prompt(
+        self, description, *, context="", retrieval_context="", retry_trace=None
+    ):
         captured["context"] = context
         return "PROMPT"
 
@@ -182,7 +186,9 @@ def test_build_visual_agent_prompt_layout(monkeypatch):
 def test_build_visual_agent_prompt_retrieval_context(monkeypatch):
     captured = {}
 
-    def fake_build_prompt(self, description, *, context="", retrieval_context="", retry_info=None):
+    def fake_build_prompt(
+        self, description, *, context="", retrieval_context="", retry_trace=None
+    ):
         captured["retrieval_context"] = retrieval_context
         return "PROMPT"
 

--- a/tests/test_prompt_engine.py
+++ b/tests/test_prompt_engine.py
@@ -48,11 +48,11 @@ def test_prompt_engine_includes_failure_trace():
     records = [_record(1.0, summary="foo", tests_passed=True, raroi=0.5)]
     engine = PromptEngine(retriever=DummyRetriever(records))
     trace = "Traceback: fail"
-    prompt = engine.build_prompt("goal", retry_info=trace)
+    prompt = engine.build_prompt("goal", retry_trace=trace)
     expected = (
-        "Previous attempt failed with:\n"
+        "Previous failure:\n"
         "Traceback: fail\n"
-        "Try a different approach."
+        "Please attempt a different solution."
     )
     assert expected in prompt
 

--- a/tests/test_prompt_engine_vector_service.py
+++ b/tests/test_prompt_engine_vector_service.py
@@ -68,8 +68,8 @@ def test_retry_trace_injection(monkeypatch, tmp_path):
     pr = _setup_store(monkeypatch, tmp_path, patches, [1.0, 0.0])
     engine = PromptEngine(retriever=pr)
     trace = "Traceback: fail"
-    prompt = engine.build_prompt("goal", retry_info=trace)
-    expected = "Previous attempt failed with:\nTraceback: fail\nTry a different approach."
+    prompt = engine.build_prompt("goal", retry_trace=trace)
+    expected = "Previous failure:\nTraceback: fail\nPlease attempt a different solution."
     assert expected in prompt
 
 


### PR DESCRIPTION
## Summary
- support retry_trace in PromptEngine.build_prompt
- document and test retry trace behavior

## Testing
- `pytest tests/test_prompt_engine.py -q`
- `pytest -q tests/test_prompt_engine_vector_service.py tests/test_build_visual_agent_prompt.py unit_tests/test_prompt_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_68b302556928832ea0a5d6af5773f3b0