### PR TITLE
Add optional parse_fn for LLMClient and helper parsers

### DIFF
--- a/completion_parsers.py
+++ b/completion_parsers.py
@@ -1,0 +1,28 @@
+"""Helper functions for parsing LLM completion text."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+
+def parse_json(text: str) -> Any:
+    """Parse *text* as JSON and return the resulting object."""
+    return json.loads(text)
+
+
+_code_block_re = re.compile(r"```(?:\w*\n)?(.*?)```", re.DOTALL)
+
+
+def extract_code_block(text: str) -> str:
+    """Return the first fenced code block found in *text*.
+
+    The code fence is removed and surrounding whitespace is stripped.  Raises
+    :class:`ValueError` if no fenced block is present.
+    """
+
+    match = _code_block_re.search(text)
+    if not match:
+        raise ValueError("No code block found")
+    return match.group(1).strip()

--- a/tests/test_completion_parsers.py
+++ b/tests/test_completion_parsers.py
@@ -1,0 +1,10 @@
+from completion_parsers import parse_json, extract_code_block
+
+
+def test_parse_json():
+    assert parse_json('{"x": 1}') == {"x": 1}
+
+
+def test_extract_code_block():
+    text = 'before\n```python\nprint("hi")\n```\nafter'
+    assert extract_code_block(text) == 'print("hi")'


### PR DESCRIPTION
## Summary
- allow `LLMClient.generate` to accept a `parse_fn` callback and store its result in `Completion.parsed`
- add `completion_parsers` module with common utilities like JSON and code block extraction
- test parse_fn integration and parser helpers

## Testing
- `pytest tests/test_llm_interface.py::test_generate_applies_parse_fn tests/test_llm_interface.py::test_generate_parse_fn_error_ignored tests/test_completion_parsers.py -q -W ignore`

------
https://chatgpt.com/codex/tasks/task_e_68b505ff88c4832eb544e380b9881f27