### PR TITLE
Log alignment evaluation event retrieval failures

### DIFF
--- a/self_improvement/__init__.py
+++ b/self_improvement/__init__.py
@@ -7160,7 +7160,15 @@ class SelfImprovementEngine:
                     if logs is None:
                         try:
                             logs = get_recent_events(limit=20)
-                        except Exception:
+                        except Exception as exc:
+                            self.logger.warning(
+                                "failed to get recent events: %s",
+                                exc,
+                                extra=log_record(
+                                    workflow_id=locals().get("workflow_id", "self_improvement"),
+                                    attempt=self._cycle_count,
+                                ),
+                            )
                             logs = None
                     try:
                         info_proc = subprocess.run(


### PR DESCRIPTION
## Summary
- warn when alignment evaluation can't fetch recent events, including workflow and cycle context

## Testing
- `pytest tests/test_self_improvement_engine.py -q` *(fails: ImportError: cannot import name 'SANDBOX_ENV_PRESETS' from 'sandbox_runner.environment')*

------
https://chatgpt.com/codex/tasks/task_e_68b3e5e2eac0832ebe173792997aaa6f