### PR TITLE
Track enhancement suggestion outcomes and reporting

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -871,6 +871,7 @@ class SelfCodingEngine:
         requesting_bot: str | None = None,
         context_meta: Dict[str, Any] | None = None,
         effort_estimate: float | None = None,
+        suggestion_id: int | None = None,
     ) -> tuple[int | None, bool, float]:
         """Patch file, run CI and benchmark a workflow.
 
@@ -1382,6 +1383,27 @@ class SelfCodingEngine:
                 )
         except Exception:
             self.logger.exception("failed to log patch outcome")
+        if (
+            suggestion_id is not None
+            and self.patch_suggestion_db
+            and patch_id is not None
+        ):
+            try:
+                error_delta = 0.0
+                if self.patch_db:
+                    rec = self.patch_db.get(patch_id)
+                    if rec:
+                        error_delta = float(
+                            (rec.errors_after or 0) - (rec.errors_before or 0)
+                        )
+                self.patch_suggestion_db.log_enhancement_outcome(
+                    suggestion_id,
+                    patch_id,
+                    roi_delta,
+                    error_delta,
+                )
+            except Exception:
+                self.logger.exception("failed to log enhancement outcome")
         if self.cognition_layer and session_id:
             try:
                 self.cognition_layer.record_patch_outcome(

--- a/tests/test_enhancement_outcomes_reporting.py
+++ b/tests/test_enhancement_outcomes_reporting.py
@@ -1,0 +1,18 @@
+import pytest
+from patch_suggestion_db import PatchSuggestionDB, SuggestionRecord
+
+
+def test_enhancement_outcome_reporting(tmp_path):
+    db = PatchSuggestionDB(tmp_path / "s.db")
+    # Add suggestion and capture ID
+    rec = SuggestionRecord(module="mod.py", description="refactor")
+    sugg_id = db.add(rec)
+    assert sugg_id
+    # Log two outcomes for same suggestion
+    db.log_enhancement_outcome(sugg_id, 1, roi_delta=0.5, error_delta=-1.0)
+    db.log_enhancement_outcome(sugg_id, 2, roi_delta=1.0, error_delta=-2.0)
+    report = db.enhancement_report()
+    assert report[0]["suggestion_id"] == sugg_id
+    assert report[0]["patch_count"] == 2
+    assert report[0]["avg_roi_delta"] == pytest.approx(0.75)
+    assert report[0]["avg_error_delta"] == pytest.approx(-1.5)


### PR DESCRIPTION
## Summary
- add `enhancement_outcomes` table to `PatchSuggestionDB` with logging and reporting helpers
- record enhancement suggestion metrics on patch completion
- cover enhancement outcome reporting in tests

## Testing
- `pytest tests/test_enhancement_suggestions_db.py tests/test_patch_suggestion_db_semantic.py tests/test_patch_suggestion_vector_search.py tests/test_enhancement_outcomes_reporting.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4d8a40434832e93e2650e62b63349