### PR TITLE
Warn when enhancement classifier assignment fails

### DIFF
--- a/self_coding_manager.py
+++ b/self_coding_manager.py
@@ -107,8 +107,12 @@ class SelfCodingManager:
         if enhancement_classifier and not getattr(self.engine, "enhancement_classifier", None):
             try:
                 self.engine.enhancement_classifier = enhancement_classifier
-            except Exception:
-                pass
+            except Exception as exc:
+                self.logger.warning(
+                    "Failed to attach enhancement classifier to engine; enhancement classification disabled: %s",
+                    exc,
+                )
+                self.enhancement_classifier = None
 
     # ------------------------------------------------------------------
     def scan_repo(self) -> None:


### PR DESCRIPTION
## Summary
- warn when unable to attach enhancement classifier to engine
- disable enhancement classification on assignment failure

## Testing
- `pytest unit_tests/test_self_coding_manager_failed_tags.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b41bb2c19c832e985ee43227798c4d