### PR TITLE
feat: add state normalization, reward scaling and periodic evaluation

### DIFF
--- a/actor_critic_agent.py
+++ b/actor_critic_agent.py
@@ -1,16 +1,58 @@
 from __future__ import annotations
 
-"""Simple actor-critic agent with replay buffer and persistence."""
+"""Simple actor-critic agent with replay buffer and persistence.
+
+This version adds optional state normalisation, reward scaling and periodic
+checkpointing/evaluation. The agent uses linear function approximation for the
+actor and critic which keeps dependencies minimal while still supporting
+general value/policy estimation.
+"""
 
 import json
 import random
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List, Tuple
+from typing import Any, Iterable, List, Tuple
 
 import numpy as np
 
 from sandbox_settings import SandboxSettings
+
+
+class RunningStat:
+    """Track running mean and variance for normalisation."""
+
+    def __init__(self, size: int) -> None:
+        self.n = 0
+        self.mean = np.zeros(size)
+        self.M2 = np.ones(size)
+
+    def update(self, x: np.ndarray) -> None:
+        self.n += 1
+        delta = x - self.mean
+        self.mean += delta / self.n
+        delta2 = x - self.mean
+        self.M2 += delta * delta2
+
+    @property
+    def var(self) -> np.ndarray:
+        if self.n < 2:
+            return np.ones_like(self.mean)
+        return self.M2 / (self.n - 1)
+
+    def normalize(self, x: np.ndarray) -> np.ndarray:
+        return (x - self.mean) / (np.sqrt(self.var) + 1e-8)
+
+    def to_json(self) -> dict[str, Any]:
+        return {"n": self.n, "mean": self.mean.tolist(), "M2": self.M2.tolist()}
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> "RunningStat":
+        obj = cls(len(data.get("mean", [])))
+        obj.n = int(data.get("n", 0))
+        obj.mean = np.array(data.get("mean", obj.mean))
+        obj.M2 = np.array(data.get("M2", obj.M2))
+        return obj
 
 
 @dataclass
@@ -68,6 +110,7 @@ class ActorCriticAgent:
         state_size: int,
         action_size: int,
         settings: SandboxSettings | None = None,
+        eval_env: Any | None = None,
     ) -> None:
         self.state_size = state_size
         self.action_size = action_size
@@ -79,11 +122,17 @@ class ActorCriticAgent:
         self.epsilon = cfg.epsilon
         self.epsilon_decay = cfg.epsilon_decay
         self.batch_size = cfg.batch_size
+        self.reward_scale = cfg.reward_scale
+        self.checkpoint_interval = cfg.checkpoint_interval
+        self.eval_interval = cfg.eval_interval
         self.replay = ReplayBuffer(cfg.buffer_size)
         self.checkpoint = Path(cfg.checkpoint_path)
         self.actor = np.zeros((state_size, action_size))
         self.critic = np.zeros(state_size)
         self.steps = 0
+        self.eval_env = eval_env
+        self.normalize_states = cfg.normalize_states
+        self.state_norm = RunningStat(state_size) if self.normalize_states else None
         self._load()
 
     # ------------------------------------------------------------------
@@ -93,13 +142,28 @@ class ActorCriticAgent:
         exp = np.exp(logits)
         return exp / np.sum(exp)
 
+    def _normalize(self, state: np.ndarray) -> np.ndarray:
+        if self.state_norm is None:
+            return state
+        return self.state_norm.normalize(state)
+
+    def _update_norm(self, state: np.ndarray) -> None:
+        if self.state_norm is not None:
+            self.state_norm.update(state)
+
     def select_action(self, state: np.ndarray) -> int:
+        state = self._normalize(state)
         if random.random() < self.epsilon:
             return random.randrange(self.action_size)
         probs = self._policy(state)
         return int(np.argmax(probs))
 
     def store(self, state: np.ndarray, action: int, reward: float, next_state: np.ndarray) -> None:
+        self._update_norm(state)
+        self._update_norm(next_state)
+        state = self._normalize(state)
+        next_state = self._normalize(next_state)
+        reward *= self.reward_scale
         self.replay.add(Transition(state, action, reward, next_state))
 
     def learn(self) -> None:
@@ -117,7 +181,10 @@ class ActorCriticAgent:
             self.actor += self.actor_lr * td_error * np.outer(trans.state, grad)
         self.epsilon *= self.epsilon_decay
         self.steps += 1
-        self._save()
+        if self.steps % self.checkpoint_interval == 0:
+            self._save()
+        if self.eval_env is not None and self.eval_interval and self.steps % self.eval_interval == 0:
+            self.evaluate(self.eval_env)
 
     # ------------------------------------------------------------------
     def _save(self) -> None:
@@ -127,6 +194,7 @@ class ActorCriticAgent:
             "epsilon": self.epsilon,
             "steps": self.steps,
             "replay": self.replay.to_json(),
+            "state_norm": self.state_norm.to_json() if self.state_norm else None,
             "hyperparams": {
                 "actor_lr": self.actor_lr,
                 "critic_lr": self.critic_lr,
@@ -134,6 +202,10 @@ class ActorCriticAgent:
                 "epsilon_decay": self.epsilon_decay,
                 "batch_size": self.batch_size,
                 "buffer_size": self.replay.capacity,
+                "reward_scale": self.reward_scale,
+                "checkpoint_interval": self.checkpoint_interval,
+                "eval_interval": self.eval_interval,
+                "normalize_states": self.normalize_states,
             },
         }
         self.checkpoint.parent.mkdir(parents=True, exist_ok=True)
@@ -156,8 +228,15 @@ class ActorCriticAgent:
         self.gamma = float(hp.get("gamma", self.gamma))
         self.epsilon_decay = float(hp.get("epsilon_decay", self.epsilon_decay))
         self.batch_size = int(hp.get("batch_size", self.batch_size))
+        self.reward_scale = float(hp.get("reward_scale", self.reward_scale))
+        self.checkpoint_interval = int(hp.get("checkpoint_interval", self.checkpoint_interval))
+        self.eval_interval = int(hp.get("eval_interval", self.eval_interval))
+        self.normalize_states = bool(hp.get("normalize_states", self.normalize_states))
         buf_items = data.get("replay", [])
         self.replay = ReplayBuffer.from_json(int(hp.get("buffer_size", len(buf_items))), buf_items)
+        sn = data.get("state_norm")
+        if self.normalize_states and sn:
+            self.state_norm = RunningStat.from_json(sn)
 
     # Convenience training step
     def step(self, state: np.ndarray, reward: float, next_state: np.ndarray) -> int:
@@ -165,3 +244,30 @@ class ActorCriticAgent:
         self.store(state, action, reward, next_state)
         self.learn()
         return action
+
+    # ------------------------------------------------------------------
+    def evaluate(self, env: Any, episodes: int = 5) -> float:
+        """Evaluate current policy on an environment.
+
+        Parameters
+        ----------
+        env:
+            Environment exposing ``reset`` and ``step`` similar to OpenAI Gym.
+        episodes:
+            Number of evaluation episodes.
+
+        Returns
+        -------
+        float
+            Average reward across evaluation episodes.
+        """
+
+        total = 0.0
+        for _ in range(episodes):
+            state = env.reset()
+            done = False
+            while not done:
+                action = self.select_action(state)
+                state, reward, done, *_ = env.step(action)
+                total += reward
+        return total / float(episodes)

--- a/tests/test_actor_critic_agent.py
+++ b/tests/test_actor_critic_agent.py
@@ -46,3 +46,16 @@ def test_actor_critic_learns_and_persists(tmp_path):
     for i, s in enumerate(states):
         assert agent2.select_action(s) == optimal[i]
     assert agent2.actor_lr == cfg.actor_critic.actor_lr
+
+
+def test_state_normalisation_and_reward_scaling(tmp_path):
+    cfg = SandboxSettings(
+        ac_reward_scale=0.5,
+        ac_checkpoint_path=str(tmp_path / "ac_state.json"),
+    )
+    agent = ActorCriticAgent(2, 2, cfg)
+    s = np.array([1.0, 0.0])
+    ns = np.array([0.0, 1.0])
+    agent.store(s, 0, 1.0, ns)
+    assert agent.replay.data[0].reward == 0.5
+    assert not np.allclose(agent.replay.data[0].state, s)


### PR DESCRIPTION
## Summary
- extend actor-critic agent with running state normalisation, reward scaling and periodic checkpoints/evaluation
- expose new hyperparameters for normalisation, reward scaling and intervals via `SandboxSettings`
- add tests covering persistence, normalisation and reward scaling

## Testing
- `pytest tests/test_actor_critic_agent.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3b6c0aed8832e8195d6f566097516