### PR TITLE
feat: make required db files configurable

### DIFF
--- a/docs/sandbox_config.sample.yaml
+++ b/docs/sandbox_config.sample.yaml
@@ -3,6 +3,10 @@ enable_meta_planner: false
 optional_service_versions:
   relevancy_radar: "1.0.0"
   quick_fix_engine: "1.0.0"
+sandbox_required_db_files:
+  - metrics.db
+  - patch_history.db
+  - visual_agent_queue.db
 roi:
   threshold: null
   confidence: null

--- a/docs/sandbox_settings.md
+++ b/docs/sandbox_settings.md
@@ -126,6 +126,24 @@ export OPTIONAL_SERVICE_VERSIONS='{"relevancy_radar": "1.2.0"}'
 
 Unset modules are ignored.
 
+## Required database files
+
+`SandboxSettings.sandbox_required_db_files` lists SQLite files that should be
+present inside `sandbox_data_dir`. The bootstrap helper ensures each file
+exists, creating empty databases when necessary. Override the defaults via a
+configuration file or the `SANDBOX_REQUIRED_DB_FILES` environment variable:
+
+```yaml
+sandbox_required_db_files:
+  - metrics.db
+  - patch_history.db
+  - visual_agent_queue.db
+```
+
+```bash
+export SANDBOX_REQUIRED_DB_FILES='["metrics.db", "custom.db"]'
+```
+
 ## LLM backends
 
 `SandboxSettings` can dynamically load different language model clients. The

--- a/sandbox_runner/bootstrap.py
+++ b/sandbox_runner/bootstrap.py
@@ -21,12 +21,6 @@ from .cycle import ensure_vector_service
 
 _SELF_IMPROVEMENT_THREAD: Any | None = None
 _INITIALISED = False
-# SQLite databases required for a healthy sandbox
-REQUIRED_DB_FILES = (
-    "metrics.db",
-    "patch_history.db",
-    "visual_agent_queue.db",
-)
 
 
 logger = logging.getLogger(__name__)
@@ -183,7 +177,7 @@ def initialize_autonomous_sandbox(
             baseline_path.write_text("{}\n", encoding="utf-8")
 
     # Create expected SQLite databases
-    for name in REQUIRED_DB_FILES:
+    for name in settings.sandbox_required_db_files:
         _ensure_sqlite_db(data_dir / name)
 
     # Verify optional services are importable and meet version requirements
@@ -294,11 +288,10 @@ def sandbox_health() -> dict[str, bool]:
     inner = getattr(thread, "_thread", thread) if thread is not None else None
     alive = bool(getattr(inner, "is_alive", lambda: False)())
 
-    data_dir = Path(
-        os.getenv("SANDBOX_DATA_DIR", load_sandbox_settings().sandbox_data_dir)
-    )
+    settings = load_sandbox_settings()
+    data_dir = Path(os.getenv("SANDBOX_DATA_DIR", settings.sandbox_data_dir))
     db_ok = True
-    for name in REQUIRED_DB_FILES:
+    for name in settings.sandbox_required_db_files:
         try:
             with open(data_dir / name, "a"):
                 pass

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -307,6 +307,15 @@ class SandboxSettings(BaseSettings):
         env="SANDBOX_REQUIRED_ENV_VARS",
         description="Environment variables required for sandbox initialisation.",
     )
+    sandbox_required_db_files: list[str] = Field(
+        default_factory=lambda: [
+            "metrics.db",
+            "patch_history.db",
+            "visual_agent_queue.db",
+        ],
+        env="SANDBOX_REQUIRED_DB_FILES",
+        description="SQLite database files expected in the sandbox data directory.",
+    )
     sandbox_repo_path: str = Field(
         ".",
         env="SANDBOX_REPO_PATH",
@@ -487,6 +496,7 @@ class SandboxSettings(BaseSettings):
             "required_python_packages",
             "optional_python_packages",
             "required_env_vars",
+            "sandbox_required_db_files",
             mode="before",
         )
         def _parse_dependency_list(cls, v: Any) -> Any:
@@ -523,6 +533,7 @@ class SandboxSettings(BaseSettings):
             "required_python_packages",
             "optional_python_packages",
             "required_env_vars",
+            "sandbox_required_db_files",
             pre=True,
         )
         def _parse_dependency_list(cls, v: Any) -> Any:  # type: ignore[override]


### PR DESCRIPTION
## Summary
- allow configuring required sandbox databases via `sandbox_required_db_files`
- use the new setting for bootstrap and health checks
- document configurable databases in sandbox settings docs

## Testing
- `pytest sandbox_runner/tests`


------
https://chatgpt.com/codex/tasks/task_e_68b645fab0b8832e902ee7bbbb93097e