### PR TITLE
feat: filter failed tags across queries

### DIFF
--- a/tests/test_context_builder_failure_filtering.py
+++ b/tests/test_context_builder_failure_filtering.py
@@ -1,5 +1,9 @@
 import json
-from vector_service.context_builder import ContextBuilder
+from vector_service.context_builder import (
+    ContextBuilder,
+    record_failed_tags,
+    _FAILED_TAG_CACHE,
+)
 
 
 class DummyRetriever:
@@ -35,6 +39,20 @@ def test_context_builder_filters_excluded_tags():
 def test_exclude_failed_strategies():
     builder = ContextBuilder(retriever=DummyRetriever())
     builder.exclude_failed_strategies(["deadbeef"])
+    ctx = builder.query("q")
+    data = json.loads(ctx)
+    infos = data["information"]
+    assert len(infos) == 1
+    assert infos[0]["id"] == 2
+
+
+def test_record_failed_tags_filters_future_queries():
+    try:
+        _FAILED_TAG_CACHE.clear()
+    except Exception:
+        pass
+    record_failed_tags(["skip"])
+    builder = ContextBuilder(retriever=DummyRetriever())
     ctx = builder.query("q")
     data = json.loads(ctx)
     infos = data["information"]


### PR DESCRIPTION
## Summary
- track failed strategy tags via `record_failed_tags`
- allow retrievers to exclude tagged vectors from results
- store sandbox failure tags so future searches skip them

## Testing
- `pre-commit run --files vector_service/context_builder.py vector_service/retriever.py self_debugger_sandbox.py tests/test_context_builder_failure_filtering.py`
- `pytest tests/test_context_builder_failure_filtering.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3addd083c832e8db14d3f424cdff4