### PR TITLE
Add success flag to prompt evolution memory logs

### DIFF
--- a/prompt_evolution_memory.py
+++ b/prompt_evolution_memory.py
@@ -91,6 +91,7 @@ class PromptEvolutionMemory:
             },
             "format": format_meta,
             "exec_result": exec_result,
+            "success": success,
         }
         if roi is not None:
             record["roi"] = roi


### PR DESCRIPTION
## Summary
- include a `success` flag in each prompt execution record written by `PromptEvolutionMemory`
- extend tests to verify success flags in both success and failure logs and provide a lightweight `llm_interface` stub to avoid heavy imports

## Testing
- `pytest unit_tests/test_prompt_evolution_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_68b631ad7f10832e96268155bae890f4