### PR TITLE
Introduce structured Prompt type

### DIFF
--- a/openai_client.py
+++ b/openai_client.py
@@ -74,10 +74,18 @@ class OpenAILLMClient(LLMClient):
 
     # ------------------------------------------------------------------
     def _generate(self, prompt: Prompt) -> LLMResult:
-        payload = {
-            "model": self.model,
-            "messages": [{"role": "user", "content": prompt.text}],
-        }
+        messages = []
+        if prompt.system:
+            messages.append({"role": "system", "content": prompt.system})
+        for ex in prompt.examples:
+            messages.append({"role": "system", "content": ex})
+        messages.append({"role": "user", "content": prompt.user})
+
+        payload: Dict[str, Any] = {"model": self.model, "messages": messages}
+        if prompt.tags:
+            payload["tags"] = prompt.tags
+        if prompt.vector_confidence is not None:
+            payload["vector_confidence"] = prompt.vector_confidence
 
         raw = self._request(payload)
         text = ""

--- a/prompt_db.py
+++ b/prompt_db.py
@@ -49,17 +49,8 @@ class PromptDB:
     def log(self, prompt: Prompt, result: Completion) -> None:
         """Persist *prompt* and *result* to the underlying SQLite store."""
 
-        tags = (
-            prompt.outcome_tags
-            or prompt.metadata.get("tags")
-            or prompt.metadata.get("outcome_tags")
-            or []
-        )
-        confs = (
-            prompt.vector_confidences
-            or prompt.metadata.get("vector_confidences")
-            or []
-        )
+        tags = prompt.outcome_tags or []
+        confs = prompt.vector_confidences
         if not isinstance(tags, list):
             tags = [str(tags)]
         try:

--- a/prompt_types.py
+++ b/prompt_types.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Common prompt related data structures."""
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass(init=False)
+class Prompt:
+    """Container describing an LLM prompt.
+
+    Parameters
+    ----------
+    system:
+        Optional system message describing high level behaviour.
+    user:
+        The main user request shown to the model.
+    examples:
+        Optional few shot examples or snippets used to prime the model.
+    vector_confidence:
+        Average confidence score returned by vector retrieval, if any.
+    tags:
+        Arbitrary tags associated with the prompt such as ROI categories.
+    """
+
+    system: str = ""
+    user: str = ""
+    examples: List[str] = field(default_factory=list)
+    vector_confidence: float | None = None
+    tags: List[str] = field(default_factory=list)
+
+    def __init__(
+        self,
+        user: str = "",
+        *,
+        system: str = "",
+        examples: List[str] | None = None,
+        vector_confidence: float | None = None,
+        tags: List[str] | None = None,
+        text: str | None = None,
+    ) -> None:
+        if text is not None and not user:
+            user = text
+        self.system = system
+        self.user = user
+        self.examples = list(examples) if examples else []
+        self.vector_confidence = vector_confidence
+        self.tags = list(tags) if tags else []
+
+    # ------------------------------------------------------------------
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.user
+
+    def __contains__(self, item: object) -> bool:  # pragma: no cover - delegation
+        return str(item) in self.user
+
+    def __getattr__(self, name: str):  # pragma: no cover - delegation
+        return getattr(self.user, name)
+
+    # Backwards compatibility properties ---------------------------------
+    @property
+    def text(self) -> str:
+        """Alias returning the user portion of the prompt."""
+        return self.user
+
+    @property
+    def vector_confidences(self) -> List[float]:
+        """Legacy list-style confidence accessor."""
+        return [self.vector_confidence] if self.vector_confidence is not None else []
+
+    @property
+    def outcome_tags(self) -> List[str]:
+        """Legacy accessor mapping to :attr:`tags`."""
+        return self.tags
+
+
+__all__ = ["Prompt"]


### PR DESCRIPTION
## Summary
- add rich Prompt dataclass with system/user/messages metadata
- emit Prompt objects from PromptEngine and log in PromptDB
- serialize Prompt fields when generating via LLM clients

## Testing
- `pytest -q` *(fails: missing packages and numerous import errors)*


------
https://chatgpt.com/codex/tasks/task_e_68b50e8d9fcc832e8b5947095dc45841