### PR TITLE
Log meta_planning reload failure in self_improvement init

### DIFF
--- a/self_improvement/init.py
+++ b/self_improvement/init.py
@@ -163,7 +163,7 @@ def init_self_improvement(new_settings: SandboxSettings | None = None) -> Sandbo
 
         meta_planning.reload_settings(settings)
     except Exception:  # pragma: no cover - best effort
-        pass
+        logger.exception("Failed to reload meta_planning settings")
     return settings
 
 
@@ -175,4 +175,3 @@ __all__ = [
     "_atomic_write",
     "DEFAULT_SYNERGY_WEIGHTS",
 ]
-


### PR DESCRIPTION
## Summary
- log meta_planning.reload_settings failures with `logger.exception`

## Testing
- `pre-commit run --files self_improvement/init.py`
- `pytest` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'menace_light_imports' and 285 other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bf00b4b4832eb477ac56cfd3ba05