### PR TITLE
Log path resolution failures in test harness

### DIFF
--- a/sandbox_runner/test_harness.py
+++ b/sandbox_runner/test_harness.py
@@ -10,12 +10,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+import logging
 import subprocess
 import sys
 import tempfile
 import time
 
 from ..error_parser import ErrorParser
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -132,8 +136,8 @@ def run_tests(
             if rel_paths:
                 try:
                     rel_paths = [p.relative_to(repo_path) for p in rel_paths]
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.warning("Failed to resolve relative paths %s: %s", rel_paths, exc)
                 if len(rel_paths) == 1:
                     rel = rel_paths[0]
                     selected = rel.as_posix()
@@ -160,8 +164,8 @@ def run_tests(
             if rel_paths:
                 try:
                     rel_paths = [p.relative_to(repo_path) for p in rel_paths]
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.warning("Failed to resolve relative paths %s: %s", rel_paths, exc)
                 if len(rel_paths) == 1:
                     rel = rel_paths[0]
                     selected = rel.as_posix()


### PR DESCRIPTION
## Summary
- initialize a module-level logger in the test harness
- log warnings when changed files cannot be made relative to the repository

## Testing
- `pytest tests/test_closed_loop_sandbox.py::test_harness_filters_specific_test_file tests/test_closed_loop_sandbox.py::test_harness_uses_k_filter_for_module tests/test_sandbox_runner_backends.py::test_run_tests_supports_backends -q`
- `python - <<'PY'
# manual run showing warning
... (see warning in logs)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b41d55fac4832e83617b190f0e650d