### PR TITLE
feat: auto bootstrap sandbox configs

### DIFF
--- a/tests/integration/test_sandbox_launch_cycle.py
+++ b/tests/integration/test_sandbox_launch_cycle.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import sys
+import types
+
+from menace_sandbox.foresight_tracker import ForesightTracker
+from sandbox_runner import bootstrap
+
+
+class DummyROITracker:
+    def __init__(self, deltas):
+        self._deltas = iter(deltas)
+        self.raroi_history = [0.0]
+        self.confidence_history = [0.0]
+        self.metrics_history = {"synergy_resilience": [0.0]}
+
+    def next_delta(self):
+        delta = next(self._deltas)
+        self.raroi_history.append(self.raroi_history[-1] + delta / 2.0)
+        return delta
+
+    def scenario_degradation(self):  # pragma: no cover - deterministic
+        return 0.0
+
+
+class MiniSelfImprovementEngine:
+    def __init__(self, tracker, foresight_tracker):
+        self.tracker = tracker
+        self.foresight_tracker = foresight_tracker
+
+    def run_cycle(self, workflow_id="wf"):
+        delta = self.tracker.next_delta()
+        raroi_delta = self.tracker.raroi_history[-1] - self.tracker.raroi_history[-2]
+        confidence = self.tracker.confidence_history[-1]
+        resilience = self.tracker.metrics_history["synergy_resilience"][-1]
+        scenario_deg = self.tracker.scenario_degradation()
+        self.foresight_tracker.record_cycle_metrics(
+            workflow_id,
+            {
+                "roi_delta": float(delta),
+                "raroi_delta": float(raroi_delta),
+                "confidence": float(confidence),
+                "resilience": float(resilience),
+                "scenario_degradation": float(scenario_deg),
+            },
+        )
+
+
+def test_launch_sandbox_runs_cycle(tmp_path, monkeypatch):
+    # Stub optional services required by bootstrap
+    for name in ("relevancy_radar", "quick_fix_engine"):
+        mod = types.ModuleType(name)
+        mod.__version__ = "1.0.0"
+        monkeypatch.setitem(sys.modules, name, mod)
+
+    # Replace CLI entry point with a minimal self-improvement cycle
+    events = []
+
+    def fake_main(_args):
+        ft = ForesightTracker(max_cycles=1)
+        tracker = DummyROITracker([1.0])
+        engine = MiniSelfImprovementEngine(tracker, ft)
+        engine.run_cycle()
+        events.append(ft.history["wf"][0]["roi_delta"])
+
+    monkeypatch.setattr(bootstrap, "_cli_main", fake_main)
+
+    import importlib
+
+    # ensure we use the real SandboxSettings in case other tests injected stubs
+    sys.modules.pop("sandbox_settings", None)
+    SandboxSettings = importlib.import_module("sandbox_settings").SandboxSettings
+
+    settings = SandboxSettings(
+        sandbox_data_dir=str(tmp_path), menace_env_file=str(tmp_path / ".env")
+    )
+
+    # Launch sandbox using the bootstrap helper
+    bootstrap.launch_sandbox(settings, verifier=lambda s: None)
+
+    assert events == [1.0]

--- a/tests/test_bootstrap_service_deps.py
+++ b/tests/test_bootstrap_service_deps.py
@@ -6,19 +6,30 @@ import pytest
 
 # Stub out heavy modules before importing bootstrap
 menace = types.ModuleType("menace")
+menace.RAISE_ERRORS = False
 auto_env_setup = types.ModuleType("menace.auto_env_setup")
 auto_env_setup.ensure_env = lambda _path: None
 menace.auto_env_setup = auto_env_setup
+# expose config helpers for bootstrap imports
+_dcm = importlib.import_module("menace_sandbox.default_config_manager")
+_cd = importlib.import_module("menace_sandbox.config_discovery")
+menace.default_config_manager = _dcm
+menace.config_discovery = _cd
 sys.modules["menace"] = menace
 sys.modules["menace.auto_env_setup"] = auto_env_setup
+sys.modules["menace.default_config_manager"] = _dcm
+sys.modules["menace.config_discovery"] = _cd
 
 sandbox_settings = types.ModuleType("sandbox_settings")
+
+
 class SandboxSettings:
     def __init__(self, sandbox_data_dir="", alignment_baseline_metrics_path=""):
         self.sandbox_data_dir = sandbox_data_dir
         self.alignment_baseline_metrics_path = alignment_baseline_metrics_path
         self.menace_mode = "test"
         self.menace_env_file = "env"
+
 
 sandbox_settings.SandboxSettings = SandboxSettings
 sandbox_settings.load_sandbox_settings = lambda: SandboxSettings()
@@ -51,23 +62,27 @@ def _settings(tmp_path):
     return SandboxSettings(sandbox_data_dir=str(tmp_path))
 
 
-def test_missing_service_raises(monkeypatch, tmp_path):
+def test_missing_service_warns(monkeypatch, tmp_path, caplog):
     _stub_services(monkeypatch, {"quick_fix_engine": "1.0.0"}, missing={"relevancy_radar"})
-    with pytest.raises(RuntimeError, match="relevancy_radar"):
-        bootstrap.initialize_autonomous_sandbox(_settings(tmp_path))
+    caplog.set_level("WARNING")
+    bootstrap.initialize_autonomous_sandbox(_settings(tmp_path))
+    assert any("relevancy_radar" in r.getMessage() for r in caplog.records)
 
 
-def test_version_too_old(monkeypatch, tmp_path):
+def test_version_too_old_warns(monkeypatch, tmp_path, caplog):
     _stub_services(monkeypatch, {"quick_fix_engine": "1.0.0", "relevancy_radar": "0.0.1"})
-    with pytest.raises(RuntimeError, match="relevancy_radar"):
-        bootstrap.initialize_autonomous_sandbox(_settings(tmp_path))
+    caplog.set_level("WARNING")
+    bootstrap.initialize_autonomous_sandbox(_settings(tmp_path))
+    assert any("too old" in r.getMessage() for r in caplog.records)
 
 
 def test_unwritable_data_dir(monkeypatch, tmp_path, caplog):
     _stub_services(monkeypatch, {"quick_fix_engine": "1.0.0", "relevancy_radar": "1.0.0"})
     data_dir = tmp_path / "data"
     data_dir.mkdir()
-    monkeypatch.setattr(bootstrap.Path, "touch", lambda *a, **k: (_ for _ in ()).throw(PermissionError()))
+    monkeypatch.setattr(
+        bootstrap.Path, "touch", lambda *a, **k: (_ for _ in ()).throw(PermissionError())
+    )
     settings = SandboxSettings(sandbox_data_dir=str(data_dir))
     with pytest.raises(RuntimeError, match="not writable"):
         bootstrap.initialize_autonomous_sandbox(settings)


### PR DESCRIPTION
## Summary
- automatically populate `.env` and default settings during sandbox bootstrap
- warn instead of aborting when optional services are missing or outdated
- add integration test exercising `launch_sandbox` and minimal self-improvement cycle

## Testing
- `pre-commit run --files sandbox_runner/bootstrap.py tests/test_bootstrap_service_deps.py tests/integration/test_sandbox_launch_cycle.py`
- `pytest tests/test_bootstrap_service_deps.py tests/integration/test_sandbox_launch_cycle.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'EvolutionEvent' from 'menace.evolution_history_db', AttributeError: 'types.SimpleNamespace' object has no attribute 'menace_light_imports', ...)*


------
https://chatgpt.com/codex/tasks/task_e_68b3aba48908832ebf87554052b1ffd2