### PR TITLE
Document prompt log path environment variables

### DIFF
--- a/docs/sandbox_environment.md
+++ b/docs/sandbox_environment.md
@@ -14,6 +14,13 @@ The sandbox expects a few variables to be set before launch:
 Run `auto_env_setup.ensure_env()` to generate a `.env` file with these variables when
 missing. Values may also be supplied via the shell environment.
 
+## Prompt logging variables
+
+These optional variables control where prompt execution results are stored:
+
+- `PROMPT_SUCCESS_LOG_PATH` – path for successful prompt logs (default `prompt_success_log.json`).
+- `PROMPT_FAILURE_LOG_PATH` – path for failed prompt logs (default `prompt_failure_log.json`).
+
 ## Optional dependencies
 
 Some features rely on additional tools. Missing components degrade

--- a/docs/sandbox_settings.md
+++ b/docs/sandbox_settings.md
@@ -70,6 +70,10 @@ settings = load_sandbox_settings("docs/sandbox_config.sample.yaml")
 - `temperature`: `1.0`
 - `exploration`: `epsilon_greedy`
 
+## Prompt logging defaults
+- `prompt_success_log_path`: `prompt_success_log.json` (`PROMPT_SUCCESS_LOG_PATH`)
+- `prompt_failure_log_path`: `prompt_failure_log.json` (`PROMPT_FAILURE_LOG_PATH`)
+
 See [`sandbox_config.sample.yaml`](sandbox_config.sample.yaml) for a complete
 example configuration file.
 


### PR DESCRIPTION
## Summary
- Document `PROMPT_SUCCESS_LOG_PATH` and `PROMPT_FAILURE_LOG_PATH` in sandbox configuration docs
- Describe optional prompt logging variables in environment setup guide

## Testing
- ⚠️ `pytest -q` (fails: ImportError: cannot import name 'Retriever' from 'vector_service' and other missing dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68b5a9f4fd6c832eb6e8b448bddfe85b