### PR TITLE
Document prompt evolution memory and optimizer integration

### DIFF
--- a/docs/prompt_evolution_memory.md
+++ b/docs/prompt_evolution_memory.md
@@ -1,0 +1,127 @@
+# Prompt Evolution Memory
+
+`PromptEvolutionMemory` persists structured records for prompt experiments so
+that optimisation tools can learn from past executions.  Each call to
+`log_prompt` writes a JSON object to either a success or failure log, allowing
+subsequent runs to analyse what formatting strategies yield the best return on
+investment (ROI).
+
+## Log format
+
+Entries are appended to line-delimited JSON files.  Successful executions are
+written to `prompt_memory_success.jsonl` while failures go to
+`prompt_memory_failure.jsonl`.
+
+```json
+{
+  "timestamp": 1711631182,
+  "prompt": {
+    "system": "sys",
+    "user": "generate code",
+    "examples": ["sample" ]
+  },
+  "format": {"tone": "neutral", "headers": ["Intro"]},
+  "exec_result": {"stdout": "ok", "runtime": 1.2},
+  "roi": {"roi_delta": 1.5, "coverage": 0.8}
+}
+```
+
+Fields:
+
+* `timestamp` – UNIX time of the execution.
+* `prompt` – captured `system`/`user` text and `examples` list.
+* `format` – metadata produced during prompt formatting (tone, section order,
+  etc.).
+* `exec_result` – structured result of running the prompt (stdout, runtime,
+  scores).
+* `roi` – optional ROI metadata.  Numbers such as `roi_delta`, `coverage` or
+  `runtime_improvement` can be stored and later used for weighting.
+
+## ROI metadata
+
+ROI fields describe the impact of a prompt.  Positive values represent an
+improvement while negative values indicate a regression.  Multiple metrics can
+be supplied and the optimizer can weight them during aggregation.  For example:
+
+```python
+memory.log_prompt(prompt, success=True,
+                  exec_result={"stdout": "ok"},
+                  roi={"roi_delta": 2.3, "coverage": 0.9},
+                  format_meta={"tone": "upbeat"})
+```
+
+## Using the optimizer
+
+`PromptOptimizer` consumes the success and failure logs to rank formatting
+configurations.  It groups entries by structural features and computes success
+rates and weighted ROI.  Suggested formats can then be fed back into a prompt
+engine.
+
+```python
+from prompt_evolution_memory import PromptEvolutionMemory
+from prompt_optimizer import PromptOptimizer
+from prompt_engine import PromptEngine
+
+memory = PromptEvolutionMemory()
+# record prompt executions ...
+
+optimizer = PromptOptimizer(
+    memory.success_path,
+    memory.failure_path,
+    stats_path="prompt_optimizer_stats.json",
+    weight_by="coverage",   # use the ``coverage`` ROI field for weighting
+    roi_weight=1.2           # emphasise ROI in ranking
+)
+
+engine = PromptEngine(retriever=my_retriever, optimizer=optimizer)
+engine.build_prompt("add caching")
+```
+
+`PromptEngine` applies the optimizer's suggestions when formatting future
+prompts, continually improving style and section ordering.
+
+## Configuration options
+
+### PromptEvolutionMemory
+
+* `success_path` – destination for successful execution logs
+  (default: `prompt_memory_success.jsonl`).
+* `failure_path` – destination for failed execution logs
+  (default: `prompt_memory_failure.jsonl`).
+
+### PromptOptimizer
+
+* `success_log` / `failure_log` – paths to the success and failure JSONL logs.
+* `stats_path` – file used to persist aggregated statistics.
+* `weight_by` – optional ROI field (`"coverage"`, `"runtime"`, etc.) used to
+  weight ROI calculations.
+* `roi_weight` – exponent applied to ROI when ranking formats; values above one
+  favour ROI over raw success rate.
+
+## Interpreting logs
+
+Logs are standard JSONL and can be processed with any text tools.  The snippet
+below prints the average ROI for successful prompts:
+
+```python
+import json
+from pathlib import Path
+
+success_log = Path("prompt_memory_success.jsonl")
+entries = [json.loads(l) for l in success_log.read_text().splitlines() if l]
+avg_roi = sum(e.get("roi", {}).get("roi_delta", 0) for e in entries) / len(entries)
+print(f"average ROI: {avg_roi:.2f}")
+```
+
+## Integrating optimizer outputs
+
+The optimizer returns ranked suggestions describing high-performing formats.
+A simple integration might apply the top suggestion's metadata directly:
+
+```python
+suggestion = optimizer.suggest_format("prompt_engine", "build_prompt")[0]
+print("Best tone:", suggestion["tone"])
+print("Headers:", suggestion["structured_sections"])
+```
+
+These hints can be used to adjust prompt templates or to inform manual review.


### PR DESCRIPTION
## Summary
- Add `docs/prompt_evolution_memory.md` covering log formats, ROI metadata, and optimizer configuration
- Provide examples of interpreting prompt logs and feeding optimizer suggestions back into the engine

## Testing
- `pytest unit_tests/test_prompt_evolution_memory.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b62f376c94832e9fd66a0eb3df9973