### PR TITLE
Log all LLM prompts to SQLite

### DIFF
--- a/llm_router.py
+++ b/llm_router.py
@@ -30,11 +30,12 @@ class LLMRouter(LLMClient):
     """
 
     def __init__(self, remote: LLMClient, local: LLMClient, *, size_threshold: int = 1000) -> None:
+        super().__init__("router", log_prompts=False)
         self.remote = remote
         self.local = local
         self.size_threshold = size_threshold
 
-    def generate(self, prompt: Prompt) -> LLMResult:
+    def _generate(self, prompt: Prompt) -> LLMResult:
         primary = self.remote if len(prompt.text) > self.size_threshold else self.local
         fallback = self.local if primary is self.remote else self.remote
         try:

--- a/local_client.py
+++ b/local_client.py
@@ -34,9 +34,10 @@ class OllamaClient(_BaseLocalClient, LLMClient):
     """Client for the `ollama` local LLM server."""
 
     def __init__(self, model: str = "mistral", base_url: str = "http://localhost:11434") -> None:
-        super().__init__(model=model, base_url=base_url)
+        LLMClient.__init__(self, model)
+        _BaseLocalClient.__init__(self, model=model, base_url=base_url)
 
-    def generate(self, prompt: Prompt) -> LLMResult:
+    def _generate(self, prompt: Prompt) -> LLMResult:
         payload = {"model": self.model, "prompt": prompt.text}
         raw = self._post("api/generate", payload)
         text = raw.get("response", "") or raw.get("text", "")
@@ -46,10 +47,15 @@ class OllamaClient(_BaseLocalClient, LLMClient):
 class VLLMClient(_BaseLocalClient, LLMClient):
     """Client for a vLLM REST server."""
 
-    def __init__(self, model: str = "facebook/opt-125m", base_url: str = "http://localhost:8000") -> None:
-        super().__init__(model=model, base_url=base_url)
+    def __init__(
+        self,
+        model: str = "facebook/opt-125m",
+        base_url: str = "http://localhost:8000",
+    ) -> None:
+        LLMClient.__init__(self, model)
+        _BaseLocalClient.__init__(self, model=model, base_url=base_url)
 
-    def generate(self, prompt: Prompt) -> LLMResult:
+    def _generate(self, prompt: Prompt) -> LLMResult:
         payload = {"model": self.model, "prompt": prompt.text}
         raw = self._post("generate", payload)
         text = raw.get("text") or raw.get("generated_text", "")

--- a/prompt_db.py
+++ b/prompt_db.py
@@ -31,8 +31,8 @@ class PromptDB:
                 id INTEGER PRIMARY KEY,
                 text TEXT,
                 examples TEXT,
-                confidence REAL,
-                tags TEXT,
+                vector_confidences TEXT,
+                outcome_tags TEXT,
                 response_raw TEXT,
                 response_text TEXT,
                 model TEXT,
@@ -43,13 +43,17 @@ class PromptDB:
         self.conn.commit()
 
     def log_prompt(
-        self, prompt: Prompt, result: LLMResult, tags: List[str], confidence: float
+        self,
+        prompt: Prompt,
+        result: LLMResult,
+        outcome_tags: List[str],
+        vector_confidences: List[float],
     ) -> None:
         cur = self.conn.cursor()
         cur.execute(
             """
             INSERT INTO prompts(
-                text, examples, confidence, tags, response_raw,
+                text, examples, vector_confidences, outcome_tags, response_raw,
                 response_text, model, timestamp
             )
             VALUES (?,?,?,?,?,?,?,?)
@@ -57,8 +61,8 @@ class PromptDB:
             (
                 prompt.text,
                 json.dumps(prompt.examples),
-                confidence,
-                json.dumps(tags),
+                json.dumps(vector_confidences),
+                json.dumps(outcome_tags),
                 json.dumps(result.raw),
                 result.text,
                 self.model,

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -5,11 +5,12 @@ from sandbox_settings import SandboxSettings
 
 class StubClient(LLMClient):
     def __init__(self, text: str, *, fail: bool = False) -> None:
+        super().__init__(text, log_prompts=False)
         self.text = text
         self.fail = fail
         self.calls = 0
 
-    def generate(self, prompt: Prompt) -> LLMResult:
+    def _generate(self, prompt: Prompt) -> LLMResult:
         self.calls += 1
         if self.fail:
             raise RuntimeError("boom")


### PR DESCRIPTION
## Summary
- expand PromptDB to record prompts, examples, vector confidences, outcome tags and model
- wrap `LLMClient.generate` to persist each request/response to PromptDB

## Testing
- `pre-commit run --files prompt_db.py llm_interface.py openai_client.py local_client.py llm_router.py tests/test_prompt_db.py tests/test_llm_interface.py tests/test_llm_router.py`
- `pytest tests/test_prompt_db.py tests/test_llm_interface.py tests/test_llm_router.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4f2919b9c832eabc6a2ec4f1c5216