### PR TITLE
feat: configure patch retries via settings

### DIFF
--- a/docs/sandbox_runner.md
+++ b/docs/sandbox_runner.md
@@ -441,6 +441,8 @@ Network behaviour can be tuned with:
   posture.
 - `SANDBOX_PATCH_RETRIES` – number of patch attempts `SelfDebuggerSandbox`
   performs before giving up (default `3`).
+- `SANDBOX_PATCH_RETRY_DELAY` – delay in seconds between patch attempts
+  (default `0.1`).
 - `VISUAL_AGENT_TOKEN` – authentication token passed to `menace_visual_agent_2.py`.
 - `SANDBOX_REPO_PATH` – local path of the sandbox repository clone.
 - `SANDBOX_DATA_DIR` – directory used for ROI history and patch records.

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -801,6 +801,16 @@ class SandboxSettings(BaseSettings):
         env="PATCH_SCORE_BACKEND",
         description="Module path to patch score backend implementation.",
     )
+    patch_retries: int = Field(
+        3,
+        env="SANDBOX_PATCH_RETRIES",
+        description="Number of attempts made when generating a patch.",
+    )
+    patch_retry_delay: float = Field(
+        0.1,
+        env="SANDBOX_PATCH_RETRY_DELAY",
+        description="Delay in seconds between patch generation attempts.",
+    )
     flakiness_runs: int = Field(
         5,
         env="FLAKINESS_RUNS",

--- a/self_improvement/patch_generation.py
+++ b/self_improvement/patch_generation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 from .utils import _load_callable, _call_with_retries
+from ..sandbox_settings import SandboxSettings
 
 try:  # pragma: no cover - simplified environments
     from ..logging_utils import log_record
@@ -13,8 +14,14 @@ except Exception:  # pragma: no cover - best effort
         return fields
 
 
+_settings = SandboxSettings()
+
+
 def generate_patch(
-    *args: object, retries: int = 3, delay: float = 0.1, **kwargs: object
+    *args: object,
+    retries: int = _settings.patch_retries,
+    delay: float = _settings.patch_retry_delay,
+    **kwargs: object,
 ) -> int:
     """Generate a patch via :mod:`quick_fix_engine`.
 

--- a/tests/test_bootstrap_service_deps.py
+++ b/tests/test_bootstrap_service_deps.py
@@ -33,6 +33,8 @@ class SandboxSettings:
             "relevancy_radar": "1.0.0",
             "quick_fix_engine": "1.0.0",
         }
+        self.patch_retries = 3
+        self.patch_retry_delay = 0.1
 
 
 sandbox_settings.SandboxSettings = SandboxSettings

--- a/tests/test_self_improvement_engine_adaptive_roi.py
+++ b/tests/test_self_improvement_engine_adaptive_roi.py
@@ -146,6 +146,8 @@ def _load_engine():
         growth_multiplier_linear=1.0,
         growth_multiplier_marginal=0.8,
         sandbox_data_dir=".",
+        patch_retries=3,
+        patch_retry_delay=0.1,
     )
     sys.modules["sandbox_settings"] = sandbox_settings
 

--- a/tests/test_self_improvement_logging.py
+++ b/tests/test_self_improvement_logging.py
@@ -146,6 +146,8 @@ sandbox_settings.SandboxSettings = lambda: types.SimpleNamespace(
     enable_alignment_flagger=True,
     alignment_warning_threshold=0.5,
     alignment_failure_threshold=0.9,
+    patch_retries=3,
+    patch_retry_delay=0.1,
 )
 sys.modules["sandbox_settings"] = sandbox_settings
 


### PR DESCRIPTION
## Summary
- source patch generation defaults from SandboxSettings
- expose patch_retries and patch_retry_delay config fields
- allow self-improvement helpers to override patch generation retries

## Testing
- `pytest tests/test_quick_fix_engine.py::test_generate_patch -q` *(fails: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68b4da1cde20832e9ea578839a36cd1f