### PR TITLE
Log patch test fetch errors

### DIFF
--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -1368,7 +1368,11 @@ class SelfImprovementEngine:
                     if row:
                         roi_meta["tests_passed"] = bool(row[0])
                 except Exception:
-                    pass
+                    self.logger.exception(
+                        "failed to fetch patch test result",
+                        extra=log_record(module=module, patch_id=patch_id),
+                    )
+                    raise
         if not success:
             fails: List[str] = []
             if error_trace:


### PR DESCRIPTION
## Summary
- log failures when retrieving patch test results
- re-raise database errors so patch application fails visibly

## Testing
- `python -m py_compile self_improvement/engine.py`
- `pytest -q unit_tests/test_self_coding_manager_failed_tags.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5926539b0832eb1ad0c0777e05891