### PR TITLE
Implement weighted enhancement classifier

### DIFF
--- a/enhancement_classifier.py
+++ b/enhancement_classifier.py
@@ -1,67 +1,94 @@
+"""Analyse patch history to suggest potential code enhancements.
+
+This module scans the repository using ``PatchHistoryDB`` and ``CodeDB`` and
+looks for modules that exhibit signs of inefficiency.  It evaluates simple
+heuristics (high refactor frequency, negative ROI deltas and complexity
+spikes) and assigns a weighted score based on metrics defined in a YAML/JSON
+configuration file.  Results are returned as :class:`EnhancementSuggestion`
+objects.
+"""
+
 from __future__ import annotations
 
+import json
 import logging
-from typing import Iterator, List, Tuple
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Optional
+
+try:  # pragma: no cover - optional dependency
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - used when PyYAML isn't installed
+    yaml = None  # type: ignore
 
 try:  # pragma: no cover - allow package/flat imports
     from .code_database import CodeDB, PatchHistoryDB
 except Exception:  # pragma: no cover - fallback for flat layout
     from code_database import CodeDB, PatchHistoryDB  # type: ignore
 
-try:  # pragma: no cover - allow package/flat imports
-    from .chatgpt_enhancement_bot import EnhancementDB
-except Exception:  # pragma: no cover - fallback for flat layout
-    from chatgpt_enhancement_bot import EnhancementDB  # type: ignore
-
-try:  # pragma: no cover - allow package/flat imports
-    from .patch_suggestion_db import SuggestionRecord, PatchSuggestionDB
-except Exception:  # pragma: no cover - fallback for flat layout
-    from patch_suggestion_db import SuggestionRecord, PatchSuggestionDB  # type: ignore
-
-try:  # pragma: no cover - allow package/flat imports
-    from .audit_trail import AuditTrail
-except Exception:  # pragma: no cover - fallback for flat layout
-    from audit_trail import AuditTrail  # type: ignore
-
 logger = logging.getLogger(__name__)
 
 
-class EnhancementClassifier:
-    """Classify modules that may benefit from further enhancement.
+# ---------------------------------------------------------------------------
+@dataclass
+class EnhancementSuggestion:
+    """Outcome of a repository scan for potential improvements."""
 
-    The classifier inspects historical patch and enhancement metadata to flag
-    modules that show signs of inefficiency such as repeated refactors with
-    low or negative ROI or steadily increasing complexity.
-    """
+    path: str
+    score: float
+    rationale: str
+
+
+# ---------------------------------------------------------------------------
+class EnhancementClassifier:
+    """Detect modules likely to benefit from further enhancement."""
 
     def __init__(
         self,
         *,
-        code_db: CodeDB | None = None,
-        patch_db: PatchHistoryDB | None = None,
-        enhancement_db: EnhancementDB | None = None,
-        suggestion_db: PatchSuggestionDB | None = None,
-        audit_trail: AuditTrail | None = None,
+        code_db: Optional[CodeDB] = None,
+        patch_db: Optional[PatchHistoryDB] = None,
+        config_path: str | None = None,
     ) -> None:
         self.code_db = code_db or CodeDB()
         self.patch_db = patch_db or PatchHistoryDB()
-        self.enhancement_db = enhancement_db or EnhancementDB()
-        self.suggestion_db = suggestion_db or PatchSuggestionDB()
-        self.audit_trail = audit_trail or AuditTrail("enhancement_audit.log")
+        self.weights = self._load_weights(config_path)
 
     # ------------------------------------------------------------------
-    def _module_stats(
-        self, code_id: int
-    ) -> tuple[str, float, float, float, int] | None:
-        """Return (filename, avg_roi, avg_complexity_delta, avg_outcome, count).
+    def _load_weights(self, config_path: str | None) -> dict[str, float]:
+        """Load metric weights from a JSON or YAML configuration file."""
 
-        ``None`` is returned when no patch history exists for ``code_id``.
-        """
+        path = config_path or os.getenv(
+            "ENHANCEMENT_CLASSIFIER_CONFIG", "enhancement_classifier_config.json"
+        )
+        weights = {"frequency": 1.0, "roi": 1.0, "errors": 1.0}
+        try:
+            text = Path(path).read_text()
+            if path.endswith((".yaml", ".yml")) and yaml is not None:
+                data = yaml.safe_load(text) or {}
+            else:
+                data = json.loads(text)
+            data = data.get("weights", data)
+            for key in weights:
+                if key in data:
+                    weights[key] = float(data[key])
+        except Exception:  # pragma: no cover - fall back to defaults
+            logger.debug("using default enhancement classifier weights", exc_info=True)
+        return weights
+
+    # ------------------------------------------------------------------
+    def _gather_metrics(
+        self, code_id: int
+    ) -> tuple[str, int, float, float, float] | None:
+        """Return metrics for ``code_id`` or ``None`` when absent."""
 
         with self.patch_db._connect() as conn:  # type: ignore[attr-defined]
             rows = conn.execute(
-                "SELECT filename, roi_delta, complexity_delta "
-                "FROM patch_history WHERE code_id=?",
+                """
+                SELECT filename, roi_delta, errors_before, errors_after, complexity_delta
+                FROM patch_history WHERE code_id=?
+                """,
                 (code_id,),
             ).fetchall()
         if not rows:
@@ -69,70 +96,40 @@ class EnhancementClassifier:
         filename = rows[0][0] or f"id:{code_id}"
         patch_count = len(rows)
         avg_roi = sum((r[1] or 0.0) for r in rows) / patch_count
-        avg_complexity_delta = sum((r[2] or 0.0) for r in rows) / patch_count
-
-        # Enhancement metadata lookup
-        with self.code_db._connect() as conn:  # type: ignore[attr-defined]
-            enh_ids = [
-                r[0]
-                for r in conn.execute(
-                    "SELECT enhancement_id FROM code_enhancements WHERE code_id=?",
-                    (code_id,),
-                ).fetchall()
-            ]
-        outcome_scores: List[float] = []
-        if enh_ids:
-            e_conn = self.enhancement_db._connect()
-            for eid in enh_ids:
-                row = e_conn.execute(
-                    "SELECT outcome_score FROM enhancements WHERE id=?",
-                    (eid,),
-                ).fetchone()
-                if row:
-                    outcome_scores.append(float(row[0] or 0.0))
-        avg_outcome = sum(outcome_scores) / len(outcome_scores) if outcome_scores else 0.0
-        return filename, avg_roi, avg_complexity_delta, avg_outcome, patch_count
+        avg_errors = sum(((r[3] or 0) - (r[2] or 0)) for r in rows) / patch_count
+        avg_complexity = sum((r[4] or 0.0) for r in rows) / patch_count
+        return filename, patch_count, avg_roi, avg_errors, avg_complexity
 
     # ------------------------------------------------------------------
-    def scan_repo(self) -> Iterator[SuggestionRecord]:
-        """Yield :class:`SuggestionRecord` instances for suspicious modules."""
+    def scan_repo(self) -> Iterator[EnhancementSuggestion]:
+        """Yield scored suggestions for modules that warrant attention."""
 
         with self.code_db._connect() as conn:  # type: ignore[attr-defined]
             code_ids = [row[0] for row in conn.execute("SELECT id FROM code").fetchall()]
 
         for cid in code_ids:
-            stats = self._module_stats(cid)
-            if not stats:
+            metrics = self._gather_metrics(cid)
+            if not metrics:
                 continue
-            filename, avg_roi, avg_comp, avg_outcome, patch_count = stats
-            # score: frequent patches or complexity growth penalised by ROI gains
-            score = patch_count + max(0.0, avg_comp) - avg_roi - avg_outcome
-            if score <= 0:
+            filename, patches, avg_roi, avg_errors, avg_complexity = metrics
+
+            # Heuristics: flag if any inefficiency indicator is observed
+            if not (patches >= 3 or avg_roi < 0 or avg_complexity > 0):
                 continue
-            rationale = (
-                f"{patch_count} patches, avg ROI delta {avg_roi:.2f}, "
-                f"avg complexity delta {avg_comp:.2f}, "
-                f"avg enhancement outcome {avg_outcome:.2f}"
+
+            score = (
+                self.weights["frequency"] * patches
+                + self.weights["roi"] * (-avg_roi)
+                + self.weights["errors"] * avg_errors
             )
-            description = f"score={score:.2f} - {rationale}"
-            logger.debug("suggestion", extra={"module": filename, "score": score})
-            rec = SuggestionRecord(module=filename, description=description)
-            try:
-                self.suggestion_db.add(rec)
-            except Exception:  # pragma: no cover - best effort
-                logger.exception("failed to persist suggestion for %s", filename)
-            try:
-                self.audit_trail.record(
-                    {
-                        "event": "suggestion_queued",
-                        "module": filename,
-                        "score": round(score, 2),
-                        "rationale": rationale,
-                    }
-                )
-            except Exception:  # pragma: no cover - best effort
-                logger.exception("failed to record audit trail for %s", filename)
-            yield rec
+
+            rationale = (
+                f"{patches} patches, avg ROI delta {avg_roi:.2f}, "
+                f"avg error delta {avg_errors:.2f}, avg complexity delta {avg_complexity:.2f}"
+            )
+
+            yield EnhancementSuggestion(path=filename, score=score, rationale=rationale)
 
 
-__all__ = ["EnhancementClassifier"]
+__all__ = ["EnhancementClassifier", "EnhancementSuggestion"]
+

--- a/enhancement_classifier_config.json
+++ b/enhancement_classifier_config.json
@@ -1,0 +1,7 @@
+{
+  "weights": {
+    "frequency": 1.0,
+    "roi": 1.0,
+    "errors": 1.0
+  }
+}

--- a/tests/test_enhancement_classifier.py
+++ b/tests/test_enhancement_classifier.py
@@ -1,98 +1,72 @@
+import contextlib
 import sqlite3
 import contextlib
-import types
+import sqlite3
 import sys
+import types
+from pathlib import Path
 
 
 class _CtxConnWrapper:
+    """Minimal wrapper exposing a ``_connect`` context manager."""
+
     def __init__(self, conn: sqlite3.Connection) -> None:
         self.conn = conn
 
-    def _connect(self):
-        @contextlib.contextmanager
-        def cm():
-            yield self.conn
-        return cm()
+    @contextlib.contextmanager
+    def _connect(self):  # pragma: no cover - simple helper
+        yield self.conn
 
 
-class _PlainConnWrapper:
-    def __init__(self, conn: sqlite3.Connection) -> None:
-        self.conn = conn
-
-    def _connect(self):
-        return self.conn
-
-
-class DummyPatchSuggestionDB:
-    def __init__(self) -> None:
-        self.records = []
-
-    def add(self, rec) -> None:
-        self.records.append(rec)
-
-
-class SuggestionRecord:
-    def __init__(self, module: str, description: str) -> None:
-        self.module = module
-        self.description = description
-
-
-class DummyAuditTrail:
-    def __init__(self) -> None:
-        self.events = []
-
-    def record(self, event) -> None:
-        self.events.append(event)
-
-
+# Provide stubs so the module under test can import ``CodeDB`` and
+# ``PatchHistoryDB`` without pulling in the full implementations.
 sys.modules['code_database'] = types.SimpleNamespace(
     CodeDB=_CtxConnWrapper, PatchHistoryDB=_CtxConnWrapper
 )
-sys.modules['chatgpt_enhancement_bot'] = types.SimpleNamespace(EnhancementDB=_PlainConnWrapper)
-sys.modules['patch_suggestion_db'] = types.SimpleNamespace(
-    SuggestionRecord=SuggestionRecord, PatchSuggestionDB=DummyPatchSuggestionDB
-)
-sys.modules['audit_trail'] = types.SimpleNamespace(AuditTrail=DummyAuditTrail)
 
-from enhancement_classifier import EnhancementClassifier
+from enhancement_classifier import EnhancementClassifier, EnhancementSuggestion
 
 
-def test_scan_repo_scores_and_queues_suggestions() -> None:
+def test_scan_repo_generates_suggestions() -> None:
     code_conn = sqlite3.connect(":memory:")
     code_conn.execute("CREATE TABLE code (id INTEGER PRIMARY KEY)")
     code_conn.execute("INSERT INTO code (id) VALUES (1)")
-    code_conn.execute(
-        "CREATE TABLE code_enhancements (code_id INTEGER, enhancement_id INTEGER)"
-    )
-    code_conn.execute("INSERT INTO code_enhancements VALUES (1, 1)")
 
     patch_conn = sqlite3.connect(":memory:")
     patch_conn.execute(
-        "CREATE TABLE patch_history (code_id INTEGER, filename TEXT, roi_delta REAL, complexity_delta REAL)"
+        """
+        CREATE TABLE patch_history (
+            code_id INTEGER,
+            filename TEXT,
+            roi_delta REAL,
+            errors_before INTEGER,
+            errors_after INTEGER,
+            complexity_delta REAL
+        )
+        """
     )
     patch_conn.executemany(
-        "INSERT INTO patch_history VALUES (1, 'mod.py', ?, ?)",
-        [(0.1, 0.2)] * 3,
+        "INSERT INTO patch_history VALUES (1, 'mod.py', ?, ?, ?, ?)",
+        [
+            (-0.1, 1, 3, 0.5),
+            (-0.2, 2, 5, 0.3),
+            (-0.05, 1, 2, 0.4),
+        ],
     )
 
-    enh_conn = sqlite3.connect(":memory:")
-    enh_conn.execute(
-        "CREATE TABLE enhancements (id INTEGER PRIMARY KEY, outcome_score REAL)"
-    )
-    enh_conn.execute("INSERT INTO enhancements VALUES (1, 0.5)")
-
-    sugg_db = DummyPatchSuggestionDB()
+    config_path = Path(__file__).resolve().parent.parent / "enhancement_classifier_config.json"
     classifier = EnhancementClassifier(
         code_db=_CtxConnWrapper(code_conn),
         patch_db=_CtxConnWrapper(patch_conn),
-        enhancement_db=_PlainConnWrapper(enh_conn),
-        suggestion_db=sugg_db,
-        audit_trail=DummyAuditTrail(),
+        config_path=str(config_path),
     )
 
     suggestions = list(classifier.scan_repo())
     assert len(suggestions) == 1
-    rec = sugg_db.records[0]
-    assert rec.module == "mod.py"
-    assert "score=2.60" in rec.description
-    assert suggestions[0] is rec
+    sugg = suggestions[0]
+    assert isinstance(sugg, EnhancementSuggestion)
+    assert sugg.path == "mod.py"
+    # Frequency=3, ROI=-0.116..., errors=2 -> score ~5.12
+    assert sugg.score > 5
+    assert "avg ROI delta -0.12" in sugg.rationale
+


### PR DESCRIPTION
## Summary
- rewrite enhancement_classifier to use heuristics on patch history and compute weighted scores
- support YAML/JSON-configured weights and return EnhancementSuggestion objects
- add config file and tests covering repo scanning and scoring

## Testing
- `pytest tests/test_enhancement_classifier.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b40005c330832ea6bbdd0a172aaaaf