### PR TITLE
Add in-memory DB fixtures and expand self-improvement tests

### DIFF
--- a/tests/self_improvement/test_cycle.py
+++ b/tests/self_improvement/test_cycle.py
@@ -16,7 +16,7 @@ def _load_module(name: str, path: Path):
     return module
 
 
-def test_self_improvement_cycle_runs(tmp_path, monkeypatch):
+def test_self_improvement_cycle_runs(tmp_path, monkeypatch, in_memory_dbs):
     menace_pkg = types.ModuleType("menace")
     menace_pkg.__path__ = []
     sys.modules["menace"] = menace_pkg
@@ -42,20 +42,15 @@ def test_self_improvement_cycle_runs(tmp_path, monkeypatch):
     )
     sys.modules["menace.logging_utils"] = logging_utils
 
-    class DummyDB:
-        def __init__(self, *a, **k):
-            pass
+    InMemoryROI, InMemoryStability = in_memory_dbs
+    roi_calls = {"count": 0}
+    orig_log = InMemoryROI.log_result
 
-        def log_result(self, *a, **k):
-            pass
+    def spy(self, **kw):
+        roi_calls["count"] += 1
+        return orig_log(self, **kw)
 
-        def record_metrics(self, *a, **k):
-            pass
-
-    sys.modules["menace.workflow_stability_db"] = types.SimpleNamespace(
-        WorkflowStabilityDB=DummyDB
-    )
-    sys.modules["menace.roi_results_db"] = types.SimpleNamespace(ROIResultsDB=DummyDB)
+    monkeypatch.setattr(InMemoryROI, "log_result", spy)
 
     class DummyLock:
         def __init__(self, *a, **k):
@@ -99,13 +94,15 @@ def test_self_improvement_cycle_runs(tmp_path, monkeypatch):
 
     class DummyPlanner:
         def __init__(self):
-            self.roi_db = None
-            self.stability_db = None
+            self.roi_db = InMemoryROI()
+            self.stability_db = InMemoryStability()
             self.cluster_map = {}
 
         def discover_and_persist(self, workflows):
             calls["count"] += 1
-            return []
+            return [
+                {"chain": ["w"], "roi_gain": 1.0, "failures": 0, "entropy": 0.1}
+            ]
 
     monkeypatch.setattr(meta_planning, "_FallbackPlanner", DummyPlanner)
     monkeypatch.setattr(meta_planning, "MetaWorkflowPlanner", None)
@@ -121,3 +118,159 @@ def test_self_improvement_cycle_runs(tmp_path, monkeypatch):
 
     asyncio.run(run_cycle())
     assert calls["count"] > 0
+    assert roi_calls["count"] > 0
+    assert InMemoryStability.instances[0].data
+
+
+def test_self_improvement_cycle_handles_db_errors(tmp_path, monkeypatch, in_memory_dbs):
+    menace_pkg = types.ModuleType("menace")
+    menace_pkg.__path__ = []
+    sys.modules["menace"] = menace_pkg
+    si_pkg = types.ModuleType("menace.self_improvement")
+    si_pkg.__path__ = [str(Path("self_improvement"))]
+    sys.modules["menace.self_improvement"] = si_pkg
+
+    bootstrap = types.ModuleType("sandbox_runner.bootstrap")
+    bootstrap.initialize_autonomous_sandbox = lambda s: None
+    sys.modules["sandbox_runner.bootstrap"] = bootstrap
+
+    logger = types.SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        exception=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+    )
+    logging_utils = types.SimpleNamespace(
+        get_logger=lambda name: logger,
+        log_record=lambda **k: k,
+        setup_logging=lambda: None,
+    )
+    sys.modules["menace.logging_utils"] = logging_utils
+
+    InMemoryROI, InMemoryStability = in_memory_dbs
+    monkeypatch.setattr(
+        InMemoryROI, "log_result", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+
+    class DummyLock:
+        def __init__(self, *a, **k):
+            pass
+
+        def acquire(self, *a, **k):
+            class Ctx:
+                def __enter__(self_inner):
+                    return self_inner
+
+                def __exit__(self_inner, exc_type, exc, tb):
+                    return False
+
+            return Ctx()
+
+    sys.modules["menace.lock_utils"] = types.SimpleNamespace(
+        SandboxLock=DummyLock, Timeout=Exception, LOCK_TIMEOUT=1
+    )
+    sys.modules["menace.unified_event_bus"] = types.SimpleNamespace(UnifiedEventBus=None)
+    sys.modules["menace.meta_workflow_planner"] = types.SimpleNamespace(
+        MetaWorkflowPlanner=None
+    )
+
+    import sandbox_settings as sandbox_settings_module
+
+    sys.modules["menace.sandbox_settings"] = sandbox_settings_module
+
+    init_module = _load_module("menace.self_improvement.init", Path("self_improvement/init.py"))
+    meta_planning = _load_module(
+        "menace.self_improvement.meta_planning", Path("self_improvement/meta_planning.py")
+    )
+
+    settings = SandboxSettings()
+    settings.sandbox_data_dir = str(tmp_path)
+    settings.sandbox_central_logging = False
+
+    monkeypatch.setattr(init_module, "load_sandbox_settings", lambda: settings)
+    init_module.init_self_improvement()
+
+    class DummyPlanner:
+        def __init__(self):
+            self.roi_db = InMemoryROI()
+            self.stability_db = InMemoryStability()
+            self.cluster_map = {}
+
+        def discover_and_persist(self, workflows):
+            return [
+                {"chain": ["w"], "roi_gain": 1.0, "failures": 0, "entropy": 0.1}
+            ]
+
+    monkeypatch.setattr(meta_planning, "_FallbackPlanner", DummyPlanner)
+    monkeypatch.setattr(meta_planning, "MetaWorkflowPlanner", None)
+
+    async def run_cycle():
+        task = asyncio.create_task(
+            meta_planning.self_improvement_cycle({"w": lambda: None}, interval=0)
+        )
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(run_cycle())
+    # error in ROI logging should not prevent stability metrics from recording
+    assert InMemoryStability.instances[0].data
+
+
+def test_start_self_improvement_cycle_dependency_failure(tmp_path, monkeypatch, in_memory_dbs):
+    menace_pkg = types.ModuleType("menace")
+    menace_pkg.__path__ = []
+    sys.modules["menace"] = menace_pkg
+    si_pkg = types.ModuleType("menace.self_improvement")
+    si_pkg.__path__ = [str(Path("self_improvement"))]
+    sys.modules["menace.self_improvement"] = si_pkg
+
+    logger = types.SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        exception=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+    )
+    logging_utils = types.SimpleNamespace(
+        get_logger=lambda name: logger,
+        log_record=lambda **k: k,
+        setup_logging=lambda: None,
+    )
+    sys.modules["menace.logging_utils"] = logging_utils
+
+    class BoomROI:
+        def __init__(self, *a, **k):
+            raise OSError("no db")
+
+    # WorkflowStabilityDB may still be instantiated successfully
+    InMemoryROI, InMemoryStability = in_memory_dbs
+
+    sys.modules["menace.lock_utils"] = types.SimpleNamespace(
+        SandboxLock=lambda *a, **k: types.SimpleNamespace(
+            __enter__=lambda self: self, __exit__=lambda self, exc_type, exc, tb: False
+        ),
+        Timeout=Exception,
+        LOCK_TIMEOUT=1,
+    )
+    sys.modules["menace.unified_event_bus"] = types.SimpleNamespace(UnifiedEventBus=None)
+    sys.modules["menace.meta_workflow_planner"] = types.SimpleNamespace(
+        MetaWorkflowPlanner=None
+    )
+
+    import sandbox_settings as sandbox_settings_module
+    sys.modules["menace.sandbox_settings"] = sandbox_settings_module
+
+    init_module = _load_module("menace.self_improvement.init", Path("self_improvement/init.py"))
+    meta_planning = _load_module(
+        "menace.self_improvement.meta_planning", Path("self_improvement/meta_planning.py")
+    )
+    monkeypatch.setattr(init_module, "load_sandbox_settings", lambda: SandboxSettings())
+    init_module.init_self_improvement()
+
+    monkeypatch.setattr(meta_planning, "ROIResultsDB", BoomROI)
+
+    with pytest.raises(RuntimeError):
+        meta_planning.start_self_improvement_cycle({"w": lambda: None}, interval=0)


### PR DESCRIPTION
## Summary
- Replace DummyDB stubs with reusable in-memory ROI and stability DB fixtures
- Cover normal, error, and dependency-failure paths in self-improvement cycle
- Exercise start_self_improvement_cycle with realistic DB logging

## Testing
- `pytest tests/self_improvement/test_cycle.py::test_self_improvement_cycle_runs tests/self_improvement/test_cycle.py::test_self_improvement_cycle_handles_db_errors tests/self_improvement/test_cycle.py::test_start_self_improvement_cycle_dependency_failure -q`
- `pre-commit run --files tests/conftest.py tests/self_improvement/test_cycle.py sandbox_runner/tests/test_self_improvement_flow.py`
- `python - <<'PY'
import types, sys
sandbox_env = types.SimpleNamespace(simulate_temporal_trajectory=lambda *a, **k: None, SANDBOX_ENV_PRESETS=[{}], load_presets=lambda: [{}])
sandbox_pkg = types.ModuleType('sandbox_runner')
sandbox_pkg.environment = sandbox_env
sys.modules['sandbox_runner'] = sandbox_pkg
sys.modules['sandbox_runner.environment'] = sandbox_env
import tests.conftest  # ensure fixtures and stubs
import pytest
pytest.main(['sandbox_runner/tests/test_self_improvement_flow.py::test_start_self_improvement_cycle_thread','-q'])
PY` *(fails: fixture 'in_memory_dbs' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d42e5654832e867e28499f4e2b72