### PR TITLE
Add prompt attempt logging helper

### DIFF
--- a/self_improvement/prompt_memory.py
+++ b/self_improvement/prompt_memory.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+"""Lightweight prompt attempt logging for self-improvement workflows.
+
+This module provides :func:`log_prompt_attempt` which appends metadata about
+prompt executions to newline-delimited JSON files under the repository root.
+"""
+
+from datetime import datetime
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from filelock import FileLock
+
+from .init import _repo_path
+
+
+def _log_path(success: bool) -> Path:
+    """Return the log file path based on *success* state."""
+
+    filename = "prompt_success_log.json" if success else "prompt_failure_log.json"
+    return _repo_path() / filename
+
+
+def log_prompt_attempt(
+    prompt: Any, success: bool, exec_result: Any, roi_meta: Dict[str, Any] | None = None
+) -> None:
+    """Record a prompt attempt outcome.
+
+    Parameters
+    ----------
+    prompt:
+        Prompt object or mapping containing ``system``, ``user``, ``examples`` and
+        ``metadata`` attributes.  ``metadata`` may include ``target_module`` and
+        ``patch_id``.
+    success:
+        ``True`` when the attempt was successful, ``False`` otherwise.  The flag
+        selects between success and failure log files.
+    exec_result:
+        Execution result information to store alongside the prompt.  The value
+        is serialised using :func:`json.dumps` with ``default=str`` so arbitrary
+        objects can be stored.
+    roi_meta:
+        Optional ROI metrics or other contextual information.
+    """
+
+    metadata = getattr(prompt, "metadata", {}) if prompt is not None else {}
+    target_module = None
+    patch_id = None
+    if isinstance(metadata, dict):
+        target_module = metadata.get("target_module") or metadata.get("module")
+        patch_id = metadata.get("patch_id")
+
+    entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "target_module": target_module,
+        "patch_id": patch_id,
+        "prompt_system": getattr(prompt, "system", ""),
+        "prompt_user": getattr(prompt, "user", ""),
+        "examples": list(getattr(prompt, "examples", [])),
+        "metadata": metadata,
+        "exec_result": exec_result,
+    }
+    if roi_meta is not None:
+        entry["roi_meta"] = roi_meta
+
+    path = _log_path(success)
+    lock = FileLock(str(path) + ".lock")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with lock:
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry, default=str) + "\n")


### PR DESCRIPTION
## Summary
- add `log_prompt_attempt` utility to record prompt success or failure with metadata and ROI metrics

## Testing
- `python -m py_compile self_improvement/prompt_memory.py`
- `pre-commit run --files self_improvement/prompt_memory.py`
- `python - <<'PY'
from prompt_types import Prompt
from self_improvement.prompt_memory import log_prompt_attempt

p = Prompt(user="Hello", system="Test system", examples=["ex1", "ex2"], metadata={"target_module": "foo", "patch_id": "123"})
log_prompt_attempt(p, True, {"status": "ok"}, roi_meta={"roi": 0.5})
PY` *(fails: RuntimeError: error_logger is required for sandbox operations)*

------
https://chatgpt.com/codex/tasks/task_e_68b58358b1ec832e9c0f920885e45edd