### PR TITLE
Parameterize sandbox scenario presets

### DIFF
--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -5752,69 +5752,76 @@ def _scenario_specific_metrics(
 
 
 # ----------------------------------------------------------------------
-def _preset_concurrency_spike(multiplier: int = 4) -> Dict[str, Any]:
+def _preset_concurrency_spike(multiplier: int | None = None) -> Dict[str, Any]:
     """Preset stressing concurrency limits."""
 
+    settings = SandboxSettings()
+    mult = multiplier if multiplier is not None else settings.preset_concurrency_multiplier
     return {
         "SCENARIO_NAME": "concurrency_spike",
         "FAILURE_MODES": "concurrency_spike",
-        "CONCURRENCY_MULTIPLIER": multiplier,
-        "CONCURRENCY_LEVEL": 8,
+        "CONCURRENCY_MULTIPLIER": mult,
+        "CONCURRENCY_LEVEL": settings.preset_concurrency_level,
     }
 
 
 def _preset_hostile_input() -> Dict[str, Any]:
     """Preset injecting adversarial or malformed inputs."""
 
+    settings = SandboxSettings()
     return {
         "SCENARIO_NAME": "hostile_input",
         "FAILURE_MODES": "hostile_input",
-        "SANDBOX_STUB_STRATEGY": "hostile",
-        "HOSTILE_INPUT": True,
+        "SANDBOX_STUB_STRATEGY": settings.preset_hostile_stub_strategy,
+        "HOSTILE_INPUT": settings.preset_hostile_input,
     }
 
 
 def _preset_schema_drift() -> Dict[str, Any]:
     """Preset simulating legacy or mismatched schemas."""
 
+    settings = SandboxSettings()
     return {
         "SCENARIO_NAME": "schema_drift",
         "FAILURE_MODES": "schema_drift",
-        "SANDBOX_STUB_STRATEGY": "legacy_schema",
-        "SCHEMA_MISMATCHES": 5,
-        "SCHEMA_CHECKS": 100,
+        "SANDBOX_STUB_STRATEGY": settings.preset_schema_stub_strategy,
+        "SCHEMA_MISMATCHES": settings.preset_schema_mismatches,
+        "SCHEMA_CHECKS": settings.preset_schema_checks,
     }
 
 
 def _preset_flaky_upstream() -> Dict[str, Any]:
     """Preset emulating unreliable upstream dependencies."""
 
+    settings = SandboxSettings()
     return {
         "SCENARIO_NAME": "flaky_upstream",
         "FAILURE_MODES": "flaky_upstream",
-        "UPSTREAM_FAILURES": 1,
-        "UPSTREAM_REQUESTS": 20,
-        "SANDBOX_STUB_STRATEGY": "flaky_upstream",
-        "API_LATENCY_MS": 500,
+        "UPSTREAM_FAILURES": settings.preset_upstream_failures,
+        "UPSTREAM_REQUESTS": settings.preset_upstream_requests,
+        "SANDBOX_STUB_STRATEGY": settings.preset_flaky_stub_strategy,
+        "API_LATENCY_MS": settings.preset_api_latency_ms,
     }
 
 
 def _preset_high_latency() -> Dict[str, Any]:
     """Preset introducing artificial network delays."""
 
+    settings = SandboxSettings()
     return {
         "SCENARIO_NAME": "high_latency",
-        "NETWORK_LATENCY_MS": 500,
+        "NETWORK_LATENCY_MS": settings.preset_network_latency_ms,
     }
 
 
 def _preset_resource_strain() -> Dict[str, Any]:
     """Preset throttling compute and disk resources."""
 
+    settings = SandboxSettings()
     return {
         "SCENARIO_NAME": "resource_strain",
-        "CPU_LIMIT": 0.5,
-        "DISK_LIMIT": "512mb",
+        "CPU_LIMIT": settings.preset_cpu_limit,
+        "DISK_LIMIT": settings.preset_disk_limit,
     }
 
 

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -1144,6 +1144,78 @@ class SandboxSettings(BaseSettings):
         description="Raise an error when canonical scenarios are missing coverage.",
     )
 
+    # Scenario preset defaults
+    preset_concurrency_multiplier: int = Field(
+        4,
+        env="SANDBOX_PRESET_CONCURRENCY_MULTIPLIER",
+        description="Multiplier applied to base concurrency in spike scenarios.",
+    )
+    preset_concurrency_level: int = Field(
+        8,
+        env="SANDBOX_PRESET_CONCURRENCY_LEVEL",
+        description="Base concurrency level used in spike scenarios.",
+    )
+    preset_hostile_stub_strategy: str = Field(
+        "hostile",
+        env="SANDBOX_PRESET_HOSTILE_STUB_STRATEGY",
+        description="Stub strategy employed for hostile input scenarios.",
+    )
+    preset_hostile_input: bool = Field(
+        True,
+        env="SANDBOX_PRESET_HOSTILE_INPUT",
+        description="Toggle to inject adversarial inputs in hostile scenarios.",
+    )
+    preset_schema_stub_strategy: str = Field(
+        "legacy_schema",
+        env="SANDBOX_PRESET_SCHEMA_STUB_STRATEGY",
+        description="Stub strategy used to emulate legacy schemas.",
+    )
+    preset_schema_mismatches: int = Field(
+        5,
+        env="SANDBOX_PRESET_SCHEMA_MISMATCHES",
+        description="Number of schema mismatches injected in schema drift scenarios.",
+    )
+    preset_schema_checks: int = Field(
+        100,
+        env="SANDBOX_PRESET_SCHEMA_CHECKS",
+        description="Total schema checks performed in schema drift scenarios.",
+    )
+    preset_upstream_failures: int = Field(
+        1,
+        env="SANDBOX_PRESET_UPSTREAM_FAILURES",
+        description="Number of simulated upstream failures in flaky scenarios.",
+    )
+    preset_upstream_requests: int = Field(
+        20,
+        env="SANDBOX_PRESET_UPSTREAM_REQUESTS",
+        description="Total upstream requests made in flaky scenarios.",
+    )
+    preset_flaky_stub_strategy: str = Field(
+        "flaky_upstream",
+        env="SANDBOX_PRESET_FLAKY_STUB_STRATEGY",
+        description="Stub strategy used to emulate flaky upstream dependencies.",
+    )
+    preset_api_latency_ms: int = Field(
+        500,
+        env="SANDBOX_PRESET_API_LATENCY_MS",
+        description="API latency in milliseconds for flaky upstream scenarios.",
+    )
+    preset_network_latency_ms: int = Field(
+        500,
+        env="SANDBOX_PRESET_NETWORK_LATENCY_MS",
+        description="Network latency in milliseconds for latency scenarios.",
+    )
+    preset_cpu_limit: float = Field(
+        0.5,
+        env="SANDBOX_PRESET_CPU_LIMIT",
+        description="CPU limit used for resource strain scenarios.",
+    )
+    preset_disk_limit: str = Field(
+        "512mb",
+        env="SANDBOX_PRESET_DISK_LIMIT",
+        description="Disk limit used for resource strain scenarios.",
+    )
+
     alignment_rules: AlignmentRules = Field(
         default_factory=AlignmentRules,
         description="Thresholds for human-alignment checks used by flaggers.",


### PR DESCRIPTION
## Summary
- Load scenario preset values from `SandboxSettings` instead of hard-coded dictionaries
- Add new settings for concurrency, schema drift, flaky upstream, latency, and resource limits

## Testing
- `pre-commit run --files sandbox_runner/environment.py sandbox_settings.py` *(fails: flake8 baseline issues in `sandbox_runner/environment.py`)*
- `pre-commit run --files sandbox_settings.py`
- `pytest tests/test_environment_generator.py` *(fails: assert 20 == 50)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d9902fe8832ea67f350e75ce6029