### PR TITLE
feat: persist prompt memory trainer weights

### DIFF
--- a/prompt_memory_trainer_cli.py
+++ b/prompt_memory_trainer_cli.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Command line interface to retrain prompt formatting preferences."""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Iterable
+
+from prompt_memory_trainer import PromptMemoryTrainer
+
+DEFAULT_OUTPUT = Path(
+    os.getenv(
+        "PROMPT_MEMORY_WEIGHTS_PATH",
+        Path(__file__).resolve().parent / "config" / "prompt_memory_weights.json",
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+
+def cli(argv: Iterable[str] | None = None) -> int:
+    """Entry point for command line execution."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="File to store computed style weights",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    trainer = PromptMemoryTrainer()
+    trainer.train()
+    trainer.save_weights(args.output)
+    print(f"Saved weights to {args.output}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+
+def main(argv: Iterable[str] | None = None) -> None:  # pragma: no cover - CLI glue
+    sys.exit(cli(argv))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()


### PR DESCRIPTION
## Summary
- persist PromptMemoryTrainer style weights to JSON via save/load helpers
- have PromptEngine load persisted weights and fall back to training once
- add CLI to retrain and save updated weights on demand

## Testing
- `pre-commit run --files prompt_memory_trainer.py prompt_engine.py prompt_memory_trainer_cli.py`
- `pytest tests/test_prompt_engine.py tests/test_prompt_engine_fallback.py tests/test_prompt_engine_vector_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4158d8a0c832ebeb8f665f9a3532e