### PR TITLE
Add SQLite-backed prompt logging

### DIFF
--- a/docs/llm_interface.md
+++ b/docs/llm_interface.md
@@ -47,7 +47,7 @@ class MemoryRouter:
         return self.conn
 
 memory_db = PromptDB(model="demo", router=MemoryRouter())
-memory_db.log_prompt(Prompt("hi"), LLMResult(text="ok", parsed={}), ["tag"], 0.9)
+memory_db.log(Prompt("hi", outcome_tags=["tag"], vector_confidences=[0.9]), LLMResult(text="ok", parsed={}))
 ```
 
 ## Fallback routing

--- a/llm_interface.py
+++ b/llm_interface.py
@@ -14,7 +14,6 @@ from typing import Any, Dict, List, Protocol
 import os
 import time
 import json
-import random
 import threading
 
 import requests
@@ -229,25 +228,8 @@ class LLMClient:
 
         result = self._generate(prompt)
         if self._log_prompts and self.db:
-            tags = (
-                prompt.outcome_tags
-                or prompt.metadata.get("tags")
-                or prompt.metadata.get("outcome_tags")
-                or []
-            )
-            confs = (
-                prompt.vector_confidences
-                or prompt.metadata.get("vector_confidences")
-                or []
-            )
-            if not isinstance(tags, list):
-                tags = [str(tags)]
             try:
-                confs = [float(c) for c in confs]
-            except Exception:  # pragma: no cover - defensive
-                confs = []
-            try:
-                self.db.log_prompt(prompt, result, tags, confs)
+                self.db.log(prompt, result)
             except Exception:  # pragma: no cover - best effort
                 pass
 

--- a/tests/test_prompt_db.py
+++ b/tests/test_prompt_db.py
@@ -6,14 +6,17 @@ from llm_interface import Prompt, LLMResult
 from openai_client import OpenAILLMClient
 
 
-def test_log_prompt(tmp_path):
+def test_log(tmp_path):
     os.environ["PROMPT_DB_PATH"] = str(tmp_path / "prompts.db")
     db = PromptDB(model="gpt-test")
-    prompt = Prompt(text="hi", examples=["ex1"])
+    prompt = Prompt(
+        text="hi", examples=["ex1"], outcome_tags=["test"], vector_confidences=[0.5]
+    )
     result = LLMResult(raw={"data": 1}, text="hello")
-    db.log_prompt(prompt, result, ["test"], [0.5])
+    db.log(prompt, result)
     row = db.conn.execute(
-        "SELECT text, examples, vector_confidences, outcome_tags, response_text, model FROM prompts"
+        "SELECT text, examples, vector_confidences, outcome_tags, response_text, model "
+        "FROM prompts",
     ).fetchone()
     assert row[0] == "hi"
     assert json.loads(row[1]) == ["ex1"]
@@ -36,7 +39,8 @@ def test_openai_client_logs_prompt(monkeypatch, tmp_path):
     res = client.generate(prompt)
     assert res.text == "world"
     row = client.db.conn.execute(
-        "SELECT text, outcome_tags, vector_confidences, response_text, model FROM prompts"
+        "SELECT text, outcome_tags, vector_confidences, response_text, model "
+        "FROM prompts",
     ).fetchone()
     assert row[0] == "hi"
     assert json.loads(row[1]) == ["t"]


### PR DESCRIPTION
## Summary
- add SQLite PromptDB that persists prompt metadata and raw/parsed completions
- expose PromptDB.log and integrate LLMClient to record every interaction
- update tests and documentation for new logging API

## Testing
- `pre-commit run --files prompt_db.py llm_interface.py tests/test_prompt_db.py tests/test_llm_interface.py docs/llm_interface.md`
- `pytest tests/test_prompt_db.py tests/test_prompt_engine_llm_client_integration.py tests/test_llm_router.py tests/test_llm_interface.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5003cfbcc832ea460f92ed24e88ba