### PR TITLE
refactor: use real Prompt in prompt evolution

### DIFF
--- a/prompt_evolution_logger.py
+++ b/prompt_evolution_logger.py
@@ -2,6 +2,17 @@ from __future__ import annotations
 
 """Backward compatibility wrapper for :mod:`prompt_evolution_memory`."""
 
+try:  # pragma: no cover - optional dependency
+    from llm_interface import Prompt  # noqa: F401
+except Exception:  # pragma: no cover - llm_interface unavailable
+    try:  # pragma: no cover - optional dependency
+        from prompt_types import Prompt  # noqa: F401
+    except Exception as exc:  # pragma: no cover - explicit failure
+        raise ImportError(
+            "Prompt dataclass is required for PromptEvolutionLogger. "
+            "Install 'prompt_types' or ensure 'llm_interface' is available."
+        ) from exc
+
 from prompt_evolution_memory import PromptEvolutionMemory as PromptEvolutionLogger
 
 __all__ = ["PromptEvolutionLogger"]

--- a/prompt_evolution_memory.py
+++ b/prompt_evolution_memory.py
@@ -11,11 +11,15 @@ from typing import Any, Dict
 from filelock import FileLock
 
 try:  # pragma: no cover - optional dependency
-    from prompt_types import Prompt
-except Exception as exc:  # pragma: no cover - explicit failure
-    raise ImportError(
-        "prompt_types.Prompt is required for PromptEvolutionMemory"
-    ) from exc
+    from llm_interface import Prompt  # type: ignore
+except Exception:  # pragma: no cover - llm_interface unavailable
+    try:  # pragma: no cover - optional dependency
+        from prompt_types import Prompt  # type: ignore
+    except Exception as exc:  # pragma: no cover - explicit failure
+        raise ImportError(
+            "Prompt dataclass is required for PromptEvolutionMemory. "
+            "Install 'prompt_types' or ensure 'llm_interface' is available."
+        ) from exc
 
 
 _ROOT = Path(__file__).resolve().parent

--- a/tests/test_prompt_evolution_memory.py
+++ b/tests/test_prompt_evolution_memory.py
@@ -3,7 +3,7 @@ import threading
 from pathlib import Path
 
 from prompt_evolution_memory import PromptEvolutionMemory
-from prompt_types import Prompt
+from llm_interface import Prompt
 
 
 def test_prompt_evolution_memory_records(tmp_path: Path) -> None:

--- a/unit_tests/test_prompt_evolution_memory.py
+++ b/unit_tests/test_prompt_evolution_memory.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from prompt_types import Prompt
+from llm_interface import Prompt
 from prompt_evolution_memory import PromptEvolutionMemory
 
 


### PR DESCRIPTION
## Summary
- ensure prompt evolution modules import the shared Prompt dataclass with helpful errors
- update tests to use the real Prompt definition

## Testing
- `PYTHONWARNINGS=ignore pytest unit_tests/test_prompt_evolution_memory.py tests/test_prompt_evolution_memory.py tests/test_prompt_logging_and_optimizer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b64c0b8514832ea7a848fb7841540e