### PR TITLE
Use session retries for local REST backend

### DIFF
--- a/tests/test_new_backends.py
+++ b/tests/test_new_backends.py
@@ -45,7 +45,11 @@ def test_anthropic_client_via_settings(monkeypatch, tmp_path):
 
 def test_mixtral_local_backend(monkeypatch):
     resp = DummyResp(200, {"text": "local"})
-    monkeypatch.setattr(local_backend.requests, "post", lambda url, json=None, timeout=None: resp)
+    monkeypatch.setattr(
+        local_backend.requests.Session,
+        "post",
+        lambda self, url, json=None, timeout=None: resp,
+    )
     settings = SandboxSettings(preferred_llm_backend="mixtral")
     client = client_from_settings(settings)
     result = client.generate(Prompt(text="hello"))
@@ -55,7 +59,11 @@ def test_mixtral_local_backend(monkeypatch):
 
 def test_llama3_local_backend(monkeypatch):
     resp = DummyResp(200, {"text": "llama"})
-    monkeypatch.setattr(local_backend.requests, "post", lambda url, json=None, timeout=None: resp)
+    monkeypatch.setattr(
+        local_backend.requests.Session,
+        "post",
+        lambda self, url, json=None, timeout=None: resp,
+    )
     settings = SandboxSettings(preferred_llm_backend="llama3")
     client = client_from_settings(settings)
     res = client.generate(Prompt(text="hi"))
@@ -68,22 +76,22 @@ def test_rest_backend_retries_and_latency(monkeypatch):
 
     calls = {"n": 0}
 
-    def fake_post(url, json=None, timeout=None):
+    def fake_post(self, url, json=None, timeout=None):
         calls["n"] += 1
         if calls["n"] == 1:
-            raise requests.RequestException("boom")
+            return DummyResp(500, {})
         return DummyResp(200, {"text": "ok"})
 
     sleeps: list[float] = []
-
-    def fake_sleep(attempt, base=1.0, max_delay=60.0):
-        sleeps.append(min(base * (2**attempt), max_delay))
-
-    monkeypatch.setattr(local_backend.rate_limit, "sleep_with_backoff", fake_sleep)
+    monkeypatch.setattr(
+        local_backend.retry_utils.time,
+        "sleep",
+        lambda s: sleeps.append(s),
+    )
     monkeypatch.setenv("LLM_MAX_RETRIES", "2")
     counter = iter([0.0, 1.0, 2.0])
     monkeypatch.setattr(local_backend.time, "perf_counter", lambda: next(counter))
-    monkeypatch.setattr(local_backend.requests, "post", fake_post)
+    monkeypatch.setattr(local_backend.requests.Session, "post", fake_post)
 
     backend = local_backend.OllamaBackend(model="m", base_url="http://x")
     result = backend.generate(Prompt(text="hi"))
@@ -96,16 +104,18 @@ def test_rest_backend_retries_and_latency(monkeypatch):
 
 
 def test_rest_backend_propagates_failure(monkeypatch):
-    monkeypatch.setattr(local_backend.rate_limit, "sleep_with_backoff", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        local_backend.retry_utils.time, "sleep", lambda *_a, **_k: None
+    )
     monkeypatch.setenv("LLM_MAX_RETRIES", "2")
 
-    def boom(url, json=None, timeout=None):
-        raise requests.RequestException("fail")
+    def boom(self, url, json=None, timeout=None):
+        return DummyResp(500, {})
 
-    monkeypatch.setattr(local_backend.requests, "post", boom)
+    monkeypatch.setattr(local_backend.requests.Session, "post", boom)
     counter = iter([0.0, 1.0])
     monkeypatch.setattr(local_backend.time, "perf_counter", lambda: next(counter))
 
     backend = local_backend.OllamaBackend(model="m", base_url="http://x")
-    with pytest.raises(requests.RequestException):
+    with pytest.raises(local_backend._RetryableHTTPError):
         backend.generate(Prompt(text="hi"))

--- a/tests/test_openai_client_http.py
+++ b/tests/test_openai_client_http.py
@@ -102,7 +102,13 @@ def test_client_fallback_to_local_backend(monkeypatch, tmp_path):
     def local_post(url, json=None, timeout=None):
         return resp
 
-    monkeypatch.setattr(local_backend.requests, "post", local_post)
+    monkeypatch.setattr(
+        local_backend.requests.Session,
+        "post",
+        lambda self, url, json=None, timeout=None: local_post(
+            url, json=json, timeout=timeout
+        ),
+    )
 
     client = LLMClient(backends=[openai_backend, local])
 


### PR DESCRIPTION
## Summary
- use a reusable `requests.Session` and retry transient HTTP errors in the local REST backend
- count prompt tokens only after successful responses

## Testing
- `pre-commit run --files local_backend.py tests/test_new_backends.py tests/test_openai_client_http.py`
- `pytest tests/test_new_backends.py -q`
- `pytest tests/test_local_backend.py tests/test_openai_client_http.py tests/test_llm_interface.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5642c2b64832ea62d06103e28f1bf