### PR TITLE
Use default_factory for InputRecord timestamp

### DIFF
--- a/sandbox_runner/input_history_db.py
+++ b/sandbox_runner/input_history_db.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any, List
@@ -15,7 +15,7 @@ router = GLOBAL_ROUTER or init_db_router("sandbox_runner_input_history_db")
 @dataclass
 class InputRecord:
     data: dict[str, Any]
-    ts: str = datetime.utcnow().isoformat()
+    ts: str = field(default_factory=lambda: datetime.utcnow().isoformat())
 
 
 class InputHistoryDB:


### PR DESCRIPTION
## Summary
- ensure `InputRecord` timestamp defaults to creation time using `field(default_factory=lambda: datetime.utcnow().isoformat())`

## Testing
- `pre-commit run --files sandbox_runner/input_history_db.py`
- `pytest sandbox_runner/tests -q` *(fails: Collector errors in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b535c407c4832e97fd68bf4fac8ad0