### PR TITLE
Improve meta_planning failure handling

### DIFF
--- a/self_improvement/init.py
+++ b/self_improvement/init.py
@@ -162,9 +162,10 @@ def init_self_improvement(new_settings: SandboxSettings | None = None) -> Sandbo
         from . import meta_planning
 
         meta_planning.reload_settings(settings)
-    except Exception:  # pragma: no cover - best effort
-        logger.exception("Failed to reload meta_planning settings")
-        raise
+    except Exception as exc:  # pragma: no cover - best effort
+        message = "failed to reload meta_planning settings"
+        logger.exception(message, extra=log_record(error=str(exc)))
+        raise RuntimeError(message) from exc
     return settings
 
 


### PR DESCRIPTION
## Summary
- log meta_planning reload failures with structured logging and raise a descriptive exception
- test meta_planning reload error logging and propagation

## Testing
- `pre-commit run --files self_improvement/init.py tests/self_improvement/test_init.py`
- `pytest tests/self_improvement/test_init.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3de4e8038832ea017514be1470a19