### PR TITLE
Introduce flexible LLM interface with OpenAI backend

### DIFF
--- a/prompt_db.py
+++ b/prompt_db.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import List
 
 from db_router import DBRouter, LOCAL_TABLES
-from llm_interface import Prompt, LLMResult
+from llm_interface import Completion, Prompt
 
 # Ensure the prompts table is treated as local
 LOCAL_TABLES.add("prompts")
@@ -45,10 +45,12 @@ class PromptDB:
     def log_prompt(
         self,
         prompt: Prompt,
-        result: LLMResult,
-        outcome_tags: List[str],
-        vector_confidences: List[float],
+        result: Completion,
+        outcome_tags: List[str] | None = None,
+        vector_confidences: List[float] | None = None,
     ) -> None:
+        vector_confidences = vector_confidences or prompt.vector_confidences
+        outcome_tags = outcome_tags or prompt.outcome_tags
         cur = self.conn.cursor()
         cur.execute(
             """


### PR DESCRIPTION
## Summary
- expand Prompt dataclass with example metadata, vector confidences, and outcome tags
- add Completion result type, LLMBackend protocol, and backend-aware LLMClient orchestrator
- implement OpenAIBackend with GPT-4o support and update prompt logging

## Testing
- `pytest tests/test_llm_interface.py tests/test_prompt_db.py tests/test_llm_router.py tests/test_prompt_engine_llm_client_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4f73f671c832e99cb68f63507358f