### PR TITLE
Track trainer and refresh prompt config

### DIFF
--- a/tests/test_prompt_memory_trainer_incremental.py
+++ b/tests/test_prompt_memory_trainer_incremental.py
@@ -1,5 +1,6 @@
 import json
 import sqlite3
+import json
 from pathlib import Path
 
 import pytest
@@ -81,3 +82,14 @@ def test_append_records_retrains_and_saves(tmp_path: Path) -> None:
     weights = trainer.style_weights
     assert weights["headers"][hdr_key] == pytest.approx(2 / 7)
     assert state.exists()
+
+
+def test_record_updates_weights(tmp_path: Path) -> None:
+    trainer = PromptMemoryTrainer(memory=object(), patch_db=object(), state_path=tmp_path / "w.json")
+    updated = trainer.record(headers=["H"], example_order=["success"], tone="neutral", success=True)
+    assert updated
+    # second call toggles success rate
+    updated = trainer.record(headers=["H"], example_order=["success"], tone="neutral", success=False)
+    assert updated
+    hdr_key = json.dumps(["H"])
+    assert trainer.style_weights["headers"][hdr_key] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- hold a reference to `PromptMemoryTrainer` so prompt config can reuse weights
- refresh prompt formatting when trainer reports new weights
- implement incremental trainer.record and tests

## Testing
- `pytest tests/test_prompt_engine.py tests/test_prompt_memory_trainer_incremental.py`


------
https://chatgpt.com/codex/tasks/task_e_68b423fe4848832e9805989fd835f586