### PR TITLE
Use sandbox data dir for fallback planner state

### DIFF
--- a/self_improvement/meta_planning.py
+++ b/self_improvement/meta_planning.py
@@ -84,7 +84,8 @@ class _FallbackPlanner:
             self.stability_db = None
 
         self.logger = get_logger("FallbackPlanner")
-        self.state_path = Path("sandbox_data/fallback_planner.json")
+        data_dir = Path(SandboxSettings().sandbox_data_dir)
+        self.state_path = data_dir / "fallback_planner.json"
         self.state_lock = SandboxLock(
             str(self.state_path.with_suffix(self.state_path.suffix + ".lock"))
         )


### PR DESCRIPTION
## Summary
- derive `_FallbackPlanner` state path from `SandboxSettings().sandbox_data_dir`
- ensure lock and temp files respect configured sandbox data directory

## Testing
- `pytest tests/test_meta_planning_entropy.py -q`
- `pytest unit_tests/test_fallback_planner.py::test_mutate_pipeline_scores_with_weights_and_penalty -q` *(fails: NameError: name '_init' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b39de82ddc832e81cc030788705799