### PR TITLE
Add tests and docs for LLM interface

### DIFF
--- a/docs/llm_interface.md
+++ b/docs/llm_interface.md
@@ -1,0 +1,64 @@
+# LLM interface
+
+The `llm_interface` module supplies a tiny protocol for working with language models. It defines
+`Prompt`, `LLMResult` and the `LLMClient` protocol which requires a single `generate` method.
+
+## Basic usage
+
+```python
+from llm_interface import Prompt, LLMResult, LLMClient
+
+class EchoClient(LLMClient):
+    def generate(self, prompt: Prompt) -> LLMResult:
+        return LLMResult(text=prompt.text.upper())
+
+client = EchoClient()
+result = client.generate(Prompt(text="hello"))
+print(result.text)
+```
+
+## Retry and backoff
+
+Use `retry_utils.with_retry` to add exponential backoff around LLM calls:
+
+```python
+from retry_utils import with_retry
+
+response = with_retry(lambda: client.generate(Prompt("hi")), attempts=3, delay=1.0)
+```
+
+## Prompt logging
+
+`PromptDB` can store prompts and responses for later inspection. An in‑memory router is
+sufficient for tests or temporary sessions:
+
+```python
+import sqlite3
+from prompt_db import PromptDB
+
+class MemoryRouter:
+    def __init__(self):
+        self.conn = sqlite3.connect(":memory:")
+    def get_connection(self, table_name: str, operation: str = "write"):
+        return self.conn
+
+memory_db = PromptDB(model="demo", router=MemoryRouter())
+memory_db.log_prompt(Prompt("hi"), LLMResult(text="ok"), ["tag"], 0.9)
+```
+
+## Fallback routing
+
+`LLMRouter` chooses between two clients and falls back if the primary fails:
+
+```python
+from llm_router import LLMRouter
+
+router = LLMRouter(remote=remote_client, local=backup_client, size_threshold=500)
+result = router.generate(Prompt("data"))
+```
+
+## Extending
+
+To support a new backend, implement `LLMClient.generate` and optionally expose a factory
+function. The router and `client_from_settings` helper can then compose the new client
+alongside existing ones.

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -1,0 +1,71 @@
+import sqlite3
+
+import retry_utils
+from llm_interface import Prompt, LLMResult, LLMClient
+from llm_router import LLMRouter
+from prompt_db import PromptDB
+
+
+class MemoryRouter:
+    """Minimal router returning an in-memory SQLite connection."""
+
+    def __init__(self):
+        self.conn = sqlite3.connect(":memory:")
+
+    def get_connection(self, table_name: str, operation: str = "write"):
+        return self.conn
+
+
+def test_promptdb_logs_to_memory():
+    db = PromptDB(model="test", router=MemoryRouter())
+    prompt = Prompt(text="hi", examples=["ex"])
+    result = LLMResult(raw={"r": 1}, text="res")
+    db.log_prompt(prompt, result, ["tag"], 0.4)
+    row = db.conn.execute(
+        "SELECT text, examples, confidence, tags, response_text, model FROM prompts"
+    ).fetchone()
+    assert row == (
+        "hi",
+        "[\"ex\"]",
+        0.4,
+        "[\"tag\"]",
+        "res",
+        "test",
+    )
+
+
+def test_retry_with_backoff(monkeypatch):
+    calls = {"count": 0}
+    sleeps: list[float] = []
+
+    def func():
+        calls["count"] += 1
+        if calls["count"] < 3:
+            raise ValueError("fail")
+        return "ok"
+
+    monkeypatch.setattr(retry_utils.time, "sleep", lambda s: sleeps.append(s))
+    result = retry_utils.with_retry(func, attempts=3, delay=1.0, exc=ValueError)
+    assert result == "ok"
+    assert sleeps == [1.0, 2.0]
+    assert calls["count"] == 3
+
+
+class FailingClient(LLMClient):
+    def generate(self, prompt: Prompt) -> LLMResult:
+        raise RuntimeError("boom")
+
+
+class EchoClient(LLMClient):
+    def __init__(self):
+        self.calls = 0
+
+    def generate(self, prompt: Prompt) -> LLMResult:
+        self.calls += 1
+        return LLMResult(text="local")
+
+
+def test_router_fallback_on_error():
+    router = LLMRouter(remote=FailingClient(), local=EchoClient(), size_threshold=1)
+    res = router.generate(Prompt(text="hi"))
+    assert res.text == "local"


### PR DESCRIPTION
## Summary
- test PromptDB logging against an in-memory database
- cover retry backoff logic using `with_retry`
- verify LLMRouter fallback routing on errors
- document basic LLM interface usage and extension points

## Testing
- `python -m pytest tests/test_llm_interface.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4ec461724832e96d1810020d3b074