### PR TITLE
Warn when psutil missing for memory limits

### DIFF
--- a/tests/test_memory_limit_no_psutil.py
+++ b/tests/test_memory_limit_no_psutil.py
@@ -1,0 +1,26 @@
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+# Ensure repository root on path for sandbox_settings import
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+module_path = pathlib.Path(__file__).resolve().parents[1] / "sandbox_runner" / "workflow_sandbox_runner.py"
+spec = importlib.util.spec_from_file_location("workflow_sandbox_runner", module_path)
+workflow_sandbox_runner = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = workflow_sandbox_runner
+spec.loader.exec_module(workflow_sandbox_runner)  # type: ignore[arg-type]
+WorkflowSandboxRunner = workflow_sandbox_runner.WorkflowSandboxRunner
+
+
+def dummy():
+    return 42
+
+
+def test_memory_limit_requires_psutil(monkeypatch):
+    monkeypatch.setattr(workflow_sandbox_runner, "psutil", None)
+    runner = WorkflowSandboxRunner()
+    with pytest.raises(RuntimeError):
+        runner.run(dummy, memory_limit=1024)


### PR DESCRIPTION
## Summary
- fail fast when memory limits requested without psutil
- log warning when psutil is unavailable for memory enforcement
- add regression test for missing psutil memory limit

## Testing
- `pytest tests/test_memory_limit_no_psutil.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b51e37e53c832eb20948101e6f7010