### PR TITLE
Log checkpoint path on restore failure

### DIFF
--- a/self_improvement/__init__.py
+++ b/self_improvement/__init__.py
@@ -664,8 +664,14 @@ class SynergyWeightLearner:
             if self.checkpoint_path.exists():
                 try:
                     shutil.copy(self.checkpoint_path, self.path)
-                except Exception:
-                    pass
+                except Exception as restore_exc:
+                    logger.exception(
+                        "failed to restore synergy weights from checkpoint %s: %s",
+                        self.checkpoint_path,
+                        restore_exc,
+                        extra=log_record(checkpoint_path=str(self.checkpoint_path)),
+                    )
+                    raise
             return
         self._save_count += 1
         if self._save_count % self.checkpoint_interval == 0:


### PR DESCRIPTION
## Summary
- log checkpoint path when restoring synergy weights fails
- re-raise restore error so callers can handle failures

## Testing
- `pytest tests/test_simple_functions.py -q`
- `pytest tests/test_synergy_weight_learner.py::test_synergy_weight_logging_info -q` *(fails: cannot import name 'SANDBOX_ENV_PRESETS')*


------
https://chatgpt.com/codex/tasks/task_e_68b3c4058e44832e857591c5220876ad