### PR TITLE
Refactor stub provider configuration with runtime reload and cache validation

### DIFF
--- a/sandbox_runner/tests/test_generative_stub_provider_config.py
+++ b/sandbox_runner/tests/test_generative_stub_provider_config.py
@@ -1,0 +1,40 @@
+import json
+import sys
+import types
+from pathlib import Path
+
+sys.modules.setdefault(
+    "db_router", types.SimpleNamespace(GLOBAL_ROUTER=None, init_db_router=lambda *a, **k: None)
+)
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from sandbox_runner import generative_stub_provider as gsp  # noqa: E402
+
+
+def test_config_reload(monkeypatch):
+    monkeypatch.setenv("SANDBOX_STUB_TIMEOUT", "1")
+    monkeypatch.setenv("SANDBOX_STUB_MAX_CONCURRENCY", "1")
+    cfg1 = gsp.get_config(refresh=True)
+    assert cfg1.timeout == 1.0
+    sem1 = cfg1.rate_limit
+
+    monkeypatch.setenv("SANDBOX_STUB_TIMEOUT", "2")
+    monkeypatch.setenv("SANDBOX_STUB_MAX_CONCURRENCY", "2")
+    cfg2 = gsp.get_config(refresh=True)
+    assert cfg2.timeout == 2.0
+    assert cfg2.max_concurrency == 2
+    # semaphore replaced
+    assert sem1 is not cfg2.rate_limit
+
+
+def test_save_cache_validates_entries(tmp_path):
+    cfg = gsp.get_config(refresh=True)
+    cfg.cache_path = tmp_path / "cache.json"
+    with gsp._CACHE_LOCK:
+        gsp._CACHE.clear()
+        gsp._CACHE[("ok", "func")] = {"a": 1}
+        gsp._CACHE[("bad", "func")] = {"a": object()}
+    gsp._save_cache(cfg)
+    data = json.loads((tmp_path / "cache.json").read_text())
+    assert data == [["ok::func", {"a": 1}]]


### PR DESCRIPTION
## Summary
- centralize stub generation settings in a `StubProviderConfig` dataclass
- validate cache entries before persisting to disk
- add unit tests covering configuration reload and cache validation

## Testing
- `pre-commit run --files sandbox_runner/generative_stub_provider.py sandbox_runner/tests/test_generative_stub_provider_config.py`
- `pytest sandbox_runner/tests/test_generative_stub_provider_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68b52f94de0c832ea2a9b553b998576c