### PR TITLE
Use parse_failure for tag extraction

### DIFF
--- a/sandbox_runner/test_harness.py
+++ b/sandbox_runner/test_harness.py
@@ -147,7 +147,7 @@ def run_tests(repo_path: Path, changed_path: Path | None = None) -> TestHarnessR
         stdout_parts.append(tests.stdout)
         failure = None
         if tests.returncode != 0:
-            failure = ErrorParser.parse(tests.stdout + tests.stderr)
+            failure = ErrorParser.parse_failure(tests.stdout + tests.stderr)
         return TestHarnessResult(
             success=tests.returncode == 0,
             stdout="".join(stdout_parts),

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -713,9 +713,8 @@ class SelfCodingEngine:
                 self._last_retry_trace = harness_result.stderr or harness_result.stdout
             trace = self._last_retry_trace or ""
             try:
-                failure = ErrorParser.parse(trace)
-                tags = failure.get("tags", [])
-                tag = tags[0] if tags else ""
+                failure = ErrorParser.parse_failure(trace)
+                tag = failure.get("strategy_tag", "")
                 if tag and self.patch_suggestion_db:
                     self.patch_suggestion_db.add_failed_strategy(tag)
             except Exception:

--- a/self_coding_manager.py
+++ b/self_coding_manager.py
@@ -153,7 +153,7 @@ class SelfCodingManager:
 
                 failure = harness_result.failure or {}
                 trace = (
-                    failure.get("trace")
+                    failure.get("stack")
                     or harness_result.stderr
                     or harness_result.stdout
                     or ""
@@ -161,8 +161,9 @@ class SelfCodingManager:
                 if self._failure_cache.seen(trace):
                     raise RuntimeError("patch tests failed")
                 if not failure:
-                    failure = ErrorParser.parse(trace)
-                tags = failure.get("tags", [])
+                    failure = ErrorParser.parse_failure(trace)
+                tag = failure.get("strategy_tag", "")
+                tags = [tag] if tag else []
                 self._failure_cache.add(ErrorReport(trace=trace, tags=tags))
                 try:
                     record_failed_tags(list(tags))

--- a/self_coding_scheduler.py
+++ b/self_coding_scheduler.py
@@ -142,8 +142,8 @@ class SelfCodingScheduler:
                             break
                         trace = getattr(module, "exception", "") or ""
                         if trace:
-                            failure = ErrorParser.parse(str(trace))
-                            exc = failure.get("error_type", "")
+                            failure = ErrorParser.parse_failure(str(trace))
+                            exc = failure.get("strategy_tag", "")
                             if exc in {"syntax_error", "import_error"}:
                                 break
 

--- a/tests/test_error_parser.py
+++ b/tests/test_error_parser.py
@@ -1,34 +1,30 @@
 import traceback
 
-from error_parser import ErrorParser
+from error_parser import ErrorParser, parse_failure
 
 
-def test_parse_pytest_assertion():
+def test_parse_failure_pytest_assertion():
     trace = (
         "tests/test_sample.py:3: in test_example\n"
         "    assert 1 == 2\n"
         "E   AssertionError: assert 1 == 2\n"
     )
-    result = ErrorParser.parse(trace)
-    assert result["error_type"] == "assertion_error"
-    assert result["files"] == ["tests/test_sample.py"]
-    assert result["tags"] == ["assertion_error"]
+    result = ErrorParser.parse_failure(trace)
+    assert result["strategy_tag"] == "assertion_error"
+    assert "tests/test_sample.py" in result["stack"]
     assert result["signature"]
 
 
-def test_parse_runtime_error():
+def test_parse_failure_runtime_error():
     try:
         1 / 0
     except ZeroDivisionError:
         trace = traceback.format_exc()
-    result = ErrorParser.parse(trace)
-    assert "zero_division_error" in result["tags"]
-    assert result["error_type"] == "zero_division_error"
+    result = ErrorParser.parse_failure(trace)
+    assert result["strategy_tag"] == "zero_division_error"
 
 
-def test_parse_duplicate_skipped():
+def test_parse_failure_extracts_tags():
     trace = "Traceback\nValueError: boom"
-    first = ErrorParser.parse(trace)
-    second = ErrorParser.parse(trace)
-    assert first
-    assert second == {}
+    report = parse_failure(trace)
+    assert report.tags == ["value_error"]


### PR DESCRIPTION
## Summary
- use `ErrorParser.parse_failure` to gather failure tags in self-coding manager, engine, scheduler and test harness
- add unit tests exercising `parse_failure` tag extraction

## Testing
- `pytest tests/test_error_parser.py`
- `pytest tests/test_self_coding_manager.py`  ❌ `tests/test_self_coding_engine.py::test_apply_patch_reverts_on_complexity` etc. (MenaceMemoryManager.__init__ TypeError)
- `pytest tests/test_self_coding_scheduler.py`  ❌ `ValueError: jinja2.__spec__ is None`


------
https://chatgpt.com/codex/tasks/task_e_68b3de418568832eb6c8152fe62a6ae7