### PR TITLE
feat: add tag exclusion to context builder

### DIFF
--- a/docs/context_builder.md
+++ b/docs/context_builder.md
@@ -27,7 +27,7 @@ builder = ContextBuilder(
     max_tokens=800,  # overall budget
 )
 
-context_json = builder.build_context("upload failed", top_k=5)
+context_json = builder.build_context("upload failed", top_k=5, exclude_tags=["failure"])
 ```
 
 - `top_k` caps how many entries are returned for each origin.
@@ -35,6 +35,7 @@ context_json = builder.build_context("upload failed", top_k=5)
   `builder.retriever` (for example `link_multiplier`) to emphasise connectivity
   or adjust ranking.  Per-database weights can be supplied via ``db_weights`` or
   configuration to bias towards certain sources.
+- `exclude_tags` skips any vectors tagged with the specified values.
 
 `ContextBuilder` can bias ranking toward specific sources and adjust the
 overall token budget via optional configuration.  Token usage is estimated for

--- a/tests/test_context_builder_failure_filtering.py
+++ b/tests/test_context_builder_failure_filtering.py
@@ -1,0 +1,32 @@
+import json
+from vector_service.context_builder import ContextBuilder
+
+
+class DummyRetriever:
+    def search(self, *_a, **_k):
+        return [
+            {
+                "origin_db": "information",
+                "record_id": 1,
+                "score": 1.0,
+                "text": "bad",
+                "metadata": {"redacted": True, "tags": ["skip"]},
+            },
+            {
+                "origin_db": "information",
+                "record_id": 2,
+                "score": 0.5,
+                "text": "good",
+                "metadata": {"redacted": True},
+            },
+        ]
+
+
+def test_context_builder_filters_excluded_tags():
+    builder = ContextBuilder(retriever=DummyRetriever())
+    ctx = builder.query("q", exclude_tags=["skip"])
+    data = json.loads(ctx)
+    assert "information" in data
+    infos = data["information"]
+    assert len(infos) == 1
+    assert infos[0]["id"] == 2


### PR DESCRIPTION
## Summary
- support excluding tagged vectors via `exclude_tags` in `ContextBuilder`
- propagate tag exclusion through patch ranking
- document usage and add test for tag filtering

## Testing
- `pytest tests/test_context_builder_failure_filtering.py -q`
- `pytest tests/test_context_builder_roi_risk.py tests/test_context_building.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b316d92e9c832e98aadc1c7b0dab4d