### PR TITLE
Use Prompt objects for self-coding prompts

### DIFF
--- a/llm_interface.py
+++ b/llm_interface.py
@@ -9,7 +9,7 @@ heavy dependencies.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Protocol
+from typing import Any, Dict, List, Protocol
 
 
 @dataclass(slots=True)
@@ -19,6 +19,47 @@ class Prompt:
     text: str
     examples: List[str] = field(default_factory=list)
     metadata: Dict[str, object] = field(default_factory=dict)
+
+    # The original codebase often treated prompts as raw strings.  To ease the
+    # transition to the structured :class:`Prompt` object, the dataclass mimics
+    # ``str`` behaviour for common operations.  This allows existing callers
+    # that perform string operations such as ``in`` checks or ``.index`` calls to
+    # continue working without modification while still exposing the structured
+    # fields.
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.text
+
+    def __eq__(self, other: object) -> bool:  # pragma: no cover - defensive
+        if isinstance(other, Prompt):
+            return (
+                self.text == other.text
+                and self.examples == other.examples
+                and self.metadata == other.metadata
+            )
+        if isinstance(other, str):
+            return self.text == other
+        return False
+
+    def __contains__(self, item: str) -> bool:  # pragma: no cover - delegation
+        return item in self.text
+
+    def __getattr__(self, name: str) -> Any:  # pragma: no cover - delegation
+        return getattr(self.text, name)
+
+    def __add__(self, other: object):  # pragma: no cover - delegation
+        if isinstance(other, Prompt):
+            return self.text + other.text
+        if isinstance(other, str):
+            return self.text + other
+        return NotImplemented
+
+    def __radd__(self, other: object):  # pragma: no cover - delegation
+        if isinstance(other, str):
+            return other + self.text
+        if isinstance(other, Prompt):
+            return other.text + self.text
+        return NotImplemented
 
 
 @dataclass(slots=True)

--- a/tests/test_self_coding_engine_logging.py
+++ b/tests/test_self_coding_engine_logging.py
@@ -3,6 +3,8 @@ import sys
 import types
 from pathlib import Path
 
+from llm_interface import LLMResult
+
 # Lightweight stubs to satisfy imports
 vec_mod = types.ModuleType("vector_service")
 class _VSError(Exception):
@@ -121,7 +123,7 @@ def test_roi_tracker_logging(caplog):
 
 
 def test_knowledge_service_logging(monkeypatch, caplog):
-    llm = types.SimpleNamespace(gpt_memory=None)
+    llm = types.SimpleNamespace(gpt_memory=None, generate=lambda prompt: LLMResult(text=""))
     engine = SelfCodingEngine(
         object(),
         DummyMemory(),
@@ -137,7 +139,6 @@ def test_knowledge_service_logging(monkeypatch, caplog):
     monkeypatch.setattr(sce, "recent_feedback", boom)
     monkeypatch.setattr(sce, "recent_improvement_path", boom)
     monkeypatch.setattr(sce, "recent_error_fix", boom)
-    monkeypatch.setattr(sce, "ask_with_memory", lambda *a, **k: {})
     monkeypatch.setattr(sce.SelfCodingEngine, "_get_repo_layout", lambda self, lines: "")
     monkeypatch.setattr(sce.PromptEngine, "build_prompt", staticmethod(lambda *a, **k: ""))
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- extend PromptEngine.build_prompt to return a `Prompt`
- update self_coding_engine to pass `Prompt` instances to `llm_client.generate`
- make `Prompt` dataclass str-compatible and adjust helper tests

## Testing
- `pytest tests/test_prompt_engine.py`
- `pytest tests/test_prompt_engine_fallback.py`
- `pytest tests/test_prompt_engine_vector_service.py`
- `pytest tests/test_context_builder.py` *(fails: ModuleNotFoundError: No module named 'pylint.reporters.text'; 'pylint.reporters' is not a package)*
- `pytest tests/test_self_coding_engine.py` *(fails: TypeError: object() takes no arguments)*
- `pytest tests/test_build_visual_agent_prompt.py` *(fails: attempted relative import with no known parent package)*
- `pytest tests/test_generate_helper_fallback.py` *(fails: ValueError: jinja2.__spec__ is None)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e40dd004832e828ff4dcdd7438a0