### PR TITLE
Add warm-up step before self-improvement cycle

### DIFF
--- a/sandbox_runner/tests/test_start_autonomous_launch.py
+++ b/sandbox_runner/tests/test_start_autonomous_launch.py
@@ -29,6 +29,11 @@ def _setup_base_packages():
     si_pkg = types.ModuleType("self_improvement")
     sys.modules["self_improvement"] = si_pkg
 
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+    os.environ.setdefault("STRIPE_API_KEY", "test")
+    os.environ.setdefault("MODELS", str(Path.cwd()))
+
 
 _setup_base_packages()
 
@@ -96,6 +101,75 @@ def test_launch_sandbox_starts_self_improvement_thread(tmp_path, monkeypatch):
     bootstrap.shutdown_autonomous_sandbox()
 
 
+def test_launch_sandbox_runs_warmup(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    data = tmp_path / "data"
+    repo.mkdir()
+    data.mkdir()
+    monkeypatch.setenv("SANDBOX_REPO_PATH", str(repo))
+    monkeypatch.setenv("SANDBOX_DATA_DIR", str(data))
+    monkeypatch.setattr("builtins.input", lambda *a, **k: pytest.fail("prompted"))
+
+    import sandbox_runner.bootstrap as bootstrap
+
+    monkeypatch.setattr(bootstrap, "_start_optional_services", lambda mods: None)
+    monkeypatch.setattr(bootstrap, "ensure_vector_service", lambda: None)
+    monkeypatch.setattr(bootstrap, "_verify_required_dependencies", lambda s: {})
+
+    warmup_called = threading.Event()
+
+    def warmup():
+        warmup_called.set()
+
+    monkeypatch.setattr(bootstrap, "_self_improvement_warmup", warmup)
+
+    started = threading.Event()
+    stop_event = threading.Event()
+
+    def init_self_improvement(settings):
+        return None
+
+    def fake_start_self_improvement_cycle(workflows):
+        def run():
+            workflows["bootstrap"]()
+            started.set()
+            stop_event.wait()
+
+        t = threading.Thread(target=run)
+        return t
+
+    def fake_stop_self_improvement_cycle():
+        stop_event.set()
+
+    api_stub = types.SimpleNamespace(
+        init_self_improvement=init_self_improvement,
+        start_self_improvement_cycle=fake_start_self_improvement_cycle,
+        stop_self_improvement_cycle=fake_stop_self_improvement_cycle,
+    )
+    sys.modules["self_improvement.api"] = api_stub
+
+    settings = SandboxSettings()
+    settings.sandbox_repo_path = str(repo)
+    settings.sandbox_data_dir = str(data)
+    settings.menace_env_file = str(tmp_path / ".env")
+    settings.optional_service_versions = {}
+    settings.sandbox_central_logging = False
+    monkeypatch.setattr(bootstrap, "load_sandbox_settings", lambda: settings)
+
+    import start_autonomous_sandbox as sas
+
+    sas.launch_sandbox()
+
+    assert warmup_called.is_set()
+    stop_event.set()
+    thread = bootstrap._SELF_IMPROVEMENT_THREAD
+    assert thread is not None
+    thread.join(timeout=1)
+    assert started.is_set()
+    assert not getattr(thread, "_thread", thread).is_alive()
+    bootstrap.shutdown_autonomous_sandbox()
+
+
 def test_initialize_autonomous_sandbox_raises_on_dead_thread(tmp_path, monkeypatch):
     repo = tmp_path / "repo"
     data = tmp_path / "data"
@@ -125,6 +199,56 @@ def test_initialize_autonomous_sandbox_raises_on_dead_thread(tmp_path, monkeypat
     api_stub = types.SimpleNamespace(
         init_self_improvement=lambda s: None,
         start_self_improvement_cycle=lambda workflows: DeadThread(),
+    )
+    sys.modules["self_improvement.api"] = api_stub
+
+    settings = SandboxSettings()
+    settings.sandbox_repo_path = str(repo)
+    settings.sandbox_data_dir = str(data)
+    settings.menace_env_file = str(tmp_path / ".env")
+    settings.optional_service_versions = {}
+    settings.sandbox_central_logging = False
+    monkeypatch.setattr(bootstrap, "load_sandbox_settings", lambda: settings)
+
+    with pytest.raises(RuntimeError):
+        bootstrap.initialize_autonomous_sandbox(settings)
+
+
+def test_initialize_autonomous_sandbox_warmup_failure(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    data = tmp_path / "data"
+    repo.mkdir()
+    data.mkdir()
+    monkeypatch.setenv("SANDBOX_REPO_PATH", str(repo))
+    monkeypatch.setenv("SANDBOX_DATA_DIR", str(data))
+
+    import sandbox_runner.bootstrap as bootstrap
+
+    monkeypatch.setattr(bootstrap, "_start_optional_services", lambda mods: None)
+    monkeypatch.setattr(bootstrap, "ensure_vector_service", lambda: None)
+    monkeypatch.setattr(bootstrap, "_verify_required_dependencies", lambda s: {})
+    monkeypatch.setattr(bootstrap, "_INITIALISED", False)
+    monkeypatch.setattr(bootstrap, "_SELF_IMPROVEMENT_THREAD", None)
+
+    def warmup():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(bootstrap, "_self_improvement_warmup", warmup)
+
+    class DummyThread:
+        def start(self):
+            pass
+
+        def join(self, timeout=None):
+            pass
+
+    def fake_start_self_improvement_cycle(workflows):
+        workflows["bootstrap"]()
+        return DummyThread()
+
+    api_stub = types.SimpleNamespace(
+        init_self_improvement=lambda s: None,
+        start_self_improvement_cycle=fake_start_self_improvement_cycle,
     )
     sys.modules["self_improvement.api"] = api_stub
 


### PR DESCRIPTION
## Summary
- Add `_self_improvement_warmup` to load defaults and settings before starting the self-improvement thread
- Replace placeholder lambda with warm-up callable and log failures
- Test sandbox launch warm-up and failure scenarios to ensure non-interactive startup

## Testing
- `pytest sandbox_runner/tests/test_start_autonomous_launch.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5a76d7f78832e9e44101b87b8e270