### PR TITLE
Add closed loop sandbox regression test

### DIFF
--- a/tests/test_closed_loop_sandbox.py
+++ b/tests/test_closed_loop_sandbox.py
@@ -52,6 +52,17 @@ class ROIResult:
 prb_stub.ROIResult = ROIResult
 sys.modules["menace.pre_execution_roi_bot"] = prb_stub
 
+# Sandbox harness stub to avoid importing heavy dependencies
+sandbox_stub = types.ModuleType("sandbox_runner.test_harness")
+sandbox_stub.run_tests = lambda *a, **k: None
+sandbox_stub.TestHarnessResult = object
+sys.modules["sandbox_runner.test_harness"] = sandbox_stub
+
+# Patch provenance stub
+pp_stub = types.ModuleType("menace.patch_provenance")
+pp_stub.record_patch_metadata = lambda *a, **k: None
+sys.modules["menace.patch_provenance"] = pp_stub
+
 import menace.self_coding_manager as scm
 
 
@@ -119,7 +130,9 @@ def test_closed_loop_patch(monkeypatch, tmp_path, backend):
     file_path.write_text("def x():\n    return 1\n", encoding="utf-8")
     monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
 
-    pushes = []
+    pushes: list[list[str]] = []
+    pytest_calls: list[list[str]] = []
+
     def fake_run(cmd, *a, cwd=None, check=None, **kw):
         if cmd[:2] == ["git", "clone"]:
             dst = Path(cmd[3])
@@ -129,7 +142,11 @@ def test_closed_loop_patch(monkeypatch, tmp_path, backend):
         if cmd[:2] == ["git", "push"]:
             pushes.append(cmd)
             return subprocess.CompletedProcess(cmd, 0)
+        if cmd and cmd[0] == "pytest":
+            pytest_calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0)
         return subprocess.CompletedProcess(cmd, 0)
+
     monkeypatch.setattr(scm.subprocess, "run", fake_run)
 
     tmpdir_path = tmp_path / "clone"
@@ -143,7 +160,14 @@ def test_closed_loop_patch(monkeypatch, tmp_path, backend):
 
     runner = DummyRunner()
     monkeypatch.setattr(scm, "WorkflowSandboxRunner", lambda: runner)
-    monkeypatch.setattr(scm.ErrorParser, "parse", staticmethod(lambda t: {"tags": ["boom"]}))
+
+    parse_calls: list[str] = []
+
+    def fake_parse(trace: str):
+        parse_calls.append(trace)
+        return {"tags": ["boom"]}
+
+    monkeypatch.setattr(scm.ErrorParser, "parse", staticmethod(fake_parse), raising=False)
     monkeypatch.setattr(scm.MutationLogger, "log_mutation", lambda *a, **k: 1)
     monkeypatch.setattr(scm.MutationLogger, "record_mutation_outcome", lambda *a, **k: None)
 
@@ -156,8 +180,14 @@ def test_closed_loop_patch(monkeypatch, tmp_path, backend):
 
     mgr.run_patch(file_path, "change")
 
-    assert builder.calls == [["boom"]]
+    # ErrorParser tags should be forwarded to the context builder only once
+    assert parse_calls and builder.calls == [["boom"]]
+    # The harness executes tests inside the sandbox
+    assert runner.calls == 2 and len(pytest_calls) == 1
+    assert runner.safe_mode is True
+    # Patch commit and ROI tracking side effects
     assert pushes and pushes[-1][-1].endswith("main")
     assert data_bot.logged and data_bot.logged[0]["roi_delta"] == 1.0
     assert logger.calls and logger.calls[0][1]["contribution"] == 1.0
-    assert runner.safe_mode is True
+    # Source file should have been modified by the dummy patch
+    assert "# patched" in file_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add regression test for SelfCodingManager's closed-loop patch flow
- ensure ErrorParser tags drive ContextBuilder, and tests execute in sandbox

## Testing
- `pytest tests/test_closed_loop_sandbox.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3a52c1118832ea48d4c6b5ce3fcea