### PR TITLE
Handle missing neurosales metadata during dependency checks

### DIFF
--- a/self_improvement/init.py
+++ b/self_improvement/init.py
@@ -77,8 +77,12 @@ def verify_dependencies(*, auto_install: bool = False) -> None:
     }
     try:  # capture version if package metadata is published
         neurosales_cfg["version"] = f">={metadata.version('neurosales')}"
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug(
+            "failed to read neurosales metadata",
+            extra=log_record(error=str(exc)),
+        )
+        neurosales_cfg["version"] = None
 
     checks: dict[str, dict[str, Any]] = {
         "quick_fix_engine": {


### PR DESCRIPTION
## Summary
- log neurosales metadata lookup failures with context
- fall back to `None` version requirement when metadata is missing
- test that missing neurosales metadata is logged

## Testing
- `pre-commit run --files self_improvement/init.py tests/self_improvement/test_verify_dependencies.py`
- `pytest tests/self_improvement/test_verify_dependencies.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b656ff6df4832eaa24693d834054c6