### PR TITLE
feat: include dependencies in module workflows

### DIFF
--- a/task_handoff_bot.py
+++ b/task_handoff_bot.py
@@ -76,6 +76,8 @@ class WorkflowRecord:
     description: str = ""
     task_sequence: List[str] = field(default_factory=list)
     tags: List[str] = field(default_factory=list)
+    dependencies: List[str] = field(default_factory=list)
+    reasons: List[str] = field(default_factory=list)
     category: str = ""
     type_: str = ""
     status: str = "pending"
@@ -133,6 +135,8 @@ class WorkflowDB(EmbeddableDBMixin):
                 description TEXT,
                 task_sequence TEXT,
                 tags TEXT,
+                dependencies TEXT,
+                reasons TEXT,
                 category TEXT,
                 type TEXT,
                 status TEXT,
@@ -151,6 +155,10 @@ class WorkflowDB(EmbeddableDBMixin):
             self.conn.execute("ALTER TABLE workflows ADD COLUMN action_chains TEXT")
         if "argument_strings" not in cols:
             self.conn.execute("ALTER TABLE workflows ADD COLUMN argument_strings TEXT")
+        if "dependencies" not in cols:
+            self.conn.execute("ALTER TABLE workflows ADD COLUMN dependencies TEXT")
+        if "reasons" not in cols:
+            self.conn.execute("ALTER TABLE workflows ADD COLUMN reasons TEXT")
         if "source_menace_id" not in cols:
             self.conn.execute(
                 "ALTER TABLE workflows ADD COLUMN "
@@ -182,6 +190,8 @@ class WorkflowDB(EmbeddableDBMixin):
             description=row["description"] or "",
             task_sequence=row["task_sequence"].split(",") if row["task_sequence"] else [],
             tags=row["tags"].split(",") if row["tags"] else [],
+            dependencies=row["dependencies"].split(",") if row["dependencies"] else [],
+            reasons=row["reasons"].split(",") if row["reasons"] else [],
             category=row["category"] or "",
             type_=row["type"] or "",
             status=row["status"] or "",
@@ -322,6 +332,8 @@ class WorkflowDB(EmbeddableDBMixin):
             "description": wf.description,
             "task_sequence": ",".join(wf.task_sequence),
             "tags": ",".join(wf.tags),
+            "dependencies": ",".join(wf.dependencies),
+            "reasons": ",".join(wf.reasons),
             "category": wf.category,
             "type": wf.type_,
             "status": wf.status,

--- a/tests/test_generate_workflows.py
+++ b/tests/test_generate_workflows.py
@@ -3,6 +3,8 @@ import sys
 import types
 from pathlib import Path
 
+import networkx as nx
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -19,25 +21,98 @@ def _load_env():
     return env
 
 
-def _load_thb():
-    spec = importlib.util.spec_from_file_location(
-        "menace.task_handoff_bot",
-        ROOT / "task_handoff_bot.py",
-        submodule_search_locations=[str(ROOT)],
-    )
-    thb = importlib.util.module_from_spec(spec)
-    sys.modules["menace.task_handoff_bot"] = thb
-    assert spec and spec.loader
-    spec.loader.exec_module(thb)  # type: ignore[attr-defined]
-    return thb
-
-
 def test_generate_workflows(tmp_path):
+    # stub import graph to avoid scanning repository
+    dmm = types.ModuleType("dynamic_module_mapper")
+    dmm.build_import_graph = lambda root: nx.DiGraph()
+    sys.modules["dynamic_module_mapper"] = dmm
+
+    vs = types.ModuleType("vector_service")
+    vs.EmbeddableDBMixin = type("EmbeddableDBMixin", (), {"__init__": lambda self, *a, **k: None})
+    sys.modules["vector_service"] = vs
+
+    thb = types.ModuleType("menace.task_handoff_bot")
+    _db: dict[str, list] = {}
+
+    class WorkflowRecord:
+        def __init__(self, workflow, title="", dependencies=None, reasons=None):
+            self.workflow = workflow
+            self.title = title
+            self.dependencies = dependencies or []
+            self.reasons = reasons or []
+            self.wid = 0
+
+    class WorkflowDB:
+        def __init__(self, path, router=None):
+            self.path = str(Path(path))
+            self.records = _db.setdefault(self.path, [])
+
+        def add(self, rec, source_menace_id=""):
+            rec.wid = len(self.records) + 1
+            self.records.append(rec)
+            return rec.wid
+
+        def fetch(self):
+            return list(self.records)
+
+    thb.WorkflowDB = WorkflowDB
+    thb.WorkflowRecord = WorkflowRecord
+    sys.modules["menace.task_handoff_bot"] = thb
+
     env = _load_env()
-    thb = _load_thb()
     db_path = tmp_path / "wf.db"
+    # avoid expensive orphan integration
+    env.integrate_new_orphans = lambda repo, router=None: []
     ids = env.generate_workflows_for_modules(["foo.py"], workflows_db=db_path)
-    db = thb.WorkflowDB(db_path)
-    recs = db.fetch()
+    recs = thb.WorkflowDB(db_path).fetch()
     assert ids and ids[0] == recs[0].wid
     assert recs[0].workflow == ["foo"]
+
+
+def test_generate_workflows_with_dependencies(tmp_path, monkeypatch):
+    g = nx.DiGraph()
+    g.add_edge("b", "a")
+    dmm = types.ModuleType("dynamic_module_mapper")
+    dmm.build_import_graph = lambda root: g
+    sys.modules["dynamic_module_mapper"] = dmm
+
+    vs = types.ModuleType("vector_service")
+    vs.EmbeddableDBMixin = type("EmbeddableDBMixin", (), {"__init__": lambda self, *a, **k: None})
+    sys.modules["vector_service"] = vs
+
+    thb = types.ModuleType("menace.task_handoff_bot")
+    _db: dict[str, list] = {}
+
+    class WorkflowRecord:
+        def __init__(self, workflow, title="", dependencies=None, reasons=None):
+            self.workflow = workflow
+            self.title = title
+            self.dependencies = dependencies or []
+            self.reasons = reasons or []
+            self.wid = 0
+
+    class WorkflowDB:
+        def __init__(self, path, router=None):
+            self.path = str(Path(path))
+            self.records = _db.setdefault(self.path, [])
+
+        def add(self, rec, source_menace_id=""):
+            rec.wid = len(self.records) + 1
+            self.records.append(rec)
+            return rec.wid
+
+        def fetch(self):
+            return list(self.records)
+
+    thb.WorkflowDB = WorkflowDB
+    thb.WorkflowRecord = WorkflowRecord
+    sys.modules["menace.task_handoff_bot"] = thb
+
+    env = _load_env()
+    db_path = tmp_path / "wf.db"
+    monkeypatch.setattr(env, "integrate_new_orphans", lambda repo, router=None: [])
+    ids = env.generate_workflows_for_modules(["b.py"], workflows_db=db_path)
+    rec = thb.WorkflowDB(db_path).fetch()[0]
+    assert rec.workflow == ["a", "b"]
+    assert rec.dependencies == ["a"]
+    assert any("b" in r and "a" in r for r in rec.reasons)


### PR DESCRIPTION
## Summary
- analyze module import graph to build ordered, multi-step workflows
- persist dependency metadata alongside workflow records
- test workflow generation and dependency inclusion

## Testing
- `pytest tests/test_generate_workflows.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b327067fa4832e9f08de3eba949b4b