### PR TITLE
Add service version checks and sandbox data permission validation

### DIFF
--- a/quick_fix_engine.py
+++ b/quick_fix_engine.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 """Automatically propose fixes for recurring errors."""
 
+__version__ = "1.0.0"
+
 from pathlib import Path
 import logging
 import subprocess

--- a/relevancy_radar.py
+++ b/relevancy_radar.py
@@ -12,6 +12,8 @@ session.
 
 from __future__ import annotations
 
+__version__ = "1.0.0"
+
 import atexit
 import json
 import sqlite3

--- a/tests/test_bootstrap_service_deps.py
+++ b/tests/test_bootstrap_service_deps.py
@@ -1,0 +1,74 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+# Stub out heavy modules before importing bootstrap
+menace = types.ModuleType("menace")
+auto_env_setup = types.ModuleType("menace.auto_env_setup")
+auto_env_setup.ensure_env = lambda _path: None
+menace.auto_env_setup = auto_env_setup
+sys.modules["menace"] = menace
+sys.modules["menace.auto_env_setup"] = auto_env_setup
+
+sandbox_settings = types.ModuleType("sandbox_settings")
+class SandboxSettings:
+    def __init__(self, sandbox_data_dir="", alignment_baseline_metrics_path=""):
+        self.sandbox_data_dir = sandbox_data_dir
+        self.alignment_baseline_metrics_path = alignment_baseline_metrics_path
+        self.menace_mode = "test"
+        self.menace_env_file = "env"
+
+sandbox_settings.SandboxSettings = SandboxSettings
+sandbox_settings.load_sandbox_settings = lambda: SandboxSettings()
+sys.modules["sandbox_settings"] = sandbox_settings
+
+sr_cli = types.ModuleType("sandbox_runner.cli")
+sr_cli.main = lambda *_a, **_k: None
+sys.modules["sandbox_runner.cli"] = sr_cli
+
+bootstrap = importlib.import_module("sandbox_runner.bootstrap")
+
+
+def _stub_services(monkeypatch, versions, missing=frozenset()):
+    original_import = importlib.import_module
+
+    def fake_import(name, package=None):
+        if name in missing:
+            raise ModuleNotFoundError(name)
+        if name in versions:
+            mod = types.ModuleType(name)
+            mod.__version__ = versions[name]
+            monkeypatch.setitem(sys.modules, name, mod)
+            return mod
+        return original_import(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+
+
+def _settings(tmp_path):
+    return SandboxSettings(sandbox_data_dir=str(tmp_path))
+
+
+def test_missing_service_raises(monkeypatch, tmp_path):
+    _stub_services(monkeypatch, {"quick_fix_engine": "1.0.0"}, missing={"relevancy_radar"})
+    with pytest.raises(RuntimeError, match="relevancy_radar"):
+        bootstrap.initialize_autonomous_sandbox(_settings(tmp_path))
+
+
+def test_version_too_old(monkeypatch, tmp_path):
+    _stub_services(monkeypatch, {"quick_fix_engine": "1.0.0", "relevancy_radar": "0.0.1"})
+    with pytest.raises(RuntimeError, match="relevancy_radar"):
+        bootstrap.initialize_autonomous_sandbox(_settings(tmp_path))
+
+
+def test_unwritable_data_dir(monkeypatch, tmp_path, caplog):
+    _stub_services(monkeypatch, {"quick_fix_engine": "1.0.0", "relevancy_radar": "1.0.0"})
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(bootstrap.Path, "touch", lambda *a, **k: (_ for _ in ()).throw(PermissionError()))
+    settings = SandboxSettings(sandbox_data_dir=str(data_dir))
+    with pytest.raises(RuntimeError, match="not writable"):
+        bootstrap.initialize_autonomous_sandbox(settings)
+    assert any("not writable" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- enforce minimum versions for relevancy_radar and quick_fix_engine during sandbox initialization
- verify sandbox_data is writable and log clear errors when it isn't
- add unit tests covering missing services, version mismatches, and permission failures

## Testing
- `pytest tests/test_bootstrap_service_deps.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b30d392ae0832ebc22c3722162f1e4