### PR TITLE
Add prompt logging database

### DIFF
--- a/prompt_db.py
+++ b/prompt_db.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+from db_router import DBRouter, LOCAL_TABLES
+from llm_interface import Prompt, LLMResult
+
+# Ensure the prompts table is treated as local
+LOCAL_TABLES.add("prompts")
+
+
+class PromptDB:
+    """Lightweight SQLite logger for LLM prompts."""
+
+    def __init__(self, model: str, path: str | None = None, router: DBRouter | None = None) -> None:
+        self.model = model
+        db_path = Path(path or os.getenv("PROMPT_DB_PATH", "prompts.db"))
+        self.router = router or DBRouter("prompts", str(db_path), str(db_path))
+        self.conn = self.router.get_connection("prompts", operation="write")
+        self._init_db()
+
+    def _init_db(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS prompts(
+                id INTEGER PRIMARY KEY,
+                text TEXT,
+                examples TEXT,
+                confidence REAL,
+                tags TEXT,
+                response_raw TEXT,
+                response_text TEXT,
+                model TEXT,
+                timestamp TEXT
+            )
+            """,
+        )
+        self.conn.commit()
+
+    def log_prompt(
+        self, prompt: Prompt, result: LLMResult, tags: List[str], confidence: float
+    ) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO prompts(
+                text, examples, confidence, tags, response_raw,
+                response_text, model, timestamp
+            )
+            VALUES (?,?,?,?,?,?,?,?)
+            """,
+            (
+                prompt.text,
+                json.dumps(prompt.examples),
+                confidence,
+                json.dumps(tags),
+                json.dumps(result.raw),
+                result.text,
+                self.model,
+                datetime.utcnow().isoformat(),
+            ),
+        )
+        self.conn.commit()

--- a/tests/test_prompt_db.py
+++ b/tests/test_prompt_db.py
@@ -1,0 +1,45 @@
+import json
+import os
+
+from prompt_db import PromptDB
+from llm_interface import Prompt, LLMResult
+from openai_client import OpenAILLMClient
+
+
+def test_log_prompt(tmp_path):
+    os.environ["PROMPT_DB_PATH"] = str(tmp_path / "prompts.db")
+    db = PromptDB(model="gpt-test")
+    prompt = Prompt(text="hi", examples=["ex1"])
+    result = LLMResult(raw={"data": 1}, text="hello")
+    db.log_prompt(prompt, result, ["test"], 0.5)
+    row = db.conn.execute(
+        "SELECT text, examples, confidence, tags, response_text, model FROM prompts"
+    ).fetchone()
+    assert row[0] == "hi"
+    assert json.loads(row[1]) == ["ex1"]
+    assert row[2] == 0.5
+    assert json.loads(row[3]) == ["test"]
+    assert row[4] == "hello"
+    assert row[5] == "gpt-test"
+
+
+def test_openai_client_logs_prompt(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setenv("PROMPT_DB_PATH", str(tmp_path / "prompts.db"))
+    client = OpenAILLMClient(model="gpt-test")
+
+    def fake_request(self, payload):
+        return {"choices": [{"message": {"content": "world"}}]}
+
+    monkeypatch.setattr(OpenAILLMClient, "_request", fake_request)
+    prompt = Prompt(text="hi", metadata={"tags": ["t"], "confidence": 0.9})
+    res = client.generate(prompt)
+    assert res.text == "world"
+    row = client.db.conn.execute(
+        "SELECT text, tags, confidence, response_text, model FROM prompts"
+    ).fetchone()
+    assert row[0] == "hi"
+    assert json.loads(row[1]) == ["t"]
+    assert row[2] == 0.9
+    assert row[3] == "world"
+    assert row[4] == "gpt-test"


### PR DESCRIPTION
## Summary
- add PromptDB for recording prompts and responses
- log tags and confidence for each OpenAI client request
- ensure prompt usage stored in SQLite

## Testing
- `pre-commit run --files prompt_db.py openai_client.py tests/test_prompt_db.py`
- `pytest tests/test_prompt_db.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4e04884c8832eb63f038443330d7e