### PR TITLE
Clarify hashlib usage in self-improvement policy

### DIFF
--- a/self_improvement_policy.py
+++ b/self_improvement_policy.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import abc
 import atexit
-import hashlib
+import hashlib  # used in _compute_checksum
 from typing import Dict, Tuple, Optional, Callable
 import pickle
 import os


### PR DESCRIPTION
## Summary
- clarify hashlib import usage in self_improvement_policy

## Testing
- `python -m py_compile self_improvement_policy.py`
- `pytest tests/self_improvement -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4f0026fcc832e80c86b9cd9fe2cad