### PR TITLE
Seed stub generation with configurable RNG

### DIFF
--- a/docs/sandbox_self_improvement.md
+++ b/docs/sandbox_self_improvement.md
@@ -20,6 +20,7 @@ generation.
 - `SANDBOX_REPO_PATH` – path to the local sandbox repository clone.
 - `SANDBOX_DATA_DIR` – directory for metrics and state files.
 - `SANDBOX_ENV_PRESETS` – comma separated scenario preset files.
+- `SANDBOX_STUB_SEED` – seed value for deterministic stub generation.
 - `AUTO_TRAIN_INTERVAL`, `SYNERGY_TRAIN_INTERVAL`,
   `ADAPTIVE_ROI_RETRAIN_INTERVAL` – control retraining frequency.
 - `ENABLE_META_PLANNER` – require meta-planning support when set to `true`.


### PR DESCRIPTION
## Summary
- Seed `random` using `SANDBOX_STUB_SEED` and funnel all stub generation randomness through a dedicated RNG
- Plumb RNG through `_stub_from_signature`, `_misuse_provider`, `_random_strategy`, and related helpers
- Document `SANDBOX_STUB_SEED` in sandbox self-improvement configuration

## Testing
- `pytest` *(fails: 388 errors during collection)*
- `pytest tests/test_sandbox_stub_fallback.py::test_generate_input_stubs_seed -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4123192a0832e9583457d49ad3b87