### PR TITLE
Default to SandboxSettings log level in start_autonomous_sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ configuration. The generated file includes stub values for critical settings:
 - `MODELS` resolves to the bundled `micro_models` directory when set to `demo`
 - `OPENAI_API_KEY` and `STRIPE_API_KEY` placeholders
 - `SANDBOX_DATA_DIR` defaults to `sandbox_data`
+- `SANDBOX_LOG_LEVEL` defaults to `INFO` (use `--log-level` to override)
 
 Bootstrap verifies these variables before launching and raises a clear error if
 any required value is missing or the model path does not exist.

--- a/start_autonomous_sandbox.py
+++ b/start_autonomous_sandbox.py
@@ -2,7 +2,7 @@
 
 This small wrapper adds a bit of resiliency around the sandbox bootstrap by
 capturing startup exceptions and allowing the log level to be configured via
-the command line.
+``SandboxSettings`` or overridden on the command line.
 """
 
 from __future__ import annotations
@@ -11,6 +11,7 @@ import argparse
 import logging
 import sys
 
+from sandbox_settings import SandboxSettings
 from sandbox_runner.bootstrap import (
     bootstrap_environment,
     launch_sandbox,
@@ -29,11 +30,13 @@ def main(argv: list[str] | None = None) -> None:
         be pulled from :data:`sys.argv`.
     """
 
+    settings = SandboxSettings()
+
     parser = argparse.ArgumentParser(description="Launch the autonomous sandbox")
     parser.add_argument(
         "--log-level",
         dest="log_level",
-        default=None,
+        default=settings.sandbox_log_level,
         help="Logging level (e.g. DEBUG, INFO, WARNING)",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- Read log level from `SandboxSettings` before argument parsing and let `--log-level` override it
- Document `SANDBOX_LOG_LEVEL` in README for headless deployments

## Testing
- `python -m pytest sandbox_runner/tests/test_start_autonomous_noninteractive.py::test_start_autonomous_sandbox_noninteractive -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68b639b7f374832e9a8612b3ddce2b1d