### PR TITLE
Apply patches in isolated worktree with commit hash output

### DIFF
--- a/self_improvement/patch_application.py
+++ b/self_improvement/patch_application.py
@@ -11,6 +11,8 @@ than the underlying generation details.
 from pathlib import Path
 import logging
 import subprocess
+import tempfile
+import shutil
 
 from .patch_generation import generate_patch
 from .utils import _load_callable, _call_with_retries
@@ -25,10 +27,13 @@ def apply_patch(
     *,
     retries: int = _settings.patch_retries,
     delay: float = _settings.patch_retry_delay,
-) -> None:
+    sign: bool = False,
+) -> str:
     """Fetch and apply patch ``patch_id`` to ``repo_path``.
 
-    Raises ``RuntimeError`` if fetching or applying the patch fails.
+    Returns the commit hash created from the patch.  Raises ``RuntimeError`` if
+    fetching or applying the patch fails or if the repository worktree is
+    dirty.
     """
 
     logger = logging.getLogger(__name__)
@@ -49,21 +54,84 @@ def apply_patch(
     if not patch_data:
         logger.error("quick_fix_engine returned no patch data")
         raise RuntimeError("quick_fix_engine did not return patch data")
+    repo_path = Path(repo_path)
+    status = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=str(repo_path),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    if status.stdout.strip():
+        raise RuntimeError("worktree has uncommitted changes")
+
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=str(repo_path),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    tmpdir = Path(
+        tempfile.mkdtemp(prefix="apply_patch_", dir=str(repo_path.parent))
+    )
     try:
+        subprocess.run(
+            ["git", "worktree", "add", "--detach", str(tmpdir), head],
+            cwd=str(repo_path),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
         proc = subprocess.run(
             ["git", "apply", "--whitespace=nowarn", "-"],
             input=patch_data,
             text=True,
             capture_output=True,
-            cwd=str(repo_path),
+            cwd=str(tmpdir),
             check=False,
         )
-    except Exception as exc:  # pragma: no cover - best effort logging
-        logger.error("git apply invocation failed", exc_info=exc)
-        raise RuntimeError("failed to apply patch") from exc
-    if proc.returncode != 0:
-        logger.error("git apply failed: %s", proc.stderr.strip())
-        raise RuntimeError("patch application failed")
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"patch application failed: {proc.stderr.strip() or proc.stdout.strip()}"
+            )
+        subprocess.run(["git", "add", "-A"], cwd=str(tmpdir), check=True)
+        commit_cmd = ["git", "commit", "-m", f"Apply patch {patch_id}"]
+        if sign:
+            commit_cmd.append("-S")
+        commit_proc = subprocess.run(
+            commit_cmd, cwd=str(tmpdir), capture_output=True, text=True
+        )
+        if commit_proc.returncode != 0:
+            raise RuntimeError(
+                f"git commit failed: {commit_proc.stderr.strip() or commit_proc.stdout.strip()}"
+            )
+        commit_hash = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(tmpdir),
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        reset_proc = subprocess.run(
+            ["git", "reset", "--hard", commit_hash],
+            cwd=str(repo_path),
+            capture_output=True,
+            text=True,
+        )
+        if reset_proc.returncode != 0:
+            raise RuntimeError(
+                f"failed to update worktree: {reset_proc.stderr.strip() or reset_proc.stdout.strip()}"
+            )
+        return commit_hash
+    finally:
+        subprocess.run(
+            ["git", "worktree", "remove", str(tmpdir), "--force"],
+            cwd=str(repo_path),
+            capture_output=True,
+        )
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 __all__ = ["generate_patch", "apply_patch"]

--- a/tests/self_improvement/test_patch_application.py
+++ b/tests/self_improvement/test_patch_application.py
@@ -4,6 +4,7 @@ import subprocess
 import importlib.machinery
 from pathlib import Path
 import importlib
+import importlib.util
 
 import pytest
 
@@ -14,10 +15,24 @@ def _load_patch_module():
     root_pkg.__path__ = [str(repo_root)]
     root_pkg.__spec__ = importlib.machinery.ModuleSpec("menace_sandbox", loader=None, is_package=True)
     sys.modules.setdefault("menace_sandbox", root_pkg)
+    si_pkg = types.ModuleType("menace_sandbox.self_improvement")
+    si_pkg.__path__ = [str(repo_root / "self_improvement")]
+    si_pkg.__spec__ = importlib.machinery.ModuleSpec(
+        "menace_sandbox.self_improvement", loader=None, is_package=True
+    )
+    sys.modules.setdefault("menace_sandbox.self_improvement", si_pkg)
     sandbox_settings = types.ModuleType("sandbox_settings")
     class SandboxSettings:
         patch_retries = 1
         patch_retry_delay = 0.0
+        meta_entropy_threshold = 0.2
+        meta_mutation_rate = 0.0
+        meta_roi_weight = 0.0
+        meta_domain_penalty = 0.0
+        meta_entropy_weight = 0.0
+        meta_search_depth = 1
+        meta_beam_width = 1
+        menace_light_imports = True
     sandbox_settings.SandboxSettings = SandboxSettings
     sandbox_settings.load_sandbox_settings = lambda: SandboxSettings()
     sandbox_runner = types.ModuleType("sandbox_runner")
@@ -27,6 +42,8 @@ def _load_patch_module():
     sys.modules.setdefault("sandbox_runner", sandbox_runner)
     sys.modules.setdefault("sandbox_runner.bootstrap", bootstrap)
     sys.modules.setdefault("sandbox_settings", sandbox_settings)
+    utils = importlib.import_module("menace_sandbox.self_improvement.utils")
+    utils.clear_import_cache()
     return importlib.import_module("menace_sandbox.self_improvement.patch_application")
 
 
@@ -45,7 +62,7 @@ SUCCESS_PATCH = """\
 diff --git a/file.txt b/file.txt
 --- a/file.txt
 +++ b/file.txt
-@@
+@@ -1 +1 @@
 -hello
 +world
 """
@@ -54,7 +71,7 @@ FAIL_PATCH = """\
 diff --git a/file.txt b/file.txt
 --- a/file.txt
 +++ b/file.txt
-@@
+@@ -1 +1 @@
 -nope
 +world
 """
@@ -65,15 +82,33 @@ def test_apply_patch_success(tmp_path, monkeypatch):
     mod.fetch_patch = lambda patch_id: SUCCESS_PATCH
     monkeypatch.setitem(sys.modules, "quick_fix_engine", mod)
     patch_module = _load_patch_module()
-    patch_module.apply_patch(1, repo)
+    commit = patch_module.apply_patch(1, repo)
+    assert len(commit) == 40
+    head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo, text=True, capture_output=True, check=True).stdout.strip()
+    assert head == commit
     assert (repo / "file.txt").read_text() == "world\n"
 
 def test_apply_patch_failure(tmp_path, monkeypatch):
     repo = _init_repo(tmp_path)
+    head_before = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo, text=True, capture_output=True, check=True).stdout.strip()
     mod = types.ModuleType("quick_fix_engine")
     mod.fetch_patch = lambda patch_id: FAIL_PATCH
     monkeypatch.setitem(sys.modules, "quick_fix_engine", mod)
     patch_module = _load_patch_module()
     with pytest.raises(RuntimeError):
         patch_module.apply_patch(1, repo)
+    head_after = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo, text=True, capture_output=True, check=True).stdout.strip()
+    assert head_before == head_after
     assert (repo / "file.txt").read_text() == "hello\n"
+
+
+def test_apply_patch_dirty_worktree(tmp_path, monkeypatch):
+    repo = _init_repo(tmp_path)
+    (repo / "file.txt").write_text("dirty\n")
+    mod = types.ModuleType("quick_fix_engine")
+    mod.fetch_patch = lambda patch_id: SUCCESS_PATCH
+    monkeypatch.setitem(sys.modules, "quick_fix_engine", mod)
+    patch_module = _load_patch_module()
+    with pytest.raises(RuntimeError) as exc:
+        patch_module.apply_patch(1, repo)
+    assert "worktree" in str(exc.value)


### PR DESCRIPTION
## Summary
- run `git apply` in a temporary worktree to avoid dirtying the main tree
- commit applied patches (optional signing) and return the new hash
- add tests covering success, patch failure, and dirty worktree scenarios

## Testing
- `pytest tests/self_improvement/test_patch_application.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5a881d84c832e80d2a43f022f638e