### PR TITLE
test: cover llm retry and prompt integration

### DIFF
--- a/tests/test_prompt_engine_llm_client_integration.py
+++ b/tests/test_prompt_engine_llm_client_integration.py
@@ -1,0 +1,49 @@
+from llm_interface import LLMClient, LLMResult, Prompt
+from prompt_engine import PromptEngine
+
+
+class SimpleRetriever:
+    """Return a single high-confidence record for any query."""
+
+    def search(self, _query: str, top_k: int):  # pragma: no cover - trivial
+        return [
+            {
+                "score": 0.9,
+                "metadata": {"summary": "example", "tests_passed": True, "ts": 1},
+            }
+        ]
+
+
+class CapturingClient(LLMClient):
+    """LLM client that records the prompt it receives."""
+
+    def __init__(self):
+        super().__init__("capture", log_prompts=False)
+        self.seen: list[Prompt] = []
+
+    def _generate(self, prompt: Prompt) -> LLMResult:
+        self.seen.append(prompt)
+        # Return JSON to exercise parsed handling
+        return LLMResult(
+            text='{"result": "ok"}',
+            parsed={"result": "ok"},
+            completions=['{"result": "ok"}'],
+        )
+
+
+def test_prompt_engine_to_llm_client_flow():
+    engine = PromptEngine(
+        retriever=SimpleRetriever(),
+        patch_retriever=SimpleRetriever(),
+        top_n=1,
+        confidence_threshold=0,
+    )
+
+    prompt = engine.build_prompt("do things")
+    client = CapturingClient()
+    result = client.generate(prompt)
+
+    assert isinstance(prompt, Prompt)
+    assert client.seen == [prompt]
+    assert result.parsed == {"result": "ok"}
+    assert result.completions == ['{"result": "ok"}']


### PR DESCRIPTION
## Summary
- add tests for OpenAI retry and router fallback with logging
- add integration test between PromptEngine and LLMClient

## Testing
- `pytest tests/test_llm_interface.py::test_openai_provider_retry_and_logging tests/test_llm_interface.py::test_router_fallback_logs tests/test_prompt_engine_llm_client_integration.py::test_prompt_engine_to_llm_client_flow -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4f5de93c8832ea29170be58af41cd