### PR TITLE
Warn when relevancy radar dependency missing

### DIFF
--- a/tests/test_relevancy_radar_warning.py
+++ b/tests/test_relevancy_radar_warning.py
@@ -1,0 +1,34 @@
+import logging
+import sys
+import types
+from pathlib import Path
+
+
+def _load_radar_snippet():
+    src = (Path(__file__).resolve().parents[1] / "sandbox_runner" / "environment.py").read_text()
+    start = src.index("# Relevancy radar integration")
+    end = src.index("import builtins", start)
+    snippet = "from __future__ import annotations\n" + src[start:end]
+    ns: dict[str, object] = {
+        "os": types.SimpleNamespace(getenv=lambda _k: "1"),
+        "queue": types.SimpleNamespace(Queue=lambda: None),
+        "threading": types.SimpleNamespace(Thread=lambda *a, **k: None),
+        "record_error": lambda _e: None,
+        "atexit": types.SimpleNamespace(register=lambda _f: None),
+        "logger": logging.getLogger("test"),
+    }
+    sys.modules["relevancy_radar"] = types.ModuleType("relevancy_radar")
+    exec(snippet, ns)
+    return ns
+
+
+def test_warns_once_when_radar_missing(caplog):
+    env = _load_radar_snippet()
+    env["_RADAR_WARNING_EMITTED"] = False
+    with caplog.at_level(logging.WARNING):
+        env["_async_radar_track"]("foo")
+        env["_async_radar_track"]("bar")
+    messages = [r.getMessage() for r in caplog.records if "relevancy_radar" in r.getMessage()]
+    assert messages == ["relevancy_radar dependency missing; tracking disabled"]
+    assert not env["RELEVANCY_RADAR_AVAILABLE"]
+


### PR DESCRIPTION
## Summary
- expose `RELEVANCY_RADAR_AVAILABLE` flag and emit a single warning when relevancy radar dependency is absent
- add regression test ensuring the warning fires exactly once

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_relevancy_radar_warning.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4f9c1379c832e89878a3490d4f4f6