### PR TITLE
Add orphan integration metrics and logging

### DIFF
--- a/metrics_exporter.py
+++ b/metrics_exporter.py
@@ -503,6 +503,16 @@ patch_failure_total = Gauge(
     "patch_failure_total", "Number of failed patch applications",
 )
 
+# Counters for orphan integration outcomes
+orphan_integration_success_total = Gauge(
+    "orphan_integration_success_total",
+    "Number of successful orphan integrations",
+)
+orphan_integration_failure_total = Gauge(
+    "orphan_integration_failure_total",
+    "Number of orphan integration failures",
+)
+
 
 # Metrics for visual agent utilisation
 visual_agent_wait_time = Gauge(

--- a/unit_tests/test_orphan_handling_metrics.py
+++ b/unit_tests/test_orphan_handling_metrics.py
@@ -1,0 +1,79 @@
+import importlib.util
+import pathlib
+import sys
+import types
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+# Ensure root directory is on sys.path for absolute imports
+sys.path.append(str(ROOT))
+
+# Create package structure without executing heavy initialisers
+root_pkg = types.ModuleType("menace_sandbox")
+root_pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("menace_sandbox", root_pkg)
+
+self_pkg = types.ModuleType("menace_sandbox.self_improvement")
+self_pkg.__path__ = [str(ROOT / "self_improvement")]
+sys.modules.setdefault("menace_sandbox.self_improvement", self_pkg)
+
+me_spec = importlib.util.spec_from_file_location(
+    "menace_sandbox.metrics_exporter", ROOT / "metrics_exporter.py"
+)
+metrics_exporter = importlib.util.module_from_spec(me_spec)
+sys.modules[me_spec.name] = metrics_exporter
+assert me_spec.loader is not None
+me_spec.loader.exec_module(metrics_exporter)
+
+spec = importlib.util.spec_from_file_location(
+    "menace_sandbox.self_improvement.orphan_handling",
+    ROOT / "self_improvement" / "orphan_handling.py",
+)
+orphan_handling = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = orphan_handling
+assert spec.loader is not None
+spec.loader.exec_module(orphan_handling)
+
+
+
+def _reset_metrics() -> None:
+    orphan_handling.orphan_integration_success_total.set(0)
+    orphan_handling.orphan_integration_failure_total.set(0)
+
+
+def test_integrate_orphans_success(monkeypatch):
+    _reset_metrics()
+
+    def dummy(*args, **kwargs):
+        return ["mod_a"]
+
+    monkeypatch.setattr(orphan_handling, "_load_orphan_module", lambda attr: dummy)
+    monkeypatch.setattr(
+        orphan_handling, "_call_with_retries", lambda func, *a, **kw: func(*a, **kw)
+    )
+
+    result = orphan_handling.integrate_orphans()
+    assert result == ["mod_a"]
+    assert orphan_handling.orphan_integration_success_total._value.get() == 1.0
+    assert orphan_handling.orphan_integration_failure_total._value.get() == 0.0
+
+
+def test_post_round_orphan_scan_failure(monkeypatch):
+    _reset_metrics()
+
+    def dummy(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(orphan_handling, "_load_orphan_module", lambda attr: dummy)
+    monkeypatch.setattr(
+        orphan_handling, "_call_with_retries", lambda func, *a, **kw: func(*a, **kw)
+    )
+
+    with pytest.raises(RuntimeError):
+        orphan_handling.post_round_orphan_scan()
+
+    assert orphan_handling.orphan_integration_success_total._value.get() == 0.0
+    assert orphan_handling.orphan_integration_failure_total._value.get() == 1.0
+


### PR DESCRIPTION
## Summary
- log sandbox orphan integration results and capture failures
- expose counters for orphan integration successes and failures
- test that orphan integration metrics increment on success and failure

## Testing
- `pytest -q unit_tests/test_orphan_handling_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68b58ff76830832eb3832ebd10e50a64