### PR TITLE
refactor: add dynamic preset loader

### DIFF
--- a/sandbox_runner/cli.py
+++ b/sandbox_runner/cli.py
@@ -47,7 +47,7 @@ from menace.metrics_dashboard import MetricsDashboard
 from logging_utils import get_logger, setup_logging, set_correlation_id
 
 from foresight_tracker import ForesightTracker
-from .environment import SANDBOX_ENV_PRESETS, simulate_full_environment
+from .environment import load_presets, simulate_full_environment
 
 try:  # optional import for tests
     from menace.environment_generator import generate_presets
@@ -90,7 +90,7 @@ def _run_sandbox(args: argparse.Namespace, sandbox_main=None) -> None:
     if sandbox_main is None:
         from sandbox_runner import _sandbox_main as sandbox_main
 
-    presets = SANDBOX_ENV_PRESETS or [{}]
+    presets = load_presets()
     settings = get_settings()
     if presets == [{}] and not settings.sandbox_env_presets:
         if settings.sandbox_generate_presets:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,8 @@ if "sentence_transformers" not in sys.modules:
 # Provide a lightweight sandbox_runner stub to avoid dependency checks
 sandbox_env = types.ModuleType("sandbox_runner.environment")
 sandbox_env.simulate_temporal_trajectory = lambda *a, **k: None
+sandbox_env.SANDBOX_ENV_PRESETS = [{}]
+sandbox_env.load_presets = lambda: sandbox_env.SANDBOX_ENV_PRESETS
 sandbox_pkg = types.ModuleType("sandbox_runner")
 sandbox_pkg.environment = sandbox_env
 sandbox_pkg.__path__ = [str(ROOT / "sandbox_runner")]

--- a/tests/test_cli_check_resources.py
+++ b/tests/test_cli_check_resources.py
@@ -19,6 +19,9 @@ import os
 
 SANDBOX_ENV_PRESETS = [{}]
 
+def load_presets():
+    return SANDBOX_ENV_PRESETS
+
 def simulate_full_environment(*a, **k):
     pass
 

--- a/tests/test_cli_cleanup.py
+++ b/tests/test_cli_cleanup.py
@@ -20,6 +20,9 @@ from pathlib import Path
 
 SANDBOX_ENV_PRESETS = [{}]
 
+def load_presets():
+    return SANDBOX_ENV_PRESETS
+
 def simulate_full_environment(*a, **k):
     pass
 

--- a/tests/test_cli_purge_leftovers.py
+++ b/tests/test_cli_purge_leftovers.py
@@ -19,6 +19,9 @@ import os
 from pathlib import Path
 SANDBOX_ENV_PRESETS = [{}]
 
+def load_presets():
+    return SANDBOX_ENV_PRESETS
+
 def simulate_full_environment(*a, **k):
     pass
 

--- a/tests/test_cli_system_cleanup.py
+++ b/tests/test_cli_system_cleanup.py
@@ -24,6 +24,9 @@ from pathlib import Path
 
 SANDBOX_ENV_PRESETS = [{}]
 
+def load_presets():
+    return SANDBOX_ENV_PRESETS
+
 def simulate_full_environment(*a, **k):
     pass
 

--- a/tests/test_sandbox_runner_cli_max_depth.py
+++ b/tests/test_sandbox_runner_cli_max_depth.py
@@ -3,10 +3,10 @@ import sys
 import types
 
 def _load_cli(monkeypatch):
-    env_mod = types.SimpleNamespace(
-        SANDBOX_ENV_PRESETS=[{}],
-        simulate_full_environment=lambda *a, **k: None,
-    )
+    env_mod = types.SimpleNamespace()
+    env_mod.SANDBOX_ENV_PRESETS = [{}]
+    env_mod.load_presets = lambda: env_mod.SANDBOX_ENV_PRESETS
+    env_mod.simulate_full_environment = lambda *a, **k: None
     monkeypatch.setitem(sys.modules, "sandbox_runner.environment", env_mod)
     import importlib
     cli = importlib.reload(__import__("sandbox_runner.cli", fromlist=["dummy"]))

--- a/tests/test_sandbox_runner_cli_recursion.py
+++ b/tests/test_sandbox_runner_cli_recursion.py
@@ -4,10 +4,10 @@ import types
 
 
 def _load_cli(monkeypatch):
-    env_mod = types.SimpleNamespace(
-        SANDBOX_ENV_PRESETS=[{}],
-        simulate_full_environment=lambda *a, **k: None,
-    )
+    env_mod = types.SimpleNamespace()
+    env_mod.SANDBOX_ENV_PRESETS = [{}]
+    env_mod.load_presets = lambda: env_mod.SANDBOX_ENV_PRESETS
+    env_mod.simulate_full_environment = lambda *a, **k: None
     monkeypatch.setitem(sys.modules, "sandbox_runner.environment", env_mod)
     import sandbox_runner.cli as cli
 


### PR DESCRIPTION
## Summary
- load SANDBOX_ENV_PRESETS lazily via new `load_presets()` helper
- switch sandbox CLI to use `load_presets()` for preset handling
- adjust tests and stubs to work with dynamic preset loading

## Testing
- `pytest test_sandbox_runner_cli_max_depth.py::test_cli_sets_max_recursion_depth -q` *(fails: argument --entropy-threshold conflict)*
- `pytest tests/test_auto_env_setup.py::test_history_and_presets -q` *(fails: missing dependencies during import)*

------
https://chatgpt.com/codex/tasks/task_e_68b445fea5d8832eaedce688f40b9944