### PR TITLE
Log and propagate meta planning init errors

### DIFF
--- a/self_improvement/init.py
+++ b/self_improvement/init.py
@@ -164,6 +164,7 @@ def init_self_improvement(new_settings: SandboxSettings | None = None) -> Sandbo
         meta_planning.reload_settings(settings)
     except Exception:  # pragma: no cover - best effort
         logger.exception("Failed to reload meta_planning settings")
+        raise
     return settings
 
 


### PR DESCRIPTION
## Summary
- log meta_planning settings reload issues during self-improvement init
- re-raise errors so initialization halts on invalid settings

## Testing
- `pytest -q unit_tests/test_self_improvement_utils.py`
- `pytest -q --maxfail=1` *(fails: No module named 'sqlalchemy.orm')*


------
https://chatgpt.com/codex/tasks/task_e_68b3d1a85700832e8021063e533ef11e