### PR TITLE
feat: extend enhancement metrics and logging

### DIFF
--- a/enhancement_classifier_config.json
+++ b/enhancement_classifier_config.json
@@ -8,11 +8,19 @@
     "duplication": 1.0,
     "length": 1.0,
     "anti": 1.0,
-    "history": 1.0
+    "history": 1.0,
+    "churn": 1.0,
+    "style": 1.0,
+    "refactor": 1.0,
+    "anti_log": 1.0
   },
   "thresholds": {
     "min_patches": 3,
     "roi_cutoff": 0.0,
-    "complexity_delta": 0.0
+    "complexity_delta": 0.0,
+    "churn": 0.0,
+    "style": 0.0,
+    "refactor": 0.0,
+    "anti_pattern": 0.0
   }
 }

--- a/tests/test_enhancement_classifier.py
+++ b/tests/test_enhancement_classifier.py
@@ -139,7 +139,13 @@ def test_ast_metrics_and_scoring(tmp_path: Path) -> None:
         long_funcs,
         neg_roi_ratio,
         error_prone_ratio,
+        func_churn,
+        style_violations,
+        refactor_count,
+        anti_pattern_hits,
         notes,
+        roi_volatility,
+        raroi,
     ) = metrics
     assert filename == "mod.py"
     assert dup_ratio == pytest.approx(1 / 3)
@@ -153,12 +159,17 @@ def test_ast_metrics_and_scoring(tmp_path: Path) -> None:
     expected = (
         classifier.weights["frequency"] * patches
         + classifier.weights["roi"] * (-avg_roi)
+        + classifier.weights["raroi"] * (-raroi)
         + classifier.weights["errors"] * avg_errors
         + classifier.weights["complexity"] * avg_complexity
         + classifier.weights["cyclomatic"] * avg_cc
         + classifier.weights["duplication"] * dup_ratio
         + classifier.weights["length"] * long_funcs
         + classifier.weights["history"] * (neg_roi_ratio + error_prone_ratio) * (avg_cc + dup_ratio)
+        + classifier.weights["churn"] * func_churn
+        + classifier.weights["style"] * style_violations
+        + classifier.weights["refactor"] * refactor_count
+        + classifier.weights["anti_log"] * anti_pattern_hits
     )
     assert suggestions[0].score == pytest.approx(expected)
     assert "duplicated" in suggestions[0].rationale


### PR DESCRIPTION
## Summary
- track churn, style violations, refactor counts, and anti-pattern logs in enhancement metrics
- weight new metrics and expose thresholds in config
- note triggering metrics in suggestion rationale and expand tests

## Testing
- `pytest tests/test_enhancement_classifier.py tests/test_enhancement_classifier_queue.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b443cac7f0832e9d5bf6828a4b7519