### PR TITLE
feat: lazily load workflow stability db

### DIFF
--- a/tests/integration/test_full_self_improvement_cycle.py
+++ b/tests/integration/test_full_self_improvement_cycle.py
@@ -120,7 +120,7 @@ def test_full_self_improvement_cycle(monkeypatch):
                     meta_entropy_threshold=None,
                 )
             ),
-            "STABLE_WORKFLOWS": global_db,
+            "get_stable_workflows": lambda: global_db,
         }
     )
 

--- a/tests/test_self_improvement_cycle_regression.py
+++ b/tests/test_self_improvement_cycle_regression.py
@@ -93,7 +93,7 @@ def test_self_improvement_cycle_matches_fixture():
                 debug=lambda *a, **k: None,
             ),
             "log_record": lambda **kw: kw,
-            "STABLE_WORKFLOWS": DummyStability(),
+            "get_stable_workflows": lambda: DummyStability(),
             "_init": types.SimpleNamespace(
                 settings=types.SimpleNamespace(
                     meta_mutation_rate=None,

--- a/unit_tests/test_meta_planning.py
+++ b/unit_tests/test_meta_planning.py
@@ -94,7 +94,16 @@ def test_cycle_uses_fallback_planner_when_missing():
                 meta_entropy_threshold=0.2,
                 enable_meta_planner=False,
             ),
-            "STABLE_WORKFLOWS": types.SimpleNamespace(),
+            "_init": types.SimpleNamespace(
+                settings=types.SimpleNamespace(
+                    meta_mutation_rate=0.0,
+                    meta_roi_weight=0.0,
+                    meta_domain_penalty=0.0,
+                    meta_entropy_threshold=0.2,
+                    enable_meta_planner=False,
+                )
+            ),
+            "get_stable_workflows": lambda: types.SimpleNamespace(),
         }
     )
 
@@ -124,7 +133,16 @@ def test_cycle_fails_when_enabled_but_missing():
                 meta_entropy_threshold=0.2,
                 enable_meta_planner=True,
             ),
-            "STABLE_WORKFLOWS": types.SimpleNamespace(),
+            "_init": types.SimpleNamespace(
+                settings=types.SimpleNamespace(
+                    meta_mutation_rate=0.0,
+                    meta_roi_weight=0.0,
+                    meta_domain_penalty=0.0,
+                    meta_entropy_threshold=0.2,
+                    enable_meta_planner=True,
+                )
+            ),
+            "get_stable_workflows": lambda: types.SimpleNamespace(),
             "_FallbackPlanner": object,
         }
     )


### PR DESCRIPTION
## Summary
- add lazy `get_stable_workflows` accessor wrapping `WorkflowStabilityDB`
- use accessor in `self_improvement_cycle` and update tests

## Testing
- `pytest unit_tests/test_meta_planning.py tests/test_self_improvement_cycle_regression.py tests/integration/test_full_self_improvement_cycle.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3ff5bfb08832ebe1396cb1179f98b