### PR TITLE
Add structured error parsing and update consumers

### DIFF
--- a/sandbox_runner/test_harness.py
+++ b/sandbox_runner/test_harness.py
@@ -106,7 +106,7 @@ def run_tests(repo_path: Path, changed_path: Path | None = None) -> TestHarnessR
         stdout_parts.append(tests.stdout)
         failure = None
         if tests.returncode != 0:
-            failure = ErrorParser.parse_failure(tests.stdout + tests.stderr)
+            failure = ErrorParser.parse(tests.stdout + tests.stderr)
         return TestHarnessResult(
             success=tests.returncode == 0,
             stdout="".join(stdout_parts),
@@ -116,4 +116,3 @@ def run_tests(repo_path: Path, changed_path: Path | None = None) -> TestHarnessR
         )
     finally:
         tmpdir_obj.cleanup()
-

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -712,8 +712,9 @@ class SelfCodingEngine:
                 self._last_retry_trace = harness_result.stderr or harness_result.stdout
             trace = self._last_retry_trace or ""
             try:
-                failure = ErrorParser.parse_failure(trace)
-                tag = failure.get("strategy_tag")
+                failure = ErrorParser.parse(trace)
+                tags = failure.get("tags", [])
+                tag = tags[0] if tags else ""
                 if tag and self.patch_suggestion_db:
                     self.patch_suggestion_db.add_failed_strategy(tag)
             except Exception:

--- a/self_coding_manager.py
+++ b/self_coding_manager.py
@@ -152,10 +152,10 @@ class SelfCodingManager:
                     raise RuntimeError("patch tests failed")
 
                 failure = harness_result.failure or {}
-                trace = failure.get("stack") or harness_result.stderr or harness_result.stdout or ""
+                trace = failure.get("trace") or harness_result.stderr or harness_result.stdout or ""
                 if self._failure_cache.seen(trace):
                     raise RuntimeError("patch tests failed")
-                tags = [t for t in [failure.get("strategy_tag")] if t]
+                tags = failure.get("tags", [])
                 self._failure_cache.add(ErrorReport(trace=trace, tags=tags))
                 try:
                     record_failed_tags(list(tags))

--- a/self_coding_scheduler.py
+++ b/self_coding_scheduler.py
@@ -142,9 +142,9 @@ class SelfCodingScheduler:
                             break
                         trace = getattr(module, "exception", "") or ""
                         if trace:
-                            failure = ErrorParser.parse_failure(str(trace))
-                            exc = failure.get("exception", "")
-                            if exc in {"SyntaxError", "ImportError"}:
+                            failure = ErrorParser.parse(str(trace))
+                            exc = failure.get("error_type", "")
+                            if exc in {"syntax_error", "import_error"}:
                                 break
 
                     after = self.data_bot.roi(self.manager.bot_name)

--- a/tests/test_error_parser.py
+++ b/tests/test_error_parser.py
@@ -1,6 +1,6 @@
 import traceback
 
-from error_parser import parse_failure
+from error_parser import ErrorParser
 
 
 def test_parse_pytest_assertion():
@@ -9,8 +9,11 @@ def test_parse_pytest_assertion():
         "    assert 1 == 2\n"
         "E   AssertionError: assert 1 == 2\n"
     )
-    report = parse_failure(trace)
-    assert report.tags == ["assertion_error"]
+    result = ErrorParser.parse(trace)
+    assert result["error_type"] == "assertion_error"
+    assert result["files"] == ["tests/test_sample.py"]
+    assert result["tags"] == ["assertion_error"]
+    assert result["signature"]
 
 
 def test_parse_runtime_error():
@@ -18,5 +21,14 @@ def test_parse_runtime_error():
         1 / 0
     except ZeroDivisionError:
         trace = traceback.format_exc()
-    report = parse_failure(trace)
-    assert "zero_division_error" in report.tags
+    result = ErrorParser.parse(trace)
+    assert "zero_division_error" in result["tags"]
+    assert result["error_type"] == "zero_division_error"
+
+
+def test_parse_duplicate_skipped():
+    trace = "Traceback\nValueError: boom"
+    first = ErrorParser.parse(trace)
+    second = ErrorParser.parse(trace)
+    assert first
+    assert second == {}

--- a/tests/test_patch_retry_loop.py
+++ b/tests/test_patch_retry_loop.py
@@ -11,7 +11,7 @@ sys.modules.setdefault("environment_bootstrap", stub_env)
 db_stub = types.ModuleType("data_bot")
 db_stub.MetricsDB = object
 sys.modules.setdefault("data_bot", db_stub)
-import menace.data_bot as db
+import menace.data_bot as db  # noqa: E402
 sys.modules["data_bot"] = db
 sys.modules["menace"].RAISE_ERRORS = False
 ns = types.ModuleType("neurosales")
@@ -21,19 +21,26 @@ ns.get_recent_messages = lambda *a, **k: []
 ns.list_conversations = lambda *a, **k: []
 sys.modules.setdefault("neurosales", ns)
 mapl_stub = types.ModuleType("menace.model_automation_pipeline")
+
+
 class AutomationResult:
     def __init__(self, package=None, roi=None):
         self.package = package
         self.roi = roi
-class ModelAutomationPipeline: ...
+
+
+class ModelAutomationPipeline:
+    ...
+
+
 mapl_stub.AutomationResult = AutomationResult
 mapl_stub.ModelAutomationPipeline = ModelAutomationPipeline
 sys.modules["menace.model_automation_pipeline"] = mapl_stub
 sce_stub = types.ModuleType("menace.self_coding_engine")
 sce_stub.SelfCodingEngine = object
 sys.modules["menace.self_coding_engine"] = sce_stub
-import menace.self_coding_manager as scm
-from menace.model_automation_pipeline import AutomationResult
+import menace.self_coding_manager as scm  # noqa: E402
+from menace.model_automation_pipeline import AutomationResult  # noqa: E402
 
 
 class DummyEngine:
@@ -108,7 +115,12 @@ def test_retry_rebuilds_context(monkeypatch, tmp_path):
         if call_state["count"] == 1:
             return types.SimpleNamespace(
                 success=False,
-                failure={"stack": "AssertionError: boom", "strategy_tag": "t1"},
+                failure={
+                    "trace": "AssertionError: boom",
+                    "tags": ["t1"],
+                    "error_type": "t1",
+                    "signature": "s1",
+                },
                 stdout="",
                 stderr="",
                 duration=0.0,
@@ -172,7 +184,12 @@ def test_retry_stops_after_max(monkeypatch, tmp_path):
     def run_tests_stub(repo, path):
         return types.SimpleNamespace(
             success=False,
-            failure={"stack": "AssertionError: boom", "strategy_tag": "t1"},
+            failure={
+                "trace": "AssertionError: boom",
+                "tags": ["t1"],
+                "error_type": "t1",
+                "signature": "s1",
+            },
             stdout="",
             stderr="",
             duration=0.0,


### PR DESCRIPTION
## Summary
- add `ErrorParser.parse` for structured error details with caching
- update callers to use new error fields
- refresh tests for new parser API

## Testing
- `pre-commit run --files error_parser.py self_coding_scheduler.py self_coding_engine.py self_coding_manager.py sandbox_runner/test_harness.py tests/test_error_parser.py tests/test_patch_retry_loop.py`
- `pytest tests/test_error_parser.py tests/test_patch_retry_loop.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3d353e7a0832eac7c48439e846679