### PR TITLE
feat: make module risk weights configurable

### DIFF
--- a/docs/sandbox_config.sample.yaml
+++ b/docs/sandbox_config.sample.yaml
@@ -47,3 +47,6 @@ alignment:
     comment_density_severity: 2
     network_call_severity: 3
     rule_modules: []
+risk_weight_commit: 0.2
+risk_weight_complexity: 0.4
+risk_weight_failures: 0.4

--- a/docs/sandbox_settings.md
+++ b/docs/sandbox_settings.md
@@ -70,6 +70,13 @@ settings = load_sandbox_settings("docs/sandbox_config.sample.yaml")
 - `temperature`: `1.0`
 - `exploration`: `epsilon_greedy`
 
+## Risk analysis defaults
+- `risk_weight_commit`: `0.2`
+- `risk_weight_complexity`: `0.4`
+- `risk_weight_failures`: `0.4`
+
+These weights influence the risk score produced by `_analyse_module`.
+
 ## Prompt logging defaults
 - `prompt_success_log_path`: `prompt_success_log.json` (`PROMPT_SUCCESS_LOG_PATH`)
 - `prompt_failure_log_path`: `prompt_failure_log.json` (`PROMPT_FAILURE_LOG_PATH`)

--- a/sandbox_runner/tests/test_module_analysis.py
+++ b/sandbox_runner/tests/test_module_analysis.py
@@ -63,3 +63,40 @@ def test_analyse_module_weighted_score(monkeypatch, tmp_path):
     assert signals["commit"] == pytest.approx(0.5)
     assert signals["complexity"] == pytest.approx(0.7)
     assert signals["failures"] == pytest.approx(0.3)
+
+
+def test_analyse_module_custom_weights(monkeypatch, tmp_path):
+    mod = tmp_path / "dummy.py"
+    mod.write_text("print('hi')")
+
+    monkeypatch.setattr(
+        subprocess, "check_output", lambda *a, **k: "c1\nc2\nc3\nc4\nc5\n"
+    )
+    analyse_module.__globals__["mi_visit"] = lambda code, *a: 30
+
+    class DummyCur:
+        def fetchone(self):
+            return (3,)
+
+    class DummyConn:
+        def execute(self, *a, **k):
+            return DummyCur()
+
+        def close(self):
+            pass
+
+    class DummyRouter:
+        def get_connection(self, *_):
+            return DummyConn()
+
+    analyse_module.__globals__["router"] = DummyRouter()
+
+    settings = SimpleNamespace(
+        risk_weight_commit=0.0, risk_weight_complexity=0.0, risk_weight_failures=1.0
+    )
+    ctx = SimpleNamespace(repo=tmp_path, settings=settings)
+    score, signals = analyse_module(ctx, "dummy.py")
+    assert score == pytest.approx(0.3)
+    assert signals["commit"] == pytest.approx(0.5)
+    assert signals["complexity"] == pytest.approx(0.7)
+    assert signals["failures"] == pytest.approx(0.3)

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -342,6 +342,9 @@ class SandboxSettings(BaseSettings):
     sandbox_module_threshold: float | None = Field(None, env="SANDBOX_MODULE_THRESHOLD")
     sandbox_semantic_modules: bool = Field(False, env="SANDBOX_SEMANTIC_MODULES")
     sandbox_stub_model: str | None = Field(None, env="SANDBOX_STUB_MODEL")
+    risk_weight_commit: float = Field(0.2, env="RISK_WEIGHT_COMMIT")
+    risk_weight_complexity: float = Field(0.4, env="RISK_WEIGHT_COMPLEXITY")
+    risk_weight_failures: float = Field(0.4, env="RISK_WEIGHT_FAILURES")
     llm_backend: str = Field("openai", env="LLM_BACKEND")
     llm_fallback_backend: str | None = Field(None, env="LLM_FALLBACK_BACKEND")
     preferred_llm_backend: str = Field(


### PR DESCRIPTION
## Summary
- allow SandboxSettings to tune commit, complexity, and failure risk weights
- _analyse_module reads weights from settings instead of hardcoding
- document risk weighting options in settings docs and sample config

## Testing
- `PYTHONPATH=. pytest sandbox_runner/tests/test_module_analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_68b62ab83480832e94407c79882c6b6f