### PR TITLE
Add patch application helper and tests

### DIFF
--- a/self_improvement/api.py
+++ b/self_improvement/api.py
@@ -17,7 +17,7 @@ from .orchestration import (
     start_self_improvement_cycle,
     stop_self_improvement_cycle,
 )
-from .patch_application import generate_patch
+from .patch_application import generate_patch, apply_patch
 from .roi_tracking import update_alignment_baseline
 from .data_stores import router, STABLE_WORKFLOWS
 from .engine import SelfImprovementEngine
@@ -50,6 +50,7 @@ __all__ = [
     "start_self_improvement_cycle",
     "stop_self_improvement_cycle",
     "generate_patch",
+    "apply_patch",
     "update_alignment_baseline",
     "router",
     "STABLE_WORKFLOWS",

--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -146,7 +146,7 @@ from .orchestration import (
     stop_self_improvement_cycle,
 )
 from .roi_tracking import update_alignment_baseline
-from .patch_application import generate_patch
+from .patch_application import generate_patch, apply_patch
 
 
 from ..self_test_service import SelfTestService
@@ -1299,6 +1299,15 @@ class SelfImprovementEngine:
                 "patch generation failed", extra=log_record(module=module)
             )
             patch_id = None
+        else:
+            if patch_id is not None:
+                try:
+                    apply_patch(patch_id, _repo_path())
+                except RuntimeError:
+                    self.logger.exception(
+                        "patch application failed", extra=log_record(module=module)
+                    )
+                    patch_id = None
         elapsed = time.perf_counter() - start
         if self.metrics_db:
             try:

--- a/self_improvement/patch_application.py
+++ b/self_improvement/patch_application.py
@@ -8,6 +8,62 @@ keeps the public interface lightweight and focused on applying patches rather
 than the underlying generation details.
 """
 
-from .patch_generation import generate_patch
+from pathlib import Path
+import logging
+import subprocess
 
-__all__ = ["generate_patch"]
+from .patch_generation import generate_patch
+from .utils import _load_callable, _call_with_retries
+from ..sandbox_settings import SandboxSettings
+
+_settings = SandboxSettings()
+
+
+def apply_patch(
+    patch_id: int,
+    repo_path: str | Path,
+    *,
+    retries: int = _settings.patch_retries,
+    delay: float = _settings.patch_retry_delay,
+) -> None:
+    """Fetch and apply patch ``patch_id`` to ``repo_path``.
+
+    Raises ``RuntimeError`` if fetching or applying the patch fails.
+    """
+
+    logger = logging.getLogger(__name__)
+    try:
+        fetch = _load_callable("quick_fix_engine", "fetch_patch")
+    except RuntimeError as exc:  # pragma: no cover - best effort logging
+        logger.error("quick_fix_engine missing", exc_info=exc)
+        raise RuntimeError(
+            "quick_fix_engine is required for patch application. Install it via `pip install quick_fix_engine`."
+        ) from exc
+    try:
+        patch_data = _call_with_retries(
+            fetch, patch_id, retries=retries, delay=delay
+        )
+    except (RuntimeError, OSError) as exc:  # pragma: no cover - best effort logging
+        logger.error("quick_fix_engine failed", exc_info=exc)
+        raise RuntimeError("quick_fix_engine failed to fetch patch") from exc
+    if not patch_data:
+        logger.error("quick_fix_engine returned no patch data")
+        raise RuntimeError("quick_fix_engine did not return patch data")
+    try:
+        proc = subprocess.run(
+            ["git", "apply", "--whitespace=nowarn", "-"],
+            input=patch_data,
+            text=True,
+            capture_output=True,
+            cwd=str(repo_path),
+            check=False,
+        )
+    except Exception as exc:  # pragma: no cover - best effort logging
+        logger.error("git apply invocation failed", exc_info=exc)
+        raise RuntimeError("failed to apply patch") from exc
+    if proc.returncode != 0:
+        logger.error("git apply failed: %s", proc.stderr.strip())
+        raise RuntimeError("patch application failed")
+
+
+__all__ = ["generate_patch", "apply_patch"]

--- a/tests/self_improvement/test_patch_application.py
+++ b/tests/self_improvement/test_patch_application.py
@@ -1,0 +1,79 @@
+import sys
+import types
+import subprocess
+import importlib.machinery
+from pathlib import Path
+import importlib
+
+import pytest
+
+
+def _load_patch_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    root_pkg = types.ModuleType("menace_sandbox")
+    root_pkg.__path__ = [str(repo_root)]
+    root_pkg.__spec__ = importlib.machinery.ModuleSpec("menace_sandbox", loader=None, is_package=True)
+    sys.modules.setdefault("menace_sandbox", root_pkg)
+    sandbox_settings = types.ModuleType("sandbox_settings")
+    class SandboxSettings:
+        patch_retries = 1
+        patch_retry_delay = 0.0
+    sandbox_settings.SandboxSettings = SandboxSettings
+    sandbox_settings.load_sandbox_settings = lambda: SandboxSettings()
+    sandbox_runner = types.ModuleType("sandbox_runner")
+    bootstrap = types.ModuleType("sandbox_runner.bootstrap")
+    bootstrap.initialize_autonomous_sandbox = lambda: None
+    sandbox_runner.bootstrap = bootstrap
+    sys.modules.setdefault("sandbox_runner", sandbox_runner)
+    sys.modules.setdefault("sandbox_runner.bootstrap", bootstrap)
+    sys.modules.setdefault("sandbox_settings", sandbox_settings)
+    return importlib.import_module("menace_sandbox.self_improvement.patch_application")
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "you@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Your Name"], cwd=repo, check=True)
+    (repo / "file.txt").write_text("hello\n")
+    subprocess.run(["git", "add", "file.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True)
+    return repo
+
+SUCCESS_PATCH = """\
+diff --git a/file.txt b/file.txt
+--- a/file.txt
++++ b/file.txt
+@@
+-hello
++world
+"""
+
+FAIL_PATCH = """\
+diff --git a/file.txt b/file.txt
+--- a/file.txt
++++ b/file.txt
+@@
+-nope
++world
+"""
+
+def test_apply_patch_success(tmp_path, monkeypatch):
+    repo = _init_repo(tmp_path)
+    mod = types.ModuleType("quick_fix_engine")
+    mod.fetch_patch = lambda patch_id: SUCCESS_PATCH
+    monkeypatch.setitem(sys.modules, "quick_fix_engine", mod)
+    patch_module = _load_patch_module()
+    patch_module.apply_patch(1, repo)
+    assert (repo / "file.txt").read_text() == "world\n"
+
+def test_apply_patch_failure(tmp_path, monkeypatch):
+    repo = _init_repo(tmp_path)
+    mod = types.ModuleType("quick_fix_engine")
+    mod.fetch_patch = lambda patch_id: FAIL_PATCH
+    monkeypatch.setitem(sys.modules, "quick_fix_engine", mod)
+    patch_module = _load_patch_module()
+    with pytest.raises(RuntimeError):
+        patch_module.apply_patch(1, repo)
+    assert (repo / "file.txt").read_text() == "hello\n"


### PR DESCRIPTION
## Summary
- implement `apply_patch` to fetch and apply patches via `git apply`
- call `apply_patch` from self improvement API and engine
- add tests covering successful and failing patch applications

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest self_improvement/test_patch_application.py -q --noconftest` *(fails: ModuleNotFoundError: No module named 'db_router')*

------
https://chatgpt.com/codex/tasks/task_e_68b5771ffe34832eaa40a277c7f325ac