### PR TITLE
Add Anthropic client and configurable local backends

### DIFF
--- a/anthropic_client.py
+++ b/anthropic_client.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+"""Anthropic API client implementing the LLMBackend protocol."""
+
+from typing import Any, Dict, List
+import os
+import time
+import requests
+
+import rate_limit
+import llm_config
+
+from llm_interface import Prompt, LLMResult, LLMClient
+
+
+class AnthropicClient(LLMClient):
+    """Lightweight client for the Anthropic Messages API."""
+
+    api_url = "https://api.anthropic.com/v1/messages"
+
+    def __init__(
+        self,
+        model: str | None = None,
+        api_key: str | None = None,
+        *,
+        max_retries: int | None = None,
+    ) -> None:
+        cfg = llm_config.get_config()
+        model = model or cfg.model
+        super().__init__(model)
+        self.api_key = api_key or os.getenv("ANTHROPIC_API_KEY") or cfg.api_key
+        if not self.api_key:
+            raise RuntimeError("ANTHROPIC_API_KEY is required")
+        self.max_retries = max_retries or cfg.max_retries
+        self._rate_limiter = rate_limit.TokenBucket(cfg.tokens_per_minute)
+
+    # ------------------------------------------------------------------
+    def _prepare_payload(self, prompt: Prompt) -> Dict[str, Any]:
+        messages: List[Dict[str, str]] = []
+        if prompt.system:
+            messages.append({"role": "system", "content": prompt.system})
+        for ex in getattr(prompt, "examples", []):
+            messages.append({"role": "system", "content": ex})
+        messages.append({"role": "user", "content": prompt.user})
+        return {"model": self.model, "max_tokens": 1024, "messages": messages}
+
+    # ------------------------------------------------------------------
+    def _generate(self, prompt: Prompt) -> LLMResult:
+        payload = self._prepare_payload(prompt)
+        headers = {
+            "x-api-key": self.api_key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        }
+        cfg = llm_config.get_config()
+        retries = self.max_retries
+        prompt_tokens_est = rate_limit.estimate_tokens(
+            " ".join(m.get("content", "") for m in payload["messages"]),
+            model=self.model,
+        )
+        for attempt in range(retries):
+            self._rate_limiter.update_rate(cfg.tokens_per_minute)
+            self._rate_limiter.consume(prompt_tokens_est)
+            try:
+                start = time.perf_counter()
+                response = requests.post(
+                    self.api_url, headers=headers, json=payload, timeout=30
+                )
+                latency_ms = (time.perf_counter() - start) * 1000
+            except requests.RequestException:
+                if attempt == retries - 1:
+                    raise
+            else:
+                if response.status_code == 429 and attempt < retries - 1:
+                    rate_limit.sleep_with_backoff(attempt)
+                    continue
+                if response.status_code >= 500 and attempt < retries - 1:
+                    rate_limit.sleep_with_backoff(attempt)
+                    continue
+                response.raise_for_status()
+                raw = response.json()
+                text = ""
+                try:
+                    parts = raw.get("content", [])
+                    text = "".join(p.get("text", "") for p in parts if isinstance(p, dict))
+                except Exception:
+                    pass
+                usage = raw.get("usage", {}) if isinstance(raw, dict) else {}
+                prompt_tokens = usage.get("input_tokens") or prompt_tokens_est
+                completion_tokens = usage.get("output_tokens") or rate_limit.estimate_tokens(
+                    text, model=self.model
+                )
+                extra = max(
+                    0, (prompt_tokens or 0) + (completion_tokens or 0) - prompt_tokens_est
+                )
+                if extra:
+                    self._rate_limiter.consume(extra)
+                return LLMResult(
+                    raw=raw,
+                    text=text,
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    latency_ms=latency_ms,
+                )
+        raise RuntimeError("Anthropic request failed")
+
+
+__all__ = ["AnthropicClient"]

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -341,8 +341,11 @@ class SandboxSettings(BaseSettings):
     available_backends: dict[str, str] = Field(
         default_factory=lambda: {
             "openai": "llm_interface.OpenAIProvider",
+            "anthropic": "anthropic_client.AnthropicClient",
             "ollama": "local_client.OllamaClient",
             "vllm": "local_client.VLLMClient",
+            "mixtral": "local_backend.mixtral_client",
+            "llama3": "local_backend.llama3_client",
         },
         env="AVAILABLE_LLM_BACKENDS",
         description="Mapping of backend names to import paths for LLM client factories.",

--- a/tests/test_new_backends.py
+++ b/tests/test_new_backends.py
@@ -1,0 +1,55 @@
+import anthropic_client
+import local_backend
+from llm_router import client_from_settings
+from sandbox_settings import SandboxSettings
+from llm_interface import Prompt
+import requests
+
+
+class DummyResp:
+    def __init__(self, status: int, data: dict):
+        self.status_code = status
+        self._data = data
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):  # pragma: no cover - simple stub
+        if self.status_code >= 400:
+            raise requests.HTTPError("boom", response=self)
+
+
+def test_anthropic_client_via_settings(monkeypatch, tmp_path):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setenv("PROMPT_DB_PATH", str(tmp_path / "prompts.db"))
+    resp = DummyResp(
+        200,
+        {"content": [{"type": "text", "text": "ok"}], "usage": {"input_tokens": 1, "output_tokens": 2}},
+    )
+    monkeypatch.setattr(anthropic_client.requests, "post", lambda url, headers=None, json=None, timeout=None: resp)
+    settings = SandboxSettings(preferred_llm_backend="anthropic")
+    client = client_from_settings(settings)
+    res = client.generate(Prompt(text="hi"))
+    assert res.text == "ok"
+    assert res.prompt_tokens == 1
+    assert res.completion_tokens == 2
+
+
+def test_mixtral_local_backend(monkeypatch):
+    resp = DummyResp(200, {"text": "local"})
+    monkeypatch.setattr(local_backend.requests, "post", lambda url, json=None, timeout=None: resp)
+    settings = SandboxSettings(preferred_llm_backend="mixtral")
+    client = client_from_settings(settings)
+    result = client.generate(Prompt(text="hello"))
+    assert result.text == "local"
+    assert client.model == "mixtral"
+
+
+def test_llama3_local_backend(monkeypatch):
+    resp = DummyResp(200, {"text": "llama"})
+    monkeypatch.setattr(local_backend.requests, "post", lambda url, json=None, timeout=None: resp)
+    settings = SandboxSettings(preferred_llm_backend="llama3")
+    client = client_from_settings(settings)
+    res = client.generate(Prompt(text="hi"))
+    assert res.text == "llama"
+    assert client.model == "llama3"


### PR DESCRIPTION
## Summary
- add AnthropicClient implementing the LLMBackend protocol via Anthropic's Messages API
- extend local_backend with Mixtral and Llama3 client factories
- register Anthropic and local Mixtral/Llama3 backends in sandbox settings and add tests

## Testing
- `pytest` (fails: 395 errors during collection)
- `pytest tests/test_new_backends.py`


------
https://chatgpt.com/codex/tasks/task_e_68b53abb3530832eafea76be8dad076e