### PR TITLE
Add dependency version checks and tests

### DIFF
--- a/self_improvement/init.py
+++ b/self_improvement/init.py
@@ -2,11 +2,12 @@
 
 The routines expect auxiliary packages to be installed:
 
-* ``quick_fix_engine`` – generates corrective patches.
-* ``sandbox_runner.orphan_integration`` – reintroduces orphaned modules.
+* ``quick_fix_engine`` >=1.0 – generates corrective patches.
+* ``sandbox_runner`` >=1.0 – provides sandbox orchestration helpers.
+* ``neurosales`` – supplies predictive sales models.
 
 Missing dependencies raise :class:`RuntimeError` with guidance on how to
-install them.
+install or upgrade them.
 
 Configuration is provided via :class:`sandbox_settings.SandboxSettings` with
 notable options:
@@ -66,10 +67,24 @@ def verify_dependencies() -> None:
         "quick_fix_engine": {
             "modules": ("quick_fix_engine",),
             "install": "pip install quick_fix_engine",
+            "version": ">=1.0",
+        },
+        "sandbox_runner": {
+            "modules": ("sandbox_runner",),
+            "install": "pip install sandbox_runner",
+            "version": ">=1.0",
         },
         "sandbox_runner.orphan_integration": {
             "modules": ("sandbox_runner.orphan_integration",),
-            "install": "Install the sandbox_runner package or ensure it is on PYTHONPATH.",
+            "install": "pip install sandbox_runner",
+        },
+        "sandbox_runner.environment": {
+            "modules": ("sandbox_runner.environment",),
+            "install": "pip install sandbox_runner",
+        },
+        "neurosales": {
+            "modules": ("neurosales",),
+            "install": "pip install neurosales",
         },
         "relevancy_radar": {
             "modules": ("relevancy_radar",),
@@ -121,8 +136,11 @@ def verify_dependencies() -> None:
             except Exception:
                 installed = "unknown"
             if installed == "unknown" or installed not in SpecifierSet(requirement):
+                cmd = cfg["install"]
+                if cmd.startswith("pip install") and "--upgrade" not in cmd:
+                    cmd += " --upgrade"
                 mismatched.append(
-                    f"{pkg} (installed {installed}, required {requirement})"
+                    f"{pkg} (installed {installed}, required {requirement}) – {cmd}"
                 )
 
     if missing or mismatched:

--- a/tests/test_dependency_checks.py
+++ b/tests/test_dependency_checks.py
@@ -1,0 +1,110 @@
+import importlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _stub_modules(exclude: set[str] | None = None) -> None:
+    exclude = exclude or set()
+    needed = {
+        "quick_fix_engine": types.ModuleType("quick_fix_engine"),
+        "sandbox_runner": types.ModuleType("sandbox_runner"),
+        "sandbox_runner.orphan_integration": types.ModuleType("sandbox_runner.orphan_integration"),
+        "sandbox_runner.environment": types.ModuleType("sandbox_runner.environment"),
+        "sandbox_runner.bootstrap": types.ModuleType("sandbox_runner.bootstrap"),
+        "sandbox_runner.cli": types.ModuleType("sandbox_runner.cli"),
+        "sandbox_runner.cycle": types.ModuleType("sandbox_runner.cycle"),
+        "relevancy_radar": types.ModuleType("relevancy_radar"),
+        "error_logger": types.ModuleType("error_logger"),
+        "telemetry_feedback": types.ModuleType("telemetry_feedback"),
+        "telemetry_backend": types.ModuleType("telemetry_backend"),
+        "torch": types.ModuleType("torch"),
+        "neurosales": types.ModuleType("neurosales"),
+    }
+    needed["sandbox_runner.bootstrap"].initialize_autonomous_sandbox = lambda *a, **k: None
+    needed["sandbox_runner.cli"].main = lambda *a, **k: None
+    needed["sandbox_runner.cycle"].ensure_vector_service = lambda: None
+    pkg_spec = importlib.util.spec_from_loader("sandbox_runner", loader=None, is_package=True)
+    needed["sandbox_runner"].__path__ = []
+    needed["sandbox_runner"].__spec__ = pkg_spec
+    err = needed["error_logger"]
+    err.ErrorLogger = object
+    rr = needed["relevancy_radar"]
+    rr.tracked_import = __import__
+    for name, mod in needed.items():
+        if name not in exclude:
+            sys.modules[name] = mod
+        elif name in sys.modules:
+            del sys.modules[name]
+    pkg = sys.modules.get("sandbox_runner")
+    if pkg:
+        pkg.bootstrap = sys.modules.get("sandbox_runner.bootstrap")
+        pkg.cli = sys.modules.get("sandbox_runner.cli")
+        pkg.cycle = sys.modules.get("sandbox_runner.cycle")
+        pkg.environment = sys.modules.get("sandbox_runner.environment")
+
+
+def _load_init():
+    spec = importlib.util.spec_from_file_location(
+        "self_improvement.init", Path("self_improvement/init.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_missing_dependency(monkeypatch):
+    _stub_modules({"neurosales"})
+    import importlib
+    import importlib.metadata as metadata
+
+    monkeypatch.setattr(
+        metadata,
+        "version",
+        lambda name: "2.0.0" if name == "torch" else "1.0.0",
+    )
+    orig_import = importlib.import_module
+
+    def fake_import(name, *a, **k):
+        if name == "neurosales":
+            raise ImportError
+        return orig_import(name, *a, **k)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    init_module = _load_init()
+    monkeypatch.setattr(init_module.settings, "auto_install_dependencies", False)
+
+    with pytest.raises(RuntimeError) as exc:
+        init_module.verify_dependencies()
+    msg = str(exc.value)
+    assert "neurosales" in msg
+    assert "pip install neurosales" in msg
+
+
+def test_version_mismatch(monkeypatch):
+    _stub_modules()
+    import importlib.metadata as metadata
+
+    def fake_version(name: str) -> str:
+        versions = {
+            "quick_fix_engine": "0.9",
+            "sandbox_runner": "0.9",
+            "torch": "2.0",
+        }
+        return versions.get(name, "1.0")
+
+    monkeypatch.setattr(metadata, "version", fake_version)
+    init_module = _load_init()
+    monkeypatch.setattr(init_module.settings, "auto_install_dependencies", False)
+
+    with pytest.raises(RuntimeError) as exc:
+        init_module.verify_dependencies()
+    msg = str(exc.value)
+    assert "quick_fix_engine (installed 0.9" in msg
+    assert "pip install quick_fix_engine --upgrade" in msg
+    assert "sandbox_runner (installed 0.9" in msg
+    assert "pip install sandbox_runner --upgrade" in msg
+


### PR DESCRIPTION
## Summary
- verify quick_fix_engine and sandbox_runner minimum versions and ensure essential modules like neurosales are present
- describe upgrade commands for mismatched dependencies
- add tests simulating missing or mismatched packages

## Testing
- `pytest tests/test_dependency_checks.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5a0b26fdc832e9adadd3235db0855