### PR TITLE
Ensure picklable audit hooks for subprocess execution

### DIFF
--- a/sandbox_runner/workflow_sandbox_runner.py
+++ b/sandbox_runner/workflow_sandbox_runner.py
@@ -48,6 +48,7 @@ import threading
 import _thread
 import logging
 import multiprocessing
+import pickle
 import traceback
 from dataclasses import dataclass, field
 from time import perf_counter, process_time
@@ -240,6 +241,15 @@ class WorkflowSandboxRunner:
                 file_data[key] = value
 
         if use_subprocess:
+            if audit_hook is not None:
+                try:
+                    pickle.dumps(audit_hook)
+                except Exception as exc:
+                    msg = (
+                        "audit_hook must be picklable when use_subprocess is True: "
+                        f"{exc}"
+                    )
+                    raise ValueError(msg) from exc
             parent_conn, child_conn = multiprocessing.Pipe()
             params = {
                 "safe_mode": safe_mode,


### PR DESCRIPTION
## Summary
- validate audit hooks are picklable before launching a subprocess
- import pickle in workflow sandbox runner

## Testing
- `pytest sandbox_runner/tests/test_minimal_cycle.py -q` *(fails: Missing dependencies for self-improvement: error_logger – Ensure the error_logger module is available.; telemetry_feedback – Ensure telemetry helpers are available.; telemetry_backend – Ensure telemetry helpers are available.)*

------
https://chatgpt.com/codex/tasks/task_e_68b522ee5a94832ebb8ce9826dc51cd3