### PR TITLE
Use changed path to limit test execution

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -724,6 +724,8 @@ class SelfCodingEngine:
             harness_result.stdout,
             harness_result.stderr,
             harness_result.duration,
+            harness_result.failure,
+            harness_result.path,
         )
 
     def _current_errors(self) -> int:

--- a/tests/test_self_coding_engine.py
+++ b/tests/test_self_coding_engine.py
@@ -15,6 +15,7 @@ vec_mod.ContextBuilder = object  # type: ignore[attr-defined]
 vec_mod.ErrorResult = object  # type: ignore[attr-defined]
 vec_mod.PatchLogger = object  # type: ignore[attr-defined]
 vec_mod.VectorServiceError = _VSError
+vec_mod.CognitionLayer = object  # type: ignore[attr-defined]
 
 
 class _EmbeddableDBMixin:
@@ -71,7 +72,15 @@ sys.modules.setdefault("bot_database", types.SimpleNamespace(BotDB=object))
 sys.modules.setdefault("task_handoff_bot", types.SimpleNamespace(WorkflowDB=object))
 sys.modules.setdefault("error_bot", types.SimpleNamespace(ErrorDB=object))
 sys.modules.setdefault("failure_learning_system", types.SimpleNamespace(DiscrepancyDB=object))
-sys.modules.setdefault("code_database", types.SimpleNamespace(CodeDB=object))
+sys.modules.setdefault(
+    "code_database",
+    types.SimpleNamespace(
+        CodeDB=object,
+        CodeRecord=object,
+        PatchHistoryDB=object,
+        PatchRecord=object,
+    ),
+)
 sys.modules.setdefault(
     "gpt_memory",
     types.SimpleNamespace(
@@ -164,11 +173,13 @@ th_stub = types.ModuleType("sandbox_runner.test_harness")
 
 
 class _THResult:
-    def __init__(self, success, stdout="", stderr="", duration=0.0):
+    def __init__(self, success, stdout="", stderr="", duration=0.0, failure=None, path=None):
         self.success = success
         self.stdout = stdout
         self.stderr = stderr
         self.duration = duration
+        self.failure = failure
+        self.path = path
 
 
 def _run_tests(*_a, **_k):
@@ -205,6 +216,7 @@ class _MMM:
 
 
 mm_stub.MenaceMemoryManager = _MMM
+mm_stub.MemoryEntry = object
 sys.modules.setdefault("menace_memory_manager", mm_stub)
 sys.modules.setdefault("menace.menace_memory_manager", mm_stub)
 sys.modules.setdefault(


### PR DESCRIPTION
## Summary
- tighten sandbox runner tests by leveraging the changed path to target impacted tests
- expose test path in `TestHarnessResult` and propagate through the self-coding engine
- add regression tests for narrowing execution to affected test files

## Testing
- `pytest tests/test_closed_loop_sandbox.py::test_harness_filters_specific_test_file -q`
- `pytest tests/test_closed_loop_sandbox.py::test_harness_uses_k_filter_for_module -q`
- `pytest tests/test_self_coding_engine.py::test_apply_patch_reverts_on_complexity -q` *(fails: ImportError: cannot import name 'PatchHistoryDB')*
- `pytest tests/test_closed_loop_sandbox.py -q` *(fails: AttributeError: <module 'menace.self_coding_manager'> has no attribute 'WorkflowSandboxRunner')*

------
https://chatgpt.com/codex/tasks/task_e_68b3d9897194832eaf21d049f5c797de