### PR TITLE
Run patches in ephemeral sandbox

### DIFF
--- a/tests/test_ephemeral_patch_sandbox.py
+++ b/tests/test_ephemeral_patch_sandbox.py
@@ -1,0 +1,96 @@
+import os
+from pathlib import Path
+import types
+import tempfile
+import shutil
+
+import menace.self_coding_manager as scm
+import menace.model_automation_pipeline as mapl
+import menace.pre_execution_roi_bot as prb
+
+
+class DummyEngine:
+    def __init__(self):
+        self.calls = []
+
+    def apply_patch(self, path: Path, desc: str, **kwargs):
+        self.calls.append(path)
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write("# patched\n")
+        return 1, False, 0.0
+
+
+class DummyPipeline:
+    def __init__(self):
+        self.calls = []
+
+    def run(self, model: str, energy: int = 1) -> mapl.AutomationResult:
+        self.calls.append((model, energy))
+        return mapl.AutomationResult(
+            package=None,
+            roi=prb.ROIResult(1.0, 0.5, 1.0, 0.5, 0.1),
+        )
+
+
+def test_ephemeral_clone_removed(monkeypatch, tmp_path):
+    file_path = tmp_path / "sample.py"
+    file_path.write_text("def x():\n    return 1\n")
+
+    tmpdir_path = tmp_path / "clone"
+
+    class DummyTempDir:
+        def __enter__(self):
+            tmpdir_path.mkdir()
+            return str(tmpdir_path)
+
+        def __exit__(self, exc_type, exc, tb):
+            shutil.rmtree(tmpdir_path)
+
+    monkeypatch.setattr(tempfile, "TemporaryDirectory", lambda: DummyTempDir())
+
+    clone_run = {}
+
+    def fake_run(cmd, *a, **kw):
+        if cmd[:2] == ["git", "clone"]:
+            dst = Path(cmd[3])
+            dst.mkdir(exist_ok=True)
+            shutil.copy2(file_path, dst / file_path.name)
+            return types.SimpleNamespace(returncode=0)
+        if cmd[0] == "pytest":
+            clone_run["cwd"] = kw.get("cwd")
+            return types.SimpleNamespace(returncode=0)
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(scm.subprocess, "run", fake_run)
+
+    class DummyRunner:
+        def __init__(self):
+            self.safe_mode = None
+            self.calls = 0
+
+        def run(self, workflow, *, safe_mode=False, **kwargs):
+            self.safe_mode = safe_mode
+            self.calls += 1
+            workflow()
+            return types.SimpleNamespace(modules=[types.SimpleNamespace(result=True)])
+
+    runner = DummyRunner()
+    monkeypatch.setattr(
+        scm, "WorkflowSandboxRunner", lambda: runner
+    )
+
+    engine = DummyEngine()
+    pipeline = DummyPipeline()
+    mgr = scm.SelfCodingManager(engine, pipeline, bot_name="bot")
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        mgr.run_patch(file_path, "add")
+    finally:
+        os.chdir(cwd)
+
+    assert runner.calls == 1
+    assert runner.safe_mode is True
+    assert clone_run.get("cwd") == str(tmpdir_path)
+    assert not tmpdir_path.exists()
+    assert "# patched" in file_path.read_text()

--- a/tests/test_self_coding_manager.py
+++ b/tests/test_self_coding_manager.py
@@ -15,6 +15,8 @@ import menace.data_bot as db
 from menace.evolution_history_db import EvolutionHistoryDB
 from pathlib import Path
 import subprocess
+import tempfile
+import shutil
 import logging
 
 
@@ -41,7 +43,7 @@ class DummyPipeline:
         )
 
 
-def test_run_patch_logs_evolution(tmp_path):
+def test_run_patch_logs_evolution(monkeypatch, tmp_path):
     hist = EvolutionHistoryDB(tmp_path / "e.db")
     mdb = db.MetricsDB(tmp_path / "m.db")
     data_bot = db.DataBot(mdb, evolution_db=hist)
@@ -50,6 +52,38 @@ def test_run_patch_logs_evolution(tmp_path):
     mgr = scm.SelfCodingManager(engine, pipeline, bot_name="bot", data_bot=data_bot)
     file_path = tmp_path / "sample.py"
     file_path.write_text("def x():\n    pass\n")
+
+    tmpdir_path = tmp_path / "clone"
+
+    class DummyTempDir:
+        def __enter__(self):
+            tmpdir_path.mkdir()
+            return str(tmpdir_path)
+
+        def __exit__(self, exc_type, exc, tb):
+            shutil.rmtree(tmpdir_path)
+
+    monkeypatch.setattr(tempfile, "TemporaryDirectory", lambda: DummyTempDir())
+
+    def fake_run(cmd, *a, **kw):
+        if cmd[:2] == ["git", "clone"]:
+            dst = Path(cmd[3])
+            dst.mkdir(exist_ok=True)
+            shutil.copy2(file_path, dst / file_path.name)
+            return subprocess.CompletedProcess(cmd, 0)
+        if cmd[0] == "pytest":
+            return subprocess.CompletedProcess(cmd, 0)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(scm.subprocess, "run", fake_run)
+
+    class DummyRunner:
+        def run(self, workflow, *, safe_mode=False, **kw):
+            workflow()
+            return types.SimpleNamespace(modules=[types.SimpleNamespace(result=True)])
+
+    monkeypatch.setattr(scm, "WorkflowSandboxRunner", lambda: DummyRunner())
+
     res = mgr.run_patch(file_path, "add")
     assert engine.calls
     assert pipeline.calls
@@ -68,6 +102,37 @@ def test_run_patch_logging_error(monkeypatch, tmp_path, caplog):
     mgr = scm.SelfCodingManager(engine, pipeline, bot_name="bot", data_bot=data_bot)
     file_path = tmp_path / "sample.py"
     file_path.write_text("def x():\n    pass\n")
+
+    tmpdir_path = tmp_path / "clone"
+
+    class DummyTempDir:
+        def __enter__(self):
+            tmpdir_path.mkdir()
+            return str(tmpdir_path)
+
+        def __exit__(self, exc_type, exc, tb):
+            shutil.rmtree(tmpdir_path)
+
+    monkeypatch.setattr(tempfile, "TemporaryDirectory", lambda: DummyTempDir())
+
+    def fake_run(cmd, *a, **kw):
+        if cmd[:2] == ["git", "clone"]:
+            dst = Path(cmd[3])
+            dst.mkdir(exist_ok=True)
+            shutil.copy2(file_path, dst / file_path.name)
+            return subprocess.CompletedProcess(cmd, 0)
+        if cmd[0] == "pytest":
+            return subprocess.CompletedProcess(cmd, 0)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(scm.subprocess, "run", fake_run)
+
+    class DummyRunner:
+        def run(self, workflow, *, safe_mode=False, **kw):
+            workflow()
+            return types.SimpleNamespace(modules=[types.SimpleNamespace(result=True)])
+
+    monkeypatch.setattr(scm, "WorkflowSandboxRunner", lambda: DummyRunner())
 
     def fail(*a, **k):
         raise RuntimeError("boom")


### PR DESCRIPTION
## Summary
- apply patches in a temporary cloned repo and run tests under WorkflowSandboxRunner safe mode before deployment
- add regression test ensuring temporary clone cleanup and sandboxed execution
- update existing SelfCodingManager tests for new sandbox workflow

## Testing
- `pytest -q` *(fails: SandboxSettings object has no attribute 'sandbox_central_logging')*

------
https://chatgpt.com/codex/tasks/task_e_68b31bb17f0c832e9e439233b68cda3e