### PR TITLE
Improve sandbox test harness error handling

### DIFF
--- a/sandbox_runner/test_harness.py
+++ b/sandbox_runner/test_harness.py
@@ -93,6 +93,10 @@ def run_tests(
         )
         stdout_parts.append(clone.stdout)
         stdout_parts.append(clone.stderr)
+        if clone.returncode != 0:
+            msg = f"git clone failed with code {clone.returncode}: {clone.stderr}"
+            logger.error(msg.strip())
+            raise RuntimeError(msg)
 
         if backend not in {"venv", "docker"}:
             raise ValueError(f"unknown backend: {backend}")
@@ -106,9 +110,9 @@ def run_tests(
             try:
                 if changed_path.is_file() and changed_path.suffix == ".txt":
                     lines = [
-                        Path(l.strip())
-                        for l in changed_path.read_text(encoding="utf-8").splitlines()
-                        if l.strip()
+                        Path(line.strip())
+                        for line in changed_path.read_text(encoding="utf-8").splitlines()
+                        if line.strip()
                     ]
                     rel_paths.extend(lines)
                 else:
@@ -131,6 +135,13 @@ def run_tests(
                 )
                 stdout_parts.append(install.stdout)
                 stdout_parts.append(install.stderr)
+                if install.returncode != 0:
+                    msg = (
+                        "dependency installation failed with code "
+                        f"{install.returncode}: {install.stderr}"
+                    )
+                    logger.error(msg.strip())
+                    raise RuntimeError(msg)
 
             pytest_cmd = [str(python), "-m", "pytest", "-q"]
             if rel_paths:

--- a/tests/test_sandbox_runner_backends.py
+++ b/tests/test_sandbox_runner_backends.py
@@ -30,6 +30,7 @@ def test_run_tests_supports_backends(monkeypatch, tmp_path):
     )
     th = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
+    sys.modules[spec.name] = th
     spec.loader.exec_module(th)
     monkeypatch.setattr(th, "_python_bin", lambda v: Path(sys.executable))
 

--- a/tests/test_sandbox_runner_failures.py
+++ b/tests/test_sandbox_runner_failures.py
@@ -1,0 +1,65 @@
+import importlib.util
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import pytest
+
+
+def _load_test_harness(monkeypatch):
+    path = Path(__file__).resolve().parents[1] / "sandbox_runner/test_harness.py"
+    spec = importlib.util.spec_from_file_location("menace.sandbox_runner.test_harness", path)
+    th = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = th
+    spec.loader.exec_module(th)
+    monkeypatch.setattr(th, "_python_bin", lambda v: Path(sys.executable))
+    return th
+
+
+def _prepare_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "requirements.txt").write_text("")
+    tests = repo / "tests"
+    tests.mkdir()
+    (tests / "test_mod.py").write_text("def test_ok():\n    assert True\n")
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True)
+    subprocess.run(["git", "add", "-A"], cwd=repo, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, capture_output=True)
+    return repo
+
+
+def test_clone_failure_raises(monkeypatch):
+    th = _load_test_harness(monkeypatch)
+
+    def fake_run(cmd, *a, **kw):
+        if cmd[:2] == ["git", "clone"]:
+            return subprocess.CompletedProcess(cmd, 1, "", "clone err")
+        pytest.fail(f"unexpected command {cmd}")
+
+    monkeypatch.setattr(th.subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError) as exc:
+        th.run_tests(Path("does_not_matter"))
+    assert "git clone failed" in str(exc.value)
+
+
+def test_install_failure_raises(monkeypatch, tmp_path):
+    th = _load_test_harness(monkeypatch)
+    repo = _prepare_repo(tmp_path)
+
+    def fake_run(cmd, *a, cwd=None, capture_output=None, text=None, check=None):
+        if cmd[:2] == ["git", "clone"]:
+            dst = Path(cmd[3])
+            shutil.copytree(repo, dst, dirs_exist_ok=True)
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[0] == sys.executable and cmd[1:3] == ["-m", "venv"]:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd[0] == sys.executable and cmd[1:3] == ["-m", "pip"]:
+            return subprocess.CompletedProcess(cmd, 1, "", "install err")
+        pytest.fail(f"unexpected command {cmd}")
+
+    monkeypatch.setattr(th.subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError) as exc:
+        th.run_tests(repo)
+    assert "dependency installation failed" in str(exc.value)


### PR DESCRIPTION
## Summary
- raise explicit RuntimeError when git clone fails
- surface dependency installation failures before running tests
- add tests covering clone and pip install error scenarios

## Testing
- `python -m pre_commit run --files sandbox_runner/test_harness.py tests/test_sandbox_runner_failures.py`
- `pytest tests/test_sandbox_runner_backends.py tests/test_sandbox_runner_failures.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4215b16e4832ea1e6b270dd3baae8