### PR TITLE
Add docker backend option for test harness

### DIFF
--- a/self_coding_manager.py
+++ b/self_coding_manager.py
@@ -101,6 +101,7 @@ class SelfCodingManager:
         confidence_threshold: float = 0.5,
         review_branch: str | None = None,
         auto_merge: bool = False,
+        backend: str = "venv",
     ) -> AutomationResult:
         """Patch *path* then deploy using the automation pipeline.
 
@@ -109,7 +110,9 @@ class SelfCodingManager:
         from the failing traceback.  After a successful patch the change is
         committed in a sandbox clone, pushed to ``review_branch`` and merged
         into ``main`` when ``auto_merge`` is ``True`` and the confidence score
-        exceeds ``confidence_threshold``.
+        exceeds ``confidence_threshold``.  ``backend`` selects the test
+        execution environment; ``"venv"`` uses a virtual environment while
+        ``"docker"`` runs tests inside a Docker container.
         """
         if self.approval_policy and not self.approval_policy.approve(path):
             raise RuntimeError("patch approval failed")
@@ -144,7 +147,9 @@ class SelfCodingManager:
                     context_meta=ctx_meta,
                 )
 
-                harness_result: TestHarnessResult = run_tests(clone_root, cloned_path)
+                harness_result: TestHarnessResult = run_tests(
+                    clone_root, cloned_path, backend=backend
+                )
                 if harness_result.success:
                     break
 

--- a/tests/test_closed_loop_sandbox.py
+++ b/tests/test_closed_loop_sandbox.py
@@ -145,7 +145,7 @@ def test_closed_loop_patch(monkeypatch, tmp_path, backend):
 
     run_calls: list[str] = []
 
-    def run_tests_stub(repo, path):
+    def run_tests_stub(repo, path, *, backend="venv"):
         run_calls.append("fail" if not run_calls else "pass")
         if len(run_calls) == 1:
             return types.SimpleNamespace(
@@ -213,7 +213,7 @@ def test_run_patch_failure_no_attribute_error(monkeypatch, tmp_path):
 
     monkeypatch.setattr(scm.tempfile, "TemporaryDirectory", lambda: DummyTempDir())
 
-    def run_tests_stub(repo, path):
+    def run_tests_stub(repo, path, *, backend="venv"):
         return types.SimpleNamespace(
             success=False,
             failure=None,

--- a/tests/test_ephemeral_patch_sandbox.py
+++ b/tests/test_ephemeral_patch_sandbox.py
@@ -98,8 +98,8 @@ def test_ephemeral_clone_removed(monkeypatch, tmp_path):
     monkeypatch.setattr(scm.subprocess, "run", fake_run)
     run_calls: list[tuple] = []
 
-    def run_tests_stub(repo, path):
-        run_calls.append((repo, path))
+    def run_tests_stub(repo, path, *, backend="venv"):
+        run_calls.append((repo, path, backend))
         return types.SimpleNamespace(
             success=True,
             failure=None,

--- a/tests/test_patch_retry_loop.py
+++ b/tests/test_patch_retry_loop.py
@@ -120,7 +120,7 @@ def test_retry_rebuilds_context(monkeypatch, tmp_path):
 
     call_state = {"count": 0}
 
-    def run_tests_stub(repo, path):
+    def run_tests_stub(repo, path, *, backend="venv"):
         call_state["count"] += 1
         if call_state["count"] == 1:
             return types.SimpleNamespace(
@@ -188,7 +188,7 @@ def test_retry_stops_after_max(monkeypatch, tmp_path):
 
     monkeypatch.setattr(scm.subprocess, "run", fake_run)
 
-    def run_tests_stub(repo, path):
+    def run_tests_stub(repo, path, *, backend="venv"):
         return types.SimpleNamespace(
             success=False,
             failure={"strategy_tag": "t1", "stack": "AssertionError: boom"},
@@ -246,7 +246,7 @@ def test_retry_skips_duplicate_trace(monkeypatch, tmp_path):
 
     monkeypatch.setattr(scm.subprocess, "run", fake_run)
 
-    def run_tests_stub(repo, path):
+    def run_tests_stub(repo, path, *, backend="venv"):
         return types.SimpleNamespace(
             success=False,
             failure={"strategy_tag": "t1", "stack": "AssertionError: boom"},

--- a/tests/test_review_branch_promotion.py
+++ b/tests/test_review_branch_promotion.py
@@ -114,8 +114,8 @@ def setup(monkeypatch, tmp_path, confidence):
 
     run_calls: list[tuple] = []
 
-    def run_tests_stub(repo, path):
-        run_calls.append((repo, path))
+    def run_tests_stub(repo, path, *, backend="venv"):
+        run_calls.append((repo, path, backend))
         return types.SimpleNamespace(
             success=True,
             failure=None,

--- a/tests/test_sandbox_runner_backends.py
+++ b/tests/test_sandbox_runner_backends.py
@@ -1,0 +1,164 @@
+import importlib
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import types
+
+
+def _prepare_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "requirements.txt").write_text("")
+    tests = repo / "tests"
+    tests.mkdir()
+    (tests / "test_mod.py").write_text("def test_ok():\n    assert True\n")
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True)
+    subprocess.run(["git", "add", "-A"], cwd=repo, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, capture_output=True)
+    return repo
+
+
+def test_run_tests_supports_backends(monkeypatch, tmp_path):
+    repo = _prepare_repo(tmp_path)
+    path = Path(__file__).resolve().parents[1] / "sandbox_runner/test_harness.py"
+    pkg = types.ModuleType("menace.sandbox_runner")
+    pkg.__path__ = []  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "menace.sandbox_runner", pkg)
+    spec = importlib.util.spec_from_file_location(
+        "menace.sandbox_runner.test_harness", path
+    )
+    th = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(th)
+    monkeypatch.setattr(th, "_python_bin", lambda v: Path(sys.executable))
+
+    executed: list[list[str]] = []
+    orig_run = subprocess.run
+
+    def fake_run(cmd, *a, cwd=None, capture_output=None, text=None, check=None):
+        executed.append(cmd)
+        if cmd[:2] == ["git", "clone"]:
+            dst = Path(cmd[3])
+            shutil.copytree(repo, dst, dirs_exist_ok=True)
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[0] == sys.executable and cmd[1:3] == ["-m", "venv"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[0] == sys.executable and cmd[1:3] == ["-m", "pip"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[0] == sys.executable and cmd[1:3] == ["-m", "pytest"]:
+            return orig_run(cmd, cwd=cwd, capture_output=capture_output, text=text)
+        if cmd[0] == "docker":
+            idx = cmd.index("-v") + 1
+            host_dir = cmd[idx].split(":", 1)[0]
+            return orig_run(
+                [sys.executable, "-m", "pytest", "-q"],
+                cwd=host_dir,
+                capture_output=True,
+                text=True,
+            )
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    res_venv = th.run_tests(repo, backend="venv")
+    res_docker = th.run_tests(repo, backend="docker")
+
+    assert res_venv.success and res_docker.success
+    assert res_venv.success == res_docker.success
+    assert any(cmd[0] == "docker" for cmd in executed)
+    assert any(cmd[0] == sys.executable and cmd[1:3] == ["-m", "venv"] for cmd in executed)
+
+
+def test_run_patch_forwards_backend(monkeypatch, tmp_path):
+    import types, sys
+
+    stub_env = types.ModuleType("environment_bootstrap")
+    stub_env.EnvironmentBootstrapper = object
+    monkeypatch.setitem(sys.modules, "environment_bootstrap", stub_env)
+    db_stub = types.ModuleType("data_bot")
+    db_stub.MetricsDB = object
+    monkeypatch.setitem(sys.modules, "data_bot", db_stub)
+    import menace.data_bot as db
+    monkeypatch.setitem(sys.modules, "data_bot", db)
+    ns = types.ModuleType("neurosales")
+    ns.add_message = lambda *a, **k: None
+    ns.get_history = lambda *a, **k: []
+    ns.get_recent_messages = lambda *a, **k: []
+    ns.list_conversations = lambda *a, **k: []
+    monkeypatch.setitem(sys.modules, "neurosales", ns)
+    mapl_stub = types.ModuleType("menace.model_automation_pipeline")
+    class AutomationResult:
+        def __init__(self, package=None, roi=None):
+            self.package = package
+            self.roi = roi
+    class ModelAutomationPipeline: ...
+    mapl_stub.AutomationResult = AutomationResult
+    mapl_stub.ModelAutomationPipeline = ModelAutomationPipeline
+    monkeypatch.setitem(sys.modules, "menace.model_automation_pipeline", mapl_stub)
+    sce_stub = types.ModuleType("menace.self_coding_engine")
+    sce_stub.SelfCodingEngine = object
+    monkeypatch.setitem(sys.modules, "menace.self_coding_engine", sce_stub)
+    prb_stub = types.ModuleType("menace.pre_execution_roi_bot")
+    class ROIResult:
+        def __init__(self, roi, errors, proi, perr, risk):
+            self.roi = roi
+            self.errors = errors
+            self.predicted_roi = proi
+            self.predicted_errors = perr
+            self.risk = risk
+    prb_stub.ROIResult = ROIResult
+    monkeypatch.setitem(sys.modules, "menace.pre_execution_roi_bot", prb_stub)
+    import menace.self_coding_manager as scm
+
+    file_path = tmp_path / "sample.py"
+    file_path.write_text("x = 1\n")
+
+    class Engine:
+        def apply_patch(self, path, desc, **kw):
+            return 1, False, 0.0
+
+    class Pipeline:
+        def run(self, model, energy=1):
+            return None
+
+    mgr = scm.SelfCodingManager(Engine(), Pipeline(), bot_name="bot")
+    monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+
+    tmpdir_path = tmp_path / "clone"
+
+    class DummyTempDir:
+        def __enter__(self):
+            tmpdir_path.mkdir()
+            return str(tmpdir_path)
+
+        def __exit__(self, exc_type, exc, tb):
+            shutil.rmtree(tmpdir_path)
+
+    monkeypatch.setattr(scm.tempfile, "TemporaryDirectory", lambda: DummyTempDir())
+
+    def fake_run(cmd, *a, **kw):
+        if cmd[:2] == ["git", "clone"]:
+            dst = Path(cmd[3])
+            dst.mkdir(exist_ok=True)
+            shutil.copy2(file_path, dst / file_path.name)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(scm.subprocess, "run", fake_run)
+
+    called = {}
+
+    def run_tests_stub(repo, path, *, backend="venv"):
+        called["backend"] = backend
+        return types.SimpleNamespace(
+            success=True,
+            failure=None,
+            stdout="",
+            stderr="",
+            duration=0.0,
+        )
+
+    monkeypatch.setattr(scm, "run_tests", run_tests_stub)
+
+    mgr.run_patch(file_path, "add", backend="docker")
+    assert called["backend"] == "docker"

--- a/tests/test_self_coding_manager.py
+++ b/tests/test_self_coding_manager.py
@@ -110,8 +110,8 @@ def test_run_patch_logs_evolution(monkeypatch, tmp_path):
 
     calls: list[tuple] = []
 
-    def run_tests_stub(repo, path):
-        calls.append((repo, path))
+    def run_tests_stub(repo, path, *, backend="venv"):
+        calls.append((repo, path, backend))
         return types.SimpleNamespace(
             success=True,
             failure=None,

--- a/unit_tests/test_self_coding_manager_failed_tags.py
+++ b/unit_tests/test_self_coding_manager_failed_tags.py
@@ -83,7 +83,7 @@ class HarnessResult:
         self.stderr = stderr
         self.duration = duration
 
-def run_tests(repo, path):
+def run_tests(repo, path, *, backend="venv"):
     return HarnessResult(True)
 thr_mod.TestHarnessResult = HarnessResult
 thr_mod.run_tests = run_tests
@@ -147,8 +147,11 @@ def test_failed_tags_recorded(monkeypatch, tmp_path):
         failure=None,
         stdout="",
         stderr="Traceback (most recent call last):\nValueError: boom",
+        duration=0.0,
     )
-    monkeypatch.setattr(scm, "run_tests", lambda repo, path: failure_result)
+    monkeypatch.setattr(
+        scm, "run_tests", lambda repo, path, *, backend="venv": failure_result
+    )
 
     with pytest.raises(RuntimeError):
         mgr.run_patch(file_path, "add", max_attempts=2)


### PR DESCRIPTION
## Summary
- allow sandbox_runner.test_harness.run_tests to run in a venv or docker container
- wire SelfCodingManager.run_patch to choose backend
- test that both backends execute and that run_patch forwards the parameter

## Testing
- `pytest tests/test_sandbox_runner_backends.py unit_tests/test_self_coding_manager_failed_tags.py -q`
- `pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e5e94914832ea2272ad3b8bda0ae