### PR TITLE
Flush caches on sandbox shutdown

### DIFF
--- a/sandbox_runner/tests/test_generative_stub_cache_cleanup.py
+++ b/sandbox_runner/tests/test_generative_stub_cache_cleanup.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import json
+
+from sandbox_runner import generative_stub_provider as gsp
+
+
+def _make_cfg(tmp_path: Path) -> gsp.StubProviderConfig:
+    return gsp.StubProviderConfig(
+        timeout=1.0,
+        retries=1,
+        retry_base=0.1,
+        retry_max=0.2,
+        cache_max=10,
+        cache_path=tmp_path / "cache.json",
+        fallback_model="none",
+    )
+
+
+def test_flush_and_cleanup_cache(tmp_path):
+    cfg = _make_cfg(tmp_path)
+    key = gsp._cache_key("foo", {"a": 1})
+    with gsp._CACHE_LOCK:
+        gsp._CACHE[key] = {"a": 1}
+    gsp.flush_caches(cfg)
+    assert not gsp._CACHE
+    assert not gsp._TARGET_STATS
+    assert cfg.cache_path.exists()
+    with open(cfg.cache_path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    assert data == [[f"{key[0]}::{key[1]}", {"a": 1}]]
+    gsp.cleanup_cache_files(cfg)
+    assert not cfg.cache_path.exists()

--- a/sandbox_runner/tests/test_shutdown_cleanup.py
+++ b/sandbox_runner/tests/test_shutdown_cleanup.py
@@ -1,0 +1,74 @@
+import sys
+import threading
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from sandbox_settings import SandboxSettings  # noqa: E402
+
+
+def _setup_base(monkeypatch):
+    monkeypatch.setattr("sandbox_runner.bootstrap._start_optional_services", lambda mods: None)
+    monkeypatch.setattr("sandbox_runner.bootstrap.ensure_vector_service", lambda: None)
+    monkeypatch.setattr("sandbox_runner.bootstrap._verify_required_dependencies", lambda s: {})
+
+
+def test_shutdown_cleans_caches(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    data = tmp_path / "data"
+    repo.mkdir()
+    data.mkdir()
+    monkeypatch.setenv("SANDBOX_REPO_PATH", str(repo))
+    monkeypatch.setenv("SANDBOX_DATA_DIR", str(data))
+    _setup_base(monkeypatch)
+
+    import sandbox_runner.bootstrap as bootstrap
+    import sandbox_runner.generative_stub_provider as gsp
+    import self_improvement.utils as si_utils
+
+    monkeypatch.setattr(bootstrap, "_INITIALISED", False)
+    monkeypatch.setattr(bootstrap, "_SELF_IMPROVEMENT_THREAD", None)
+
+    flags = {"gf": 0, "gc": 0, "cf": 0, "cc": 0}
+
+    def _inc(name: str) -> None:
+        flags[name] += 1
+
+    monkeypatch.setattr(gsp, "flush_caches", lambda config=None: _inc("gf"))
+    monkeypatch.setattr(gsp, "cleanup_cache_files", lambda config=None: _inc("gc"))
+    monkeypatch.setattr(si_utils, "clear_import_cache", lambda: _inc("cf"))
+    monkeypatch.setattr(si_utils, "remove_import_cache_files", lambda base=None: _inc("cc"))
+
+    stop_event = threading.Event()
+
+    def init_self_improvement(settings):
+        return None
+
+    def fake_start_self_improvement_cycle(workflows):
+        def run():
+            stop_event.wait()
+        t = threading.Thread(target=run)
+        return t
+
+    def fake_stop_self_improvement_cycle():
+        stop_event.set()
+
+    api_stub = types.SimpleNamespace(
+        init_self_improvement=init_self_improvement,
+        start_self_improvement_cycle=fake_start_self_improvement_cycle,
+        stop_self_improvement_cycle=fake_stop_self_improvement_cycle,
+    )
+    sys.modules["self_improvement.api"] = api_stub
+
+    settings = SandboxSettings()
+    settings.sandbox_repo_path = str(repo)
+    settings.sandbox_data_dir = str(data)
+    settings.menace_env_file = str(tmp_path / ".env")
+    settings.optional_service_versions = {}
+    settings.sandbox_central_logging = False
+    monkeypatch.setattr(bootstrap, "load_sandbox_settings", lambda: settings)
+
+    bootstrap.initialize_autonomous_sandbox(settings)
+    bootstrap.shutdown_autonomous_sandbox()
+    assert flags == {"gf": 1, "gc": 1, "cf": 1, "cc": 1}

--- a/self_improvement/tests/test_utils_cache_cleanup.py
+++ b/self_improvement/tests/test_utils_cache_cleanup.py
@@ -1,0 +1,10 @@
+from self_improvement import utils
+
+
+def test_remove_import_cache_files(tmp_path):
+    root = tmp_path / "pkg"
+    pycache = root / "__pycache__"
+    pycache.mkdir(parents=True)
+    (pycache / "mod.pyc").write_text("data")
+    utils.remove_import_cache_files(root)
+    assert not pycache.exists()

--- a/self_improvement/utils.py
+++ b/self_improvement/utils.py
@@ -24,6 +24,8 @@ import asyncio
 import inspect
 import random
 import threading
+import shutil
+from pathlib import Path
 from functools import lru_cache
 from typing import Any, Callable
 
@@ -89,6 +91,21 @@ def clear_import_cache() -> None:
         _diagnostics["cache_hits"] = 0
         _diagnostics["cache_misses"] = 0
     _load_callable.diagnostics = _diagnostics
+
+
+def remove_import_cache_files(base: str | Path | None = None) -> None:
+    """Delete ``__pycache__`` directories to free disk space."""
+
+    root = Path(base) if base is not None else Path(__file__).resolve().parent
+    for pycache in root.rglob("__pycache__"):
+        try:
+            shutil.rmtree(pycache)
+        except FileNotFoundError:
+            continue
+        except Exception:  # pragma: no cover - best effort
+            logging.getLogger(__name__).debug(
+                "failed to remove cache directory %s", pycache, exc_info=True
+            )
 
 
 def _call_with_retries(


### PR DESCRIPTION
## Summary
- persist and clear stub generation cache, removing stale cache files
- add utility to clear import bytecode caches
- flush in-memory caches during sandbox shutdown to avoid leaks

## Testing
- `pre-commit run --files sandbox_runner/generative_stub_provider.py self_improvement/utils.py sandbox_runner/bootstrap.py sandbox_runner/tests/test_generative_stub_cache_cleanup.py self_improvement/tests/test_utils_cache_cleanup.py sandbox_runner/tests/test_shutdown_cleanup.py`
- `pytest` *(fails: error_logger is required for sandbox operations. [386 errors during collection])*

------
https://chatgpt.com/codex/tasks/task_e_68b5a3a80f4c832eb375917b8de5e583