### PR TITLE
Log backend provider name

### DIFF
--- a/anthropic_client.py
+++ b/anthropic_client.py
@@ -95,6 +95,8 @@ class AnthropicClient(LLMClient):
                 )
                 if extra:
                     self._rate_limiter.consume(extra)
+                raw.setdefault("model", self.model)
+                raw["backend"] = "anthropic"
                 return LLMResult(
                     raw=raw,
                     text=text,

--- a/local_backend.py
+++ b/local_backend.py
@@ -54,6 +54,10 @@ class _RESTBackend(LLMBackend):
         self._rate_limiter.consume(prompt_tokens)
 
         raw = with_retry(do_request, exc=requests.RequestException)
+        raw["backend"] = getattr(
+            self, "backend_name", self.__class__.__name__.replace("Backend", "").lower()
+        )
+        raw.setdefault("model", self.model)
         text = (
             raw.get("text")
             or raw.get("response", "")
@@ -75,6 +79,7 @@ class OllamaBackend(_RESTBackend):
     def __init__(self, model: str | None = None, base_url: str | None = None) -> None:
         model = model or os.getenv("OLLAMA_MODEL", "mistral")
         base_url = base_url or os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+        self.backend_name = "ollama"
         super().__init__(model=model, base_url=base_url, endpoint="api/generate")
 
 
@@ -84,6 +89,7 @@ class VLLMBackend(_RESTBackend):
     def __init__(self, model: str | None = None, base_url: str | None = None) -> None:
         model = model or os.getenv("VLLM_MODEL", "llama3")
         base_url = base_url or os.getenv("VLLM_BASE_URL", "http://localhost:8000")
+        self.backend_name = "vllm"
         super().__init__(model=model, base_url=base_url, endpoint="generate")
 
 def mixtral_client(model: str | None = None, base_url: str | None = None) -> LLMClient:

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -15,7 +15,7 @@ class StubClient(LLMClient):
         self.calls += 1
         if self.fail:
             raise RuntimeError("boom")
-        return LLMResult(raw={}, text=self.text)
+        return LLMResult(raw={"backend": self.model}, text=self.text)
 
 
 def test_router_uses_local_for_small_prompts():
@@ -89,8 +89,9 @@ def test_router_logs_backend_choice(monkeypatch):
 
     monkeypatch.setattr(lr, "PromptDB", DummyDB)
     router = LLMRouter(remote=StubClient("remote"), local=StubClient("local"), size_threshold=5)
-    router.generate(Prompt(text="hi"))
+    res = router.generate(Prompt(text="hi"))
     assert logged == ["local"]
+    assert res.raw["backend"] == "local"
 
 
 def custom_factory() -> StubClient:


### PR DESCRIPTION
## Summary
- allow LLMClient.generate and _log to forward backend name for accurate logging
- record backend source in OpenAI, Anthropic, and local REST backends
- adjust tests to ensure backend choice is logged correctly

## Testing
- `pytest tests/test_llm_interface.py tests/test_llm_router.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b54647238c832eb5f73c2a0ad9dd1b