### PR TITLE
Add code chunking and summary cache utilities

### DIFF
--- a/prompt_chunking.py
+++ b/prompt_chunking.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+"""Utilities for splitting code into token-limited chunks and caching summaries."""
+
+import ast
+import json
+import hashlib
+from pathlib import Path
+from datetime import datetime
+from typing import List, Dict
+
+# Optional encoder dependency -------------------------------------------------
+try:  # pragma: no cover - try to reuse existing encoder
+    from prompt_engine import _ENCODER as _PE_ENCODER  # type: ignore
+except Exception:  # pragma: no cover - avoid hard dependency
+    _PE_ENCODER = None
+
+try:  # pragma: no cover - fallback to direct tiktoken import
+    import tiktoken  # type: ignore
+except Exception:  # pragma: no cover - dependency may be missing
+    tiktoken = None  # type: ignore
+
+if _PE_ENCODER is not None:
+    _ENCODER = _PE_ENCODER
+elif tiktoken is not None:
+    _ENCODER = tiktoken.get_encoding("cl100k_base")
+else:  # pragma: no cover - final fallback when no tokenizer is available
+    _ENCODER = None
+
+
+def _count_tokens(text: str) -> int:
+    """Return the number of tokens in ``text`` using the best available encoder."""
+
+    if _ENCODER is not None:
+        try:  # pragma: no cover - defensive
+            return len(_ENCODER.encode(text))
+        except Exception:
+            pass
+    return len(text.split())
+
+
+def _split_to_limit(code: str, token_limit: int) -> List[str]:
+    """Yield ``code`` split into chunks under ``token_limit`` tokens."""
+
+    if _count_tokens(code) <= token_limit:
+        return [code]
+    out: List[str] = []
+    current: List[str] = []
+    for line in code.splitlines():
+        tentative = "\n".join(current + [line])
+        if _count_tokens(tentative) <= token_limit or not current:
+            current.append(line)
+            continue
+        out.append("\n".join(current))
+        current = [line]
+    if current:
+        out.append("\n".join(current))
+    return out
+
+
+def chunk_code(path: Path, token_limit: int) -> List[str]:
+    """Split ``path`` into top-level function/class chunks ≤ ``token_limit`` tokens."""
+
+    source = path.read_text()
+    module = ast.parse(source)
+    lines = source.splitlines()
+    chunks: List[str] = []
+    prev_end = 1
+    for node in module.body:
+        if hasattr(node, "lineno"):
+            start = getattr(node, "lineno")
+            end = getattr(node, "end_lineno", start)
+            # Include any intervening top-level statements
+            if start > prev_end:
+                segment = "\n".join(lines[prev_end - 1 : start - 1]).rstrip()
+                if segment:
+                    chunks.extend(_split_to_limit(segment, token_limit))
+            block = "\n".join(lines[start - 1 : end]).rstrip()
+            chunks.extend(_split_to_limit(block, token_limit))
+            prev_end = end + 1
+    # Trailing statements
+    if prev_end <= len(lines):
+        segment = "\n".join(lines[prev_end - 1 :]).rstrip()
+        if segment:
+            chunks.extend(_split_to_limit(segment, token_limit))
+    return chunks
+
+
+def summarize_code(code: str) -> str:
+    """Return a short summary for ``code`` using available micro-models."""
+
+    try:  # pragma: no cover - optional dependency
+        from micro_models.diff_summarizer import summarize_diff as _summ
+    except Exception:  # pragma: no cover - summariser may be missing
+        return code
+    try:  # pragma: no cover - defensive
+        return _summ("", code) or code
+    except Exception:
+        return code
+
+
+CACHE_DIR = Path(__file__).resolve().parent / "chunk_summary_cache"
+
+
+def get_chunk_summaries(path: Path, token_limit: int) -> List[Dict[str, str]]:
+    """Return cached or freshly generated summaries for ``path`` chunks."""
+
+    CACHE_DIR.mkdir(exist_ok=True)
+    out: List[Dict[str, str]] = []
+    for chunk in chunk_code(path, token_limit):
+        h = hashlib.sha256(chunk.encode("utf-8")).hexdigest()
+        cache_file = CACHE_DIR / f"{h}.json"
+        if cache_file.exists():
+            try:
+                data = json.loads(cache_file.read_text())
+                if data.get("code") == chunk:
+                    out.append(data)
+                    continue
+            except Exception:
+                pass
+        summary = summarize_code(chunk)
+        data = {
+            "hash": h,
+            "code": chunk,
+            "summary": summary,
+            "path": str(path),
+            "created_at": datetime.utcnow().isoformat(),
+            "token_limit": token_limit,
+        }
+        cache_file.write_text(json.dumps(data, indent=2, sort_keys=True))
+        out.append(data)
+    return out
+
+
+__all__ = ["chunk_code", "summarize_code", "get_chunk_summaries"]
+

--- a/tests/test_prompt_chunking.py
+++ b/tests/test_prompt_chunking.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import json
+
+import prompt_chunking as pc
+
+
+def _write_sample(path: Path) -> Path:
+    code = """
+def a():
+    return 1
+
+
+def b():
+    return 2
+"""
+    file = path / "sample.py"
+    file.write_text(code)
+    return file
+
+
+def test_chunk_code_splits_top_level_defs(tmp_path: Path) -> None:
+    file = _write_sample(tmp_path)
+    chunks = pc.chunk_code(file, 100)
+    assert len(chunks) == 2
+    assert chunks[0].lstrip().startswith("def a")
+    assert chunks[1].lstrip().startswith("def b")
+    for chunk in chunks:
+        assert pc._count_tokens(chunk) <= 100
+
+
+def test_get_chunk_summaries_cache(tmp_path: Path, monkeypatch) -> None:
+    file = _write_sample(tmp_path)
+    cache = tmp_path / "cache"
+    monkeypatch.setattr(pc, "CACHE_DIR", cache)
+    cache.mkdir()
+
+    calls: List[str] = []
+
+    def fake_sum(code: str) -> str:
+        calls.append(code)
+        return f"summary-{len(calls)}"
+
+    monkeypatch.setattr(pc, "summarize_code", fake_sum)
+
+    first = pc.get_chunk_summaries(file, 100)
+    assert len(first) == 2
+    assert len(calls) == 2
+    assert len(list(cache.glob("*.json"))) == 2
+
+    second = pc.get_chunk_summaries(file, 100)
+    assert len(second) == 2
+    assert len(calls) == 2  # cache hit
+
+    # modify file -> one chunk changes
+    file.write_text(file.read_text().replace("return 1", "return 42"))
+    third = pc.get_chunk_summaries(file, 100)
+    assert len(third) == 2
+    assert len(calls) == 3  # one new summary
+


### PR DESCRIPTION
## Summary
- implement `prompt_chunking.py` for AST-based chunking and summary caching
- include `chunk_summary_cache/` directory for cached chunk summaries
- add tests covering chunking and caching behaviour

## Testing
- `pytest tests/test_prompt_chunking.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6514cb37c832eb03b785e7657132b