### PR TITLE
Log interaction count failures in self-learning prune task

### DIFF
--- a/self_learning_service.py
+++ b/self_learning_service.py
@@ -92,7 +92,8 @@ def main(
             try:
                 cur = gpt_mem.conn.execute("SELECT COUNT(*) FROM interactions")
                 count = cur.fetchone()[0]
-            except Exception:
+            except Exception as exc:
+                logger.exception("interaction count failed", exc_info=exc)
                 count = 0
             if count - last >= prune_interval:
                 try:


### PR DESCRIPTION
## Summary
- Log a detailed exception when retrieving interaction counts fails in the self-learning service

## Testing
- `pre-commit run --files self_learning_service.py`
- `pytest -q` *(fails: 286 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d73359c8832eb29f939a52cdb919