### PR TITLE
feat: persist prompt style metrics

### DIFF
--- a/prompt_memory_trainer_cli.py
+++ b/prompt_memory_trainer_cli.py
@@ -17,6 +17,12 @@ DEFAULT_STATE_PATH = Path(
         Path(__file__).resolve().parent / "config" / "prompt_memory_weights.json",
     )
 )
+DEFAULT_DB_PATH = Path(
+    os.getenv(
+        "PROMPT_STYLE_DB_PATH",
+        Path(__file__).resolve().parent / "prompt_styles.db",
+    )
+)
 
 
 # ---------------------------------------------------------------------------
@@ -32,13 +38,19 @@ def cli(argv: Iterable[str] | None = None) -> int:
         help="File storing persistent style weights",
     )
     parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=DEFAULT_DB_PATH,
+        help="SQLite database for prompt style statistics",
+    )
+    parser.add_argument(
         "--records",
         type=Path,
         help="JSON file containing new records to append before retraining",
     )
     args = parser.parse_args(list(argv) if argv is not None else None)
 
-    trainer = PromptMemoryTrainer(state_path=args.state_path)
+    trainer = PromptMemoryTrainer(state_path=args.state_path, db_path=args.db_path)
     if args.records:
         with args.records.open("r", encoding="utf-8") as fh:
             data = json.load(fh)
@@ -49,7 +61,7 @@ def cli(argv: Iterable[str] | None = None) -> int:
         trainer.append_records(records)
     else:
         trainer.train()
-    print(f"Saved weights to {args.state_path}")
+    print(f"Saved weights to {args.state_path} and stats to {args.db_path}")
     return 0
 
 

--- a/tests/test_prompt_engine.py
+++ b/tests/test_prompt_engine.py
@@ -5,6 +5,7 @@ import pytest
 import sqlite3 as sq3
 import sys
 import types
+import tempfile
 
 # Stub heavy dependencies before importing the trainer
 sys.modules.setdefault("gpt_memory", types.SimpleNamespace(GPTMemoryManager=object))
@@ -213,7 +214,9 @@ def test_roi_tag_weights_adjust_ranking():
 
 
 def test_prompt_memory_trainer_extracts_new_cues():
-    trainer = PromptMemoryTrainer(memory=object(), patch_db=object())
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    trainer = PromptMemoryTrainer(memory=object(), patch_db=object(), db_path=tmp.name)
     prompt = (
         "System: guidelines\nUser: do this\n- bullet\n```python\npass\n```"
     )
@@ -256,7 +259,9 @@ def test_prompt_memory_trainer_weights_success_by_roi_or_complexity():
     mem.conn.commit()
     pdb.conn.commit()
 
-    trainer = PromptMemoryTrainer(memory=mem, patch_db=pdb)
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    trainer = PromptMemoryTrainer(memory=mem, patch_db=pdb, db_path=tmp.name)
     weights = trainer.train()
     hdr_key = json.dumps(["H"])
     assert weights["headers"][hdr_key] == pytest.approx(2 / 7)


### PR DESCRIPTION
## Summary
- persist prompt style statistics in a sqlite database
- log prompt features and outcomes after each patch
- expose style confidence metrics for monitoring tools

## Testing
- `pytest tests/test_prompt_memory_trainer_incremental.py tests/test_prompt_engine.py::test_prompt_memory_trainer_extracts_new_cues tests/test_prompt_engine.py::test_prompt_memory_trainer_weights_success_by_roi_or_complexity -q`
- `pre-commit run --files prompt_memory_trainer.py prompt_memory_trainer_cli.py tests/test_prompt_memory_trainer_incremental.py tests/test_prompt_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_68b44a0f06c8832eb15b9203198bafbd