### PR TITLE
refactor: add vector service dependency check

### DIFF
--- a/sandbox_runner/bootstrap.py
+++ b/sandbox_runner/bootstrap.py
@@ -16,6 +16,7 @@ from menace.default_config_manager import DefaultConfigManager
 from sandbox_settings import SandboxSettings, load_sandbox_settings
 
 from .cli import main as _cli_main
+from .cycle import ensure_vector_service
 
 
 logger = logging.getLogger(__name__)
@@ -48,6 +49,10 @@ def initialize_autonomous_sandbox(
         DefaultConfigManager(getattr(settings, "menace_env_file", ".env")).apply_defaults()
     except Exception:  # pragma: no cover - best effort
         logger.warning("failed to ensure default configuration", exc_info=True)
+
+    # Ensure the mandatory vector_service dependency is available before
+    # proceeding with further sandbox initialisation.
+    ensure_vector_service()
 
     data_dir = Path(settings.sandbox_data_dir)
     data_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- defer `vector_service` import in sandbox cycle into `ensure_vector_service`
- validate vector service availability during `initialize_autonomous_sandbox`

## Testing
- `pytest tests/test_bootstrap_service_deps.py -q` *(fails: ImportError: cannot import name 'SANDBOX_ENV_PRESETS' from 'sandbox_runner.environment')*

------
https://chatgpt.com/codex/tasks/task_e_68b415184c80832e923e7bd636ff2062