### PR TITLE
Expose metrics skip directories via settings

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -1433,6 +1433,24 @@ class SandboxSettings(BaseSettings):
         ),
     )
 
+    metrics_skip_dirs: list[str] = Field(
+        default_factory=lambda: [
+            ".git",
+            "bin",
+            "build",
+            "dist",
+            "node_modules",
+            "site-packages",
+            "venv",
+            ".venv",
+            "vendor",
+            "third_party",
+            "__pycache__",
+        ],
+        env="METRICS_SKIP_DIRS",
+        description="Directories to skip when collecting code metrics.",
+    )
+
     # self test integration scoring knobs
     integration_score_threshold: float = Field(
         0.0,

--- a/tests/test_metrics_maintainability.py
+++ b/tests/test_metrics_maintainability.py
@@ -102,3 +102,23 @@ def test_radon_metrics_used(monkeypatch, tmp_path):
     assert avg == 88.0
     assert calls == {"cc": 1, "mi": 1}
     assert tests == 0
+
+
+def test_skip_dirs_setting(tmp_path):
+    metrics = _load_metrics()
+    build = tmp_path / "build"
+    build.mkdir()
+    src = build / "foo.py"
+    src.write_text("def f():\n    return 1\n")
+
+    per_file, total, avg, tests = metrics._collect_metrics([src], tmp_path)
+    assert per_file == {}
+    assert total == 0
+    assert avg == 0.0
+    assert tests == 0
+
+    settings = metrics.SandboxSettings(metrics_skip_dirs=[])
+    per_file, total, avg, tests = metrics._collect_metrics(
+        [src], tmp_path, settings=settings
+    )
+    assert "build/foo.py" in per_file


### PR DESCRIPTION
## Summary
- make skipped directories for metrics configurable through `SandboxSettings`
- use `metrics_skip_dirs` when collecting alignment metrics
- test configurable skip directories

## Testing
- `pytest tests/test_metrics_maintainability.py -q`
- `pytest tests/test_alignment_baseline_update.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4e5b56718832e845a49c3ff31eab2