### PR TITLE
Add traceback error parser and tests

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -13,6 +13,7 @@ import time
 from typing import TYPE_CHECKING
 
 from .roi_calculator import ROICalculator
+from .error_parser import ErrorParser
 from .truth_adapter import TruthAdapter
 from .foresight_tracker import ForesightTracker
 from .upgrade_forecaster import UpgradeForecaster
@@ -196,6 +197,8 @@ __all__ = [
     "__version__",
     "ROICalculator",
     "roi_calculator",
+    "ErrorParser",
+    "error_parser",
     "TruthAdapter",
     "truth_adapter",
     "ForesightTracker",

--- a/error_parser.py
+++ b/error_parser.py
@@ -1,0 +1,73 @@
+"""Utilities for parsing Python traceback outputs.
+
+The :class:`ErrorParser` provides a small helper to extract useful
+information from tracebacks such as file paths involved, the final error
+class and a set of suggested tags describing the error.  The implementation
+intentionally keeps dependencies light so it can be used in diagnostic
+contexts without pulling in the entire project.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+
+
+class ErrorParser:
+    """Parse traceback strings for quick error analysis."""
+
+    # Match ``File "..."`` entries from standard Python tracebacks or
+    # bare ``path/to/file.py`` lines from pytest output.
+    _FILE_RE = re.compile(r'File "([^"]+)"|^([\w./-]+\.py)', re.MULTILINE)
+
+    # Match the final error type such as ``ValueError`` or ``AssertionError``.
+    _ERROR_RE = re.compile(r'^\s*(?:E\s+)?(?P<error>\w+(?:Error|Exception|Failed))', re.MULTILINE)
+
+    # Heuristic mapping from error types to suggested tags.
+    _TAG_MAP = {
+        "AssertionError": ["test", "assertion"],
+        "Failed": ["test"],
+        "SyntaxError": ["syntax"],
+        "TypeError": ["runtime"],
+        "ValueError": ["runtime"],
+        "ZeroDivisionError": ["runtime", "math"],
+        "ModuleNotFoundError": ["missing-dependency"],
+        "ImportError": ["missing-dependency"],
+        "RuntimeError": ["runtime"],
+    }
+
+    @classmethod
+    def parse(cls, trace: str) -> Dict[str, object]:
+        """Parse ``trace`` and return extracted information.
+
+        Parameters
+        ----------
+        trace:
+            A traceback string from ``traceback.format_exc()`` or pytest
+            output.
+
+        Returns
+        -------
+        dict
+            ``{"files": list[str], "error_type": str | None, "tags": list[str]}``
+        """
+
+        files: List[str] = []
+        for match in cls._FILE_RE.finditer(trace):
+            path = match.group(1) or match.group(2)
+            if path and path not in files:
+                files.append(path)
+
+        error_type = None
+        last_line = trace.splitlines()[-1] if trace.splitlines() else ""
+        match = cls._ERROR_RE.search(last_line)
+        if not match:
+            match = cls._ERROR_RE.search(trace)
+        if match:
+            error_type = match.group("error")
+
+        tags = cls._TAG_MAP.get(error_type, [])
+        return {"files": files, "error_type": error_type, "tags": tags}
+
+
+__all__ = ["ErrorParser"]

--- a/tests/test_error_parser.py
+++ b/tests/test_error_parser.py
@@ -1,0 +1,26 @@
+import traceback
+
+from error_parser import ErrorParser
+
+
+def test_parse_pytest_assertion():
+    trace = (
+        "tests/test_sample.py:3: in test_example\n"
+        "    assert 1 == 2\n"
+        "E   AssertionError: assert 1 == 2\n"
+    )
+    result = ErrorParser.parse(trace)
+    assert "tests/test_sample.py" in result["files"]
+    assert result["error_type"] == "AssertionError"
+    assert "test" in result["tags"]
+
+
+def test_parse_runtime_error():
+    try:
+        1 / 0
+    except ZeroDivisionError:
+        trace = traceback.format_exc()
+    result = ErrorParser.parse(trace)
+    assert any(path.endswith("test_error_parser.py") for path in result["files"])
+    assert result["error_type"] == "ZeroDivisionError"
+    assert "runtime" in result["tags"]


### PR DESCRIPTION
## Summary
- expose `ErrorParser` through top-level package
- parse tracebacks for file paths, error type and tags
- cover common pytest and runtime errors

## Testing
- `pytest tests/test_error_parser.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b315fb6414832ea593577c3701e37b