### PR TITLE
Use tokenizer-based token estimates for local backends

### DIFF
--- a/tests/test_openai_client_http.py
+++ b/tests/test_openai_client_http.py
@@ -108,6 +108,12 @@ def test_client_fallback_to_local_backend(monkeypatch, tmp_path):
 
     result = client.generate(Prompt(text="hi"), parse_fn=json.loads)
     assert result.parsed == {"b": 2}
+    expected_prompt_tokens = rate_limit.estimate_tokens("hi", model="local")
+    expected_completion_tokens = rate_limit.estimate_tokens(
+        json.dumps({"b": 2}), model="local"
+    )
+    assert result.prompt_tokens == expected_prompt_tokens
+    assert result.completion_tokens == expected_completion_tokens
     row = client.db.conn.execute(
         "SELECT response_text, response_parsed FROM prompts",
     ).fetchone()


### PR DESCRIPTION
## Summary
- enhance rate limit utilities with tokenizer-based token estimation
- propagate new estimator to local backends and clients to return prompt/completion counts
- expand tests to verify token counting for local backends

## Testing
- `pytest tests/test_rate_limit_token_estimator.py tests/test_openai_client_http.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b52f9259b4832eaac25ddefc56dbfc