### PR TITLE
Integrate static metrics with patch history for enhancement scoring

### DIFF
--- a/enhancement_classifier_config.json
+++ b/enhancement_classifier_config.json
@@ -7,7 +7,8 @@
     "cyclomatic": 1.0,
     "duplication": 1.0,
     "length": 1.0,
-    "anti": 1.0
+    "anti": 1.0,
+    "history": 1.0
   },
   "thresholds": {
     "min_patches": 3,


### PR DESCRIPTION
## Summary
- incorporate patch-history correlation and duplication ratios in enhancement scoring
- allow configuration weights and thresholds to be overridden by environment variables
- test new metrics and env overrides

## Testing
- `pytest tests/test_enhancement_classifier.py`


------
https://chatgpt.com/codex/tasks/task_e_68b427d1a6d4832e8db6b7ac1d0d4119