### PR TITLE
Extend prompt style learning

### DIFF
--- a/docs/prompt_engine.md
+++ b/docs/prompt_engine.md
@@ -67,3 +67,12 @@ Correct example:
 Incorrect example:
 <failing snippet>
 ```
+
+## Learning from history
+
+`PromptMemoryTrainer` analyses previous prompts and patch outcomes to infer
+effective formatting.  The trainer now detects additional cues such as the
+presence of fenced code blocks, bullet lists and separate `System`/`User`
+sections.  Success rates for each observed style are weighted by the ROI or
+patch complexity improvement recorded for the corresponding patch, allowing
+the prompt engine to favour styles linked to more impactful changes.


### PR DESCRIPTION
## Summary
- capture code fences, bullet lists and System/User sections in prompt style extraction
- weight style success by ROI or complexity improvements from `PatchHistoryDB`
- document trainer capabilities and test new style cues

## Testing
- `pytest tests/test_prompt_engine.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4122ef298832e8fc4c1a8edb21105