### PR TITLE
Use sandbox test harness in patch flow

### DIFF
--- a/self_coding_manager.py
+++ b/self_coding_manager.py
@@ -164,6 +164,14 @@ class SelfCodingManager:
                     failure = ErrorParser.parse_failure(trace)
                 tag = failure.get("strategy_tag", "")
                 tags = [tag] if tag else []
+                self.logger.error(
+                    "patch tests failed",
+                    extra={
+                        "stdout": harness_result.stdout,
+                        "stderr": harness_result.stderr,
+                        "tags": tags,
+                    },
+                )
                 self._failure_cache.add(ErrorReport(trace=trace, tags=tags))
                 try:
                     record_failed_tags(list(tags))

--- a/tests/test_patch_retry_loop.py
+++ b/tests/test_patch_retry_loop.py
@@ -125,12 +125,7 @@ def test_retry_rebuilds_context(monkeypatch, tmp_path):
         if call_state["count"] == 1:
             return types.SimpleNamespace(
                 success=False,
-                failure={
-                    "trace": "AssertionError: boom",
-                    "tags": ["t1"],
-                    "error_type": "t1",
-                    "signature": "s1",
-                },
+                failure={"strategy_tag": "t1", "stack": "AssertionError: boom"},
                 stdout="",
                 stderr="",
                 duration=0.0,
@@ -151,6 +146,7 @@ def test_retry_rebuilds_context(monkeypatch, tmp_path):
     assert len(engine.calls) == 2
     assert query_calls == [["t1"]]
     assert pipeline.calls == [("bot", 1)]
+    assert call_state["count"] == 2
 
 
 def test_retry_stops_after_max(monkeypatch, tmp_path):
@@ -195,12 +191,7 @@ def test_retry_stops_after_max(monkeypatch, tmp_path):
     def run_tests_stub(repo, path):
         return types.SimpleNamespace(
             success=False,
-            failure={
-                "trace": "AssertionError: boom",
-                "tags": ["t1"],
-                "error_type": "t1",
-                "signature": "s1",
-            },
+            failure={"strategy_tag": "t1", "stack": "AssertionError: boom"},
             stdout="",
             stderr="",
             duration=0.0,
@@ -258,12 +249,7 @@ def test_retry_skips_duplicate_trace(monkeypatch, tmp_path):
     def run_tests_stub(repo, path):
         return types.SimpleNamespace(
             success=False,
-            failure={
-                "trace": "AssertionError: boom",
-                "tags": ["t1"],
-                "error_type": "t1",
-                "signature": "s1",
-            },
+            failure={"strategy_tag": "t1", "stack": "AssertionError: boom"},
             stdout="",
             stderr="",
             duration=0.0,

--- a/tests/test_self_coding_manager.py
+++ b/tests/test_self_coding_manager.py
@@ -108,21 +108,24 @@ def test_run_patch_logs_evolution(monkeypatch, tmp_path):
 
     monkeypatch.setattr(scm.subprocess, "run", fake_run)
 
-    monkeypatch.setattr(
-        scm,
-        "run_tests",
-        lambda repo, path: types.SimpleNamespace(
+    calls: list[tuple] = []
+
+    def run_tests_stub(repo, path):
+        calls.append((repo, path))
+        return types.SimpleNamespace(
             success=True,
             failure=None,
             stdout="",
             stderr="",
             duration=0.0,
-        ),
-    )
+        )
+
+    monkeypatch.setattr(scm, "run_tests", run_tests_stub)
 
     res = mgr.run_patch(file_path, "add")
     assert engine.calls
     assert pipeline.calls
+    assert calls
     assert "# patched" in file_path.read_text()
     rows = hist.fetch()
     assert any(r[0].startswith("self_coding") for r in rows)


### PR DESCRIPTION
## Summary
- run SelfCodingManager patches through sandbox_runner.test_harness
- log harness stdout/stderr and failure tags before context rebuild
- assert harness invocation in patch flow tests

## Testing
- `pytest -q tests/test_patch_retry_loop.py`
- `pytest -q tests/test_review_branch_promotion.py`
- `pytest -q tests/test_ephemeral_patch_sandbox.py`
- `pytest -q tests/test_mutation_outcomes.py`
- `pytest -q tests/test_closed_loop_sandbox.py`
- `pytest -q tests/test_self_coding_manager.py`
- `pytest -q unit_tests/test_self_coding_manager_failed_tags.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3e1f56f58832e8db946b9b266794c