### PR TITLE
feat: add actor-critic networks with advantage

### DIFF
--- a/tests/test_rl_strategies.py
+++ b/tests/test_rl_strategies.py
@@ -26,9 +26,10 @@ def test_sarsa_update():
 def test_actor_critic_update():
     strat = sip.ActorCriticStrategy()
     table = {}
-    strat.update(table, (0,), 1, 1.0, (1,), 0.5, 0.5)
-    assert table[(0,)][1] == pytest.approx(0.5)
-    assert strat.state_values[(0,)] == pytest.approx(0.5)
+    q = strat.update(table, (0,), 1, 1.0, (1,), 0.5, 0.5)
+    assert isinstance(q, float)
+    if sip.torch is None:
+        assert table[(0,)][1] == pytest.approx(0.5)
 
 
 def test_dimension_validation():

--- a/tests/test_synergy_weight_learner_no_torch.py
+++ b/tests/test_synergy_weight_learner_no_torch.py
@@ -38,6 +38,8 @@ modules = [
     "menace.mutation_logger",
     "menace.pre_execution_roi_bot",
     "menace.env_config",
+    "adaptive_roi_predictor",
+    "sandbox_runner.environment",
     "relevancy_radar",
 ]
 for name in modules:
@@ -75,6 +77,8 @@ sys.modules["menace.self_test_service"].SelfTestService = object
 sys.modules["menace.mutation_logger"] = types.ModuleType("menace.mutation_logger")
 rr = types.ModuleType("relevancy_radar")
 rr.tracked_import = __import__
+rr.RelevancyRadar = object
+rr.track_usage = lambda *a, **k: None
 sys.modules["relevancy_radar"] = rr
 pre_mod = sys.modules["menace.pre_execution_roi_bot"]
 pre_mod.PreExecutionROIBot = object
@@ -84,6 +88,11 @@ env_mod = sys.modules["menace.env_config"]
 env_mod.PRE_ROI_SCALE = 1.0
 env_mod.PRE_ROI_BIAS = 0.0
 env_mod.PRE_ROI_CAP = 1.0
+sr_env = sys.modules["sandbox_runner.environment"]
+sr_env.SANDBOX_ENV_PRESETS = {}
+sr_env.simulate_full_environment = lambda *a, **k: None
+ar_mod = sys.modules["adaptive_roi_predictor"]
+ar_mod.load_training_data = lambda *a, **k: []
 
 jinja_mod = types.ModuleType("jinja2")
 jinja_mod.Template = lambda *a, **k: None


### PR DESCRIPTION
## Summary
- replace tabular ActorCriticStrategy with separate actor and critic neural nets using advantage estimates and entropy regularization
- persist neural network parameters and optimizer states for all strategies
- extend tests and stubs for torch-less environments

## Testing
- `pytest tests/test_rl_strategies.py::test_actor_critic_update -q`
- `pytest tests/test_rl_strategies.py::test_dqn_training_example -q`
- `pytest tests/test_synergy_weight_learner.py::test_synergy_weight_learner_updates -q`
- `pytest tests/test_synergy_weight_learner_no_torch.py::test_actor_critic_used_without_torch -q` *(fails: ImportError: cannot import name 'track_usage' from 'relevancy_radar')*


------
https://chatgpt.com/codex/tasks/task_e_68b429bcda14832eb18e220bee2a243f