### PR TITLE
Log prompt style metadata in patch history

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -1028,6 +1028,10 @@ class SelfCodingEngine:
                             parent_patch_id=parent_patch_id,
                             reason=reason,
                             trigger=trigger,
+                            outcome="FAIL",
+                            prompt_headers=json.dumps(self._last_prompt_metadata.get("headers", [])),
+                            prompt_order=json.dumps(self._last_prompt_metadata.get("example_order", [])),
+                            prompt_tone=self._last_prompt_metadata.get("tone", ""),
                         )
                     )
                 except Exception:
@@ -1269,6 +1273,10 @@ class SelfCodingEngine:
                         parent_patch_id=parent_patch_id,
                         reason=reason,
                         trigger=trigger,
+                        outcome="SUCCESS" if not reverted else "FAIL",
+                        prompt_headers=json.dumps(self._last_prompt_metadata.get("headers", [])),
+                        prompt_order=json.dumps(self._last_prompt_metadata.get("example_order", [])),
+                        prompt_tone=self._last_prompt_metadata.get("tone", ""),
                     )
                 )
             except Exception as exc:


### PR DESCRIPTION
## Summary
- Record prompt style metadata (headers, example order, tone) and outcomes for each patch in `PatchHistoryDB`
- Teach `PromptMemoryTrainer` to read stored prompt style metadata when updating success metrics
- Store style metadata with patch outcomes inside `SelfCodingEngine`

## Testing
- `pytest tests/test_prompt_memory_trainer_incremental.py::test_record_updates_weights -q`
- `pytest tests/test_prompt_memory_trainer_incremental.py::test_trainer_persists_and_loads_weights -q`
- `pytest tests/test_patch_history.py -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68b43382d414832eba6acc391422449c