### PR TITLE
Add LLM interface protocol and dataclasses

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,6 +19,7 @@ from .foresight_tracker import ForesightTracker
 from .upgrade_forecaster import UpgradeForecaster
 from .workflow_synthesizer import WorkflowSynthesizer
 from .workflow_synergy_comparator import WorkflowSynergyComparator
+from .llm_interface import LLMClient, LLMResult, Prompt
 
 from . import metrics_exporter
 
@@ -374,6 +375,10 @@ __all__ = [
     "variant_manager",
     "cognition_layer",
     "CompositeWorkflowScorer",
+    "Prompt",
+    "LLMResult",
+    "LLMClient",
+    "llm_interface",
 ]
 __all__.append("readiness_index")
 __version__ = "0.1.0"

--- a/llm_interface.py
+++ b/llm_interface.py
@@ -1,0 +1,43 @@
+"""Lightweight LLM interface definitions.
+
+This module defines simple dataclasses for LLM prompts and results as well as
+an ``LLMClient`` protocol for generating responses.  The goal is to provide a
+minimal interface that different LLM backends can implement without pulling in
+heavy dependencies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Protocol
+
+
+@dataclass(slots=True)
+class Prompt:
+    """Input to an LLM generation call."""
+
+    text: str
+    examples: List[str] = field(default_factory=list)
+    metadata: Dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class LLMResult:
+    """Result returned by an :class:`LLMClient`."""
+
+    raw: Dict[str, object] = field(default_factory=dict)
+    text: str = ""
+
+
+class LLMClient(Protocol):
+    """Protocol describing the minimal LLM client interface."""
+
+    def generate(self, prompt: Prompt) -> LLMResult:  # pragma: no cover - interface
+        """Generate a response for *prompt*.
+
+        Implementations should return an :class:`LLMResult` with the model's
+        response as ``text`` and any raw payload in ``raw``.
+        """
+
+
+__all__ = ["Prompt", "LLMResult", "LLMClient"]


### PR DESCRIPTION
## Summary
- add `llm_interface` module defining `Prompt`, `LLMResult`, and `LLMClient`
- expose new LLM interfaces at package root via `__all__`

## Testing
- `pytest` (fails: 384 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68b4db57ee98832ebced5d19cd4a7479