### PR TITLE
Use JSON for replay data

### DIFF
--- a/tests/test_dqn_synergy_learner_persistence.py
+++ b/tests/test_dqn_synergy_learner_persistence.py
@@ -1,7 +1,54 @@
-import pickle
+import json
 import pytest
 
-import menace.self_improvement as sie
+import importlib.util
+import os
+import sys
+import types
+
+import menace
+
+menace.RAISE_ERRORS = False
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+
+# set up minimal package hierarchy to load learners without heavy deps
+menace_pkg = sys.modules.setdefault("menace", menace)
+si_pkg = types.ModuleType("menace.self_improvement")
+si_pkg.__path__ = [os.path.join(ROOT, "self_improvement")]
+sys.modules.setdefault("menace.self_improvement", si_pkg)
+
+policy_mod = types.ModuleType("menace.self_improvement_policy")
+# minimal strategy stub
+class DummyStrategy:
+    def __init__(self, **kw):
+        self.memory = []
+
+    def update(self, table, state, action, reward, next_state, *args):
+        self.memory.append((state, action, reward, next_state, False))
+        return reward
+
+    def predict(self, state):
+        return state
+
+policy_mod.ActorCriticStrategy = DummyStrategy
+policy_mod.DQNStrategy = DummyStrategy
+policy_mod.DoubleDQNStrategy = DummyStrategy
+policy_mod.SelfImprovementPolicy = object
+policy_mod.torch = None
+sys.modules.setdefault("menace.self_improvement_policy", policy_mod)
+
+bootstrap_mod = types.ModuleType("sandbox_runner.bootstrap")
+bootstrap_mod.initialize_autonomous_sandbox = lambda *a, **k: None
+sys.modules.setdefault("sandbox_runner.bootstrap", bootstrap_mod)
+
+spec = importlib.util.spec_from_file_location(
+    "menace.self_improvement.learners",
+    os.path.join(ROOT, "self_improvement", "learners.py"),
+)
+sie = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = sie
+spec.loader.exec_module(sie)
 
 
 def test_dqn_weight_persistence_without_torch(tmp_path, monkeypatch):
@@ -21,28 +68,3 @@ def test_dqn_weight_persistence_without_torch(tmp_path, monkeypatch):
     learner2 = sie.DQNSynergyLearner(path=path, lr=0.5)
     assert learner2.weights == pytest.approx(changed)
 
-
-def test_policy_pickle_called(tmp_path, monkeypatch):
-    monkeypatch.setattr(sie, "sip_torch", None)
-    path = tmp_path / "w.json"
-    called = {"dump": 0, "load": 0}
-    real_dump = pickle.dump
-    real_load = pickle.load
-
-    def wrap_dump(obj, fh, *a, **k):
-        called["dump"] += 1
-        return real_dump(obj, fh, *a, **k)
-
-    def wrap_load(fh, *a, **k):
-        called["load"] += 1
-        return real_load(fh, *a, **k)
-
-    monkeypatch.setattr(sie.pickle, "dump", wrap_dump)
-    monkeypatch.setattr(sie.pickle, "load", wrap_load)
-
-    learner = sie.DQNSynergyLearner(path=path, lr=0.1)
-    learner.update(0.5, {"synergy_roi": 1.0})
-    assert called["dump"] >= 1
-
-    sie.DQNSynergyLearner(path=path, lr=0.1)
-    assert called["load"] >= 1


### PR DESCRIPTION
## Summary
- store replay buffers as JSON instead of pickle
- validate replay data when loading to skip malformed entries
- adapt persistence test with lightweight imports

## Testing
- `pytest tests/test_dqn_synergy_learner_persistence.py -q`
- `pytest tests/test_torch_replay_strategy.py::test_torch_replay_strategy_converges -q`


------
https://chatgpt.com/codex/tasks/task_e_68b62f0982a0832eaa9742cda4c9df67