### PR TITLE
refactor: modularize self improvement

### DIFF
--- a/run_autonomous.py
+++ b/run_autonomous.py
@@ -1972,7 +1972,8 @@ def bootstrap(config_path: str = "config/bootstrap.yaml") -> None:
     """
     from pydantic import ValidationError
     from sandbox_settings import load_sandbox_settings
-    from self_improvement.meta_planning import start_self_improvement_cycle
+    from self_improvement import init_self_improvement
+    from self_improvement.orchestration import start_self_improvement_cycle
     from unified_event_bus import UnifiedEventBus
     from roi_results_db import ROIResultsDB
     from workflow_stability_db import WorkflowStabilityDB
@@ -1991,6 +1992,8 @@ def bootstrap(config_path: str = "config/bootstrap.yaml") -> None:
     bootstrap_environment(settings, _verify_required_dependencies)
     os.environ.setdefault("SANDBOX_REPO_PATH", settings.sandbox_repo_path)
     os.environ.setdefault("SANDBOX_DATA_DIR", settings.sandbox_data_dir)
+
+    init_self_improvement(settings)
 
     try:
         ROIResultsDB()

--- a/self_improvement/__init__.py
+++ b/self_improvement/__init__.py
@@ -139,41 +139,14 @@ except ImportError as exc:  # pragma: no cover - explicit guidance for users
     ) from exc
 
 
-from .utils import _load_callable, _call_with_retries
-from .orphan_integration import integrate_orphans, post_round_orphan_scan
-from .meta_planning import self_improvement_cycle
+from .orchestration import (
+    integrate_orphans,
+    post_round_orphan_scan,
+    self_improvement_cycle,
+    start_self_improvement_cycle,
+)
 from .metrics import _update_alignment_baseline
-
-
-
-
-def generate_patch(
-    *args: object, retries: int = 3, delay: float = 0.1, **kwargs: object
-) -> int:
-    """Generate a patch via :mod:`quick_fix_engine`.
-
-    This wrapper ensures the optional dependency is available and converts
-    missing or unsuccessful patch generation into a structured
-    :class:`RuntimeError` with logging instead of returning ``None``.
-    """
-
-    logger = logging.getLogger(__name__)
-    func = _load_callable("quick_fix_engine", "generate_patch")
-    try:
-        patch_id = _call_with_retries(
-            func, *args, retries=retries, delay=delay, **kwargs
-        )
-    except (RuntimeError, OSError) as exc:  # pragma: no cover - best effort logging
-        logger.error(
-            "quick_fix_engine failed",
-            extra=log_record(module=__name__),
-            exc_info=exc,
-        )
-        raise RuntimeError("quick_fix_engine failed to generate patch") from exc
-    if patch_id is None:
-        logger.error("quick_fix_engine returned no patch")
-        raise RuntimeError("quick_fix_engine did not produce a patch")
-    return int(patch_id)
+from .patch_generation import generate_patch
 
 
 from ..self_test_service import SelfTestService

--- a/self_improvement/init.py
+++ b/self_improvement/init.py
@@ -158,6 +158,12 @@ def init_self_improvement(new_settings: SandboxSettings | None = None) -> Sandbo
     if getattr(settings, "sandbox_central_logging", False):
         setup_logging()
     _load_initial_synergy_weights()
+    try:
+        from . import meta_planning
+
+        meta_planning.reload_settings(settings)
+    except Exception:  # pragma: no cover - best effort
+        pass
     return settings
 
 

--- a/self_improvement/orchestration.py
+++ b/self_improvement/orchestration.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+"""Orchestration helpers for the self-improvement engine."""
+
+from .orphan_integration import integrate_orphans, post_round_orphan_scan
+from .meta_planning import self_improvement_cycle, start_self_improvement_cycle
+
+__all__ = [
+    "integrate_orphans",
+    "post_round_orphan_scan",
+    "self_improvement_cycle",
+    "start_self_improvement_cycle",
+]

--- a/self_improvement/patch_generation.py
+++ b/self_improvement/patch_generation.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Patch generation utilities for the self-improvement engine."""
+
+import logging
+
+from .utils import _load_callable, _call_with_retries
+
+try:  # pragma: no cover - simplified environments
+    from ..logging_utils import log_record
+except Exception:  # pragma: no cover - best effort
+    def log_record(**fields: object) -> dict[str, object]:  # type: ignore
+        return fields
+
+
+def generate_patch(
+    *args: object, retries: int = 3, delay: float = 0.1, **kwargs: object
+) -> int:
+    """Generate a patch via :mod:`quick_fix_engine`.
+
+    This wrapper ensures the optional dependency is available and converts
+    missing or unsuccessful patch generation into a structured
+    :class:`RuntimeError` with logging instead of returning ``None``.
+    """
+
+    logger = logging.getLogger(__name__)
+    func = _load_callable("quick_fix_engine", "generate_patch")
+    try:
+        patch_id = _call_with_retries(func, *args, retries=retries, delay=delay, **kwargs)
+    except (RuntimeError, OSError) as exc:  # pragma: no cover - best effort logging
+        logger.error(
+            "quick_fix_engine failed",
+            extra=log_record(module=__name__),
+            exc_info=exc,
+        )
+        raise RuntimeError("quick_fix_engine failed to generate patch") from exc
+    if patch_id is None:
+        logger.error("quick_fix_engine returned no patch")
+        raise RuntimeError("quick_fix_engine did not produce a patch")
+    return int(patch_id)
+
+
+__all__ = ["generate_patch"]

--- a/tests/integration/test_full_self_improvement_cycle.py
+++ b/tests/integration/test_full_self_improvement_cycle.py
@@ -35,7 +35,14 @@ def _load_meta_planning():
         "Callable": Callable,
         "Mapping": Mapping,
         "DEFAULT_ENTROPY_THRESHOLD": 0.2,
-        "load_sandbox_settings": lambda: None,
+        "_init": types.SimpleNamespace(
+            settings=types.SimpleNamespace(
+                meta_mutation_rate=0,
+                meta_roi_weight=0,
+                meta_domain_penalty=0,
+                meta_entropy_threshold=None,
+            )
+        ),
     }
     exec(compile(module, "<ast>", "exec"), ns)
     return ns
@@ -105,11 +112,13 @@ def test_full_self_improvement_cycle(monkeypatch):
                 warning=lambda *a, **k: None, exception=lambda *a, **k: None
             ),
             "log_record": lambda **kw: kw,
-            "load_sandbox_settings": lambda: types.SimpleNamespace(
-                meta_mutation_rate=None,
-                meta_roi_weight=None,
-                meta_domain_penalty=None,
-                meta_entropy_threshold=None,
+            "_init": types.SimpleNamespace(
+                settings=types.SimpleNamespace(
+                    meta_mutation_rate=None,
+                    meta_roi_weight=None,
+                    meta_domain_penalty=None,
+                    meta_entropy_threshold=None,
+                )
             ),
             "STABLE_WORKFLOWS": global_db,
         }

--- a/tests/test_self_improvement_cycle_regression.py
+++ b/tests/test_self_improvement_cycle_regression.py
@@ -33,7 +33,14 @@ def _load_meta_planning():
         "Callable": Callable,
         "Mapping": Mapping,
         "DEFAULT_ENTROPY_THRESHOLD": 0.2,
-        "load_sandbox_settings": lambda: None,
+        "_init": types.SimpleNamespace(
+            settings=types.SimpleNamespace(
+                meta_mutation_rate=0,
+                meta_roi_weight=0,
+                meta_domain_penalty=0,
+                meta_entropy_threshold=None,
+            )
+        ),
     }
     exec(compile(module, "<ast>", "exec"), ns)
     return ns
@@ -52,6 +59,7 @@ def test_self_improvement_cycle_matches_fixture():
     class DummyStability:
         def __init__(self):
             self.recorded = []
+            self.data = {}
 
         def record_metrics(self, wf, roi, failures, entropy, roi_delta=None):
             self.recorded.append((wf, roi, entropy))
@@ -80,15 +88,19 @@ def test_self_improvement_cycle_matches_fixture():
         {
             "MetaWorkflowPlanner": DummyPlanner,
             "get_logger": lambda name: types.SimpleNamespace(
-                warning=lambda *a, **k: None, exception=lambda *a, **k: None
+                warning=lambda *a, **k: None,
+                exception=lambda *a, **k: None,
+                debug=lambda *a, **k: None,
             ),
             "log_record": lambda **kw: kw,
             "STABLE_WORKFLOWS": DummyStability(),
-            "load_sandbox_settings": lambda: types.SimpleNamespace(
-                meta_mutation_rate=None,
-                meta_roi_weight=None,
-                meta_domain_penalty=None,
-                meta_entropy_threshold=None,
+            "_init": types.SimpleNamespace(
+                settings=types.SimpleNamespace(
+                    meta_mutation_rate=None,
+                    meta_roi_weight=None,
+                    meta_domain_penalty=None,
+                    meta_entropy_threshold=None,
+                )
             ),
         }
     )

--- a/tests/test_start_self_improvement_cycle.py
+++ b/tests/test_start_self_improvement_cycle.py
@@ -26,10 +26,18 @@ def _load_module():
         "Mapping": Mapping,
         "Callable": Callable,
         "Any": Any,
-        "load_sandbox_settings": lambda: None,
         "ROIResultsDB": lambda *a, **k: None,
         "WorkflowStabilityDB": lambda *a, **k: None,
         "UnifiedEventBus": object,
+        "_init": types.SimpleNamespace(
+            settings=types.SimpleNamespace(
+                meta_planning_interval=0.0,
+                meta_mutation_rate=0,
+                meta_roi_weight=0,
+                meta_domain_penalty=0,
+                meta_entropy_threshold=None,
+            )
+        ),
     }
     exec(compile(module, "<ast>", "exec"), ns)
     return ns


### PR DESCRIPTION
## Summary
- modularize self-improvement engine into configuration, orchestration, patch generation, and metrics modules
- require explicit init_self_improvement() invocation and expose reloadable settings
- adjust run_autonomous and tests accordingly

## Testing
- `pytest tests/test_start_self_improvement_cycle.py tests/test_self_improvement_cycle_regression.py tests/integration/test_full_self_improvement_cycle.py -q`
- `pytest tests/integration/test_self_improvement_cycle.py::test_background_self_improvement_loop -q` *(fails: ImportError: cannot import name 'RAISE_ERRORS' from 'menace')*


------
https://chatgpt.com/codex/tasks/task_e_68b3998268f8832ea8a3113578bba524