### PR TITLE
Remove unused allow_install flag

### DIFF
--- a/self_improvement/utils.py
+++ b/self_improvement/utils.py
@@ -34,17 +34,15 @@ def _import_callable(module: str, attr: str) -> Callable[..., Any]:
 def _load_callable(
     module: str,
     attr: str,
-    *,
-    allow_install: bool = False,
 ) -> Callable[..., Any]:
     """Dynamically import ``attr`` from ``module`` with logging and caching.
 
     Successful imports are cached for future lookups. When the dependency is
     missing a stub is returned. The stub carries a structured error object and,
     depending on :class:`SandboxSettings`, may attempt to lazily retry the
-    import on first use. Automatic installation attempts have been removed; the
-    caller instead receives a :class:`RuntimeError` with instructions on how to
-    install the missing package.
+    import on first use. Automatic installation attempts are not performed; the
+    caller receives a :class:`RuntimeError` with guidance on how to install the
+    missing package.
     """
 
     logger = logging.getLogger(__name__)
@@ -68,15 +66,11 @@ def _load_callable(
             module: str
             attr: str
             exc: Exception
-            install_attempted: bool
-            install_output: str | None = None
 
         error = MissingDependencyError(
             module,
             attr,
             exc,
-            install_attempted=False,
-            install_output=None,
         )
         guide = f"Install it via `pip install {module.split('.')[0]}` to use {attr}"
 

--- a/unit_tests/test_self_improvement_utils.py
+++ b/unit_tests/test_self_improvement_utils.py
@@ -85,12 +85,11 @@ def test_load_callable_success_and_cache():
 def test_load_callable_missing_returns_stub_and_records_metric():
     utils, counter = _load_utils()
     with patch("importlib.import_module", side_effect=ImportError):
-        fn = utils["_load_callable"]("missing", "attr", allow_install=True)
+        fn = utils["_load_callable"]("missing", "attr")
         with pytest.raises(RuntimeError) as ei:
             fn()
     assert counter.count == 1
     assert fn.error.module == "missing"
-    assert fn.error.install_attempted is False
     assert "pip install missing" in str(ei.value)
 
 


### PR DESCRIPTION
## Summary
- drop unused `allow_install` argument from `_load_callable`
- simplify missing dependency error handling and update docs
- adjust self-improvement utility tests accordingly

## Testing
- `pytest unit_tests/test_self_improvement_utils.py unit_tests/test_self_improvement_engine_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b315fa4aa4832e82b7386a8c48f88e