### PR TITLE
Refactor ROI calculations and patch provenance service

### DIFF
--- a/central_evaluation_loop.py
+++ b/central_evaluation_loop.py
@@ -180,7 +180,8 @@ def process_action(raw_line: str) -> bool:
     if "metrics" in action and "roi_profile" in action:
         calc = ROICalculator()
         metrics = {**action["metrics"], **action.get("flags", {})}
-        score, vetoed, _ = calc.calculate(metrics, action["roi_profile"])
+        result = calc.calculate(metrics, action["roi_profile"])
+        score, vetoed = result.score, result.vetoed
         low_conf = False
         if TRUTH_ADAPTER is not None:
             try:

--- a/composite_workflow_scorer.py
+++ b/composite_workflow_scorer.py
@@ -84,7 +84,6 @@ class ROIScorer(BaseROIScorer):
 
             calc = ROICalculator.__new__(ROICalculator)
             calc.profiles = {default_type: default_profile}
-            calc.hard_fail = False
             calc.logger = logging.getLogger(__name__)
             try:
                 calc._validate_profiles()
@@ -309,10 +308,10 @@ class CompositeWorkflowScorer(ROIScorer):
                 "reliability": 1.0 if ok else 0.0,
                 "efficiency": 1.0 / duration if duration > 0 else 0.0,
             }
-            roi_after, _, _ = self.calculator.calculate(metrics, self.profile_type)
+            result = self.calculator.calculate(metrics, self.profile_type)
             self.tracker.update(
                 0.0,
-                roi_after,
+                result.score,
                 modules=[name],
                 metrics=metrics,
                 profile_type=self.profile_type,

--- a/docs/roi_calculator.md
+++ b/docs/roi_calculator.md
@@ -37,11 +37,12 @@ from menace_sandbox.roi_calculator import ROICalculator
 
 calc = ROICalculator()  # loads configs/roi_profiles.yaml by default
 metrics = {"profitability": 0.8, "security": 0.5}
-score, vetoed, triggers = calc.calculate(metrics, "scraper_bot")
+result = calc.calculate(metrics, "scraper_bot")
+score, vetoed, triggers = result.score, result.vetoed, result.triggers
 ```
-
-The tuple contains the weighted score, a boolean indicating whether any veto
-fired and a list of the triggered veto descriptions.
+The returned :class:`ROIResult` exposes the weighted score, a boolean
+indicating whether any veto fired and a list of the triggered veto descriptions.
+It also supports tuple unpacking for backwards compatibility.
 
 `log_debug()` uses the standard :mod:`logging` module to emit a human readable
 breakdown of each contribution and any veto triggers at ``DEBUG`` level.

--- a/patch_provenance.py
+++ b/patch_provenance.py
@@ -5,112 +5,231 @@ from __future__ import annotations
 from typing import Any, Dict, List, Mapping
 import json
 import logging
+import sqlite3
 
 from code_database import PatchHistoryDB
 from vector_service import PatchLogger
 
 
-# ---------------------------------------------------------------------------
-def get_patch_provenance(
-    patch_id: int, *, patch_db: PatchHistoryDB | None = None
-) -> List[Dict[str, Any]]:
-    """Return vectors influencing ``patch_id`` ordered by influence.
+class PatchProvenanceService:
+    """High level interface for patch provenance and search helpers."""
 
-    Results are read from the ``patch_ancestry`` table and include the
-    origin, influence score, detected license and any semantic alerts for each
-    vector.
-    """
+    def __init__(self, patch_db: PatchHistoryDB | None = None) -> None:
+        self.db = patch_db or PatchHistoryDB()
+        self.logger = logging.getLogger(__name__)
 
-    db = patch_db or PatchHistoryDB()
-    rows = db.get_ancestry(patch_id)
-    try:
-        rec = db.get(patch_id)
+    # ------------------------------------------------------------------
+    def get_provenance(self, patch_id: int) -> List[Dict[str, Any]]:
+        """Return vectors influencing ``patch_id`` ordered by influence."""
+
+        rows = self.db.get_ancestry(patch_id)
+        try:
+            rec = self.db.get(patch_id)
+        except sqlite3.DatabaseError as exc:  # pragma: no cover - best effort
+            self.logger.exception("failed to fetch patch %s", patch_id)
+            raise
+
         roi_before = float(getattr(rec, "roi_before", 0.0)) if rec else 0.0
         roi_after = float(getattr(rec, "roi_after", 0.0)) if rec else 0.0
         roi_delta = float(getattr(rec, "roi_delta", roi_after - roi_before))
         if roi_delta == 0.0:
             roi_delta = roi_after - roi_before
-    except Exception:
-        roi_before = roi_after = roi_delta = 0.0
-    result: List[Dict[str, Any]] = []
-    for row in rows:
-        origin, vid, infl, *rest = row
-        lic = rest[0] if len(rest) > 0 else None
-        fp = rest[1] if len(rest) > 1 else None
-        alerts = rest[2] if len(rest) > 2 else None
-        result.append(
-            {
-                "origin": origin,
-                "vector_id": vid,
-                "influence": float(infl),
-                "license": lic,
-                "license_fingerprint": fp,
-                "semantic_alerts": json.loads(alerts) if alerts else [],
-                "roi_before": roi_before,
-                "roi_after": roi_after,
-                "roi_delta": roi_delta,
-            }
+
+        result: List[Dict[str, Any]] = []
+        for row in rows:
+            origin, vid, infl, *rest = row
+            lic = rest[0] if len(rest) > 0 else None
+            fp = rest[1] if len(rest) > 1 else None
+            alerts = rest[2] if len(rest) > 2 else None
+            try:
+                alerts_list = json.loads(alerts) if alerts else []
+            except json.JSONDecodeError:
+                alerts_list = []
+            result.append(
+                {
+                    "origin": origin,
+                    "vector_id": vid,
+                    "influence": float(infl),
+                    "license": lic,
+                    "license_fingerprint": fp,
+                    "semantic_alerts": alerts_list,
+                    "roi_before": roi_before,
+                    "roi_after": roi_after,
+                    "roi_delta": roi_delta,
+                }
+            )
+        return result
+
+    # ------------------------------------------------------------------
+    def get_roi_history(self, patch_id: int) -> Dict[str, Any]:
+        """Return stored ROI information for ``patch_id``."""
+
+        try:
+            rec = self.db.get(patch_id)
+        except sqlite3.DatabaseError as exc:  # pragma: no cover - best effort
+            self.logger.exception("failed to fetch patch %s", patch_id)
+            raise
+        if not rec:
+            return {}
+        try:
+            roi_deltas = json.loads(getattr(rec, "roi_deltas", "") or "{}")
+        except json.JSONDecodeError:
+            roi_deltas = {}
+        return {
+            "roi_before": float(getattr(rec, "roi_before", 0.0)),
+            "roi_after": float(getattr(rec, "roi_after", 0.0)),
+            "roi_delta": float(
+                getattr(
+                    rec,
+                    "roi_delta",
+                    getattr(rec, "roi_after", 0.0)
+                    - getattr(rec, "roi_before", 0.0),
+                )
+            ),
+            "roi_deltas": {k: float(v) for k, v in roi_deltas.items()},
+        }
+
+    # ------------------------------------------------------------------
+    def record_metadata(self, patch_id: int, metadata: Mapping[str, Any]) -> None:
+        """Persist arbitrary metadata for ``patch_id`` in ``patch_history``."""
+
+        try:
+            self.db.record_vector_metrics(
+                "",
+                [],
+                patch_id=patch_id,
+                contribution=0.0,
+                win=False,
+                regret=False,
+                summary=json.dumps(metadata),
+            )
+        except sqlite3.DatabaseError:  # pragma: no cover - best effort
+            self.logger.exception("failed to record patch metadata")
+
+    # ------------------------------------------------------------------
+    def search_by_vector(
+        self,
+        vector_id: str,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+        index_hint: str | None = None,
+    ) -> List[Dict[str, Any]]:
+        rows = self.db.find_patches_by_vector(
+            vector_id, limit=limit, offset=offset, index_hint=index_hint
         )
-    return result
+        return [
+            {
+                "patch_id": pid,
+                "influence": infl,
+                "filename": filename,
+                "description": desc,
+            }
+            for pid, infl, filename, desc in rows
+        ]
+
+    # ------------------------------------------------------------------
+    def search_by_hash(self, code_hash: str) -> List[Dict[str, Any]]:
+        rows = self.db.find_patches_by_hash(code_hash)
+        return [
+            {"patch_id": pid, "filename": filename, "description": desc}
+            for pid, filename, desc in rows
+        ]
+
+    # ------------------------------------------------------------------
+    def search_by_license(
+        self,
+        license: str,
+        *,
+        license_fingerprint: str | None = None,
+    ) -> List[Dict[str, Any]]:
+        rows = self.db.find_patches_by_provenance(
+            license=license, license_fingerprint=license_fingerprint
+        )
+        return [
+            {"patch_id": pid, "filename": filename, "description": desc}
+            for pid, filename, desc in rows
+        ]
+
+    # ------------------------------------------------------------------
+    def search_by_license_fingerprint(
+        self, fingerprint: str
+    ) -> List[Dict[str, Any]]:
+        rows = self.db.find_patches_by_provenance(license_fingerprint=fingerprint)
+        return [
+            {"patch_id": pid, "filename": filename, "description": desc}
+            for pid, filename, desc in rows
+        ]
+
+    # ------------------------------------------------------------------
+    def search_by_semantic_alert(self, alert: str) -> List[Dict[str, Any]]:
+        rows = self.db.find_patches_by_provenance(semantic_alert=alert)
+        return [
+            {"patch_id": pid, "filename": filename, "description": desc}
+            for pid, filename, desc in rows
+        ]
+
+    # ------------------------------------------------------------------
+    def search(
+        self,
+        license: str | None = None,
+        semantic_alert: str | None = None,
+        license_fingerprint: str | None = None,
+    ) -> List[Dict[str, Any]]:
+        rows = self.db.find_patches_by_provenance(
+            license=license,
+            semantic_alert=semantic_alert,
+            license_fingerprint=license_fingerprint,
+        )
+        return [
+            {"patch_id": pid, "filename": filename, "description": desc}
+            for pid, filename, desc in rows
+        ]
+
+    # ------------------------------------------------------------------
+    def build_chain(self, patch_id: int) -> List[Dict[str, Any]]:
+        """Return ancestry chain for ``patch_id`` including vector provenance."""
+
+        chain: List[Dict[str, Any]] = []
+        for pid, rec in self.db.get_ancestry_chain(patch_id):
+            chain.append(
+                {
+                    "patch_id": pid,
+                    "filename": rec.filename,
+                    "parent_patch_id": rec.parent_patch_id,
+                    "roi_before": rec.roi_before,
+                    "roi_after": rec.roi_after,
+                    "roi_delta": rec.roi_delta,
+                    "vectors": self.get_provenance(pid),
+                }
+            )
+        return chain
 
 
-# ---------------------------------------------------------------------------
+# Backwards compatible functional wrappers -----------------------------------
+
+
+def get_patch_provenance(
+    patch_id: int, *, patch_db: PatchHistoryDB | None = None
+) -> List[Dict[str, Any]]:
+    return PatchProvenanceService(patch_db).get_provenance(patch_id)
+
+
 def get_roi_history(
     patch_id: int, *, patch_db: PatchHistoryDB | None = None
 ) -> Dict[str, Any]:
-    """Return stored ROI information for ``patch_id``.
-
-    The result contains the overall ``roi_before``, ``roi_after`` and
-    ``roi_delta`` values along with any per-origin ``roi_deltas`` mapping
-    recorded during :func:`PatchLogger.track_contributors`.
-    Missing records yield an empty mapping.
-    """
-
-    db = patch_db or PatchHistoryDB()
-    try:
-        rec = db.get(patch_id)
-    except Exception:
-        rec = None
-    if not rec:
-        return {}
-    try:
-        roi_deltas = json.loads(getattr(rec, "roi_deltas", "") or "{}")
-    except Exception:
-        roi_deltas = {}
-    return {
-        "roi_before": float(getattr(rec, "roi_before", 0.0)),
-        "roi_after": float(getattr(rec, "roi_after", 0.0)),
-        "roi_delta": float(
-            getattr(rec, "roi_delta", getattr(rec, "roi_after", 0.0) - getattr(rec, "roi_before", 0.0))
-        ),
-        "roi_deltas": {k: float(v) for k, v in roi_deltas.items()},
-    }
+    return PatchProvenanceService(patch_db).get_roi_history(patch_id)
 
 
-# ---------------------------------------------------------------------------
 def record_patch_metadata(
     patch_id: int,
     metadata: Mapping[str, Any],
     *,
     patch_db: PatchHistoryDB | None = None,
 ) -> None:
-    """Persist arbitrary metadata for ``patch_id`` in ``patch_history``.
-
-    The metadata is serialised to JSON and stored in the ``summary`` field so
-    :mod:`patch_provenance` queries can later reconstruct the full context of a
-    patch.
-    """
-
-    db = patch_db or PatchHistoryDB()
-    try:
-        db.record_vector_metrics(
-            "", [], patch_id=patch_id, contribution=0.0, win=False, regret=False, summary=json.dumps(metadata)
-        )
-    except Exception:
-        logging.getLogger(__name__).exception("failed to record patch metadata")
+    PatchProvenanceService(patch_db).record_metadata(patch_id, metadata)
 
 
-# ---------------------------------------------------------------------------
 def search_patches_by_vector(
     vector_id: str,
     *,
@@ -119,89 +238,42 @@ def search_patches_by_vector(
     offset: int = 0,
     index_hint: str | None = None,
 ) -> List[Dict[str, Any]]:
-    """Return patches influenced by ``vector_id`` ordered by influence.
-
-    ``limit`` and ``offset`` provide pagination while ``index_hint`` forces a
-    specific SQLite index when querying ``patch_ancestry``.
-    """
-
-    db = patch_db or PatchHistoryDB()
-    rows = db.find_patches_by_vector(
+    return PatchProvenanceService(patch_db).search_by_vector(
         vector_id, limit=limit, offset=offset, index_hint=index_hint
     )
-    return [
-        {
-            "patch_id": pid,
-            "influence": infl,
-            "filename": filename,
-            "description": desc,
-        }
-        for pid, infl, filename, desc in rows
-    ]
 
 
-# ---------------------------------------------------------------------------
 def search_patches_by_hash(
     code_hash: str, *, patch_db: PatchHistoryDB | None = None
 ) -> List[Dict[str, Any]]:
-    """Return patches matching ``code_hash``."""
-
-    db = patch_db or PatchHistoryDB()
-    rows = db.find_patches_by_hash(code_hash)
-    return [
-        {"patch_id": pid, "filename": filename, "description": desc}
-        for pid, filename, desc in rows
-    ]
+    return PatchProvenanceService(patch_db).search_by_hash(code_hash)
 
 
-# ---------------------------------------------------------------------------
 def search_patches_by_license(
     license: str,
     *,
     license_fingerprint: str | None = None,
     patch_db: PatchHistoryDB | None = None,
 ) -> List[Dict[str, Any]]:
-    """Return patches matching ``license`` and optional fingerprint."""
-
-    db = patch_db or PatchHistoryDB()
-    rows = db.find_patches_by_provenance(
-        license=license, license_fingerprint=license_fingerprint
+    return PatchProvenanceService(patch_db).search_by_license(
+        license, license_fingerprint=license_fingerprint
     )
-    return [
-        {"patch_id": pid, "filename": filename, "description": desc}
-        for pid, filename, desc in rows
-    ]
 
 
-# ---------------------------------------------------------------------------
 def search_patches_by_license_fingerprint(
     fingerprint: str, *, patch_db: PatchHistoryDB | None = None
 ) -> List[Dict[str, Any]]:
-    """Return patches matching ``fingerprint``."""
-
-    db = patch_db or PatchHistoryDB()
-    rows = db.find_patches_by_provenance(license_fingerprint=fingerprint)
-    return [
-        {"patch_id": pid, "filename": filename, "description": desc}
-        for pid, filename, desc in rows
-    ]
+    return PatchProvenanceService(patch_db).search_by_license_fingerprint(
+        fingerprint
+    )
 
 
-# ---------------------------------------------------------------------------
 def search_patches_by_semantic_alert(
     alert: str, *, patch_db: PatchHistoryDB | None = None
 ) -> List[Dict[str, Any]]:
-    """Return patches matching ``alert`` semantic alert."""
-
-    db = patch_db or PatchHistoryDB()
-    rows = db.find_patches_by_provenance(semantic_alert=alert)
-    return [
-        {"patch_id": pid, "filename": filename, "description": desc}
-        for pid, filename, desc in rows
-    ]
+    return PatchProvenanceService(patch_db).search_by_semantic_alert(alert)
 
 
-# ---------------------------------------------------------------------------
 def search_patches(
     license: str | None = None,
     semantic_alert: str | None = None,
@@ -209,44 +281,21 @@ def search_patches(
     *,
     patch_db: PatchHistoryDB | None = None,
 ) -> List[Dict[str, Any]]:
-    """Return patches filtered by license, fingerprint and/or semantic alert."""
-
-    db = patch_db or PatchHistoryDB()
-    rows = db.find_patches_by_provenance(
+    return PatchProvenanceService(patch_db).search(
         license=license,
         semantic_alert=semantic_alert,
         license_fingerprint=license_fingerprint,
     )
-    return [
-        {"patch_id": pid, "filename": filename, "description": desc}
-        for pid, filename, desc in rows
-    ]
 
 
-# ---------------------------------------------------------------------------
 def build_chain(
     patch_id: int, *, patch_db: PatchHistoryDB | None = None
 ) -> List[Dict[str, Any]]:
-    """Return ancestry chain for ``patch_id`` including vector provenance."""
-
-    db = patch_db or PatchHistoryDB()
-    chain: List[Dict[str, Any]] = []
-    for pid, rec in db.get_ancestry_chain(patch_id):
-        chain.append(
-            {
-                "patch_id": pid,
-                "filename": rec.filename,
-                "parent_patch_id": rec.parent_patch_id,
-                "roi_before": rec.roi_before,
-                "roi_after": rec.roi_after,
-                "roi_delta": rec.roi_delta,
-                "vectors": get_patch_provenance(pid, patch_db=db),
-            }
-        )
-    return chain
+    return PatchProvenanceService(patch_db).build_chain(patch_id)
 
 
 __all__ = [
+    "PatchProvenanceService",
     "get_patch_provenance",
     "get_roi_history",
     "search_patches_by_vector",

--- a/roi_tracker.py
+++ b/roi_tracker.py
@@ -2089,7 +2089,8 @@ class ROITracker:
         if profile_type is not None and metrics:
             try:
                 calc = ROICalculator()
-                score, vetoed, _ = calc.calculate(metrics, profile_type)
+                result = calc.calculate(metrics, profile_type)
+                score, vetoed = result.score, result.vetoed
                 if score < self.raroi_borderline_threshold or vetoed:
                     suggestions = propose_fix(metrics, profile_type)
                     if suggestions:

--- a/tests/test_composite_workflow_scorer.py
+++ b/tests/test_composite_workflow_scorer.py
@@ -40,6 +40,7 @@ sys.modules.setdefault(
 )
 sys.modules.setdefault("db_router", sys.modules["menace_sandbox.db_router"])
 from menace_sandbox.db_router import init_db_router  # noqa: E402
+from menace_sandbox.roi_calculator import ROIResult
 
 
 class _StubPatchDB:
@@ -72,7 +73,7 @@ def _copy_fixture_modules(tmp_path: Path) -> None:
 
 def _stub_calculator_factory():
     return types.SimpleNamespace(
-        calculate=lambda metrics, _p: (
+        calculate=lambda metrics, _p: ROIResult(
             sum(float(v) for v in metrics.values()),
             False,
             [],

--- a/tests/test_composite_workflow_scorer_db.py
+++ b/tests/test_composite_workflow_scorer_db.py
@@ -47,11 +47,14 @@ class StubTracker:
         self.correlation_history.update(correlations)
 
 
+from menace_sandbox.roi_calculator import ROIResult
+
+
 class StubCalculator:
     profiles = {"default": {}}
 
     def calculate(self, metrics, profile_type):
-        return 0.0, 0.0, 0.0
+        return ROIResult(0.0, False, [])
 
 
 def test_score_workflow_records_and_updates(tmp_path):

--- a/tests/test_default_roi_profiles.py
+++ b/tests/test_default_roi_profiles.py
@@ -19,7 +19,7 @@ def test_default_roi_profile_scores_finite():
         "alignment_violation": False,  # avoids equals true veto
     }
 
-    score, vetoed, triggers = calc.calculate(metrics, "scraper_bot")
-    assert math.isfinite(score)
-    assert not vetoed
-    assert triggers == []
+    result = calc.calculate(metrics, "scraper_bot")
+    assert math.isfinite(result.score)
+    assert not result.vetoed
+    assert result.triggers == []

--- a/tests/test_patch_ancestry.py
+++ b/tests/test_patch_ancestry.py
@@ -5,10 +5,10 @@ import pytest
 
 sys.modules.setdefault("unified_event_bus", types.SimpleNamespace(UnifiedEventBus=object))
 
-from code_database import PatchHistoryDB, PatchRecord
-from vector_service.patch_logger import PatchLogger
-from patch_provenance import get_patch_provenance
-from vector_metrics_db import VectorMetricsDB
+from menace_sandbox.code_database import PatchHistoryDB, PatchRecord
+from menace_sandbox.vector_service.patch_logger import PatchLogger
+from menace_sandbox.patch_provenance import PatchProvenanceService
+from menace_sandbox.vector_metrics_db import VectorMetricsDB
 
 
 def test_patch_logger_logs_ancestry(tmp_path):
@@ -34,7 +34,8 @@ def test_patch_logger_records_provenance(tmp_path):
     rows = db.get_ancestry(pid)
     assert rows[0][3] == "MIT"
     assert json.loads(rows[0][5]) == ["unsafe"]
-    prov = get_patch_provenance(pid, patch_db=db)
+    service = PatchProvenanceService(patch_db=db)
+    prov = service.get_provenance(pid)
     assert prov[0]["origin"] == "o1"
     assert prov[0]["vector_id"] == "v1"
     assert prov[0]["influence"] == pytest.approx(0.8)

--- a/tests/test_roi_calculator.py
+++ b/tests/test_roi_calculator.py
@@ -45,10 +45,10 @@ def test_weighted_roi(tmp_path):
         "latency": 1,
         "energy": 1,
     }
-    score, vetoed, triggers = calc.calculate(metrics, "scraper_bot")
-    assert score == pytest.approx(0.8)
-    assert vetoed is False
-    assert triggers == []
+    result = calc.calculate(metrics, "scraper_bot")
+    assert result.score == pytest.approx(0.8)
+    assert result.vetoed is False
+    assert result.triggers == []
 
 
 @pytest.mark.parametrize("metrics,trigger", [
@@ -58,10 +58,10 @@ def test_weighted_roi(tmp_path):
 def test_veto_triggers(tmp_path, metrics, trigger):
     profile_path = _write_profiles(tmp_path / "roi_profiles.yaml")
     calc = ROICalculator(profiles_path=profile_path)
-    score, vetoed, triggers = calc.calculate(metrics, "scraper_bot")
-    assert score == float("-inf")
-    assert vetoed is True
-    assert any(trigger in t for t in triggers)
+    result = calc.calculate(metrics, "scraper_bot")
+    assert result.score == float("-inf")
+    assert result.vetoed is True
+    assert any(trigger in t for t in result.triggers)
 
 
 def test_log_debug_outputs_components_and_veto(tmp_path, caplog):
@@ -144,7 +144,7 @@ def test_profile_negative_weights_abs_sum_valid(tmp_path):
     profile_path = _write_profiles(tmp_path / "roi_profiles.yaml", weights)
     calc = ROICalculator(profiles_path=profile_path)
     metrics = {"profitability": 1, "energy": 1, "security": 0.5}
-    score, vetoed, triggers = calc.calculate(metrics, "scraper_bot")
-    assert score == 0.0
-    assert vetoed is False
-    assert triggers == []
+    result = calc.calculate(metrics, "scraper_bot")
+    assert result.score == 0.0
+    assert result.vetoed is False
+    assert result.triggers == []


### PR DESCRIPTION
## Summary
- encapsulate ROI scoring results in new `ROIResult` dataclass and remove mutable `hard_fail` state
- add `PatchProvenanceService` class with targeted error handling
- update call sites, docs and tests to use structured interfaces

## Testing
- `pytest tests/test_roi_calculator.py tests/test_default_roi_profiles.py tests/test_roi_bottlenecks.py`
- `pytest tests/test_composite_workflow_scorer.py`
- `pytest tests/test_composite_workflow_scorer_methods.py`
- `pytest tests/test_roi_scorer_workflow.py`
- `pytest tests/test_patch_ancestry.py` *(failed: sqlite3.OperationalError: 33 values for 31 columns)*
- `pytest tests/test_composite_workflow_scorer_db.py` *(failed: ImportError: cannot import name 'GLOBAL_ROUTER')*

------
https://chatgpt.com/codex/tasks/task_e_68b5aa713d08832ea37d50f23c63ddb3