### PR TITLE
Add prompt formatting optimizer

### DIFF
--- a/prompt_optimizer.py
+++ b/prompt_optimizer.py
@@ -2,10 +2,14 @@
 
 This module analyses prompt experiment logs to discover which formatting
 styles yield the best outcomes. Logs are expected to be line delimited JSON
-with at least ``module``, ``action``, ``prompt``, ``success`` and ``roi``
-fields. Statistics are aggregated across multiple features such as tone,
-header usage and example counts. A ROI weighted success rate ensures that
-prompts leading to higher return on investment are preferred.
+containing at least ``module``, ``action``, ``prompt``, ``success`` and
+``roi`` fields. Additional optional fields such as ``coverage`` or
+``runtime_improvement`` can be used to weight ROI calculations.
+
+The optimiser groups prompts by structural features – tone, header set and
+example placement – and computes success rates as well as weighted ROI
+improvements. These aggregated statistics are persisted so that subsequent
+runs can build upon previous observations.
 """
 
 from __future__ import annotations
@@ -29,36 +33,56 @@ class _Stat:
     module: str
     action: str
     tone: str
-    headers: int
-    example_count: int
+    header_set: Tuple[str, ...]
+    example_placement: str
     has_code: bool
     has_bullets: bool
     success: int = 0
     total: int = 0
-    roi_success: float = 0.0
-    roi_total: float = 0.0
+    roi_sum: float = 0.0
+    weighted_roi_sum: float = 0.0
+    weight_sum: float = 0.0
 
-    def update(self, success: bool, roi: float) -> None:
+    def update(self, success: bool, roi: float, weight: float) -> None:
         """Update counters with a single observation."""
 
         self.total += 1
-        self.roi_total += roi
+        self.roi_sum += roi
+        self.weighted_roi_sum += roi * weight
+        self.weight_sum += weight
         if success:
             self.success += 1
-            self.roi_success += roi
+
+    # ------------------------------------------------------------------
+    def success_rate(self) -> float:
+        return self.success / self.total if self.total else 0.0
+
+    def weighted_roi(self) -> float:
+        if self.weight_sum:
+            return self.weighted_roi_sum / self.weight_sum
+        return self.roi_sum / self.total if self.total else 0.0
 
     def score(self) -> float:
-        """Return ROI-weighted success rate for this configuration."""
+        """Combined score used to rank configurations."""
 
-        if self.roi_total:
-            return self.roi_success / self.roi_total
-        if self.total:
-            return self.success / self.total
-        return 0.0
+        return self.success_rate() * self.weighted_roi()
 
 
 class PromptOptimizer:
-    """Analyse logs and suggest high-performing prompt formats."""
+    """Analyse logs and recommend high-performing prompt formats.
+
+    Parameters
+    ----------
+    log_a, log_b:
+        Paths to prompt experiment log files.
+    stats_path:
+        File used to persist aggregated statistics (JSON format).
+    weight_by:
+        Optional weighting mode. ``"coverage"`` uses the ``coverage`` field
+        of each log entry as the weight, ``"runtime"`` uses the
+        ``runtime_improvement`` field and ``None`` applies no additional
+        weighting.
+    """
 
     def __init__(
         self,
@@ -66,9 +90,11 @@ class PromptOptimizer:
         log_b: str | Path,
         *,
         stats_path: str | Path = "prompt_optimizer_stats.json",
+        weight_by: str | None = None,
     ) -> None:
         self.log_paths = [Path(log_a), Path(log_b)]
         self.stats_path = Path(stats_path)
+        self.weight_by = weight_by
         self._sentiment = (
             SentimentIntensityAnalyzer() if SentimentIntensityAnalyzer else None
         )
@@ -90,7 +116,20 @@ class PromptOptimizer:
             for item in data:
                 try:
                     key = self._key_from_item(item)
-                    self.stats[key] = _Stat(**item)
+                    self.stats[key] = _Stat(
+                        module=item["module"],
+                        action=item["action"],
+                        tone=item["tone"],
+                        header_set=tuple(item.get("header_set", [])),
+                        example_placement=item.get("example_placement", "none"),
+                        has_code=bool(item.get("has_code")),
+                        has_bullets=bool(item.get("has_bullets")),
+                        success=int(item.get("success", 0)),
+                        total=int(item.get("total", 0)),
+                        roi_sum=float(item.get("roi_sum", 0.0)),
+                        weighted_roi_sum=float(item.get("weighted_roi_sum", 0.0)),
+                        weight_sum=float(item.get("weight_sum", 0.0)),
+                    )
                 except Exception:
                     continue
 
@@ -99,12 +138,13 @@ class PromptOptimizer:
             item["module"],
             item["action"],
             item["tone"],
-            int(item["headers"]),
-            int(item["example_count"]),
+            tuple(item.get("header_set", [])),
+            item.get("example_placement", "none"),
             bool(item.get("has_code")),
             bool(item.get("has_bullets")),
         )
 
+    # ------------------------------------------------------------------
     def _load_logs(self) -> List[Dict[str, Any]]:
         """Read and parse all configured log files."""
 
@@ -123,15 +163,38 @@ class PromptOptimizer:
                         continue
         return entries
 
+    # ------------------------------------------------------------------
     def _extract_features(self, prompt: str) -> Dict[str, Any]:
         """Derive structural features from ``prompt``."""
 
-        headers = len(re.findall(r"^#+\s", prompt, flags=re.MULTILINE))
-        example_count = len(re.findall(r"Example", prompt, flags=re.IGNORECASE))
+        header_matches = list(
+            re.finditer(r"^#+\s*(.+)$", prompt, flags=re.MULTILINE)
+        )
+        headers = [m.group(1).strip() for m in header_matches]
+        header_set = tuple(sorted(headers))
+
+        example_positions = [
+            m.start() for m in re.finditer(r"Example", prompt, flags=re.IGNORECASE)
+        ]
+        example_placement: str
+        if not example_positions:
+            example_placement = "none"
+        else:
+            half = len(prompt) / 2
+            before = [p for p in example_positions if p <= half]
+            after = [p for p in example_positions if p > half]
+            if before and after:
+                example_placement = "mixed"
+            elif before:
+                example_placement = "start"
+            else:
+                example_placement = "end"
+
         has_code = bool(re.search(r"```", prompt))
         has_bullets = bool(
             re.search(r"^\s*(?:[-*]|\d+\.)\s+", prompt, flags=re.MULTILINE)
         )
+
         tone = "neutral"
         if self._sentiment:
             try:
@@ -142,10 +205,11 @@ class PromptOptimizer:
                     tone = "negative"
             except Exception:  # pragma: no cover - best effort
                 pass
+
         return {
             "tone": tone,
-            "headers": headers,
-            "example_count": example_count,
+            "header_set": header_set,
+            "example_placement": example_placement,
             "has_code": has_code,
             "has_bullets": has_bullets,
         }
@@ -158,6 +222,12 @@ class PromptOptimizer:
             prompt = entry.get("prompt", "")
             success = bool(entry.get("success"))
             roi = float(entry.get("roi", 1.0))
+            if self.weight_by == "coverage":
+                weight = float(entry.get("coverage", 1.0))
+            elif self.weight_by == "runtime":
+                weight = float(entry.get("runtime_improvement", 1.0))
+            else:
+                weight = 1.0
             module = entry.get("module", "unknown")
             action = entry.get("action", "unknown")
             feats = self._extract_features(prompt)
@@ -165,8 +235,8 @@ class PromptOptimizer:
                 module,
                 action,
                 feats["tone"],
-                feats["headers"],
-                feats["example_count"],
+                feats["header_set"],
+                feats["example_placement"],
                 feats["has_code"],
                 feats["has_bullets"],
             )
@@ -176,13 +246,13 @@ class PromptOptimizer:
                     module=module,
                     action=action,
                     tone=feats["tone"],
-                    headers=feats["headers"],
-                    example_count=feats["example_count"],
+                    header_set=feats["header_set"],
+                    example_placement=feats["example_placement"],
                     has_code=feats["has_code"],
                     has_bullets=feats["has_bullets"],
                 )
                 self.stats[key] = stat
-            stat.update(success, roi)
+            stat.update(success, roi, weight)
         self.persist_statistics()
         return self.stats
 
@@ -190,11 +260,16 @@ class PromptOptimizer:
     def persist_statistics(self) -> None:
         """Persist aggregated statistics to ``stats_path``."""
 
-        data = [asdict(stat) for stat in self.stats.values()]
+        data = []
+        for stat in self.stats.values():
+            item = asdict(stat)
+            # convert tuple to list for JSON serialisation
+            item["header_set"] = list(stat.header_set)
+            data.append(item)
         self.stats_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
     # ------------------------------------------------------------------
-    def suggest_format(self, module: str, action: str) -> Dict[str, Any]:
+    def select_format(self, module: str, action: str) -> Dict[str, Any]:
         """Return the best performing configuration for ``module`` and ``action``."""
 
         best: _Stat | None = None
@@ -210,8 +285,14 @@ class PromptOptimizer:
             return {}
         return {
             "tone": best.tone,
-            "headers": best.headers,
-            "example_count": best.example_count,
-            "has_code": best.has_code,
-            "has_bullets": best.has_bullets,
+            "structured_sections": list(best.header_set),
+            "example_placement": best.example_placement,
+            "include_code": best.has_code,
+            "use_bullets": best.has_bullets,
         }
+
+    # Backwards compatibility ------------------------------------------------
+    def suggest_format(self, module: str, action: str) -> Dict[str, Any]:
+        """Alias for :meth:`select_format`."""
+
+        return self.select_format(module, action)


### PR DESCRIPTION
## Summary
- add `PromptOptimizer` for analysing two prompt log files
- compute success rates and weighted ROI grouped by tone, headers, and example placement
- expose `select_format()` to recommend prompt parameters for `PromptEngine`

## Testing
- `pre-commit run --files prompt_optimizer.py`
- `pytest -k prompt_optimizer -q` *(fails: 385 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a0be2638832ea0cc83decb2bf31d