### PR TITLE
feat: add configurable local LLM backend and multi-backend client

### DIFF
--- a/local_backend.py
+++ b/local_backend.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+"""Local LLM backend implementations for Ollama and vLLM servers.
+
+The backends speak a very small REST dialect expected by the corresponding
+servers.  They implement the :class:`LLMBackend` protocol so they can be used
+with :class:`llm_interface.LLMClient`.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict
+import os
+
+import requests
+
+try:  # pragma: no cover - package vs module import
+    from .retry_utils import with_retry
+except Exception:  # pragma: no cover - fallback when not a package
+    from retry_utils import with_retry
+
+from llm_interface import Prompt, Completion, LLMBackend
+
+
+@dataclass
+class _RESTBackend(LLMBackend):
+    """Shared helper for simple JSON-over-HTTP model servers."""
+
+    model: str
+    base_url: str
+    endpoint: str
+
+    def _post(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        url = f"{self.base_url.rstrip('/')}/{self.endpoint.lstrip('/')}"
+        response = requests.post(url, json=payload, timeout=30)
+        response.raise_for_status()
+        return response.json()
+
+    def generate(self, prompt: Prompt) -> Completion:
+        payload = {"model": self.model, "prompt": prompt.text}
+
+        def do_request() -> Dict[str, Any]:
+            return self._post(payload)
+
+        raw = with_retry(do_request, exc=requests.RequestException)
+        text = raw.get("text") or raw.get("response", "") or raw.get("generated_text", "")
+        return Completion(raw=raw, text=text)
+
+
+class OllamaBackend(_RESTBackend):
+    """Backend speaking to an ``ollama`` model server."""
+
+    def __init__(self, model: str | None = None, base_url: str | None = None) -> None:
+        model = model or os.getenv("OLLAMA_MODEL", "mistral")
+        base_url = base_url or os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+        super().__init__(model=model, base_url=base_url, endpoint="api/generate")
+
+
+class VLLMBackend(_RESTBackend):
+    """Backend for a vLLM REST server."""
+
+    def __init__(self, model: str | None = None, base_url: str | None = None) -> None:
+        model = model or os.getenv("VLLM_MODEL", "llama3")
+        base_url = base_url or os.getenv("VLLM_BASE_URL", "http://localhost:8000")
+        super().__init__(model=model, base_url=base_url, endpoint="generate")
+
+
+__all__ = ["OllamaBackend", "VLLMBackend"]

--- a/openai_client.py
+++ b/openai_client.py
@@ -16,7 +16,7 @@ class OpenAILLMClient(LLMClient):
     """Simple client for the OpenAI chat completions API."""
 
     def __init__(self, model: str | None = None, api_key: str | None = None) -> None:
-        super().__init__(model or "gpt-4o")
+        super().__init__(model or os.getenv("OPENAI_MODEL", "gpt-4o"))
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         if not self.api_key:
             raise RuntimeError("OPENAI_API_KEY is required")


### PR DESCRIPTION
## Summary
- add `local_backend` module with Ollama and vLLM REST support
- allow `LLMClient` to try a priority list of backends and honor `small_task` prompts
- make models and backend order configurable via environment variables

## Testing
- `pytest tests/test_llm_interface.py`


------
https://chatgpt.com/codex/tasks/task_e_68b50278dd18832ea479f9d5bce6a219