### PR TITLE
Handle sandbox launch errors

### DIFF
--- a/sandbox_runner/tests/test_start_autonomous_failure.py
+++ b/sandbox_runner/tests/test_start_autonomous_failure.py
@@ -1,0 +1,46 @@
+import sys
+import types
+import logging
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+
+def _setup_base_packages():
+    menace_pkg = types.ModuleType("menace")
+    menace_pkg.__path__ = []  # type: ignore[attr-defined]
+    sys.modules["menace"] = menace_pkg
+    sys.modules["menace.auto_env_setup"] = types.SimpleNamespace(ensure_env=lambda *a, **k: None)
+    sys.modules["menace.default_config_manager"] = types.SimpleNamespace(
+        DefaultConfigManager=lambda *a, **k: types.SimpleNamespace(apply_defaults=lambda: None)
+    )
+    sys.modules["menace.environment_generator"] = types.SimpleNamespace(
+        _CPU_LIMITS={}, _MEMORY_LIMITS={}
+    )
+    sys.modules["sandbox_runner.cli"] = types.SimpleNamespace(main=lambda *a, **k: None)
+    sys.modules["sandbox_runner.cycle"] = types.SimpleNamespace(
+        ensure_vector_service=lambda: None
+    )
+    si_pkg = types.ModuleType("self_improvement")
+    sys.modules["self_improvement"] = si_pkg
+
+
+_setup_base_packages()
+
+
+def test_failed_launch_surfaces_error(monkeypatch, caplog):
+    import start_autonomous_sandbox as sas
+
+    def boom():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(sas, "launch_sandbox", boom)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(SystemExit) as exc:
+            sas.main([])
+
+    assert exc.value.code == 1
+    assert any("Failed to launch sandbox" in record.message for record in caplog.records)

--- a/start_autonomous_sandbox.py
+++ b/start_autonomous_sandbox.py
@@ -1,4 +1,48 @@
+"""Entry point for launching the autonomous sandbox.
+
+This small wrapper adds a bit of resiliency around the sandbox bootstrap by
+capturing startup exceptions and allowing the log level to be configured via
+the command line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
 from sandbox_runner.bootstrap import launch_sandbox
 
+
+def main(argv: list[str] | None = None) -> None:
+    """Launch the sandbox with optional log level configuration.
+
+    Parameters
+    ----------
+    argv:
+        Optional list of command line arguments. If ``None`` the arguments will
+        be pulled from :data:`sys.argv`.
+    """
+
+    parser = argparse.ArgumentParser(description="Launch the autonomous sandbox")
+    parser.add_argument(
+        "--log-level",
+        dest="log_level",
+        default=None,
+        help="Logging level (e.g. DEBUG, INFO, WARNING)",
+    )
+    args = parser.parse_args(argv)
+
+    # Configure logging; errors are always shown but the level can be raised
+    # for debugging during initialization.
+    logging.basicConfig(level=getattr(logging, str(args.log_level).upper(), None))
+
+    try:
+        launch_sandbox()
+    except Exception:  # pragma: no cover - defensive catch
+        logging.exception("Failed to launch sandbox")
+        sys.exit(1)
+
+
 if __name__ == "__main__":
-    launch_sandbox()
+    main()


### PR DESCRIPTION
## Summary
- wrap `launch_sandbox` to log failures and exit non-zero
- add optional `--log-level` flag for easier debugging
- test that a launch failure logs a clear error

## Testing
- `pre-commit run --files start_autonomous_sandbox.py sandbox_runner/tests/test_start_autonomous_failure.py`
- `pytest sandbox_runner/tests/test_start_autonomous_launch.py sandbox_runner/tests/test_start_autonomous_failure.py`


------
https://chatgpt.com/codex/tasks/task_e_68b584375958832eb977374b9fc69dee