### PR TITLE
Add lock-aware log rotation and configuration knobs

### DIFF
--- a/sandbox_runner/cli.py
+++ b/sandbox_runner/cli.py
@@ -1389,6 +1389,7 @@ def main(argv: List[str] | None = None) -> None:
     p_autorun = sub.add_parser(
         "full-autonomous-run",
         help="iterate presets until ROI improvements fade",
+        conflict_handler="resolve",
     )
     p_autorun.add_argument("--max-iterations", type=int, help="maximum iterations")
     p_autorun.add_argument(

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -317,6 +317,24 @@ class SandboxSettings(BaseSettings):
         env="SANDBOX_CENTRAL_LOGGING",
         description="Enable centralised logging output.",
     )
+    log_rotation_max_bytes: int = Field(
+        5 * 1024 * 1024,
+        env="LOG_ROTATION_MAX_BYTES",
+        ge=0,
+        description="Rotate logs when file exceeds this size in bytes; 0 disables size-based rotation.",
+    )
+    log_rotation_backup_count: int = Field(
+        5,
+        env="LOG_ROTATION_BACKUP_COUNT",
+        ge=0,
+        description="Number of rotated log files to keep.",
+    )
+    log_rotation_seconds: int | None = Field(
+        None,
+        env="LOG_ROTATION_SECONDS",
+        gt=0,
+        description="Rotate logs after this many seconds; when set, overrides size-based rotation.",
+    )
     visual_agent_monitor_interval: float = Field(
         30.0, env="VISUAL_AGENT_MONITOR_INTERVAL"
     )


### PR DESCRIPTION
## Summary
- add file-locking rotating log handlers
- expose log rotation thresholds in `SandboxSettings`
- rotate `violation_logger` output using locked handlers
- resolve argparse conflict in `sandbox_runner` CLI

## Testing
- `pytest tests/test_violation_logger.py -q`
- `pytest tests/test_alignment_warnings.py -q` *(fails: ImportError: cannot import name 'CodeDB')*

------
https://chatgpt.com/codex/tasks/task_e_68b62c1e5280832eb544d0cd00f4cb56