### PR TITLE
Log exceptions when retrieving recent events

### DIFF
--- a/self_improvement/__init__.py
+++ b/self_improvement/__init__.py
@@ -6772,8 +6772,8 @@ class SelfImprovementEngine:
                         logs: list[dict[str, Any]] | None = None
                         try:
                             logs = get_recent_events(limit=20)
-                        except Exception:
-                            pass
+                        except Exception as exc:
+                            logger.warning("Failed to get recent events: %s", exc)
                         warnings = agent.evaluate_changes(actions, metrics, logs, None)
                         if any(warnings.values()):
                             scorecard["alignment"] = {


### PR DESCRIPTION
## Summary
- log a warning with exception details if fetching recent events fails

## Testing
- `pytest self_improvement -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3c8a1ac8c832eb752fc74121f4897