### PR TITLE
Track enhancement suggestion frequency

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -274,7 +274,7 @@ class SelfCodingEngine:
         try:
             suggestions = list(classifier.scan_repo())
             if self.patch_suggestion_db:
-                self.patch_suggestion_db.queue_suggestions(suggestions)
+                self.patch_suggestion_db.queue_enhancement_suggestions(suggestions)
             if self.event_bus:
                 try:
                     self.event_bus.publish(

--- a/tests/test_enhancement_suggestions_db.py
+++ b/tests/test_enhancement_suggestions_db.py
@@ -1,0 +1,22 @@
+import types
+from patch_suggestion_db import PatchSuggestionDB, EnhancementSuggestionRecord
+
+
+def test_upsert_and_fetch(tmp_path):
+    db = PatchSuggestionDB(tmp_path / "s.db")
+
+    Suggestion = types.SimpleNamespace
+    suggs = [
+        Suggestion(path="mod1.py", score=1.0, rationale="r1"),
+        Suggestion(path="mod1.py", score=2.0, rationale="r1"),
+        Suggestion(path="mod2.py", score=3.0, rationale="r2"),
+    ]
+    db.queue_enhancement_suggestions(suggs)
+
+    rows = db.fetch_top_enhancement_suggestions(5)
+    by_module = {r.module: r for r in rows}
+    assert by_module["mod1.py"].occurrences == 2
+    assert by_module["mod1.py"].score == 2.0
+    assert by_module["mod2.py"].occurrences == 1
+    # After fetching they should be removed
+    assert db.fetch_top_enhancement_suggestions(5) == []


### PR DESCRIPTION
## Summary
- record enhancement suggestions with occurrence counts and timestamps
- upsert enhancement recommendations during repo scans
- expose API for retrieving and consuming top enhancement suggestions

## Testing
- `pytest tests/test_enhancement_suggestions_db.py tests/test_enhancement_classifier_queue.py::test_classifier_queue_and_top_suggestions -q`


------
https://chatgpt.com/codex/tasks/task_e_68b429c32ba0832eb32f167041ea06d0