### PR TITLE
feat: track failed strategy tags for retrieval

### DIFF
--- a/tests/test_context_builder_failure_filtering.py
+++ b/tests/test_context_builder_failure_filtering.py
@@ -10,7 +10,7 @@ class DummyRetriever:
                 "record_id": 1,
                 "score": 1.0,
                 "text": "bad",
-                "metadata": {"redacted": True, "tags": ["skip"]},
+                "metadata": {"redacted": True, "tags": ["skip"], "strategy_hash": "deadbeef"},
             },
             {
                 "origin_db": "information",
@@ -27,6 +27,16 @@ def test_context_builder_filters_excluded_tags():
     ctx = builder.query("q", exclude_tags=["skip"])
     data = json.loads(ctx)
     assert "information" in data
+    infos = data["information"]
+    assert len(infos) == 1
+    assert infos[0]["id"] == 2
+
+
+def test_exclude_failed_strategies():
+    builder = ContextBuilder(retriever=DummyRetriever())
+    builder.exclude_failed_strategies(["deadbeef"])
+    ctx = builder.query("q")
+    data = json.loads(ctx)
     infos = data["information"]
     assert len(infos) == 1
     assert infos[0]["id"] == 2

--- a/tests/test_patch_suggestion_db_semantic.py
+++ b/tests/test_patch_suggestion_db_semantic.py
@@ -1,4 +1,17 @@
 import pytest
+import types
+import sys
+
+vec_mod = types.ModuleType("vector_service")
+
+
+class _EmbeddableDBMixin:
+    def __init__(self, *a, **k):
+        pass
+
+
+vec_mod.EmbeddableDBMixin = _EmbeddableDBMixin
+sys.modules.setdefault("vector_service", vec_mod)
 
 from patch_suggestion_db import PatchSuggestionDB, SuggestionRecord
 from patch_safety import PatchSafety
@@ -22,3 +35,9 @@ def test_failure_similarity_rejected(tmp_path):
     db = PatchSuggestionDB(tmp_path / "s.db", safety=safety)
     with pytest.raises(ValueError):
         db.add(SuggestionRecord(module="m.py", description="fail"))
+
+
+def test_failed_strategy_storage(tmp_path):
+    db = PatchSuggestionDB(tmp_path / "s.db")
+    db.add_failed_strategy("abc")
+    assert db.failed_strategy_tags() == ["abc"]

--- a/tests/test_self_coding_engine.py
+++ b/tests/test_self_coding_engine.py
@@ -16,6 +16,14 @@ vec_mod.ErrorResult = object  # type: ignore[attr-defined]
 vec_mod.PatchLogger = object  # type: ignore[attr-defined]
 vec_mod.VectorServiceError = _VSError
 
+
+class _EmbeddableDBMixin:
+    def __init__(self, *a, **k):
+        pass
+
+
+vec_mod.EmbeddableDBMixin = _EmbeddableDBMixin  # type: ignore[attr-defined]
+
 class FallbackResult(list):
     def __init__(self, reason, results=None):
         super().__init__(results or [])
@@ -118,6 +126,87 @@ sys.modules.setdefault("cryptography.hazmat.primitives.serialization", serializa
 sys.modules.setdefault("env_config", types.SimpleNamespace(DATABASE_URL="sqlite:///:memory:"))
 sys.modules.setdefault("httpx", types.ModuleType("httpx"))
 sys.modules.setdefault("run_autonomous", types.SimpleNamespace(LOCAL_KNOWLEDGE_MODULE=None))
+db_stub = types.ModuleType("data_bot")
+
+
+class _MetricsDB:
+    def __init__(self, *_a, **_k):
+        pass
+
+
+class _DataBot:
+    def __init__(self, mdb, patch_db=None):
+        self.db = mdb
+
+    def roi(self, *_a, **_k):
+        return 0.0
+
+    def complexity_score(self, *_a, **_k):
+        return 0.0
+
+
+db_stub.MetricsDB = _MetricsDB
+db_stub.DataBot = _DataBot
+sys.modules.setdefault("data_bot", db_stub)
+sys.modules.setdefault("menace.data_bot", db_stub)
+cg_stub = types.ModuleType("chatgpt_idea_bot")
+
+
+class _ChatGPTClient:
+    def __init__(self, *a, **k):
+        pass
+
+
+cg_stub.ChatGPTClient = _ChatGPTClient
+sys.modules.setdefault("chatgpt_idea_bot", cg_stub)
+sys.modules.setdefault("menace.chatgpt_idea_bot", cg_stub)
+th_stub = types.ModuleType("sandbox_runner.test_harness")
+
+
+class _THResult:
+    def __init__(self, success, stdout="", stderr="", duration=0.0):
+        self.success = success
+        self.stdout = stdout
+        self.stderr = stderr
+        self.duration = duration
+
+
+def _run_tests(*_a, **_k):
+    return _THResult(True)
+
+
+th_stub.run_tests = _run_tests
+th_stub.TestHarnessResult = _THResult
+sys.modules.setdefault("sandbox_runner.test_harness", th_stub)
+sys.modules.setdefault("menace.sandbox_runner.test_harness", th_stub)
+ws_stub = types.ModuleType("sandbox_runner.workflow_sandbox_runner")
+
+
+class _WSRunner:
+    def run(self, func, test_data=None):
+        class _M:
+            result = True
+
+        class _Metrics:
+            modules = [_M()]
+
+        return _Metrics()
+
+
+ws_stub.WorkflowSandboxRunner = _WSRunner
+sys.modules.setdefault("sandbox_runner.workflow_sandbox_runner", ws_stub)
+sys.modules.setdefault("menace.sandbox_runner.workflow_sandbox_runner", ws_stub)
+mm_stub = types.ModuleType("menace_memory_manager")
+
+
+class _MMM:
+    def __init__(self, *a, **k):
+        pass
+
+
+mm_stub.MenaceMemoryManager = _MMM
+sys.modules.setdefault("menace_memory_manager", mm_stub)
+sys.modules.setdefault("menace.menace_memory_manager", mm_stub)
 sys.modules.setdefault(
     "menace.run_autonomous", types.SimpleNamespace(LOCAL_KNOWLEDGE_MODULE=None)
 )


### PR DESCRIPTION
## Summary
- track failed strategy tags in `PatchSuggestionDB` and expose retrieval helpers
- allow `ContextBuilder` to exclude previous strategies via `exclude_failed_strategies`
- feed ErrorParser strategy tags into self-coding flows to skip failed approaches

## Testing
- `pytest tests/test_context_builder_failure_filtering.py`
- `pytest tests/test_patch_suggestion_db_semantic.py::test_failed_strategy_storage`
- `pytest tests/test_self_coding_engine.py -k apply_patch_reverts_on_complexity` *(fails: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68b397318714832e9335077e23af52cd