### PR TITLE
Add self-improvement initialization and cycle tests

### DIFF
--- a/sandbox_runner/tests/test_self_improvement_flow.py
+++ b/sandbox_runner/tests/test_self_improvement_flow.py
@@ -1,0 +1,151 @@
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+import pytest
+from sandbox_settings import SandboxSettings
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    sys.modules[name] = module
+    return module
+
+
+def _setup_base_packages():
+    menace_pkg = types.ModuleType("menace")
+    menace_pkg.__path__ = []
+    sys.modules["menace"] = menace_pkg
+    si_pkg = types.ModuleType("menace.self_improvement")
+    si_pkg.__path__ = [str(Path("self_improvement"))]
+    sys.modules["menace.self_improvement"] = si_pkg
+    # minimal logging utils
+    logger = types.SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        exception=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+    )
+    logging_utils = types.SimpleNamespace(
+        get_logger=lambda name: logger,
+        log_record=lambda **k: k,
+        setup_logging=lambda: None,
+    )
+    sys.modules["menace.logging_utils"] = logging_utils
+
+
+# ---------------------------------------------------------------------------
+
+def test_init_creates_and_clamps_synergy_weights(tmp_path, monkeypatch):
+    _setup_base_packages()
+    bootstrap = types.ModuleType("sandbox_runner.bootstrap")
+    bootstrap.initialize_autonomous_sandbox = lambda s: None
+    sys.modules["sandbox_runner.bootstrap"] = bootstrap
+
+    meta_stub = types.ModuleType("menace.self_improvement.meta_planning")
+    meta_stub.reload_settings = lambda cfg: None
+    sys.modules["menace.self_improvement.meta_planning"] = meta_stub
+
+    init_module = _load_module(
+        "menace.self_improvement.init", Path("self_improvement/init.py")
+    )
+
+    settings = SandboxSettings()
+    settings.sandbox_data_dir = str(tmp_path)
+    settings.sandbox_repo_path = str(tmp_path)
+    settings.synergy_weight_file = str(tmp_path / "synergy_weights.json")
+    settings.sandbox_central_logging = False
+
+    # pre-populate with out-of-range weights
+    bad = {"_doc": "", "roi": 20, "efficiency": -5}
+    (tmp_path / "synergy_weights.json").write_text(json.dumps(bad))
+
+    monkeypatch.setattr(init_module, "load_sandbox_settings", lambda: settings)
+
+    init_module.init_self_improvement()
+
+    synergy_file = Path(settings.synergy_weight_file)
+    assert synergy_file.exists()
+    data = json.loads(synergy_file.read_text())
+    assert data["roi"] == 10.0
+    assert data["efficiency"] == 0.0
+    # defaults applied for missing keys and clamped into range
+    for key in init_module.DEFAULT_SYNERGY_WEIGHTS:
+        assert 0.0 <= data[key] <= 10.0
+
+
+# ---------------------------------------------------------------------------
+
+def test_start_self_improvement_cycle_thread(tmp_path, monkeypatch):
+    _setup_base_packages()
+    bootstrap = types.ModuleType("sandbox_runner.bootstrap")
+    bootstrap.initialize_autonomous_sandbox = lambda s: None
+    sys.modules["sandbox_runner.bootstrap"] = bootstrap
+
+    # stub modules required by meta_planning
+    class DummyDB:
+        def __init__(self, *a, **k):
+            pass
+
+        def log_result(self, *a, **k):
+            pass
+
+        def record_metrics(self, *a, **k):
+            pass
+
+    sys.modules["menace.workflow_stability_db"] = types.SimpleNamespace(
+        WorkflowStabilityDB=DummyDB
+    )
+    sys.modules["menace.roi_results_db"] = types.SimpleNamespace(ROIResultsDB=DummyDB)
+    sys.modules["menace.lock_utils"] = types.SimpleNamespace(
+        SandboxLock=lambda *a, **k: types.SimpleNamespace(
+            __enter__=lambda self: self, __exit__=lambda self, exc_type, exc, tb: False
+        ),
+        Timeout=Exception,
+        LOCK_TIMEOUT=1,
+    )
+    sys.modules["menace.unified_event_bus"] = types.SimpleNamespace(UnifiedEventBus=None)
+    sys.modules["menace.meta_workflow_planner"] = types.SimpleNamespace(
+        MetaWorkflowPlanner=None
+    )
+
+    import sandbox_settings as sandbox_settings_module
+    sys.modules["menace.sandbox_settings"] = sandbox_settings_module
+
+    init_module = _load_module(
+        "menace.self_improvement.init", Path("self_improvement/init.py")
+    )
+    meta_planning = _load_module(
+        "menace.self_improvement.meta_planning", Path("self_improvement/meta_planning.py")
+    )
+
+    settings = SandboxSettings()
+    settings.sandbox_data_dir = str(tmp_path)
+    settings.sandbox_repo_path = str(tmp_path)
+    settings.sandbox_central_logging = False
+    monkeypatch.setattr(init_module, "load_sandbox_settings", lambda: settings)
+    init_module.init_self_improvement()
+
+    calls = {"count": 0}
+
+    async def fake_cycle(workflows, *, interval, event_bus=None):
+        calls["count"] += 1
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(meta_planning, "self_improvement_cycle", fake_cycle)
+
+    thread = meta_planning.start_self_improvement_cycle(
+        {"w": lambda: None}, event_bus=types.SimpleNamespace(publish=lambda *a, **k: None), interval=0
+    )
+
+    assert thread.daemon
+    thread.join(timeout=1)
+    assert calls["count"] >= 1


### PR DESCRIPTION
## Summary
- add tests verifying `init_self_improvement` creates and clamps synergy weight file
- add test ensuring `start_self_improvement_cycle` launches a daemon thread and runs once

## Testing
- `pytest sandbox_runner/tests/test_self_improvement_flow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b40aaedd34832ea04e025dcca00489