### PR TITLE
Use tokenizer to calculate model-specific token counts

### DIFF
--- a/llm_interface.py
+++ b/llm_interface.py
@@ -247,7 +247,8 @@ class OpenAIProvider(LLMClient):
         for attempt in range(retries):
             self._rate_limiter.update_rate(cfg.tokens_per_minute)
             tokens = rate_limit.estimate_tokens(
-                " ".join(m.get("content", "") for m in payload["messages"])
+                " ".join(m.get("content", "") for m in payload["messages"]),
+                model=self.model,
             )
             self._rate_limiter.consume(tokens)
             try:

--- a/openai_client.py
+++ b/openai_client.py
@@ -51,7 +51,8 @@ class OpenAILLMClient(LLMClient):
         retries = cfg.max_retries
         for attempt in range(retries):
             tokens = rate_limit.estimate_tokens(
-                " ".join(m.get("content", "") for m in payload.get("messages", []))
+                " ".join(m.get("content", "") for m in payload.get("messages", [])),
+                model=self.model,
             )
             self._rate_limiter.consume(tokens)
             try:

--- a/tests/test_rate_limit_token_estimator.py
+++ b/tests/test_rate_limit_token_estimator.py
@@ -1,0 +1,10 @@
+import pytest
+
+from rate_limit import estimate_tokens
+
+pytest.importorskip("tiktoken")
+
+
+def test_estimate_tokens_known_models():
+    assert estimate_tokens("hello world", model="gpt-3.5-turbo") == 2
+    assert estimate_tokens("This is a test.", model="gpt-4o") == 5


### PR DESCRIPTION
## Summary
- use tiktoken to count tokens per model in `rate_limit.estimate_tokens`
- consult token estimator in OpenAI clients before each request
- cover token estimation with unit tests

## Testing
- `pytest tests/test_rate_limit_token_estimator.py tests/test_llm_interface.py::test_openai_provider_retry_and_logging tests/test_openai_client_http.py::test_openai_rate_limit_retry -q`


------
https://chatgpt.com/codex/tasks/task_e_68b521bbf6d0832e8ff9691c32928e21