### PR TITLE
feat: flag anti-patterns in enhancement classifier

### DIFF
--- a/enhancement_classifier.py
+++ b/enhancement_classifier.py
@@ -10,6 +10,7 @@ objects.
 
 from __future__ import annotations
 
+import ast
 import json
 import logging
 import os
@@ -62,7 +63,7 @@ class EnhancementClassifier:
         path = config_path or os.getenv(
             "ENHANCEMENT_CLASSIFIER_CONFIG", "enhancement_classifier_config.json"
         )
-        weights = {"frequency": 1.0, "roi": 1.0, "errors": 1.0}
+        weights = {"frequency": 1.0, "roi": 1.0, "errors": 1.0, "anti": 1.0}
         try:
             text = Path(path).read_text()
             if path.endswith((".yaml", ".yml")) and yaml is not None:
@@ -101,6 +102,67 @@ class EnhancementClassifier:
         return filename, patch_count, avg_roi, avg_errors, avg_complexity
 
     # ------------------------------------------------------------------
+    def _detect_anti_patterns(self, code_id: int) -> tuple[float, list[str]]:
+        """Analyse source code for basic anti-patterns.
+
+        Returns a tuple of ``(score_penalty, notes)`` where ``score_penalty`` is a
+        positive number added to the overall score when issues are found and
+        ``notes`` contains human-readable descriptions of the problems.
+        """
+
+        try:
+            with self.code_db._connect() as conn:  # type: ignore[attr-defined]
+                row = conn.execute(
+                    "SELECT code FROM code WHERE id=?", (code_id,)
+                ).fetchone()
+        except Exception:  # pragma: no cover - tolerant to schema mismatch
+            logger.debug("anti-pattern scan skipped", exc_info=True)
+            return 0.0, []
+        if not row or not row[0]:
+            return 0.0, []
+        source = row[0]
+        try:
+            tree = ast.parse(source)
+        except Exception:  # pragma: no cover - invalid source
+            return 0.0, []
+
+        issues: list[str] = []
+        penalty = 0.0
+
+        def complexity(node: ast.AST) -> int:
+            count = 1
+            for child in ast.walk(node):
+                if isinstance(
+                    child,
+                    (
+                        ast.If,
+                        ast.For,
+                        ast.While,
+                        ast.Try,
+                        ast.With,
+                        ast.IfExp,
+                        ast.ExceptHandler,
+                        ast.BoolOp,
+                    ),
+                ):
+                    if isinstance(child, ast.BoolOp):
+                        count += max(0, len(child.values) - 1)
+                    else:
+                        count += 1
+            return count
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                cplx = complexity(node)
+                if cplx > 10:
+                    issues.append(
+                        f"function {node.name} exhibits high cyclomatic complexity ({cplx})"
+                    )
+                    penalty += cplx - 10
+
+        return penalty, issues
+
+    # ------------------------------------------------------------------
     def scan_repo(self) -> Iterator[EnhancementSuggestion]:
         """Yield scored suggestions for modules that warrant attention."""
 
@@ -112,21 +174,27 @@ class EnhancementClassifier:
             if not metrics:
                 continue
             filename, patches, avg_roi, avg_errors, avg_complexity = metrics
+            anti_score, anti_notes = self._detect_anti_patterns(cid)
 
             # Heuristics: flag if any inefficiency indicator is observed
-            if not (patches >= 3 or avg_roi < 0 or avg_complexity > 0):
+            if not (
+                patches >= 3 or avg_roi < 0 or avg_complexity > 0 or anti_score > 0
+            ):
                 continue
 
             score = (
                 self.weights["frequency"] * patches
                 + self.weights["roi"] * (-avg_roi)
                 + self.weights["errors"] * avg_errors
+                + self.weights["anti"] * anti_score
             )
 
             rationale = (
                 f"{patches} patches, avg ROI delta {avg_roi:.2f}, "
                 f"avg error delta {avg_errors:.2f}, avg complexity delta {avg_complexity:.2f}"
             )
+            if anti_notes:
+                rationale += "; " + "; ".join(anti_notes)
 
             yield EnhancementSuggestion(path=filename, score=score, rationale=rationale)
 


### PR DESCRIPTION
## Summary
- detect simple anti-patterns by analyzing source from CodeDB
- factor anti-pattern findings into repository scan scoring and rationale

## Testing
- `pytest tests/test_enhancement_classifier.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b40ab1d87c832eb7d898a39bd2e512