### PR TITLE
Add dependency verification for self-improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1309,8 +1309,11 @@ workflows and troubleshooting tips.
 
 #### Required packages
 
-- `sandbox_runner`
+- `sandbox_runner` (including the `sandbox_runner.orphan_integration` module)
 - `quick_fix_engine`
+
+The `init_self_improvement` routine verifies these dependencies at startup and
+raises a `RuntimeError` with installation guidance when they are missing.
 
 #### Optional packages
 

--- a/docs/sandbox_self_improvement.md
+++ b/docs/sandbox_self_improvement.md
@@ -6,10 +6,11 @@ to run self-improvement cycles inside the sandbox.
 ## Required packages
 
 - Install core dependencies with `./setup_env.sh` or `pip install -r requirements.txt`.
-- `sandbox_runner` and `quick_fix_engine` provide the execution harness and patch
-  generation. These packages are **not** installed automatically; if they are
-  missing the self-improvement utilities raise a ``RuntimeError`` with guidance
-  to install them manually (e.g. ``pip install sandbox_runner quick_fix_engine``).
+- `sandbox_runner` (including the ``sandbox_runner.orphan_integration`` module)
+  and `quick_fix_engine` provide the execution harness and patch generation.
+  These packages are **not** installed automatically; if they are missing the
+  self-improvement utilities raise a ``RuntimeError`` with guidance to install
+  them manually (e.g. ``pip install sandbox_runner quick_fix_engine``).
 
 ## Optional packages
 

--- a/docs/sandbox_self_improvement_configuration.md
+++ b/docs/sandbox_self_improvement_configuration.md
@@ -7,8 +7,8 @@ advice for common setup problems.
 ## Required dependencies
 - Run `./setup_env.sh` or install packages from `requirements.txt` to provide core Python libraries.
 - The self-improvement engine requires optional helpers. Missing modules such as
-  `sandbox_runner` or `quick_fix_engine` raise a runtime error, so ensure they are
-  available before enabling related features.
+  `sandbox_runner.orphan_integration` or `quick_fix_engine` raise a runtime
+  error, so ensure they are available before enabling related features.
 - Some sandbox features rely on external binaries like `ffmpeg` and `tesseract`.
   Verify they are on your `PATH` after installing the Python environment.
 
@@ -31,8 +31,8 @@ advice for common setup problems.
 ## Troubleshooting
 ### Missing modules
 - Self-improvement cycles fail fast when helper modules are missing. Install
-  `sandbox_runner` and `quick_fix_engine` or remove the feature flags that
-  enable them.
+  `sandbox_runner` (with the `sandbox_runner.orphan_integration` module) and
+  `quick_fix_engine` or remove the feature flags that enable them.
 - If Python dependencies are missing, rerun `./setup_env.sh` and check that
   `ffmpeg` and `tesseract` are installed.
 

--- a/self_improvement/init.py
+++ b/self_improvement/init.py
@@ -1,3 +1,13 @@
+"""Helpers for the self-improvement subsystem.
+
+The routines expect auxiliary packages to be installed:
+
+* ``quick_fix_engine`` – generates corrective patches.
+* ``sandbox_runner.orphan_integration`` – reintroduces orphaned modules.
+
+Missing dependencies raise :class:`RuntimeError` with guidance on how to
+install them.
+"""
 from __future__ import annotations
 
 import json
@@ -27,6 +37,26 @@ except Exception:  # pragma: no cover - simplified environments
 
 logger = get_logger(__name__)
 settings = SandboxSettings()
+
+
+def verify_dependencies() -> None:
+    """Ensure optional helper packages for self-improvement are installed."""
+
+    try:
+        import quick_fix_engine  # type: ignore # noqa: F401
+    except Exception as exc:  # pragma: no cover - import guidance
+        raise RuntimeError(
+            "quick_fix_engine is required for self-improvement. "
+            "Install it with 'pip install quick_fix_engine'."
+        ) from exc
+
+    try:
+        import sandbox_runner.orphan_integration  # type: ignore # noqa: F401
+    except Exception as exc:  # pragma: no cover - import guidance
+        raise RuntimeError(
+            "sandbox_runner.orphan_integration is required for self-improvement. "
+            "Install the sandbox_runner package or ensure it is on PYTHONPATH."
+        ) from exc
 
 
 def _lock_for(path: Path) -> FileLock:
@@ -246,6 +276,7 @@ def init_self_improvement(new_settings: SandboxSettings | None = None) -> Sandbo
 
     global settings
     settings = new_settings or load_sandbox_settings()
+    verify_dependencies()
     initialize_autonomous_sandbox(settings)
     if getattr(settings, "sandbox_central_logging", False):
         setup_logging()
@@ -271,4 +302,5 @@ __all__ = [
     "_atomic_write",
     "get_default_synergy_weights",
     "reload_synergy_weights",
+    "verify_dependencies",
 ]

--- a/tests/integration/test_self_improvement_cycle.py
+++ b/tests/integration/test_self_improvement_cycle.py
@@ -212,6 +212,22 @@ def test_background_self_improvement_loop(monkeypatch):
     monkeypatch.setitem(sys.modules, "sandbox_runner.orphan_integration", orphan_mod)
     monkeypatch.setitem(sys.modules, "sandbox_runner.bootstrap", bootstrap_mod)
 
+    quick_fix = types.ModuleType("quick_fix_engine")
+    monkeypatch.setitem(sys.modules, "quick_fix_engine", quick_fix)
+
+    cws_mod = types.ModuleType("composite_workflow_scorer")
+    cws_mod.CompositeWorkflowScorer = object
+    monkeypatch.setitem(sys.modules, "composite_workflow_scorer", cws_mod)
+    monkeypatch.setitem(
+        sys.modules, "menace_sandbox.composite_workflow_scorer", cws_mod
+    )
+    wem = types.ModuleType("workflow_evolution_manager")
+    wem.WorkflowEvolutionManager = object
+    monkeypatch.setitem(sys.modules, "workflow_evolution_manager", wem)
+    monkeypatch.setitem(
+        sys.modules, "menace_sandbox.workflow_evolution_manager", wem
+    )
+
     orphan_disc = types.ModuleType("orphan_discovery")
     orphan_disc.append_orphan_cache = lambda *a, **k: None
     orphan_disc.append_orphan_classifications = lambda *a, **k: None

--- a/tests/self_improvement/test_cycle.py
+++ b/tests/self_improvement/test_cycle.py
@@ -16,7 +16,22 @@ def _load_module(name: str, path: Path):
     return module
 
 
+def _stub_deps():
+    sys.modules.setdefault("quick_fix_engine", types.ModuleType("quick_fix_engine"))
+    sr_pkg = types.ModuleType("sandbox_runner")
+    sr_pkg.__path__ = []
+    sys.modules.setdefault("sandbox_runner", sr_pkg)
+    boot = types.ModuleType("sandbox_runner.bootstrap")
+    boot.initialize_autonomous_sandbox = lambda *a, **k: None
+    sys.modules.setdefault("sandbox_runner.bootstrap", boot)
+    sys.modules.setdefault(
+        "sandbox_runner.orphan_integration",
+        types.ModuleType("sandbox_runner.orphan_integration"),
+    )
+
+
 def test_self_improvement_cycle_runs(tmp_path, monkeypatch, in_memory_dbs):
+    _stub_deps()
     menace_pkg = types.ModuleType("menace")
     menace_pkg.__path__ = []
     sys.modules["menace"] = menace_pkg

--- a/tests/self_improvement/test_init.py
+++ b/tests/self_improvement/test_init.py
@@ -16,7 +16,22 @@ def _load_module(name: str, path: Path):
     return module
 
 
+def _stub_deps():
+    sys.modules.setdefault("quick_fix_engine", types.ModuleType("quick_fix_engine"))
+    sr_pkg = types.ModuleType("sandbox_runner")
+    sr_pkg.__path__ = []
+    sys.modules.setdefault("sandbox_runner", sr_pkg)
+    boot = types.ModuleType("sandbox_runner.bootstrap")
+    boot.initialize_autonomous_sandbox = lambda *a, **k: None
+    sys.modules.setdefault("sandbox_runner.bootstrap", boot)
+    sys.modules.setdefault(
+        "sandbox_runner.orphan_integration",
+        types.ModuleType("sandbox_runner.orphan_integration"),
+    )
+
+
 def test_get_default_synergy_weights_reflects_settings(monkeypatch):
+    _stub_deps()
     menace_pkg = types.ModuleType("menace")
     menace_pkg.__path__ = []
     sys.modules["menace"] = menace_pkg
@@ -61,6 +76,7 @@ def test_get_default_synergy_weights_reflects_settings(monkeypatch):
 
 
 def test_init_creates_synergy_weights(tmp_path, monkeypatch):
+    _stub_deps()
     menace_pkg = types.ModuleType("menace")
     menace_pkg.__path__ = []
     sys.modules["menace"] = menace_pkg
@@ -107,6 +123,7 @@ def test_init_creates_synergy_weights(tmp_path, monkeypatch):
 
 
 def test_init_meta_planning_failure(tmp_path, monkeypatch, caplog):
+    _stub_deps()
     menace_pkg = types.ModuleType("menace")
     menace_pkg.__path__ = []
     sys.modules["menace"] = menace_pkg


### PR DESCRIPTION
## Summary
- add `verify_dependencies` to ensure `quick_fix_engine` and `sandbox_runner.orphan_integration` are present
- call `verify_dependencies` during self-improvement initialisation
- document required packages in README and self-improvement docs

## Testing
- `pytest tests/self_improvement/test_init.py tests/self_improvement/test_cycle.py -q`
- `pytest tests/integration/test_self_improvement_cycle.py::test_background_self_improvement_loop -q` *(fails: ImportError: cannot import name 'RAISE_ERRORS' from 'menace')*

------
https://chatgpt.com/codex/tasks/task_e_68b4e10b4678832eabb2d7ef0ecf627e