### PR TITLE
Log and persist default synergy weights when file missing

### DIFF
--- a/self_improvement/__init__.py
+++ b/self_improvement/__init__.py
@@ -417,7 +417,20 @@ def _load_initial_synergy_weights() -> None:
             for k in weights:
                 weights[k] = float(data[k])
     except FileNotFoundError:
-        pass
+        logger.info(
+            "synergy weights file %s missing; writing defaults",
+            path,
+            extra=log_record(path=str(path)),
+        )
+        try:
+            _atomic_write(path, json.dumps(weights, indent=2))
+        except OSError as exc:  # pragma: no cover - best effort
+            logger.warning(
+                "failed to write default synergy weights %s",
+                path,
+                extra=log_record(path=str(path)),
+                exc_info=exc,
+            )
     except (OSError, ValueError) as exc:
         logger.warning(
             "failed to load synergy weights %s", path,


### PR DESCRIPTION
## Summary
- log informative message when synergy weights file is absent
- create synergy weight file with default values to ensure explicit configuration

## Testing
- `python -m py_compile self_improvement/__init__.py`
- `pytest -q self_improvement`


------
https://chatgpt.com/codex/tasks/task_e_68b30435094c832e97105c083c4ce1da