### PR TITLE
Add structured LLM interface and prompt handling

### DIFF
--- a/docs/llm_interface.md
+++ b/docs/llm_interface.md
@@ -1,7 +1,9 @@
 # LLM interface
 
-The `llm_interface` module supplies a tiny protocol for working with language models. It defines
-`Prompt`, `LLMResult` and the `LLMClient` protocol which requires a single `generate` method.
+The `llm_interface` module supplies a tiny interface for working with language models. It defines
+the `Prompt` and `LLMResult` dataclasses together with the `LLMClient` base class which exposes a
+single `generate` method. `LLMResult` captures both the raw text produced by the model and an
+optional parsed representation.
 
 ## Basic usage
 
@@ -10,6 +12,8 @@ from llm_interface import Prompt, LLMResult, LLMClient
 
 class EchoClient(LLMClient):
     def generate(self, prompt: Prompt) -> LLMResult:
+        # ``parsed`` may contain structured data such as a JSON dict.  It is
+        # optional and defaults to ``None``.
         return LLMResult(text=prompt.text.upper())
 
 client = EchoClient()
@@ -43,7 +47,7 @@ class MemoryRouter:
         return self.conn
 
 memory_db = PromptDB(model="demo", router=MemoryRouter())
-memory_db.log_prompt(Prompt("hi"), LLMResult(text="ok"), ["tag"], 0.9)
+memory_db.log_prompt(Prompt("hi"), LLMResult(text="ok", parsed={}), ["tag"], 0.9)
 ```
 
 ## Fallback routing

--- a/prompt_engine.py
+++ b/prompt_engine.py
@@ -4,9 +4,10 @@ This module now relies on lightweight service objects that can be injected
 from the outside.  ``Retriever`` is used to fetch historical patches while
 ``ContextBuilder`` exposes optional helpers such as ROI tracking.  The
 ``PromptEngine`` orchestrates snippet retrieval, compression and ranking to
-produce a compact prompt for the language model.  When retrieval fails or the
-average confidence falls below a configurable threshold a static fallback
-template is returned instead of an unhelpful prompt.
+produce a compact :class:`llm_interface.Prompt` object for the language model.
+When retrieval fails or the average confidence falls below a configurable
+threshold a static fallback template is returned instead of an unhelpful
+prompt.
 """
 
 from __future__ import annotations
@@ -505,7 +506,7 @@ class PromptEngine:
         retry_trace: str | None = None,
         tone: str | None = None,
     ) -> Prompt:
-        """Return a prompt for *task* using retrieved patch examples.
+        """Return a :class:`Prompt` for *task* using retrieved patch examples.
 
         ``context`` and ``retrieval_context`` allow callers to prepend
         additional information such as the snippet body, repository layout or
@@ -898,8 +899,12 @@ def build_prompt(
     failure_header: str = "Avoid {summary} because it caused {outcome}:",
     tone: str = "neutral",
     trainer: PromptMemoryTrainer | None = None,
-) -> Prompt:
-    """Convenience wrapper mirroring :meth:`PromptEngine.construct_prompt`."""
+    ) -> Prompt:
+    """Convenience wrapper mirroring :meth:`PromptEngine.construct_prompt`.
+
+    The helper instantiates a temporary :class:`PromptEngine` and returns the
+    resulting :class:`Prompt` instance.
+    """
 
     return PromptEngine.construct_prompt(
         goal,


### PR DESCRIPTION
## Summary
- add `Prompt` and `LLMResult` dataclasses and abstract `LLMClient` base class
- document the interface and clarify `PromptEngine` returns structured prompts
- expose convenience wrapper returning a `Prompt` object

## Testing
- `pytest tests/test_llm_interface.py tests/test_prompt_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4ee0b750c832ea4d2f4dca3983a02