### PR TITLE
feat: centralize LLM config and rate limiting

### DIFF
--- a/llm_config.py
+++ b/llm_config.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Configuration helpers for language model backends.
+
+This module centralises reading of model selection, API keys, retry limits
+and rate limiting thresholds.  Environment variables take precedence over
+values specified in an optional JSON configuration file referenced via the
+``LLM_CONFIG_FILE`` environment variable.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+import json
+import os
+
+
+@dataclass
+class LLMConfig:
+    """Simple container holding configuration for LLM backends."""
+
+    model: str = "gpt-4o"
+    api_key: str | None = None
+    max_retries: int = 5
+    tokens_per_minute: int = 0
+
+
+def _load_file(path: str | None) -> Dict[str, Any]:
+    """Load configuration from *path* if it exists, else return an empty dict."""
+
+    if not path:
+        return {}
+    p = Path(path)
+    if not p.exists():
+        return {}
+    try:
+        return json.loads(p.read_text())
+    except Exception:
+        return {}
+
+
+def get_config() -> LLMConfig:
+    """Return the current configuration for LLM backends."""
+
+    file_cfg = _load_file(os.getenv("LLM_CONFIG_FILE"))
+    model = os.getenv("LLM_MODEL") or file_cfg.get("model") or "gpt-4o"
+    api_key = os.getenv("OPENAI_API_KEY") or file_cfg.get("api_key")
+    max_retries = int(
+        os.getenv("LLM_MAX_RETRIES", file_cfg.get("max_retries", 5))
+    )
+    tokens_per_minute = int(
+        os.getenv("LLM_TPM", file_cfg.get("tokens_per_minute", 0))
+    )
+    return LLMConfig(
+        model=model,
+        api_key=api_key,
+        max_retries=max_retries,
+        tokens_per_minute=tokens_per_minute,
+    )
+
+
+__all__ = ["LLMConfig", "get_config"]

--- a/rate_limit.py
+++ b/rate_limit.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Shared rate limiting helpers for LLM backends.
+
+The :class:`TokenBucket` tracks token usage per minute and blocks when the
+configured allowance would be exceeded.  ``sleep_with_backoff`` implements a
+simple exponential backoff strategy that can be reused by backends when
+retrying requests.
+"""
+
+import threading
+import time
+from typing import Optional
+
+
+class TokenBucket:
+    """Token based rate limiter allowing *tokens_per_minute* usage."""
+
+    def __init__(self, tokens_per_minute: int = 0) -> None:
+        self.capacity = tokens_per_minute
+        self.tokens = tokens_per_minute
+        self.reset_time = time.time() + 60
+        self._lock = threading.Lock()
+
+    def update_rate(self, tokens_per_minute: int) -> None:
+        """Adjust the bucket capacity to *tokens_per_minute*."""
+
+        with self._lock:
+            self.capacity = tokens_per_minute
+            if self.tokens > tokens_per_minute:
+                self.tokens = tokens_per_minute
+
+    def consume(self, tokens: int) -> None:
+        """Consume *tokens*, blocking if allowance is exceeded."""
+
+        if self.capacity <= 0:
+            return
+        while True:
+            with self._lock:
+                now = time.time()
+                if now >= self.reset_time:
+                    self.tokens = self.capacity
+                    self.reset_time = now + 60
+                if tokens <= self.tokens:
+                    self.tokens -= tokens
+                    return
+                wait = self.reset_time - now
+            time.sleep(wait)
+
+
+def estimate_tokens(text: str) -> int:
+    """Very small heuristic to estimate token usage from *text*."""
+
+    # Rough heuristic: assume 4 characters per token
+    return max(1, len(text) // 4)
+
+
+def sleep_with_backoff(attempt: int, base: float = 1.0, max_delay: float = 60.0) -> None:
+    """Sleep using exponential backoff based on *attempt* number."""
+
+    delay = min(base * (2**attempt), max_delay)
+    time.sleep(delay)
+
+
+__all__ = ["TokenBucket", "estimate_tokens", "sleep_with_backoff"]


### PR DESCRIPTION
## Summary
- add `llm_config` for environment and file-based LLM settings
- implement shared `rate_limit` utilities with token bucket and backoff
- update OpenAI backends and tests to use new config and rate limiting

## Testing
- `pytest tests/test_openai_client_http.py tests/test_llm_interface.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b51a059750832ebd2e43b6289563f7