### PR TITLE
Refine prompt headers and preamble

### DIFF
--- a/docs/prompt_engine.md
+++ b/docs/prompt_engine.md
@@ -20,13 +20,12 @@ print(prompt)
 A successful lookup yields a prompt such as:
 
 ```
-Given the following pattern...
-- Code summary: handle edge case
-  Diff summary: adjust parsing
-  Outcome: works (tests passed)
-Previous failure:
-Traceback: ValueError
-Please attempt a different solution.
+Given the following pattern, fix the failing parser
+
+Given the following pattern:
+Code summary: handle edge case
+Diff summary: adjust parsing
+Outcome: works (tests passed)
 ```
 
 ## Configuration
@@ -43,8 +42,9 @@ Please attempt a different solution.
   Please attempt a different solution.
   ```
 * `success_header` and `failure_header` – control the section titles for
-  successful and failing examples.  The defaults are `"Successful example:"`
-  and `"Avoid pattern:"`.
+  successful and failing examples.  The defaults are
+  `"Given the following pattern:"` and
+  `"Avoid {summary} because it caused {outcome}:"`.
 
 ### Custom headers
 

--- a/tests/test_prompt_engine.py
+++ b/tests/test_prompt_engine.py
@@ -44,13 +44,15 @@ def test_prompt_engine_sections_and_ranking():
     prompt = engine.build_prompt("desc")
 
     # Sections from build_snippets are present
-    assert "Successful example:" in prompt
-    assert "Avoid pattern:" in prompt
+    assert "Given the following pattern:" in prompt
+    assert "Avoid fail because it caused a failure:" in prompt
 
     # Ranking respects ROI values
     assert prompt.index("Code summary: high") < prompt.index("Code summary: low")
     # Failure snippet appears after successes
-    assert prompt.rindex("Code summary: fail") > prompt.index("Avoid pattern:")
+    assert prompt.rindex("Code summary: fail") > prompt.index(
+        "Avoid fail because it caused a failure:"
+    )
 
 
 def test_prompt_engine_custom_headers():
@@ -69,8 +71,8 @@ def test_prompt_engine_custom_headers():
     prompt = engine.build_prompt("desc")
     assert "Correct example:" in prompt
     assert "Incorrect example:" in prompt
-    assert "Successful example:" not in prompt
-    assert "Avoid pattern:" not in prompt
+    assert "Given the following pattern:" not in prompt
+    assert "Avoid bad because it caused a failure:" not in prompt
 
 
 def test_prompt_engine_handles_retry_trace():

--- a/tests/test_prompt_engine_vector_service.py
+++ b/tests/test_prompt_engine_vector_service.py
@@ -42,7 +42,7 @@ def test_prompt_engine_retrieves_top_n_snippets(monkeypatch, tmp_path):
     pr = _setup_store(monkeypatch, tmp_path, patches, [1.0, 0.0])
     engine = PromptEngine(retriever=pr, top_n=2, confidence_threshold=0.0)
     prompt = engine.build_prompt("goal")
-    assert "Successful example:" in prompt
+    assert "Given the following pattern:" in prompt
     assert "Code summary: A1" in prompt
     assert "Code summary: A2" in prompt
     assert "A3" not in prompt

--- a/unit_tests/test_prompt_engine.py
+++ b/unit_tests/test_prompt_engine.py
@@ -29,7 +29,8 @@ def test_retrieval_snippets_included():
     ]
     engine = PromptEngine(retriever=DummyRetriever(records))
     prompt = engine.build_prompt("desc")
-    assert "Successful example:" in prompt
+    assert prompt.startswith("Given the following pattern, desc")
+    assert "Given the following pattern:" in prompt
     assert "Code summary: fixed bug" in prompt
     assert "Diff summary: changed logic" in prompt
     assert "Outcome: works (tests passed)" in prompt


### PR DESCRIPTION
## Summary
- add contextual success and failure headers with outcome details
- wrap task descriptions with a standard "Given the following pattern" preamble
- adjust tests and docs to new prompt formatting

## Testing
- `pytest unit_tests/test_prompt_engine.py tests/test_prompt_engine.py tests/test_prompt_engine_vector_service.py tests/test_prompt_engine_fallback.py`

------
https://chatgpt.com/codex/tasks/task_e_68b30fd0ca94832e9f73bc5ab5cc5226