### PR TITLE
Remove simple_functions fallback in sandbox runner

### DIFF
--- a/docs/sandbox_runner.md
+++ b/docs/sandbox_runner.md
@@ -39,6 +39,10 @@ tracker, summary = run_scenarios(["simple_functions:print_ten"])
 print(summary["worst_scenario"], summary["scenarios"]["normal"]["roi_delta"])
 ```
 
+Each workflow step must specify its module path using ``module:function`` or
+``module.function``. Bare function names are no longer supported and will
+raise ``ValueError``.
+
 Both forms run the workflow in five predefined scenarios. Each scenario is
 executed twice – once with the workflow enabled and once with it disabled – so
 the ROI delta reflects the workflow's direct contribution. The disabled run


### PR DESCRIPTION
## Summary
- require explicit module paths for workflow steps and verify imports with `importlib.util.find_spec`
- document module requirement for workflow steps in sandbox runner docs

## Testing
- `python -m py_compile sandbox_runner/environment.py`
- `pytest tests/test_run_scenarios.py tests/test_temporal_trajectory.py tests/test_run_sandbox.py::test_dynamic_workflows_build_from_repo -q` *(fails: ImportError: cannot import name 'temporal_presets' from 'sandbox_runner.environment')*

------
https://chatgpt.com/codex/tasks/task_e_68b311bd5180832eb79762a6d78023bd