### PR TITLE
feat: make enhancement thresholds configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1731,6 +1731,28 @@ Performance isn’t a luxury; it’s a multiplier on ROI. Each critical function
 
 Technically, this layer relies on `psutil` for cross-platform metrics and `sqlite3` for zero-setup storage. For heavier loads, export to Prometheus + Grafana so you can watch Menace’s pulse in real time. The scanner feeds its findings into the Resource Allocation Optimizer, ensuring slow code is either optimized or throttled.
 
+### Enhancement classifier configuration
+
+`enhancement_classifier.py` scores modules based on patch history and code metrics.
+Weights and thresholds live in `enhancement_classifier_config.json`:
+
+```json
+{
+  "weights": {"frequency": 1.0, ...},
+  "thresholds": {
+    "min_patches": 3,
+    "roi_cutoff": 0.0,
+    "complexity_delta": 0.0
+  }
+}
+```
+
+- **min_patches** – minimum number of patches before a file is evaluated.
+- **roi_cutoff** – average ROI delta below which a module is flagged.
+- **complexity_delta** – minimum average complexity increase to trigger a suggestion.
+
+Tune these values to control how aggressively the classifier surfaces potential improvements.
+
 ### Meta-Logging & Replay Training
 
 All inputs, outputs and decisions flow into Kafka topics with the prefix `menace.events.*`. A nightly Spark job (`ReplayTrainer`) aggregates sequences of `error` → `fix` → `success` and trains a lightweight gradient-boosted tree to predict failure likelihood from prompt features and context tokens. The resulting model updates the Prompt Rewriter so history informs future decisions.

--- a/enhancement_classifier_config.json
+++ b/enhancement_classifier_config.json
@@ -8,5 +8,10 @@
     "duplication": 1.0,
     "length": 1.0,
     "anti": 1.0
+  },
+  "thresholds": {
+    "min_patches": 3,
+    "roi_cutoff": 0.0,
+    "complexity_delta": 0.0
   }
 }

--- a/tests/test_enhancement_classifier.py
+++ b/tests/test_enhancement_classifier.py
@@ -70,6 +70,7 @@ def test_scan_repo_generates_suggestions() -> None:
     # Frequency=3, ROI=-0.116..., errors=2, complexity=0.4 -> score ~5.52
     assert sugg.score > 5.5
     assert "avg ROI delta -0.12" in sugg.rationale
+    assert classifier.thresholds["min_patches"] == 3
 
 
 def test_ast_metrics_and_scoring(tmp_path: Path) -> None:
@@ -114,7 +115,7 @@ def test_ast_metrics_and_scoring(tmp_path: Path) -> None:
 
     cfg = tmp_path / "cfg.json"
     cfg.write_text(
-        """{\n  \"weights\": {\n    \"frequency\": 1.0,\n    \"roi\": 1.0,\n    \"errors\": 1.0,\n    \"complexity\": 1.0,\n    \"cyclomatic\": 1.0,\n    \"duplication\": 1.0,\n    \"length\": 1.0,\n    \"anti\": 1.0\n  }\n}\n"""
+        """{\n  \"weights\": {\n    \"frequency\": 1.0,\n    \"roi\": 1.0,\n    \"errors\": 1.0,\n    \"complexity\": 1.0,\n    \"cyclomatic\": 1.0,\n    \"duplication\": 1.0,\n    \"length\": 1.0,\n    \"anti\": 1.0\n  },\n  \"thresholds\": {\n    \"min_patches\": 5,\n    \"roi_cutoff\": -0.5,\n    \"complexity_delta\": 0.0\n  }\n}\n"""
     )
 
     classifier = EnhancementClassifier(
@@ -144,6 +145,7 @@ def test_ast_metrics_and_scoring(tmp_path: Path) -> None:
 
     suggestions = list(classifier.scan_repo())
     assert suggestions and suggestions[0].path == "mod.py"
+    assert classifier.thresholds["min_patches"] == 5
     expected = (
         classifier.weights["frequency"] * patches
         + classifier.weights["roi"] * (-avg_roi)


### PR DESCRIPTION
## Summary
- read patch count, ROI, and complexity thresholds from config
- use loaded thresholds to trigger enhancement suggestions
- document new `thresholds` section in config and README

## Testing
- `pytest tests/test_enhancement_classifier.py tests/test_enhancement_classifier_queue.py`

------
https://chatgpt.com/codex/tasks/task_e_68b41be18440832e9db67ba3d8e30c0c