### PR TITLE
refactor: adopt new LLM client

### DIFF
--- a/docs/self_coding_engine.md
+++ b/docs/self_coding_engine.md
@@ -15,7 +15,7 @@ engine.apply_patch(Path("utils.py"), "normalize text", threshold=0.5)
 ```
 
 - **suggest_snippets** – fetch related `CodeRecord` objects from `CodeDB`.
-- **generate_helper** – uses `ChatGPTClient` to produce a helper based on the description and snippet context.
+- **generate_helper** – uses `LLMClient` to produce a helper based on the description and snippet context.
 - **apply_patch** – append the helper, run CI checks and revert if ROI or error metrics drop beyond ``threshold``.
 - **Patch metrics** – `PatchHistoryDB` stores ROI delta and error counts for each patch.
 - **Forecasts** – `TrendPredictor` estimates ROI and error trends for rollback decisions.


### PR DESCRIPTION
## Summary
- use LLMClient from settings in SelfCodingEngine
- handle missing prompt memory trainer dependencies gracefully
- reference LLMClient in self-coding engine docs

## Testing
- `pre-commit run --files self_coding_engine.py docs/self_coding_engine.md`
- `pytest tests/test_self_coding_engine.py tests/test_self_coding_engine_logging.py tests/test_self_coding_engine_patch_logger.py -q` *(fails: AttributeError: <menace_sandbox.tests.test_self_coding_engine._MetricsDB object has no attribute 'fetch', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b4f41036b8832e8d53c4ed36ee0b86