### PR TITLE
Use alignment evaluator in scorecard

### DIFF
--- a/deployment_governance.py
+++ b/deployment_governance.py
@@ -586,7 +586,14 @@ def evaluate_workflow(
         ),
     )
 
-    alignment_status = str(scorecard.get("alignment_status", "pass"))
+    alignment_info = scorecard.get("alignment_status") or scorecard.get("alignment")
+    if isinstance(alignment_info, Mapping):
+        alignment_status = alignment_info.get("status", "pass")
+    elif alignment_info is not None:
+        alignment_status = alignment_info
+    else:
+        alignment_status = "pass"
+    alignment_status = str(alignment_status)
     raroi = scorecard.get("raroi")
     confidence = scorecard.get("confidence")
     sandbox_roi = scorecard.get("sandbox_roi")
@@ -879,8 +886,13 @@ def evaluate(
         }
 
     # ------------------------------------------------------------------ vetoes
+    alignment_info = scorecard.get("alignment") or scorecard.get("alignment_status")
+    if isinstance(alignment_info, Mapping):
+        alignment_status = alignment_info.get("status")
+    else:
+        alignment_status = alignment_info
     veto_card = {
-        "alignment": scorecard.get("alignment") or scorecard.get("alignment_status"),
+        "alignment": alignment_status,
         "security": scorecard.get("security") or scorecard.get("security_status"),
     }
     veto_rules = [
@@ -1055,9 +1067,14 @@ class RuleEvaluator:
         borderline_bucket: BorderlineBucket | None = None,
     ) -> Dict[str, Any]:
         scorecard = scorecard or {}
-        alignment = str(
+        alignment_info = (
             scorecard.get("alignment_status") or scorecard.get("alignment") or ""
-        ).lower()
+        )
+        if isinstance(alignment_info, Mapping):
+            alignment_status = alignment_info.get("status") or ""
+        else:
+            alignment_status = alignment_info
+        alignment = str(alignment_status).lower()
         security = str(
             scorecard.get("security_status") or scorecard.get("security") or ""
         ).lower()

--- a/docs/autonomous_sandbox.md
+++ b/docs/autonomous_sandbox.md
@@ -207,7 +207,7 @@ bucket = BorderlineBucket("sandbox_data/borderline_bucket.jsonl")
 tracker = ForesightTracker()
 
 result = evaluate(
-    {"alignment": "pass"},
+    {"alignment": {"status": "pass", "rationale": ""}},
     {"raroi": 1.0, "confidence": 0.8},
     patch=["step_a"],
     foresight_tracker=tracker,

--- a/tests/test_deployment_evaluate.py
+++ b/tests/test_deployment_evaluate.py
@@ -52,7 +52,7 @@ def _patch_gate(monkeypatch, ok, reasons):
 def test_deployment_evaluate_promote(monkeypatch):
     tracker = _patch_gate(monkeypatch, True, [])
     res = evaluate(
-        {"alignment": "pass", "security": "pass"},
+        {"alignment": {"status": "pass", "rationale": ""}, "security": "pass"},
         {"raroi": 1.0, "confidence": 0.9},
         patch=[],
         foresight_tracker=tracker,
@@ -68,7 +68,7 @@ def test_deployment_evaluate_borderline(monkeypatch):
     tracker = _patch_gate(monkeypatch, False, ["low_confidence"])
     bucket = DummyBucket()
     res = evaluate(
-        {"alignment": "pass", "security": "pass"},
+        {"alignment": {"status": "pass", "rationale": ""}, "security": "pass"},
         {"raroi": 1.0, "confidence": 0.9},
         patch=[],
         foresight_tracker=tracker,
@@ -83,7 +83,7 @@ def test_deployment_evaluate_borderline(monkeypatch):
 def test_deployment_evaluate_pilot(monkeypatch):
     tracker = _patch_gate(monkeypatch, False, ["negative_dag_impact"])
     res = evaluate(
-        {"alignment": "pass", "security": "pass"},
+        {"alignment": {"status": "pass", "rationale": ""}, "security": "pass"},
         {"raroi": 1.0, "confidence": 0.9},
         patch=[],
         foresight_tracker=tracker,

--- a/tests/test_deployment_governance_eval.py
+++ b/tests/test_deployment_governance_eval.py
@@ -2,14 +2,17 @@ import menace.deployment_governance as dg
 
 
 def test_alignment_veto():
-    res = dg.evaluate({"alignment": "fail"}, {})
+    res = dg.evaluate({"alignment": {"status": "fail", "rationale": ""}}, {})
     assert res["verdict"] == "demote"
     assert "alignment_veto" in res["reasons"]
     assert res["overridable"] is False
 
 
 def test_promote_path():
-    scorecard = {"alignment": "pass", "security": "pass"}
+    scorecard = {
+        "alignment": {"status": "pass", "rationale": ""},
+        "security": "pass",
+    }
     metrics = {
         "raroi": 0.9,
         "confidence": 0.7,
@@ -23,7 +26,10 @@ def test_promote_path():
 
 
 def test_micro_pilot_path():
-    scorecard = {"alignment": "pass", "security": "pass"}
+    scorecard = {
+        "alignment": {"status": "pass", "rationale": ""},
+        "security": "pass",
+    }
     metrics = {
         "raroi": 0.55,
         "confidence": 0.52,
@@ -39,7 +45,10 @@ def test_micro_pilot_path():
 
 
 def test_variance_demotes():
-    scorecard = {"alignment": "pass", "security": "pass"}
+    scorecard = {
+        "alignment": {"status": "pass", "rationale": ""},
+        "security": "pass",
+    }
     metrics = {
         "raroi": 0.5,
         "confidence": 0.6,
@@ -54,7 +63,10 @@ def test_variance_demotes():
 
 
 def test_per_scenario_threshold():
-    scorecard = {"alignment": "pass", "security": "pass"}
+    scorecard = {
+        "alignment": {"status": "pass", "rationale": ""},
+        "security": "pass",
+    }
     metrics = {
         "raroi": 0.5,
         "confidence": 0.6,

--- a/tests/test_deployment_governance_evaluate.py
+++ b/tests/test_deployment_governance_evaluate.py
@@ -15,7 +15,10 @@ def test_evaluate_honours_override(tmp_path, monkeypatch):
     sig = generate_signature(data, str(key))
     override = tmp_path / "override.json"
     override.write_text(json.dumps({"data": data, "signature": sig}))
-    scorecard = {"alignment": "pass", "security": "pass"}
+    scorecard = {
+        "alignment": {"status": "pass", "rationale": ""},
+        "security": "pass",
+    }
     metrics = {"raroi": 0.1, "confidence": 0.2}
     res = dg.evaluate(
         scorecard,

--- a/tests/test_evaluation_dashboard.py
+++ b/tests/test_evaluation_dashboard.py
@@ -231,12 +231,24 @@ def test_governance_panel(tmp_path, monkeypatch):
     log_path = tmp_path / "gov.log"
     monkeypatch.setattr(ed, "GOVERNANCE_LOG", log_path)
     ed.append_governance_result(
-        {"decision": "ship", "alignment": "pass", "raroi_increase": 0}, [],
-        {"confidence": 0.9}, ["auto"]
+        {
+            "decision": "ship",
+            "alignment": {"status": "pass", "rationale": ""},
+            "raroi_increase": 0,
+        },
+        [],
+        {"confidence": 0.9},
+        ["auto"],
     )
     ed.append_governance_result(
-        {"decision": "rollback", "alignment": "fail", "raroi_increase": 1}, ["rule"],
-        {"confidence": 0.1}, ["rule"]
+        {
+            "decision": "rollback",
+            "alignment": {"status": "fail", "rationale": ""},
+            "raroi_increase": 1,
+        },
+        ["rule"],
+        {"confidence": 0.1},
+        ["rule"],
     )
     panel = dash.governance_panel()
     assert len(panel) == 2


### PR DESCRIPTION
## Summary
- Replace static alignment pass marker with `HumanAlignmentAgent` evaluation in self-improvement scorecards
- Propagate structured alignment results through deployment governance utilities
- Adjust tests and docs for new alignment result format

## Testing
- `PYTHONPATH=. pytest tests/test_deployment_evaluate.py tests/test_deployment_governance_eval.py tests/test_deployment_governance_evaluate.py`
- ⚠️ `pytest tests/test_evaluation_dashboard.py::test_governance_panel` (ImportError: cannot import name 'RAISE_ERRORS' from 'menace')


------
https://chatgpt.com/codex/tasks/task_e_68b32a53c1c8832eac119979d770411c