### PR TITLE
feat: parameterize usage queue size

### DIFF
--- a/sandbox_runner/cycle.py
+++ b/sandbox_runner/cycle.py
@@ -152,8 +152,10 @@ from .orphan_discovery import (
 
 _ENABLE_RELEVANCY_RADAR = os.getenv("SANDBOX_ENABLE_RELEVANCY_RADAR") == "1"
 
-_USAGE_QUEUE_MAXSIZE = 256
-_usage_queue: "queue.Queue[tuple[str, float]]" = queue.Queue(maxsize=_USAGE_QUEUE_MAXSIZE)
+_settings = SandboxSettings()
+_usage_queue: "queue.Queue[tuple[str, float]]" = queue.Queue(
+    maxsize=_settings.usage_queue_maxsize
+)
 _usage_thread: threading.Thread | None = None
 _usage_stop_event: threading.Event | None = None
 

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -1358,6 +1358,11 @@ class SandboxSettings(BaseSettings):
         env="RELEVANCY_RADAR_REPLACE_RATIO",
         description="Call and time ratio below which modules are suggested for replacement.",
     )
+    usage_queue_maxsize: int = Field(
+        256,
+        env="USAGE_QUEUE_MAXSIZE",
+        description="Maximum number of module usage events queued for relevancy tracking.",
+    )
     relevancy_metrics_retention_days: int | None = Field(
         None,
         env="RELEVANCY_METRICS_RETENTION_DAYS",

--- a/unit_tests/test_async_track_usage_logging.py
+++ b/unit_tests/test_async_track_usage_logging.py
@@ -18,10 +18,10 @@ class DummyQueue:
     def __init__(self):
         self.items = []
 
-    def put(self, item):
+    def put(self, item, *args, **kwargs):
         self.items.append(item)
 
-    def get(self):
+    def get(self, *args, **kwargs):
         return self.items.pop(0)
 
     def task_done(self):
@@ -45,6 +45,8 @@ def _load_async_track_usage():
         "record_output_impact": lambda *a, **k: None,
         "logger": DummyLogger(),
         "_usage_queue": DummyQueue(),
+        "_usage_stop_event": types.SimpleNamespace(is_set=lambda: False),
+        "dispatch_alert": lambda *a, **k: None,
         "time": types.SimpleNamespace(sleep=lambda *a, **k: None),
         "log_record": lambda **kw: kw,
     }


### PR DESCRIPTION
## Summary
- draw relevancy radar usage queue size from SandboxSettings
- add `usage_queue_maxsize` option to SandboxSettings
- update async usage tracking test to handle queue parameters and stub dependencies

## Testing
- `pytest unit_tests/test_async_track_usage_logging.py -q`
- `pytest sandbox_runner/tests/test_minimal_cycle.py -q` *(fails: Missing dependencies for self-improvement)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b3891ddc832eb68f9acd7e21ba33