### PR TITLE
Use parse_failure for patch context rebuilding

### DIFF
--- a/tests/test_error_parser.py
+++ b/tests/test_error_parser.py
@@ -1,6 +1,6 @@
 import traceback
 
-from error_parser import ErrorParser
+from error_parser import parse_failure
 
 
 def test_parse_pytest_assertion():
@@ -9,10 +9,8 @@ def test_parse_pytest_assertion():
         "    assert 1 == 2\n"
         "E   AssertionError: assert 1 == 2\n"
     )
-    result = ErrorParser.parse(trace)
-    assert "tests/test_sample.py" in result["files"]
-    assert result["error_type"] == "AssertionError"
-    assert "test" in result["tags"]
+    report = parse_failure(trace)
+    assert report.tags == ["assertion_error"]
 
 
 def test_parse_runtime_error():
@@ -20,7 +18,5 @@ def test_parse_runtime_error():
         1 / 0
     except ZeroDivisionError:
         trace = traceback.format_exc()
-    result = ErrorParser.parse(trace)
-    assert any(path.endswith("test_error_parser.py") for path in result["files"])
-    assert result["error_type"] == "ZeroDivisionError"
-    assert "runtime" in result["tags"]
+    report = parse_failure(trace)
+    assert "zero_division_error" in report.tags


### PR DESCRIPTION
## Summary
- Parse failure traces with `parse_failure` and rebuild context using extracted tags.
- Raise an error when no tags are found and forward tags to the context builder.
- Update error parser tests for the new `parse_failure` API.

## Testing
- `pre-commit run --files self_coding_manager.py tests/test_error_parser.py`
- `pytest tests/test_error_parser.py -q`
- `pytest -q` *(fails: 149 errors, missing `menace_light_imports` attributes)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c0286884832e9cfbef6f36c75c5c