### PR TITLE
refactor: add templated enhancement rationales

### DIFF
--- a/enhancement_classifier.py
+++ b/enhancement_classifier.py
@@ -385,11 +385,17 @@ class EnhancementClassifier:
                 + self.weights["history"] * history_corr
             )
 
+            roi_phrase = "dropped" if avg_roi < 0 else "improved"
+            if avg_errors > 0:
+                err_phrase = f"errors increased by {avg_errors:.2f}"
+            elif avg_errors < 0:
+                err_phrase = f"errors decreased by {abs(avg_errors):.2f}"
+            else:
+                err_phrase = "errors unchanged"
             rationale = (
-                f"{patches} patches, avg ROI delta {avg_roi:.2f}, "
-                f"avg error delta {avg_errors:.2f}, avg complexity delta {avg_complexity:.2f}, "
-                f"avg cyclomatic {avg_cc:.2f}, duplication ratio {dup_ratio:.2f}, long functions {long_funcs}, "
-                f"low ROI ratio {neg_roi_ratio:.2f}, error-prone ratio {error_prone_ratio:.2f}"
+                f"module {filename} refactored {patches} times; "
+                f"ROI {roi_phrase} {abs(avg_roi):.2f}%; "
+                f"{err_phrase}"
             )
             all_notes = notes + anti_notes
             if all_notes:

--- a/tests/test_enhancement_classifier.py
+++ b/tests/test_enhancement_classifier.py
@@ -69,7 +69,9 @@ def test_scan_repo_generates_suggestions() -> None:
     assert sugg.path == "mod.py"
     # Frequency=3, ROI=-0.116..., errors=2, complexity=0.4 -> score ~5.52
     assert sugg.score > 5.5
-    assert "avg ROI delta -0.12" in sugg.rationale
+    assert "module mod.py refactored 3 times" in sugg.rationale
+    assert "ROI dropped 0.12%" in sugg.rationale
+    assert "errors increased by 2.00" in sugg.rationale
     assert classifier.thresholds["min_patches"] == 3
 
 


### PR DESCRIPTION
## Summary
- generate templated rationales for modules summarizing refactor count, ROI change, and error trends
- store rationale text when queuing suggestions in PatchSuggestionDB
- adjust tests for new rationale style

## Testing
- `pytest tests/test_enhancement_classifier.py tests/test_enhancement_classifier_queue.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b438d1b8d8832eb1ff63ba02ab1d66