### PR TITLE
Add local LLM clients with routing and configurable backends

### DIFF
--- a/llm_router.py
+++ b/llm_router.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+"""Routing helpers for language model backends."""
+
+from typing import Dict, Callable
+
+from llm_interface import Prompt, LLMResult, LLMClient
+from sandbox_settings import SandboxSettings
+
+# Deferred imports to avoid pulling in heavy dependencies on module import.
+ClientFactory = Callable[[], LLMClient]
+
+
+def _openai_factory() -> LLMClient:  # pragma: no cover - simple wrapper
+    from openai_client import OpenAILLMClient
+    return OpenAILLMClient()
+
+
+def _ollama_factory() -> LLMClient:  # pragma: no cover - simple wrapper
+    from local_client import OllamaClient
+    return OllamaClient()
+
+
+def _vllm_factory() -> LLMClient:  # pragma: no cover - simple wrapper
+    from local_client import VLLMClient
+    return VLLMClient()
+
+
+_FACTORIES: Dict[str, ClientFactory] = {
+    "openai": _openai_factory,
+    "ollama": _ollama_factory,
+    "vllm": _vllm_factory,
+}
+
+
+class LLMRouter(LLMClient):
+    """Route requests between remote and local backends.
+
+    The router chooses the remote backend for larger prompts while favouring
+    the local backend for smaller ones.  If the selected backend raises an
+    exception, the other backend is attempted as a fallback.
+    """
+
+    def __init__(self, remote: LLMClient, local: LLMClient, *, size_threshold: int = 1000) -> None:
+        self.remote = remote
+        self.local = local
+        self.size_threshold = size_threshold
+
+    def generate(self, prompt: Prompt) -> LLMResult:
+        primary = self.remote if len(prompt.text) > self.size_threshold else self.local
+        fallback = self.local if primary is self.remote else self.remote
+        try:
+            return primary.generate(prompt)
+        except Exception:
+            return fallback.generate(prompt)
+
+
+def client_from_settings(settings: SandboxSettings | None = None, *, size_threshold: int = 1000) -> LLMClient:
+    """Create an :class:`LLMClient` based on :class:`SandboxSettings`.
+
+    When a fallback backend is configured, an :class:`LLMRouter` is returned
+    that dispatches between the primary (assumed remote) and fallback
+    (assumed local) backends.
+    """
+    settings = settings or SandboxSettings()
+    backend = settings.llm_backend.lower()
+    fallback = settings.llm_fallback_backend
+    fallback = fallback.lower() if fallback else None
+
+    try:
+        primary_factory = _FACTORIES[backend]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Unknown LLM backend: {backend}") from exc
+    primary = primary_factory()
+
+    if not fallback:
+        return primary
+
+    try:
+        fallback_factory = _FACTORIES[fallback]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Unknown fallback backend: {fallback}") from exc
+    fallback_client = fallback_factory()
+    return LLMRouter(remote=primary, local=fallback_client, size_threshold=size_threshold)
+
+
+__all__ = ["LLMRouter", "client_from_settings"]

--- a/local_client.py
+++ b/local_client.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""Local LLM client implementations.
+
+This module provides lightweight wrappers around local language model
+servers so they can be used through the :class:`llm_interface.LLMClient`
+protocol.  The goal is to offer drop-in replacements for the remote
+clients used elsewhere in the codebase.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Any
+
+import requests
+
+from llm_interface import Prompt, LLMResult, LLMClient
+
+
+@dataclass
+class _BaseLocalClient:
+    """Shared logic for simple HTTP based local LLM servers."""
+
+    model: str
+    base_url: str
+
+    def _post(self, endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        url = f"{self.base_url.rstrip('/')}/{endpoint.lstrip('/')}"
+        response = requests.post(url, json=payload, timeout=30)
+        response.raise_for_status()
+        return response.json()
+
+
+class OllamaClient(_BaseLocalClient, LLMClient):
+    """Client for the `ollama` local LLM server."""
+
+    def __init__(self, model: str = "mistral", base_url: str = "http://localhost:11434") -> None:
+        super().__init__(model=model, base_url=base_url)
+
+    def generate(self, prompt: Prompt) -> LLMResult:
+        payload = {"model": self.model, "prompt": prompt.text}
+        raw = self._post("api/generate", payload)
+        text = raw.get("response", "") or raw.get("text", "")
+        return LLMResult(raw=raw, text=text)
+
+
+class VLLMClient(_BaseLocalClient, LLMClient):
+    """Client for a vLLM REST server."""
+
+    def __init__(self, model: str = "facebook/opt-125m", base_url: str = "http://localhost:8000") -> None:
+        super().__init__(model=model, base_url=base_url)
+
+    def generate(self, prompt: Prompt) -> LLMResult:
+        payload = {"model": self.model, "prompt": prompt.text}
+        raw = self._post("generate", payload)
+        text = raw.get("text") or raw.get("generated_text", "")
+        return LLMResult(raw=raw, text=text)
+
+
+__all__ = ["OllamaClient", "VLLMClient"]

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -318,6 +318,8 @@ class SandboxSettings(BaseSettings):
     sandbox_module_threshold: float | None = Field(None, env="SANDBOX_MODULE_THRESHOLD")
     sandbox_semantic_modules: bool = Field(False, env="SANDBOX_SEMANTIC_MODULES")
     sandbox_stub_model: str | None = Field(None, env="SANDBOX_STUB_MODEL")
+    llm_backend: str = Field("openai", env="LLM_BACKEND")
+    llm_fallback_backend: str | None = Field(None, env="LLM_FALLBACK_BACKEND")
     huggingface_token: str | None = Field(
         None, env=["HUGGINGFACE_API_TOKEN", "HF_TOKEN"]
     )

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -1,0 +1,42 @@
+from llm_interface import Prompt, LLMResult, LLMClient
+from llm_router import LLMRouter
+
+
+class StubClient(LLMClient):
+    def __init__(self, text: str, *, fail: bool = False) -> None:
+        self.text = text
+        self.fail = fail
+        self.calls = 0
+
+    def generate(self, prompt: Prompt) -> LLMResult:
+        self.calls += 1
+        if self.fail:
+            raise RuntimeError("boom")
+        return LLMResult(raw={}, text=self.text)
+
+
+def test_router_uses_local_for_small_prompts():
+    local = StubClient("local")
+    remote = StubClient("remote")
+    router = LLMRouter(remote=remote, local=local, size_threshold=5)
+    res = router.generate(Prompt(text="hi"))
+    assert res.text == "local"
+    assert local.calls == 1
+    assert remote.calls == 0
+
+def test_router_uses_remote_for_large_prompts():
+    local = StubClient("local")
+    remote = StubClient("remote")
+    router = LLMRouter(remote=remote, local=local, size_threshold=5)
+    res = router.generate(Prompt(text="this is long"))
+    assert res.text == "remote"
+    assert remote.calls == 1
+
+def test_router_fallback_on_failure():
+    local = StubClient("local", fail=True)
+    remote = StubClient("remote")
+    router = LLMRouter(remote=remote, local=local, size_threshold=5)
+    res = router.generate(Prompt(text="hi"))
+
+    assert res.text == "remote"
+    assert remote.calls == 1


### PR DESCRIPTION
## Summary
- add OllamaClient and VLLMClient to talk to local model servers
- introduce LLMRouter to switch between remote and local models with fallback logic
- expose `llm_backend` and `llm_fallback_backend` settings

## Testing
- `pytest tests/test_llm_router.py`
- `pytest tests/test_prompt_db.py`
- `pytest` *(fails: ValueError: I/O operation on closed file / segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e88358c0832e846f0690c8fe7ed4