### PR TITLE
Improve orphan discovery evaluator

### DIFF
--- a/tests/test_eval_simple.py
+++ b/tests/test_eval_simple.py
@@ -1,0 +1,33 @@
+import ast
+import logging
+import os
+
+from sandbox_runner.orphan_discovery import _eval_simple
+
+
+def _parse(expr: str) -> ast.AST:
+    return ast.parse(expr, mode="eval").body
+
+
+def test_env_var_resolution(monkeypatch):
+    monkeypatch.setenv("MY_VAR", "value")
+    node = _parse('os.getenv("MY_VAR", "fallback")')
+    assert _eval_simple(node, {}, 1) == "value"
+    monkeypatch.delenv("MY_VAR")
+    assert _eval_simple(node, {}, 1) == "fallback"
+
+
+def test_concat_with_assignment():
+    assignments = {
+        "a": [(0, _parse('"foo"'))],
+    }
+    node = _parse('a + "bar"')
+    assert _eval_simple(node, assignments, 10) == "foobar"
+
+
+def test_unresolved_logs(caplog):
+    node = _parse("unknown")
+    with caplog.at_level(logging.DEBUG):
+        assert _eval_simple(node, {}, 1) is None
+    assert "Unresolved expression" in caplog.text
+


### PR DESCRIPTION
## Summary
- replace `_eval_simple` with ast.literal_eval-based implementation using safe symbol table for functions like `os.getenv`
- add logging for unresolved expressions
- add tests covering environment variables, assignments, and logging

## Testing
- `pytest tests/test_eval_simple.py -q`
- `pytest tests/test_orphan_discovery_dynamic_import.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b32600740c832e9bcececddbba7e7b