### PR TITLE
Refactor RLStrategy as abstract base

### DIFF
--- a/self_improvement_policy.py
+++ b/self_improvement_policy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Q-learning policy predicting ROI improvement from self-improvement cycles."""
 
+import abc
 from typing import Dict, Tuple, Optional, Callable
 import pickle
 import os
@@ -31,7 +32,7 @@ class RLConfig:
     action_dim: int | None = None
 
 
-class RLStrategy:
+class RLStrategy(abc.ABC):
     """Base class for reinforcement learning update strategies."""
 
     def __init__(self, config: RLConfig | None = None) -> None:
@@ -49,6 +50,7 @@ class RLStrategy:
                 f"action {action} outside range(0, {self.config.action_dim})"
             )
 
+    @abc.abstractmethod
     def update(
         self,
         table: Dict[Tuple[int, ...], Dict[int, float]],
@@ -59,7 +61,8 @@ class RLStrategy:
         alpha: float,
         gamma: float,
     ) -> float:
-        raise NotImplementedError
+        """Update the value table for a transition."""
+        ...
 
     @staticmethod
     def value(table: Dict[Tuple[int, ...], Dict[int, float]], state: Tuple[int, ...]) -> float:

--- a/tests/test_rl_strategy_abstract.py
+++ b/tests/test_rl_strategy_abstract.py
@@ -1,0 +1,6 @@
+import pytest
+import self_improvement_policy as sip
+
+def test_rl_strategy_cannot_instantiate():
+    with pytest.raises(TypeError):
+        sip.RLStrategy()


### PR DESCRIPTION
## Summary
- Make `RLStrategy` inherit from `abc.ABC` and mark `update` as abstract
- Add unit test confirming `RLStrategy` cannot be instantiated directly

## Testing
- `pytest tests/test_rl_strategy_abstract.py -q`
- `pytest tests/test_synergy_learner_update_logic.py::test_weight_learner_rl_update -q` *(fails: No module named 'pydantic._hypothesis_plugin'; 'pydantic' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68b3292cc300832eaa7d8e522b281aa5