### PR TITLE
refactor: use shared Prompt dataclass

### DIFF
--- a/prompt_evolution_logger.py
+++ b/prompt_evolution_logger.py
@@ -11,13 +11,11 @@ from typing import Any, Dict
 from filelock import FileLock
 
 try:  # pragma: no cover - optional dependency
-    from prompt_types import Prompt  # type: ignore
-except Exception:  # pragma: no cover - minimal fallback for tests
-    class Prompt:  # type: ignore
-        system: str = ""
-        user: str = ""
-        examples: list[str] = []
-        metadata: Dict[str, Any] = {}
+    from prompt_types import Prompt
+except Exception as exc:  # pragma: no cover - explicit failure
+    raise ImportError(
+        "prompt_types.Prompt is required for PromptEvolutionLogger"
+    ) from exc
 
 
 _ROOT = Path(__file__).resolve().parent
@@ -77,10 +75,10 @@ class PromptEvolutionLogger:
         record: Dict[str, Any] = {
             "timestamp": int(time.time()),
             "prompt": {
-                "system": getattr(prompt, "system", ""),
-                "user": getattr(prompt, "user", ""),
-                "examples": list(getattr(prompt, "examples", [])),
-                "metadata": dict(getattr(prompt, "metadata", {})),
+                "system": prompt.system,
+                "user": prompt.user,
+                "examples": list(prompt.examples),
+                "metadata": dict(prompt.metadata),
             },
             "result": result,
             "roi": roi or {},

--- a/unit_tests/test_prompt_evolution_logger.py
+++ b/unit_tests/test_prompt_evolution_logger.py
@@ -2,23 +2,12 @@ import json
 from pathlib import Path
 import types
 
+import json
+from pathlib import Path
+
 import pytest
 
-import sys
-sys.path.append(str(Path(__file__).resolve().parent.parent))
-
-# Provide a lightweight stand-in for the heavy llm_interface module
-if "llm_interface" not in sys.modules:
-    class _Prompt:
-        def __init__(self, system: str = "", user: str = "", examples=None, **kwargs):
-            self.system = system
-            self.user = user
-            self.examples = examples or []
-            for k, v in kwargs.items():
-                setattr(self, k, v)
-
-    sys.modules["llm_interface"] = types.SimpleNamespace(Prompt=_Prompt)
-
+from prompt_types import Prompt
 from prompt_evolution_logger import PromptEvolutionLogger
 
 
@@ -47,25 +36,9 @@ def test_log_prompt_records_success_and_failure(tmp_path: Path):
     failure = tmp_path / "failure.json"
     logger = PromptEvolutionLogger(success_path=success, failure_path=failure)
 
-    class P:
-        system = "sys"
-        user = "u"
-        examples = ["e"]
-
-    logger.log(
-        P(),
-        True,
-        {"out": "ok"},
-        {"roi": 1},
-        format_meta={"fmt": "a"},
-    )
-    logger.log(
-        P(),
-        False,
-        {"out": "bad"},
-        {"roi": -1},
-        format_meta={"fmt": "b"},
-    )
+    prompt = Prompt(system="sys", user="u", examples=["e"])
+    logger.log(prompt, True, {"out": "ok"}, {"roi": 1}, format_meta={"fmt": "a"})
+    logger.log(prompt, False, {"out": "bad"}, {"roi": -1}, format_meta={"fmt": "b"})
 
     s = read_lines(success)
     f = read_lines(failure)


### PR DESCRIPTION
## Summary
- import `Prompt` from shared module in `prompt_evolution_logger`
- log prompt evolution with unified dataclass fields
- update prompt evolution tests to construct real `Prompt` objects

## Testing
- `pytest tests/test_prompt_evolution_logger.py tests/test_prompt_logging_and_optimizer.py tests/test_prompt_engine_optimizer_integration.py unit_tests/test_prompt_evolution_logger.py`


------
https://chatgpt.com/codex/tasks/task_e_68b639c09280832e86aae420bb44f5e5