### PR TITLE
Log Windows cleanup fallback results

### DIFF
--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -2894,11 +2894,21 @@ def reconcile_active_containers() -> None:
             try:
                 shutil.rmtree(td)
             except Exception:
-                if os.name == "nt" and _rmtree_windows(td):
-                    pass
+                if os.name == "nt":
+                    if _rmtree_windows(td):
+                        logger.debug(
+                            "temporary directory removed via Windows fallback for %s",
+                            td,
+                        )
+                    else:
+                        logger.warning(
+                            "temporary directory removal failed for %s", td,
+                            exc_info=True,
+                        )
                 else:
-                    logger.exception(
-                        "temporary directory removal failed for %s", td
+                    logger.warning(
+                        "temporary directory removal failed for %s", td,
+                        exc_info=True,
                     )
 
 


### PR DESCRIPTION
## Summary
- add debug logging when Windows-specific rmtree fallback succeeds
- warn if Windows cleanup fallback fails instead of silently passing

## Testing
- `pre-commit run --files sandbox_runner/environment.py` *(fails: F401 etc.)*
- `pytest tests/test_purge_stale_vms_windows.py tests/test_retry_failed_cleanup.py tests/test_container_pool_cleanup.py tests/test_self_test_service_cleanup.py tests/test_self_test_service_lock_stress.py tests/test_active_container_cleanup.py -q` *(fails: ImportError: cannot import name 'RAISE_ERRORS' from 'menace')*


------
https://chatgpt.com/codex/tasks/task_e_68b3ca5266e8832ebcdb5aa91afc63ea