### PR TITLE
Log write failures and add regression tests

### DIFF
--- a/micro_models/prefix_injector.py
+++ b/micro_models/prefix_injector.py
@@ -19,6 +19,7 @@ by any component that prepares prompts for Codex or OpenAI APIs.
 """
 
 import os
+import logging
 from pathlib import Path
 from typing import Any, Dict, List, Union
 
@@ -26,6 +27,8 @@ try:  # pragma: no cover - yaml is an optional dependency
     import yaml  # type: ignore
 except Exception:  # pragma: no cover
     yaml = None  # type: ignore
+
+logger = logging.getLogger(__name__)
 
 PromptType = Union[str, List[Dict[str, str]]]
 
@@ -58,7 +61,11 @@ def _load_config() -> tuple[bool, float]:
                         except ValueError:
                             pass
             except Exception:
-                pass
+                logger.warning(
+                    "Failed to load prefix injection config from %s",
+                    path,
+                    exc_info=True,
+                )
     return enabled, threshold
 
 

--- a/relevancy_metrics_db.py
+++ b/relevancy_metrics_db.py
@@ -1,9 +1,12 @@
 import json
+import logging
 import sqlite3
 from pathlib import Path
 from typing import Iterable, TYPE_CHECKING, Any
 
 from db_router import DBRouter, GLOBAL_ROUTER, LOCAL_TABLES, init_db_router
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
     from module_index_db import ModuleIndexDB  # type: ignore
@@ -65,7 +68,12 @@ class RelevancyMetricsDB:
             try:
                 tag_set.update(module_index.get_tags(module))
             except Exception:
-                pass
+                logger.warning(
+                    "Failed to fetch tags for %s from module index at %s",
+                    module,
+                    self.path,
+                    exc_info=True,
+                )
         conn = self.router.get_connection("module_metrics")
         row = conn.execute(
             "SELECT call_count, total_time, roi_delta, tags FROM module_metrics WHERE module_id=?",

--- a/tests/test_workflow_synergy_logging.py
+++ b/tests/test_workflow_synergy_logging.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from workflow_synergy_comparator import WorkflowSynergyComparator
+
+
+def test_update_best_practices_logs_write_failure(tmp_path, monkeypatch):
+    path = tmp_path / "best.json"
+    WorkflowSynergyComparator.best_practices_file = path
+
+    def failing_write(self, *args, **kwargs):
+        raise IOError("disk full")
+
+    monkeypatch.setattr(Path, "write_text", failing_write)
+
+    with patch("workflow_synergy_comparator.logger.warning") as warn:
+        WorkflowSynergyComparator._update_best_practices(["m1", "m2"])
+
+    warn.assert_called()
+    # Ensure the path of the failing file is included in the log call
+    assert str(path) in str(warn.call_args[0][1]) or str(path) in str(warn.call_args[0][0])


### PR DESCRIPTION
## Summary
- avoid silent failure when reading tag metadata in `RelevancyMetricsDB`
- log prefix injection config parse errors
- ensure workflow best practice updates log read/write failures
- add test verifying write failures are logged

## Testing
- `pytest tests/test_workflow_synergy_logging.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6366a4080832ea747abcd838596f8