### PR TITLE
Ensure logging import in retry_utils

### DIFF
--- a/retry_utils.py
+++ b/retry_utils.py
@@ -6,7 +6,7 @@ import logging
 import random
 import time
 from functools import wraps
-from typing import Callable, Type, Any
+from typing import Any, Callable, Type
 
 
 def retry(exc: Type[BaseException], attempts: int = 3, delay: float = 1.0) -> Callable[[Callable[..., Any]], Callable[..., Any]]:


### PR DESCRIPTION
## Summary
- confirm logging is imported in `retry_utils`
- tidy import ordering

## Testing
- `python -m py_compile retry_utils.py`
- `pytest tests/test_autoscaler_light.py::test_light_mode_retry -q` *(fails: ImportError: attempted relative import with no known parent package)*
- `python - <<'PY'
import retry_utils

@retry_utils.retry(ValueError, attempts=2, delay=0.01)
def test_retry():
    raise ValueError('fail')

try:
    test_retry()
except ValueError:
    print('retry raised ValueError after retries as expected')

class Bus:
    def publish(self, topic, event):
        raise RuntimeError('fail')

retry_utils.publish_with_retry(Bus(), 'topic', object(), attempts=2, delay=0.01)

def func():
    raise RuntimeError('boom')

try:
    retry_utils.with_retry(func, attempts=2, delay=0.01)
except RuntimeError:
    print('with_retry raised after retries as expected')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b52a483bfc832eac317786fb9091a1