### PR TITLE
Integrate sandbox harness and metrics for self-coding

### DIFF
--- a/sandbox_metrics.yaml
+++ b/sandbox_metrics.yaml
@@ -7,3 +7,5 @@ extra_metrics:
   orphan_modules_added: 0.0
   synergy_update_success: 0.0
   intent_update_success: 0.0
+  self_coding_cycle_success: 0.0
+  self_coding_cycle_retries: 0.0


### PR DESCRIPTION
## Summary
- run self-coding patch attempts inside WorkflowSandboxRunner
- retry or abort using ErrorParser and track retry count
- record self-coding cycle metrics in sandbox_metrics.yaml

## Testing
- `pytest` *(fails: 285 errors during collection)*
- `make mypy`


------
https://chatgpt.com/codex/tasks/task_e_68b3a0eaa3b0832ea9632d31c32bbf80