### PR TITLE
Remove automatic dependency installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
-.PHONY: mypy synergy-graph
+.PHONY: mypy synergy-graph install-self-improvement-deps
 mypy:
-	mypy --config mypy.ini self_* sandbox_runner
-	python scripts/check_governed_embeddings.py
-	python scripts/check_governed_retrieval.py
+        mypy --config mypy.ini self_* sandbox_runner
+        python scripts/check_governed_embeddings.py
+        python scripts/check_governed_retrieval.py
 
 synergy-graph:
-	python module_synergy_grapher.py --build
+        python module_synergy_grapher.py --build
+
+install-self-improvement-deps:
+        python scripts/install_self_improvement_deps.py

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ configuration. The generated file includes stub values for critical settings:
 Bootstrap verifies these variables before launching and raises a clear error if
 any required value is missing or the model path does not exist.
 
+Install the auxiliary packages for self-improvement ahead of time:
+
+```
+make install-self-improvement-deps
+```
+
+`verify_dependencies()` merely reports missing or mismatched packages and no
+longer attempts to install them automatically, keeping startup non-interactive.
+
 - Revenue tracking and monetisation helpers
 - **Profit density evaluation** keeping only the most lucrative clips
 - Intelligent culling for clips, accounts and topics

--- a/scripts/install_self_improvement_deps.py
+++ b/scripts/install_self_improvement_deps.py
@@ -1,0 +1,26 @@
+"""Install dependencies required for the self-improvement subsystem.
+
+This script installs the packages expected by :mod:`self_improvement.init`.
+Run ``make install-self-improvement-deps`` to execute it.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+REQUIRED = [
+    "quick_fix_engine>=1.0",
+    "sandbox_runner>=1.0",
+    "neurosales",
+    "relevancy_radar",
+    "torch>=2.0",
+]
+
+
+def main() -> None:
+    cmd = [sys.executable, "-m", "pip", "install", *REQUIRED]
+    subprocess.check_call(cmd)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dependency_checks.py
+++ b/tests/test_dependency_checks.py
@@ -1,3 +1,9 @@
+"""Dependency verification tests for self-improvement helpers.
+
+These tests assume required packages are installed separately using
+``make install-self-improvement-deps``.  The runtime does not perform
+automatic installation.
+"""
 import importlib
 import importlib.util
 import sys
@@ -75,7 +81,6 @@ def test_missing_dependency(monkeypatch):
 
     monkeypatch.setattr(importlib, "import_module", fake_import)
     init_module = _load_init()
-    monkeypatch.setattr(init_module.settings, "auto_install_dependencies", False)
 
     with pytest.raises(RuntimeError) as exc:
         init_module.verify_dependencies()
@@ -98,7 +103,6 @@ def test_version_mismatch(monkeypatch):
 
     monkeypatch.setattr(metadata, "version", fake_version)
     init_module = _load_init()
-    monkeypatch.setattr(init_module.settings, "auto_install_dependencies", False)
 
     with pytest.raises(RuntimeError) as exc:
         init_module.verify_dependencies()
@@ -107,4 +111,3 @@ def test_version_mismatch(monkeypatch):
     assert "pip install quick_fix_engine --upgrade" in msg
     assert "sandbox_runner (installed 0.9" in msg
     assert "pip install sandbox_runner --upgrade" in msg
-

--- a/tests/test_self_improvement_dependencies.py
+++ b/tests/test_self_improvement_dependencies.py
@@ -1,3 +1,8 @@
+"""Integration tests for self-improvement dependency checks.
+
+Dependencies are expected to be installed separately via
+``make install-self-improvement-deps``; the verifier only reports problems.
+"""
 import importlib
 import importlib.util
 import types


### PR DESCRIPTION
## Summary
- stop `verify_dependencies` from installing missing packages and raise clear errors instead
- add `install-self-improvement-deps` helper and document workflow
- adjust tests for non-interactive dependency checks

## Testing
- `python -m pre_commit run --files self_improvement/init.py scripts/install_self_improvement_deps.py tests/self_improvement/test_verify_dependencies.py tests/test_dependency_checks.py tests/test_self_improvement_dependencies.py`
- `pytest tests/self_improvement/test_verify_dependencies.py tests/test_dependency_checks.py tests/test_self_improvement_dependencies.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5b1dadb94832eb7b4d59a36ed2d40