### PR TITLE
feat: make self-improvement dependencies auto-installable

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -286,6 +286,11 @@ class SandboxSettings(BaseSettings):
     menace_offline_install: bool = Field(False, env="MENACE_OFFLINE_INSTALL")
     menace_wheel_dir: str | None = Field(None, env="MENACE_WHEEL_DIR")
     menace_light_imports: bool = Field(False, env="MENACE_LIGHT_IMPORTS")
+    auto_install_dependencies: bool = Field(
+        False,
+        env="AUTO_INSTALL_DEPENDENCIES",
+        description="Automatically install missing Python packages when possible.",
+    )
     roi_cycles: int | None = Field(None, env="ROI_CYCLES")
     synergy_cycles: int | None = Field(None, env="SYNERGY_CYCLES")
     save_synergy_history: bool | None = Field(None, env="SAVE_SYNERGY_HISTORY")

--- a/tests/test_self_improvement_dependencies.py
+++ b/tests/test_self_improvement_dependencies.py
@@ -52,7 +52,11 @@ def test_verify_dependencies_reports_all_missing(monkeypatch):
             return types.ModuleType(name)
         return original_import(name, package)
 
+    def fake_version(name):
+        return "2.0.0"
+
     monkeypatch.setattr(importlib, "import_module", fake_import)
+    monkeypatch.setattr(importlib.metadata, "version", fake_version)
 
     with pytest.raises(RuntimeError) as excinfo:
         verify_dependencies()


### PR DESCRIPTION
## Summary
- add `auto_install_dependencies` setting to control dependency auto-installation
- expand `verify_dependencies` to report version mismatches and optionally install packages
- test auto-install, version mismatch, and existing dependency behaviour

## Testing
- `pytest tests/self_improvement/test_verify_dependencies.py tests/test_self_improvement_dependencies.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5884e7770832e8901f3d8af9c0694