### PR TITLE
feat: isolate sandbox tests

### DIFF
--- a/docs/self_coding_engine.md
+++ b/docs/self_coding_engine.md
@@ -49,4 +49,23 @@ Key options mirror those in `GPTMemoryManager`:
 
 See [gpt_memory.md](gpt_memory.md) for more examples and configuration details.
 
+## Ephemeral Test Environments
+
+`SelfCodingEngine` evaluates patches inside isolated environments. The helper
+`create_ephemeral_env` clones the working directory into a temporary virtual
+environment (or Docker container) and installs dependencies from
+`requirements.txt` before running tests.
+
+```python
+from pathlib import Path
+from sandbox_runner.environment import create_ephemeral_env
+
+with create_ephemeral_env(Path(".")) as (repo, run):
+    (repo / "test_example.py").write_text("def test_ok():\n    assert True\n")
+    run(["pytest", "-q"], check=True)
+```
+
+Startup time and installation failures are logged via the sandbox logging
+utilities so that callers can track environment issues.
+
 


### PR DESCRIPTION
## Summary
- add `create_ephemeral_env` helper to spin up a temporary venv or Docker container with requirements installed
- run `SelfDebuggerSandbox` tests inside `create_ephemeral_env`
- document ephemeral environment workflow for self-coding engine

## Testing
- `pre-commit run --files self_debugger_sandbox.py docs/self_coding_engine.md`
- `pre-commit run --files sandbox_runner/environment.py self_debugger_sandbox.py docs/self_coding_engine.md` *(fails: flake8 errors in sandbox_runner/environment.py)*
- `pytest tests/test_self_debugger_sandbox.py -k test_score_config_from_env -q` *(fails: ValueError: jinja2.__spec__ is None)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b247a2d8832e805fd4b62ae6005f