### PR TITLE
Clarify EmptyWorkflowError with offending workflow details

### DIFF
--- a/tests/test_workflow_sandbox_runner.py
+++ b/tests/test_workflow_sandbox_runner.py
@@ -50,8 +50,9 @@ def _no_psutil(monkeypatch):
 
 def test_empty_workflow_errors():
     runner = WorkflowSandboxRunner()
-    with pytest.raises(EmptyWorkflowError):
+    with pytest.raises(EmptyWorkflowError) as exc:
         runner.run([])
+    assert "contained no actionable steps" in str(exc.value)
 
 
 def test_files_confined_to_temp_dir(monkeypatch):


### PR DESCRIPTION
## Summary
- Expand `EmptyWorkflowError` to capture and display the offending workflow identifier
- Raise `EmptyWorkflowError` with workflow details when no actionable steps are present
- Test the new error message for empty workflows

## Testing
- `pytest tests/test_workflow_sandbox_runner.py::test_empty_workflow_errors -q`


------
https://chatgpt.com/codex/tasks/task_e_68b519cce3e8832e8b304ffbb681242f