### PR TITLE
feat: centralize LLM rate limiting

### DIFF
--- a/anthropic_client.py
+++ b/anthropic_client.py
@@ -33,7 +33,7 @@ class AnthropicClient(LLMClient):
         if not self.api_key:
             raise RuntimeError("ANTHROPIC_API_KEY is required")
         self.max_retries = max_retries or cfg.max_retries
-        self._rate_limiter = rate_limit.TokenBucket(cfg.tokens_per_minute)
+        # Token bucket shared across clients is initialised by ``LLMClient``.
 
     # ------------------------------------------------------------------
     def _prepare_payload(self, prompt: Prompt) -> Dict[str, Any]:

--- a/private_backend.py
+++ b/private_backend.py
@@ -37,7 +37,8 @@ class LocalWeightsBackend(LLMBackend):
         if torch is not None:
             self._model.to(self.device)
         cfg = llm_config.get_config()
-        self._rate_limiter = rate_limit.TokenBucket(cfg.tokens_per_minute)
+        self._rate_limiter = rate_limit.SHARED_TOKEN_BUCKET
+        self._rate_limiter.update_rate(getattr(cfg, "tokens_per_minute", 0))
 
     def generate(self, prompt: Prompt) -> LLMResult:
         cfg = llm_config.get_config()

--- a/rate_limit.py
+++ b/rate_limit.py
@@ -60,6 +60,12 @@ class TokenBucket:
             time.sleep(wait)
 
 
+# Singleton bucket shared by all clients.  Callers should invoke ``update_rate``
+# before consuming tokens to ensure the capacity reflects the current
+# configuration.
+SHARED_TOKEN_BUCKET = TokenBucket()
+
+
 def _get_encoder(model: str | None) -> Any | None:
     """Return a tiktoken encoder for *model* if available."""
 
@@ -122,4 +128,4 @@ def sleep_with_backoff(attempt: int, base: float = 1.0, max_delay: float = 60.0)
     time.sleep(delay)
 
 
-__all__ = ["TokenBucket", "estimate_tokens", "sleep_with_backoff"]
+__all__ = ["TokenBucket", "estimate_tokens", "sleep_with_backoff", "SHARED_TOKEN_BUCKET"]

--- a/unit_tests/test_shared_rate_limiter.py
+++ b/unit_tests/test_shared_rate_limiter.py
@@ -1,0 +1,51 @@
+import types
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parent.parent
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+import llm_config
+import rate_limit
+from llm_interface import LLMClient, LLMResult, Prompt
+
+
+def test_clients_share_token_bucket(monkeypatch):
+    cfg = types.SimpleNamespace(
+        model="m",
+        api_key="key",
+        max_retries=1,
+        tokens_per_minute=100,
+    )
+    monkeypatch.setattr(llm_config, "get_config", lambda: cfg)
+
+    bucket = rate_limit.SHARED_TOKEN_BUCKET
+    bucket.update_rate(100)
+    bucket.tokens = 100
+
+    class Dummy(LLMClient):
+        def __init__(self, tokens: int):
+            super().__init__("dummy", log_prompts=False)
+            self._tokens = tokens
+
+        def _generate(self, prompt: Prompt) -> LLMResult:
+            self._rate_limiter.consume(self._tokens)
+            return LLMResult(text="", raw={"backend": "dummy"})
+
+    c1 = Dummy(30)
+    c2 = Dummy(50)
+
+    c1.generate(Prompt("hi"))
+    assert bucket.tokens == 70
+
+    c2.generate(Prompt("hi"))
+    assert bucket.tokens == 20
+
+    assert c1._rate_limiter is bucket and c2._rate_limiter is bucket
+
+    # Reset global bucket to avoid interference with other tests.  Use a large
+    # value so subsequent ``update_rate`` calls refill the allowance fully.
+    bucket.tokens = 10**9
+    bucket.capacity = 10**9
+


### PR DESCRIPTION
## Summary
- introduce module-level TokenBucket shared across all LLM clients
- hook LLMClient and backends into shared limiter
- add test ensuring token bucket is coordinated

## Testing
- `pytest unit_tests/test_llm_client.py::test_ollama_backend_retries unit_tests/test_llm_client.py::test_vllm_backend_retries unit_tests/test_llm_client.py::test_openai_provider_retries -q`
- `pytest unit_tests/test_shared_rate_limiter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b56ac293e0832e9bfe9f90fd4c91df