### PR TITLE
Refactor self-improvement cycle thread management

### DIFF
--- a/run_autonomous.py
+++ b/run_autonomous.py
@@ -2046,7 +2046,9 @@ def bootstrap(config_path: str = "config/bootstrap.yaml") -> None:
     def _noop():
         return None
 
-    start_self_improvement_cycle({"bootstrap": _noop}, event_bus=bus)
+    cycle_thread = start_self_improvement_cycle({"bootstrap": _noop}, event_bus=bus)
+    cycle_thread.start()
+    cleanup_funcs.append(cycle_thread.stop)
 
     def _cleanup() -> None:
         for func in cleanup_funcs:

--- a/sandbox_runner/tests/test_self_improvement_flow.py
+++ b/sandbox_runner/tests/test_self_improvement_flow.py
@@ -143,9 +143,11 @@ def test_start_self_improvement_cycle_thread(tmp_path, monkeypatch):
     monkeypatch.setattr(meta_planning, "self_improvement_cycle", fake_cycle)
 
     thread = meta_planning.start_self_improvement_cycle(
-        {"w": lambda: None}, event_bus=types.SimpleNamespace(publish=lambda *a, **k: None), interval=0
+        {"w": lambda: None},
+        event_bus=types.SimpleNamespace(publish=lambda *a, **k: None),
+        interval=0,
     )
 
-    assert thread.daemon
+    thread.start()
     thread.join(timeout=1)
     assert calls["count"] >= 1


### PR DESCRIPTION
## Summary
- Refactor `start_self_improvement_cycle` to return a thread wrapper with `start`, `join`, and `stop` methods
- Relay exceptions from the background cycle via a thread-safe queue and cancel gracefully on `stop`
- Update orchestration and tests for the new lifecycle management

## Testing
- `pytest tests/test_start_self_improvement_cycle.py sandbox_runner/tests/test_self_improvement_flow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b44a100e6c832eae15b722032f3ac5