### PR TITLE
Add self-improvement quickstart docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1330,7 +1330,9 @@ The Menace integrity model interprets tiers as follows:
 
 See [docs/sandbox_self_improvement.md](docs/sandbox_self_improvement.md) for a
 full walkthrough covering package requirements, environment variables, example
-workflows and troubleshooting tips.
+workflows and troubleshooting tips. For a quickstart on launching the sandbox
+and monitoring metrics, see
+[docs/self_improvement.md](docs/self_improvement.md).
 
 #### Required packages
 

--- a/docs/self_improvement.md
+++ b/docs/self_improvement.md
@@ -1,0 +1,50 @@
+# Self-Improvement Quickstart
+
+This guide covers the basics for running the autonomous sandbox in
+self-improvement mode.
+
+## Required packages
+
+- Install core dependencies with `pip install -r requirements.txt` or run
+  `./setup_env.sh`.
+- `sandbox_runner` (including the `sandbox_runner.orphan_integration`
+  module) and `quick_fix_engine` provide the execution harness and patch
+  generation. Install them explicitly when missing:
+  `pip install sandbox_runner quick_fix_engine`.
+- Optional: `prometheus-client` exposes metrics via HTTP.
+
+## Launch `start_autonomous_sandbox.py`
+
+Start the sandbox with an optional log level:
+
+```bash
+python start_autonomous_sandbox.py --log-level INFO
+```
+
+The wrapper forwards control to `sandbox_runner.bootstrap.launch_sandbox` and
+exits with a non-zero status when initialisation fails.
+
+## Environment variables
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `SANDBOX_REPO_PATH` | repository root used during self-improvement | current working directory |
+| `SANDBOX_DATA_DIR` | directory for metrics and state files | `sandbox_data` |
+| `SANDBOX_ENV_PRESETS` | comma separated scenario preset files | unset |
+| `AUTO_TRAIN_INTERVAL` | seconds between sandbox training passes | `600` |
+| `SYNERGY_TRAIN_INTERVAL` | steps between synergy weight updates | `10` |
+| `ADAPTIVE_ROI_RETRAIN_INTERVAL` | cycles between adaptive ROI model retraining | `20` |
+| `METRICS_PORT` | start metrics server on this port when set | unset (disabled) |
+
+## Monitoring metrics and logs
+
+Set `METRICS_PORT` to expose Prometheus gauges via
+`metrics_exporter.start_metrics_server`. Metrics are available at
+`http://localhost:<port>/` and can be scraped by Prometheus or viewed with a
+browser.
+
+Runtime logs are written under the `logs/` directory and streamed to stdout.
+Increase verbosity with `--log-level DEBUG` when launching the sandbox and use
+`tail -f logs/*.log` to monitor activity. ROI, synergy and error messages help
+identify regressions during self-improvement cycles.
+


### PR DESCRIPTION
## Summary
- Document required packages, environment variables, metrics monitoring and logs for running the autonomous sandbox
- Link the new self-improvement quickstart guide from the README

## Testing
- `pytest` *(fails: 385 errors during collection; missing docker and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b59e9d7b60832ebe1d693492c071b0