### PR TITLE
Propagate prompt metadata through backends

### DIFF
--- a/local_backend.py
+++ b/local_backend.py
@@ -46,6 +46,10 @@ class _RESTBackend(LLMBackend):
 
     def generate(self, prompt: Prompt) -> Completion:
         payload = {"model": self.model, "prompt": prompt.text}
+        if getattr(prompt, "tags", None):
+            payload["tags"] = list(prompt.tags)
+        if getattr(prompt, "vector_confidence", None) is not None:
+            payload["vector_confidence"] = prompt.vector_confidence
 
         cfg = llm_config.get_config()
         retries = cfg.max_retries
@@ -68,6 +72,10 @@ class _RESTBackend(LLMBackend):
                     self.__class__.__name__.replace("Backend", "").lower(),
                 )
                 raw.setdefault("model", self.model)
+                if getattr(prompt, "tags", None):
+                    raw.setdefault("tags", list(prompt.tags))
+                if getattr(prompt, "vector_confidence", None) is not None:
+                    raw.setdefault("vector_confidence", prompt.vector_confidence)
                 text = (
                     raw.get("text")
                     or raw.get("response", "")
@@ -103,6 +111,10 @@ class _RESTBackend(LLMBackend):
             raise RuntimeError("httpx is required for async streaming")
 
         payload = {"model": self.model, "prompt": prompt.text, "stream": True}
+        if getattr(prompt, "tags", None):
+            payload["tags"] = list(prompt.tags)
+        if getattr(prompt, "vector_confidence", None) is not None:
+            payload["vector_confidence"] = prompt.vector_confidence
         url = f"{self.base_url.rstrip('/')}/{self.endpoint.lstrip('/')}"
 
         cfg = llm_config.get_config()

--- a/tests/test_local_backend.py
+++ b/tests/test_local_backend.py
@@ -1,0 +1,40 @@
+def test_rest_backend_propagates_metadata(monkeypatch):
+    import local_backend
+    from llm_interface import LLMClient, Prompt
+    import prompt_db
+
+    captured_payload = {}
+
+    def fake_post(self, payload):
+        captured_payload.update(payload)
+        return {"text": "ok"}
+
+    monkeypatch.setattr(local_backend._RESTBackend, "_post", fake_post)
+
+    logged = {}
+
+    class DummyDB:
+        def __init__(self, *_a, **_k):
+            pass
+
+        def log(self, prompt, result, backend=None):
+            logged["prompt"] = prompt
+            logged["raw"] = result.raw
+            logged["backend"] = backend
+
+    monkeypatch.setattr(prompt_db, "PromptDB", DummyDB)
+
+    backend = local_backend._RESTBackend(model="m", base_url="http://x", endpoint="/gen")
+    client = LLMClient(model="m", backends=[backend])
+
+    prompt = Prompt(text="hi", examples=["ex"], outcome_tags=["tag"], vector_confidence=0.5)
+    client.generate(prompt)
+
+    assert captured_payload["tags"] == ["tag"]
+    assert captured_payload["vector_confidence"] == 0.5
+    assert logged["prompt"].examples == ["ex"]
+    assert logged["prompt"].vector_confidence == 0.5
+    assert logged["prompt"].outcome_tags == ["tag"]
+    assert logged["raw"]["tags"] == ["tag"]
+    assert logged["raw"]["vector_confidence"] == 0.5
+    assert logged["backend"] == "m"


### PR DESCRIPTION
## Summary
- include `tags` and `vector_confidence` in local REST backend payloads and results
- ensure LLMRouter forwards prompt metadata and logs enriched raw outputs
- add tests confirming metadata logging for REST backend and router

## Testing
- `pre-commit run --files local_backend.py llm_router.py tests/test_local_backend.py tests/test_llm_router.py`
- `pytest tests/test_local_backend.py tests/test_llm_router.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b559fa4050832eabb3d534825c030d