### PR TITLE
feat: make LLM backend configurable

### DIFF
--- a/docs/sandbox_settings.md
+++ b/docs/sandbox_settings.md
@@ -112,3 +112,30 @@ export OPTIONAL_SERVICE_VERSIONS='{"relevancy_radar": "1.2.0"}'
 ```
 
 Unset modules are ignored.
+
+## LLM backends
+
+`SandboxSettings` can dynamically load different language model clients. The
+`preferred_llm_backend` field selects the primary backend. Available backends
+are defined by the `available_backends` mapping, which associates backend names
+with dotted import paths pointing to a factory function or client class
+returning an `LLMClient` instance.
+
+Register a custom or private adapter by extending the mapping and selecting it
+as the preferred backend:
+
+```yaml
+preferred_llm_backend: custom
+available_backends:
+  custom: "my_package.custom_client.CustomClient"
+```
+
+Environment variables accept the same configuration using JSON:
+
+```bash
+export PREFERRED_LLM_BACKEND=custom
+export AVAILABLE_LLM_BACKENDS='{"custom": "my_package.custom_client.CustomClient"}'
+```
+
+The selected entry must resolve to a callable that returns an `LLMClient`
+instance when invoked without arguments.


### PR DESCRIPTION
## Summary
- allow selecting LLM backends via SandboxSettings
- instantiate LLM clients dynamically according to settings
- document how to register custom or private backends

## Testing
- `pre-commit run --files docs/sandbox_settings.md llm_router.py sandbox_settings.py tests/test_llm_router.py`
- `pytest tests/test_llm_router.py`
- `pytest tests/test_bootstrap_service_deps.py tests/test_local_knowledge_refresh_thread.py` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ea273144832eb71b99ed0947b3cc