### PR TITLE
Expose optional service versions in settings

### DIFF
--- a/docs/autonomous_sandbox.md
+++ b/docs/autonomous_sandbox.md
@@ -19,6 +19,9 @@ running the fully autonomous sandbox.
   knowledge module (default `600`).
 - `MENACE_LOCAL_DB_PATH` and `MENACE_SHARED_DB_PATH` – override default SQLite
   database locations.
+- `OPTIONAL_SERVICE_VERSIONS` – JSON mapping of optional service modules to
+  minimum versions, e.g.
+  `{"relevancy_radar": "1.2.0", "quick_fix_engine": "1.1.0"}`.
 
 The `.env` file referenced by `MENACE_ENV_FILE` is loaded automatically when
 present. Additional configuration files such as synergy weights or self‑test

--- a/docs/sandbox_config.sample.yaml
+++ b/docs/sandbox_config.sample.yaml
@@ -1,5 +1,8 @@
 meta_entropy_threshold: 0.2
 enable_meta_planner: false
+optional_service_versions:
+  relevancy_radar: "1.0.0"
+  quick_fix_engine: "1.0.0"
 roi:
   threshold: null
   confidence: null

--- a/docs/sandbox_settings.md
+++ b/docs/sandbox_settings.md
@@ -86,3 +86,22 @@ SYNERGY_TRAIN_INTERVAL=20
 ```
 
 Any field listed above can be overridden in the same manner.
+
+## Optional service versions
+
+`SandboxSettings.optional_service_versions` controls which optional services are
+checked during bootstrap and the minimum versions required. The default ensures
+`relevancy_radar` and `quick_fix_engine` are available, but you can override the
+mapping via configuration files or the environment:
+
+```yaml
+optional_service_versions:
+  relevancy_radar: "1.2.0"
+  quick_fix_engine: "1.1.0"
+```
+
+```bash
+export OPTIONAL_SERVICE_VERSIONS='{"relevancy_radar": "1.2.0"}'
+```
+
+Unset modules are ignored.

--- a/sandbox_runner/bootstrap.py
+++ b/sandbox_runner/bootstrap.py
@@ -21,12 +21,6 @@ from .cli import main as _cli_main
 logger = logging.getLogger(__name__)
 
 
-OPTIONAL_SERVICE_VERSIONS = {
-    "relevancy_radar": "1.0.0",
-    "quick_fix_engine": "1.0.0",
-}
-
-
 def _ensure_sqlite_db(path: Path) -> None:
     """Ensure an SQLite database exists at ``path``."""
     if not path.exists():
@@ -88,7 +82,7 @@ def initialize_autonomous_sandbox(
     # Verify optional services are importable and meet version requirements
     from importlib import metadata
 
-    for mod, min_version in OPTIONAL_SERVICE_VERSIONS.items():
+    for mod, min_version in settings.optional_service_versions.items():
         try:
             module = importlib.import_module(mod)
         except ModuleNotFoundError:

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -339,6 +339,34 @@ class SandboxSettings(BaseSettings):
         env="RETRY_OPTIONAL_DEPENDENCIES",
         description="Retry loading optional modules instead of using a stub.",
     )
+    optional_service_versions: dict[str, str] = Field(
+        default_factory=lambda: {
+            "relevancy_radar": "1.0.0",
+            "quick_fix_engine": "1.0.0",
+        },
+        env="OPTIONAL_SERVICE_VERSIONS",
+        description="Mapping of optional service modules to minimum versions.",
+    )
+    if PYDANTIC_V2:
+
+        @field_validator("optional_service_versions", mode="before")
+        def _parse_optional_service_versions(cls, v: Any) -> Any:
+            if isinstance(v, str):
+                try:
+                    return json.loads(v) if v else {}
+                except Exception:
+                    return {}
+            return v
+    else:  # pragma: no cover - pydantic<2
+
+        @field_validator("optional_service_versions", pre=True)
+        def _parse_optional_service_versions(cls, v: Any) -> Any:  # type: ignore[override]
+            if isinstance(v, str):
+                try:
+                    return json.loads(v) if v else {}
+                except Exception:
+                    return {}
+            return v
     openai_api_key: str | None = Field(
         None, env="OPENAI_API_KEY", description="API key for OpenAI access."
     )

--- a/tests/test_bootstrap_service_deps.py
+++ b/tests/test_bootstrap_service_deps.py
@@ -29,6 +29,10 @@ class SandboxSettings:
         self.alignment_baseline_metrics_path = alignment_baseline_metrics_path
         self.menace_mode = "test"
         self.menace_env_file = "env"
+        self.optional_service_versions = {
+            "relevancy_radar": "1.0.0",
+            "quick_fix_engine": "1.0.0",
+        }
 
 
 sandbox_settings.SandboxSettings = SandboxSettings


### PR DESCRIPTION
## Summary
- allow overriding optional service versions via `SandboxSettings.optional_service_versions`
- bootstrap uses settings-driven map instead of hard-coded list
- document `OPTIONAL_SERVICE_VERSIONS` for config files and environment variables

## Testing
- `pytest tests/test_bootstrap_service_deps.py tests/integration/test_sandbox_launch_cycle.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b40e617954832eac965674854d7a20