### PR TITLE
feat: optional auto-install for self-improvement deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ Install the auxiliary packages for self-improvement ahead of time:
 make install-self-improvement-deps
 ```
 
-`verify_dependencies()` merely reports missing or mismatched packages and no
-longer attempts to install them automatically, keeping startup non-interactive.
+`verify_dependencies()` reports missing or mismatched packages.  When the
+`AUTO_INSTALL_DEPENDENCIES` setting or ``auto_install`` flag is enabled it will
+attempt to install requirements automatically, falling back to the same error
+message if installation fails.
 
 - Revenue tracking and monetisation helpers
 - **Profit density evaluation** keeping only the most lucrative clips

--- a/tests/test_dependency_checks.py
+++ b/tests/test_dependency_checks.py
@@ -1,8 +1,8 @@
 """Dependency verification tests for self-improvement helpers.
 
 These tests assume required packages are installed separately using
-``make install-self-improvement-deps``.  The runtime does not perform
-automatic installation.
+``make install-self-improvement-deps``.  Automatic installation is available
+but disabled for these tests.
 """
 import importlib
 import importlib.util

--- a/tests/test_self_improvement_dependencies.py
+++ b/tests/test_self_improvement_dependencies.py
@@ -1,7 +1,8 @@
 """Integration tests for self-improvement dependency checks.
 
 Dependencies are expected to be installed separately via
-``make install-self-improvement-deps``; the verifier only reports problems.
+``make install-self-improvement-deps``; the verifier reports problems by
+default but can optionally install missing packages when enabled.
 """
 import importlib
 import importlib.util


### PR DESCRIPTION
## Summary
- allow verify_dependencies to optionally auto-install missing or outdated packages
- expose AUTO_INSTALL_DEPENDENCIES via SandboxSettings and docs
- test auto-install flow and failure handling

## Testing
- `pre-commit run --files README.md self_improvement/init.py tests/test_dependency_checks.py tests/test_self_improvement_dependencies.py tests/self_improvement/test_verify_dependencies.py`
- `pytest tests/test_dependency_checks.py tests/test_self_improvement_dependencies.py tests/self_improvement/test_verify_dependencies.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6529fafdc832e9e1a8c6be0f39fcb