### PR TITLE
Refactor simple AST evaluation with NodeVisitor

### DIFF
--- a/sandbox_runner/tests/test_simple_evaluator.py
+++ b/sandbox_runner/tests/test_simple_evaluator.py
@@ -1,0 +1,28 @@
+import ast
+
+from sandbox_runner.orphan_discovery import _eval_simple
+
+
+def _parse(expr: str) -> ast.AST:
+    return ast.parse(expr, mode="eval").body
+
+
+def test_list_comprehension():
+    node = _parse("[x * 2 for x in [1, 2, 3]]")
+    assert _eval_simple(node, {}, 1) == [2, 4, 6]
+
+
+def test_dict_comprehension():
+    node = _parse("{k: v for k, v in [('a', 1), ('b', 2)]}")
+    assert _eval_simple(node, {}, 1) == {"a": 1, "b": 2}
+
+
+def test_fstring():
+    node = _parse("f'foo {1 + 1}'")
+    assert _eval_simple(node, {}, 1) == "foo 2"
+
+
+def test_arithmetic_expression():
+    node = _parse("1 + 2 * 3 - (-4)")
+    assert _eval_simple(node, {}, 1) == 1 + 2 * 3 - (-4)
+

--- a/tests/test_eval_simple.py
+++ b/tests/test_eval_simple.py
@@ -2,7 +2,9 @@ import ast
 import logging
 import os
 
-from sandbox_runner.orphan_discovery import _eval_simple
+import pytest
+
+from sandbox_runner.orphan_discovery import EvaluationError, _eval_simple
 
 
 def _parse(expr: str) -> ast.AST:
@@ -28,6 +30,7 @@ def test_concat_with_assignment():
 def test_unresolved_logs(caplog):
     node = _parse("unknown")
     with caplog.at_level(logging.DEBUG):
-        assert _eval_simple(node, {}, 1) is None
+        with pytest.raises(EvaluationError):
+            _eval_simple(node, {}, 1)
     assert "Unresolved expression" in caplog.text
 

--- a/unit_tests/test_eval_simple_logging.py
+++ b/unit_tests/test_eval_simple_logging.py
@@ -1,58 +1,25 @@
 import ast
 import logging
-from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
 
-source = (
-    Path(__file__).resolve().parents[1] / "sandbox_runner" / "orphan_discovery.py"
-).read_text()
-module = ast.parse(source)
-functions: Dict[str, str] = {}
-for node in module.body:
-    if isinstance(node, ast.FunctionDef) and node.name in {"_log_unresolved", "_eval_simple"}:
-        functions[node.name] = ast.get_source_segment(source, node)
+import pytest
 
-globals_dict = {
-    "ast": ast,
-    "Any": Any,
-    "Iterable": Iterable,
-    "List": List,
-    "Dict": Dict,
-    "Mapping": Mapping,
-    "Sequence": Sequence,
-    "Tuple": Tuple,
-    "logger": logging.getLogger(__name__),
-    "SAFE_CALLS": {},
-}
-
-
-def _resolve_assignment(*_a, **_k):
-    return None
-
-
-globals_dict["_resolve_assignment"] = _resolve_assignment
-
-exec(functions["_log_unresolved"], globals_dict)
-exec(functions["_eval_simple"], globals_dict)
-
-_eval_simple = globals_dict["_eval_simple"]
+from sandbox_runner.orphan_discovery import EvaluationError, _eval_simple
 
 
 def test_eval_simple_logs_binop_exception(caplog):
     node = ast.parse("'%s' % ()", mode="eval").body
     with caplog.at_level(logging.DEBUG):
-        assert _eval_simple(node, {}, 1) is None
-    assert any(
-        "Unresolved expression" in record.message and "not enough arguments" in record.message
-        for record in caplog.records
-    )
+        with pytest.raises(EvaluationError):
+            _eval_simple(node, {}, 1)
+    assert "Unresolved expression" in caplog.text
+    assert "not enough arguments" in caplog.text
 
 
 def test_eval_simple_logs_call_exception(caplog):
     node = ast.parse("'hello'.index('x')", mode="eval").body
     with caplog.at_level(logging.DEBUG):
-        assert _eval_simple(node, {}, 1) is None
-    assert any(
-        "Unresolved expression" in record.message and "substring not found" in record.message
-        for record in caplog.records
-    )
+        with pytest.raises(EvaluationError):
+            _eval_simple(node, {}, 1)
+    assert "Unresolved expression" in caplog.text
+    assert "substring not found" in caplog.text
+


### PR DESCRIPTION
## Summary
- replace `_eval_simple` with a safe `ast.NodeVisitor` supporting literals, dicts, comprehensions, unary and numeric operations
- raise descriptive `EvaluationError` for unsupported nodes
- add tests for lists, dicts, f-strings, arithmetic and update existing tests

## Testing
- `pytest sandbox_runner/tests/test_simple_evaluator.py -q`
- `pytest tests/test_eval_simple.py -q`
- `pytest unit_tests/test_eval_simple_logging.py -q` *(fails: ModuleNotFoundError / heavy torch import)*


------
https://chatgpt.com/codex/tasks/task_e_68b580f30758832ebeafbcbd9b6ac5f9