### PR TITLE
feat: log prompt evolution for self-coding attempts

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -532,6 +532,16 @@ class SandboxSettings(BaseSettings):
         env="AUDIT_PRIVKEY",
         description="Base64-encoded private key for signing audit entries.",
     )
+    prompt_success_log_path: str = Field(
+        "prompt_success_log.json",
+        env="PROMPT_SUCCESS_LOG_PATH",
+        description="Path for recording successful prompt executions.",
+    )
+    prompt_failure_log_path: str = Field(
+        "prompt_failure_log.json",
+        env="PROMPT_FAILURE_LOG_PATH",
+        description="Path for recording failed prompt executions.",
+    )
     stub_timeout: float = Field(
         10.0,
         env="SANDBOX_STUB_TIMEOUT",

--- a/self_improvement/prompt_memory.py
+++ b/self_improvement/prompt_memory.py
@@ -13,13 +13,20 @@ from typing import Any, Dict
 
 from filelock import FileLock
 
+from sandbox_settings import SandboxSettings
 from .init import _repo_path
+
+_settings = SandboxSettings()
 
 
 def _log_path(success: bool) -> Path:
     """Return the log file path based on *success* state."""
 
-    filename = "prompt_success_log.json" if success else "prompt_failure_log.json"
+    filename = (
+        _settings.prompt_success_log_path
+        if success
+        else _settings.prompt_failure_log_path
+    )
     return _repo_path() / filename
 
 


### PR DESCRIPTION
## Summary
- configure prompt success and failure log paths via `SandboxSettings`
- update prompt memory to honor configurable log paths
- integrate `PromptEvolutionLogger` into `SelfCodingEngine` and log each patch attempt

## Testing
- `pytest self_improvement/tests/test_minimal_workflow.py` *(fails: RuntimeError: error_logger is required for sandbox run)*

------
https://chatgpt.com/codex/tasks/task_e_68b59ea4ec7c832e927e94b9bf5fac3a