### PR TITLE
Add patch branch manager with audit trail integration

### DIFF
--- a/patch_branch_manager.py
+++ b/patch_branch_manager.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+"""Manage patch branches based on confidence scores."""
+
+from pathlib import Path
+from datetime import datetime
+import subprocess
+import logging
+import json
+
+try:  # pragma: no cover - fallback for flat layout
+    from .audit_trail import AuditTrail
+except Exception:  # pragma: no cover - fallback
+    from audit_trail import AuditTrail  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+class PatchBranchManager:
+    """Push patches to ``main`` or ``review/<patch_id>`` branches."""
+
+    def __init__(
+        self,
+        repo: str | Path = ".",
+        *,
+        audit_trail: AuditTrail | None = None,
+        main_branch: str = "main",
+    ) -> None:
+        self.repo = Path(repo)
+        self.audit_trail = audit_trail
+        self.main_branch = main_branch
+
+    # ------------------------------------------------------------------
+    def finalize_patch(self, patch_id: str, score: float, threshold: float) -> str:
+        """Push the current HEAD to a branch based on ``score``.
+
+        Parameters
+        ----------
+        patch_id:
+            Identifier for the patch.
+        score:
+            Confidence score for the patch.
+        threshold:
+            Minimum score required for automatic merge into ``main``.
+
+        Returns
+        -------
+        str
+            The branch name that received the commit.
+        """
+
+        branch = self.main_branch if score >= threshold else f"review/{patch_id}"
+        action = "merged" if branch == self.main_branch else "review"
+        try:
+            subprocess.run(
+                ["git", "push", "origin", f"HEAD:{branch}"],
+                check=True,
+                cwd=str(self.repo),
+            )
+        except Exception:
+            logger.exception("git push failed for patch %s", patch_id)
+            action = "failed"
+        if self.audit_trail:
+            try:
+                payload = json.dumps(
+                    {
+                        "timestamp": datetime.utcnow().isoformat(),
+                        "action": "patch_branch",
+                        "patch_id": str(patch_id),
+                        "branch": branch,
+                        "score": float(score),
+                        "result": action,
+                    },
+                    sort_keys=True,
+                )
+                self.audit_trail.record(payload)
+            except Exception:
+                logger.exception("audit trail logging failed")
+        return branch
+
+
+# ---------------------------------------------------------------------------
+
+def finalize_patch_branch(
+    patch_id: str,
+    score: float,
+    threshold: float,
+    *,
+    repo: str | Path = ".",
+    audit_trail: AuditTrail | None = None,
+    main_branch: str = "main",
+) -> str:
+    """Convenience wrapper around :class:`PatchBranchManager`."""
+
+    manager = PatchBranchManager(repo, audit_trail=audit_trail, main_branch=main_branch)
+    return manager.finalize_patch(patch_id, score, threshold)
+
+
+__all__ = ["PatchBranchManager", "finalize_patch_branch"]

--- a/tests/test_branch_log_cli.py
+++ b/tests/test_branch_log_cli.py
@@ -1,0 +1,49 @@
+import json
+import types
+import sys
+
+plugins_stub = types.ModuleType("menace.plugins")
+plugins_stub.load_plugins = lambda sub: None
+sys.modules.setdefault("menace.plugins", plugins_stub)
+
+db_router_stub = types.ModuleType("db_router")
+db_router_stub.init_db_router = lambda *a, **k: None
+sys.modules.setdefault("db_router", db_router_stub)
+
+code_db_stub = types.ModuleType("code_database")
+code_db_stub.PatchHistoryDB = object
+sys.modules.setdefault("code_database", code_db_stub)
+
+patch_prov_stub = types.ModuleType("patch_provenance")
+patch_prov_stub.PatchLogger = object
+patch_prov_stub.build_chain = lambda *a, **k: None
+patch_prov_stub.search_patches_by_vector = lambda *a, **k: None
+patch_prov_stub.search_patches_by_license = lambda *a, **k: None
+sys.modules.setdefault("patch_provenance", patch_prov_stub)
+
+cache_utils_stub = types.ModuleType("cache_utils")
+cache_utils_stub.get_cached_chain = lambda *a, **k: None
+cache_utils_stub.set_cached_chain = lambda *a, **k: None
+cache_utils_stub._get_cache = lambda *a, **k: None
+cache_utils_stub.clear_cache = lambda *a, **k: None
+cache_utils_stub.show_cache = lambda *a, **k: {}
+cache_utils_stub.cache_stats = lambda *a, **k: {}
+sys.modules.setdefault("cache_utils", cache_utils_stub)
+
+workflow_stub = types.ModuleType("workflow_synthesizer_cli")
+workflow_stub.run = lambda *a, **k: 0
+sys.modules.setdefault("workflow_synthesizer_cli", workflow_stub)
+
+import menace_cli
+
+
+def test_branch_log_cli(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(menace_cli, "load_plugins", lambda sub: None)
+    log_path = tmp_path / "audit.log"
+    entry = {"action": "patch_branch", "patch_id": "1", "branch": "review/1"}
+    with open(log_path, "w", encoding="utf-8") as fh:
+        fh.write(f"- {json.dumps(entry)}\n")
+    monkeypatch.setenv("AUDIT_LOG_PATH", str(log_path))
+    assert menace_cli.main(["branch-log"]) == 0
+    out = capsys.readouterr().out.strip()
+    assert "review/1" in out

--- a/tests/test_patch_branch_manager.py
+++ b/tests/test_patch_branch_manager.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+import subprocess
+
+from patch_branch_manager import PatchBranchManager, finalize_patch_branch
+
+
+class DummyTrail:
+    def __init__(self):
+        self.records = []
+
+    def record(self, msg):
+        self.records.append(msg)
+
+
+def test_finalize_patch_branch_merges(monkeypatch):
+    import patch_branch_manager as pbm
+
+    calls = []
+
+    def fake_run(cmd, *a, **kw):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(pbm.subprocess, "run", fake_run)
+    trail = DummyTrail()
+    branch = finalize_patch_branch("1", 0.9, 0.5, audit_trail=trail)
+    assert any(cmd[-1].endswith("main") for cmd in calls)
+    data = json.loads(trail.records[0])
+    assert data["branch"] == "main"
+    assert branch == "main"
+
+
+def test_finalize_patch_branch_review(monkeypatch):
+    import patch_branch_manager as pbm
+
+    calls = []
+
+    def fake_run(cmd, *a, **kw):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(pbm.subprocess, "run", fake_run)
+    trail = DummyTrail()
+    mgr = PatchBranchManager(audit_trail=trail)
+    branch = mgr.finalize_patch("2", 0.2, 0.5)
+    assert any("review/2" in cmd[-1] for cmd in calls)
+    data = json.loads(trail.records[0])
+    assert data["branch"] == "review/2"
+    assert branch == "review/2"


### PR DESCRIPTION
## Summary
- add `patch_branch_manager` to push commits to `main` or `review/<patch_id>` and log audit entries
- extend `SelfDebuggerSandbox` with `merge_threshold` and branch finalization
- expose patch branch actions through new `branch-log` CLI command

## Testing
- `pytest tests/test_patch_branch_manager.py tests/test_branch_log_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3293741b8832eb749bc55d97cb44d