### PR TITLE
Add async streaming for local LLM backends

### DIFF
--- a/local_backend.py
+++ b/local_backend.py
@@ -185,6 +185,11 @@ class OllamaBackend(_RESTBackend):
         self.backend_name = "ollama"
         super().__init__(model=model, base_url=base_url, endpoint="api/generate")
 
+    async def async_generate(self, prompt: Prompt) -> AsyncGenerator[str, None]:
+        """Stream a completion from the Ollama server."""
+        async for chunk in super().async_generate(prompt):
+            yield chunk
+
 
 class VLLMBackend(_RESTBackend):
     """Backend for a vLLM REST server."""
@@ -194,6 +199,11 @@ class VLLMBackend(_RESTBackend):
         base_url = base_url or os.getenv("VLLM_BASE_URL", "http://localhost:8000")
         self.backend_name = "vllm"
         super().__init__(model=model, base_url=base_url, endpoint="generate")
+
+    async def async_generate(self, prompt: Prompt) -> AsyncGenerator[str, None]:
+        """Stream a completion from the vLLM server."""
+        async for chunk in super().async_generate(prompt):
+            yield chunk
 
 
 def mixtral_client(model: str | None = None, base_url: str | None = None) -> LLMClient:

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -475,3 +475,58 @@ def test_rest_backend_async_stream(monkeypatch):
 
     asyncio.run(run())
     assert chunks == ["Hel", "lo"]
+
+
+def _setup_fake_sse_httpx(monkeypatch):
+    import types
+    import local_backend as lb
+
+    class FakeStream:
+        status_code = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def aiter_lines(self):
+            yield 'data: {"delta":{"content":"Hel"}}'
+            yield 'data: {"delta":{"content":"lo"}}'
+            yield 'data: [DONE]'
+
+        def raise_for_status(self):
+            pass
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def stream(self, method, url, json=None, timeout=None):
+            return FakeStream()
+
+    monkeypatch.setattr(lb, "httpx", types.SimpleNamespace(AsyncClient=FakeClient))
+    return lb
+
+
+def test_rest_backend_async_stream_sse(monkeypatch):
+    lb = _setup_fake_sse_httpx(monkeypatch)
+    from llm_interface import Prompt, LLMClient
+
+    backend = lb.VLLMBackend(model="m", base_url="http://x")
+    client = LLMClient(model="m", backends=[backend], log_prompts=False)
+
+    chunks: list[str] = []
+
+    async def run():
+        async for part in client.async_generate(Prompt(text="hi")):
+            chunks.append(part)
+
+    asyncio.run(run())
+    assert chunks == ["Hel", "lo"]


### PR DESCRIPTION
## Summary
- Expose async streaming via `async_generate` for Ollama and vLLM backends
- Support backend streaming in `LLMClient.async_generate`
- Add tests demonstrating streamed responses for JSON and SSE local backends

## Testing
- `pytest tests/test_llm_interface.py::test_rest_backend_async_stream tests/test_llm_interface.py::test_rest_backend_async_stream_sse tests/test_local_backend.py::test_rest_backend_propagates_metadata -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5624eb1f0832e937bcbadf48e387d