### PR TITLE
feat: enhance prompt style tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ clipped/*.mp4
 # BLOCK EVERYTHING JSON EXCEPT clip_projects.json
 clipped/*.json
 !clipped/clip_projects.json
+prompt_style_weights.json
 
 # Global media ignore (safety)
 *.mp4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ dependencies = [
     ,"sentry-sdk"
     ,"cryptography"
     ,"tiktoken"
+    ,"vaderSentiment"
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -488,6 +488,8 @@ urllib3==2.4.0
     #   requests
     #   selenium
     #   sentry-sdk
+vaderSentiment==3.3.2
+    # via menace (pyproject.toml)
 vine==5.1.0
     # via
     #   amqp

--- a/tests/approved_sqlite3_usage.txt
+++ b/tests/approved_sqlite3_usage.txt
@@ -59,3 +59,4 @@ tests/test_db_dedup_concurrent.py
 tests/test_db_router_logging.py
 tests/integration/test_workflow_policy_integration.py
 tests/test_enhancement_classifier_queue.py
+tests/test_prompt_memory_trainer_incremental.py

--- a/tests/test_prompt_memory_trainer_incremental.py
+++ b/tests/test_prompt_memory_trainer_incremental.py
@@ -1,6 +1,5 @@
 import json
 import sqlite3
-import json
 from pathlib import Path
 import types
 import sys
@@ -10,9 +9,11 @@ import pytest
 
 class _DummyMem:
     def __init__(self, db_path=":memory:") -> None:
-        self.conn = sqlite3.connect(db_path)
+        self.conn = sqlite3.connect(db_path)  # noqa: SQL001
         self.conn.execute(
-            "CREATE TABLE interactions(prompt TEXT, response TEXT, tags TEXT, ts TEXT, embedding TEXT, alerts TEXT)"
+            "CREATE TABLE interactions("
+            "prompt TEXT, response TEXT, tags TEXT, ts TEXT, "
+            "embedding TEXT, alerts TEXT)"
         )
 
     def log_interaction(self, *a, **k) -> None:
@@ -21,28 +22,39 @@ class _DummyMem:
 
 class _DummyPatchDB:
     def __init__(self, path=":memory:") -> None:
-        self.conn = sqlite3.connect(path)
+        self.conn = sqlite3.connect(path)  # noqa: SQL001
         self.conn.execute(
-            "CREATE TABLE patch_history(id INTEGER PRIMARY KEY AUTOINCREMENT, outcome TEXT, roi_before REAL, roi_after REAL, complexity_before REAL, complexity_after REAL)"
+            "CREATE TABLE patch_history("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, outcome TEXT, "
+            "roi_before REAL, roi_after REAL, complexity_before REAL, "
+            "complexity_after REAL)"
         )
 
 
-sys.modules.setdefault("gpt_memory", types.SimpleNamespace(GPTMemoryManager=_DummyMem))
-sys.modules.setdefault("code_database", types.SimpleNamespace(PatchHistoryDB=_DummyPatchDB))
+sys.modules.setdefault(
+    "gpt_memory", types.SimpleNamespace(GPTMemoryManager=_DummyMem)
+)
+sys.modules.setdefault(
+    "code_database", types.SimpleNamespace(PatchHistoryDB=_DummyPatchDB)
+)
 
-from prompt_memory_trainer import PromptMemoryTrainer
+from prompt_memory_trainer import PromptMemoryTrainer  # noqa: E402
 
 
 class Mem:
     def __init__(self) -> None:
-        self.conn = sqlite3.connect(":memory:")
+        self.conn = sqlite3.connect(":memory:")  # noqa: SQL001
         self.conn.execute(
-            "CREATE TABLE interactions(prompt TEXT, response TEXT, tags TEXT, ts TEXT, embedding TEXT, alerts TEXT)"
+            "CREATE TABLE interactions("
+            "prompt TEXT, response TEXT, tags TEXT, ts TEXT, "
+            "embedding TEXT, alerts TEXT)"
         )
 
     def log_interaction(self, prompt: str, response: str, tags=None) -> None:
         self.conn.execute(
-            "INSERT INTO interactions(prompt, response, tags, ts, embedding, alerts) VALUES(?, ?, '', '', '', '')",
+            "INSERT INTO interactions("
+            "prompt, response, tags, ts, embedding, alerts) "
+            "VALUES(?, ?, '', '', '', '')",
             (prompt, response),
         )
         self.conn.commit()
@@ -50,9 +62,12 @@ class Mem:
 
 class PDB:
     def __init__(self) -> None:
-        self.conn = sqlite3.connect(":memory:")
+        self.conn = sqlite3.connect(":memory:")  # noqa: SQL001
         self.conn.execute(
-            "CREATE TABLE patch_history(id INTEGER PRIMARY KEY AUTOINCREMENT, outcome TEXT, roi_before REAL, roi_after REAL, complexity_before REAL, complexity_after REAL)"
+            "CREATE TABLE patch_history("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, outcome TEXT, "
+            "roi_before REAL, roi_after REAL, complexity_before REAL, "
+            "complexity_after REAL)"
         )
 
 
@@ -60,7 +75,9 @@ def test_trainer_persists_and_loads_weights(tmp_path: Path) -> None:
     mem = Mem()
     pdb = PDB()
     state = tmp_path / "weights.json"
-    trainer = PromptMemoryTrainer(memory=mem, patch_db=pdb, state_path=state)
+    trainer = PromptMemoryTrainer(
+        memory=mem, patch_db=pdb, state_path=state
+    )
     trainer.append_records(
         [
             {
@@ -82,7 +99,9 @@ def test_append_records_retrains_and_saves(tmp_path: Path) -> None:
     mem = Mem()
     pdb = PDB()
     state = tmp_path / "weights.json"
-    trainer = PromptMemoryTrainer(memory=mem, patch_db=pdb, state_path=state)
+    trainer = PromptMemoryTrainer(
+        memory=mem, patch_db=pdb, state_path=state
+    )
     trainer.append_records(
         [
             {
@@ -110,14 +129,35 @@ def test_append_records_retrains_and_saves(tmp_path: Path) -> None:
 
 
 def test_record_updates_weights(tmp_path: Path) -> None:
-    trainer = PromptMemoryTrainer(memory=object(), patch_db=object(), state_path=tmp_path / "w.json")
-    updated = trainer.record(headers=["H"], example_order=["success"], tone="neutral", success=True)
+    trainer = PromptMemoryTrainer(
+        memory=object(), patch_db=object(), state_path=tmp_path / "w.json"
+    )
+    updated = trainer.record(
+        headers=["H"],
+        example_order=["success"],
+        tone="neutral",
+        has_bullets=True,
+        has_code=False,
+        example_count=2,
+        success=True,
+    )
     assert updated
     # second call toggles success rate
-    updated = trainer.record(headers=["H"], example_order=["success"], tone="neutral", success=False)
+    updated = trainer.record(
+        headers=["H"],
+        example_order=["success"],
+        tone="neutral",
+        has_bullets=True,
+        has_code=False,
+        example_count=2,
+        success=False,
+    )
     assert updated
     hdr_key = json.dumps(["H"])
     assert trainer.style_weights["headers"][hdr_key] == pytest.approx(0.5)
+    assert trainer.style_weights["has_bullets"]["True"] == pytest.approx(0.5)
+    assert trainer.style_weights["has_code"]["False"] == pytest.approx(0.5)
+    assert trainer.style_weights["example_count"]["2"] == pytest.approx(0.5)
 
 
 def test_new_features_influence_weights() -> None:
@@ -155,3 +195,5 @@ def test_new_features_influence_weights() -> None:
     assert weights["example_placement"]["end"] == pytest.approx(0.0)
     assert weights["length"]["short"] == pytest.approx(1.0)
     assert weights["length"]["long"] == pytest.approx(0.0)
+    assert weights["has_bullets"]["True"] == pytest.approx(1.0)
+    assert weights["has_bullets"]["False"] == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- replace regex tone check with VADER sentiment analysis
- track bullets, code blocks, and example count in incremental updates
- persist style weights to prompt_style_weights.json

## Testing
- `pre-commit run --files prompt_memory_trainer.py tests/test_prompt_memory_trainer_incremental.py pyproject.toml requirements.txt .gitignore tests/approved_sqlite3_usage.txt`
- `pytest tests/test_prompt_memory_trainer_incremental.py tests/test_prompt_engine.py::test_prompt_memory_trainer_extracts_new_cues tests/test_prompt_engine.py::test_prompt_memory_trainer_weights_success_by_roi_or_complexity`


------
https://chatgpt.com/codex/tasks/task_e_68b42cb46938832e88854d20eabf50c8