### PR TITLE
Guard orphan_analyzer import and add missing-module test

### DIFF
--- a/sandbox_runner/orphan_discovery.py
+++ b/sandbox_runner/orphan_discovery.py
@@ -8,7 +8,16 @@ import os
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
 
-import orphan_analyzer
+try:  # pragma: no cover - executed during import
+    import orphan_analyzer
+except ModuleNotFoundError as exc:  # pragma: no cover - import-time guard
+    logging.getLogger(__name__).error(
+        "Failed to import 'orphan_analyzer'. Please install or configure the module.",
+    )
+    raise RuntimeError(
+        "orphan_analyzer is required for orphan discovery. "
+        "Ensure it is installed and properly configured.",
+    ) from exc
 
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/test_orphan_analyzer_missing.py
+++ b/tests/integration/test_orphan_analyzer_missing.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def test_orphan_analyzer_missing(monkeypatch, caplog):
+    pkg_path = Path(__file__).resolve().parents[2] / "sandbox_runner"
+    pkg = types.ModuleType("sandbox_runner")
+    pkg.__path__ = [str(pkg_path)]
+    monkeypatch.setitem(sys.modules, "sandbox_runner", pkg)
+    monkeypatch.delitem(sys.modules, "sandbox_runner.orphan_discovery", raising=False)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "orphan_analyzer":
+            raise ModuleNotFoundError("No module named 'orphan_analyzer'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError, match="orphan_analyzer is required"):
+            importlib.import_module("sandbox_runner.orphan_discovery")
+
+    assert any(
+        "Failed to import 'orphan_analyzer'" in rec.message for rec in caplog.records
+    )


### PR DESCRIPTION
## Summary
- handle missing `orphan_analyzer` dependency with a clear runtime error
- verify runtime message with an integration test

## Testing
- `pre-commit run --files sandbox_runner/orphan_discovery.py tests/integration/test_orphan_analyzer_missing.py`
- `pytest tests/integration/test_orphan_analyzer_missing.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5831880d0832e84ea021b63fc89df