### PR TITLE
Require configured visual agent credentials

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,11 @@
 import sys
 import types
 from pathlib import Path
+import os
 
 sandbox_runner_pkg = types.ModuleType("sandbox_runner")
 sandbox_runner_pkg.__path__ = [str(Path(__file__).resolve().parent / "sandbox_runner")]
 sys.modules.setdefault("sandbox_runner", sandbox_runner_pkg)
+
+os.environ.setdefault("VISUAL_AGENT_URLS", "http://127.0.0.1:8001")
+os.environ.setdefault("VISUAL_AGENT_TOKEN", "test-token")

--- a/run_autonomous.py
+++ b/run_autonomous.py
@@ -523,6 +523,7 @@ def check_env() -> None:
         name
         for name, val in (
             ("VISUAL_AGENT_TOKEN", settings.visual_agent_token),
+            ("VISUAL_AGENT_URLS", settings.visual_agent_urls),
             ("SANDBOX_REPO_PATH", settings.sandbox_repo_path),
         )
         if not val

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -1139,7 +1139,7 @@ class SandboxSettings(BaseSettings):
     )
     auto_dashboard_port: int | None = Field(None, env="AUTO_DASHBOARD_PORT")
     visual_agent_autostart: bool = Field(True, env="VISUAL_AGENT_AUTOSTART")
-    visual_agent_urls: str = Field("http://127.0.0.1:8001", env="VISUAL_AGENT_URLS")
+    visual_agent_urls: str = Field("", env="VISUAL_AGENT_URLS")
     va_prompt_template: str | None = Field(None, env="VA_PROMPT_TEMPLATE")
     va_prompt_prefix: str = Field("", env="VA_PROMPT_PREFIX")
     va_repo_layout_lines: int = Field(20, env="VA_REPO_LAYOUT_LINES")


### PR DESCRIPTION
## Summary
- stop persisting VISUAL_AGENT_TOKEN and VISUAL_AGENT_URLS defaults in the environment
- validate required visual agent configuration on startup
- ensure visual agent client fails fast when credentials are missing

## Testing
- `pre-commit run --files auto_env_setup.py conftest.py run_autonomous.py sandbox_settings.py visual_agent_client.py`
- `pytest tests/test_visual_agent_client.py::test_default_prefix -q`

------
https://chatgpt.com/codex/tasks/task_e_68b564c3d0e8832eb6d46bf76a539bd7