### PR TITLE
Add stoppable self-improvement cycle

### DIFF
--- a/run_autonomous.py
+++ b/run_autonomous.py
@@ -1985,7 +1985,10 @@ def bootstrap(config_path: str = "config/bootstrap.yaml") -> None:
     from pydantic import ValidationError
     from sandbox_settings import load_sandbox_settings
     from self_improvement import init_self_improvement
-    from self_improvement.orchestration import start_self_improvement_cycle
+    from self_improvement.orchestration import (
+        start_self_improvement_cycle,
+        stop_self_improvement_cycle,
+    )
     from unified_event_bus import UnifiedEventBus
     from roi_results_db import ROIResultsDB
     from workflow_stability_db import WorkflowStabilityDB
@@ -2048,7 +2051,7 @@ def bootstrap(config_path: str = "config/bootstrap.yaml") -> None:
 
     cycle_thread = start_self_improvement_cycle({"bootstrap": _noop}, event_bus=bus)
     cycle_thread.start()
-    cleanup_funcs.append(cycle_thread.stop)
+    cleanup_funcs.append(stop_self_improvement_cycle)
 
     def _cleanup() -> None:
         for func in cleanup_funcs:

--- a/self_improvement/__init__.py
+++ b/self_improvement/__init__.py
@@ -144,6 +144,7 @@ from .orchestration import (
     post_round_orphan_scan,
     self_improvement_cycle,
     start_self_improvement_cycle,
+    stop_self_improvement_cycle,
 )
 from .metrics import _update_alignment_baseline
 from .patch_generation import generate_patch

--- a/self_improvement/orchestration.py
+++ b/self_improvement/orchestration.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 """Orchestration helpers for the self-improvement engine."""
 
 from .orphan_integration import integrate_orphans, post_round_orphan_scan
-from .meta_planning import self_improvement_cycle, start_self_improvement_cycle
+from .meta_planning import (
+    self_improvement_cycle,
+    start_self_improvement_cycle,
+    stop_self_improvement_cycle,
+)
 
 __all__ = [
     "integrate_orphans",
     "post_round_orphan_scan",
     "self_improvement_cycle",
     "start_self_improvement_cycle",
+    "stop_self_improvement_cycle",
 ]


### PR DESCRIPTION
## Summary
- allow the self-improvement cycle to stop cleanly via a threading.Event
- expose `stop_self_improvement_cycle` and wire it into orchestrators

## Testing
- `pytest unit_tests/test_meta_planning.py -q`
- `pytest tests/test_start_self_improvement_cycle.py -q`
- `pytest tests/test_self_improvement_cycle_regression.py -q`
- `pytest tests/integration/test_self_improvement_cycle.py -q` *(fails: ImportError: cannot import name 'RAISE_ERRORS')*
- `pytest tests/integration/test_full_self_improvement_cycle.py -q`
- `pytest tests/self_improvement/test_cycle.py -q`
- `pytest sandbox_runner/tests/test_self_improvement_flow.py -q` *(fails: fixture 'in_memory_dbs' not found)*
- `pytest tests/test_foresight_tracker.py::test_capture_from_roi_self_improvement_cycle_affects_stability -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4de684bf0832ebe9f0d37f4515f46