### PR TITLE
feat: persist repo scans and configurable scanning

### DIFF
--- a/self_services_config.py
+++ b/self_services_config.py
@@ -100,4 +100,32 @@ class SelfTestConfig(BaseSettings):
             extra = "ignore"
 
 
-__all__ = ["SelfLearningConfig", "SelfTestConfig"]
+class RepoScanConfig(BaseSettings):
+    """Configuration for repository scanning."""
+
+    enabled: bool = Field(
+        default=True,
+        validation_alias="REPO_SCAN_ENABLED",
+        description="Enable periodic repository scanning for enhancement suggestions.",
+    )
+    interval: int = Field(
+        default=3600,
+        validation_alias="REPO_SCAN_INTERVAL",
+        description="Seconds between repository scans.",
+    )
+
+    @field_validator("interval")
+    @classmethod
+    def _validate_interval(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("interval must be positive")
+        return v
+
+    model_config = SettingsConfigDict(env_prefix="", extra="ignore")
+    if not PYDANTIC_V2:  # pragma: no cover - pydantic v1 fallback
+        class Config:  # type: ignore[no-redef]
+            env_prefix = ""
+            extra = "ignore"
+
+
+__all__ = ["SelfLearningConfig", "SelfTestConfig", "RepoScanConfig"]


### PR DESCRIPTION
## Summary
- log enhancement scan timestamps in patch suggestion database for auditing
- add repo scan config options for enabling and tuning scan interval
- publish repo scan metrics with suggestion counts and top scores

## Testing
- `pre-commit run --files self_coding_manager.py patch_suggestion_db.py self_services_config.py`
- `pytest tests/test_patch_suggestion_db_semantic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b44816f1bc832ea54044f6bb2af209