### PR TITLE
Add token-aware context summaries

### DIFF
--- a/prompt_engine.py
+++ b/prompt_engine.py
@@ -134,6 +134,10 @@ class PromptEngine:
         prompts.
     max_tokens:
         Maximum number of tokens allowed for each snippet block.
+    token_threshold:
+        Maximum number of tokens permitted for the assembled prompt. Text
+        exceeding this limit is trimmed and long files are summarised when
+        included as context.
     success_header:
         Header inserted before successful examples. Defaults to
         ``"Given the following pattern:"``.
@@ -155,6 +159,7 @@ class PromptEngine:
     confidence_threshold: float = 0.3
     top_n: int = 5
     max_tokens: int = 200
+    token_threshold: int = 3500
     roi_weight: float = 1.0
     recency_weight: float = 0.1
     roi_tag_weights: Dict[str, float] = field(
@@ -745,6 +750,7 @@ class PromptEngine:
         if retry_trace:
             lines.extend(self._format_retry_trace(retry_trace))
         text = "\n".join(line for line in lines if line)
+        text = self._trim_tokens(text, self.token_threshold)
         prompt_obj = Prompt(
             system="",
             user=text,

--- a/tests/test_prompt_engine.py
+++ b/tests/test_prompt_engine.py
@@ -386,3 +386,15 @@ def test_prompt_engine_uses_optimizer_preferences():
     assert engine.trained_structured_sections == ["overview"]
     assert engine.trained_example_placement == "start"
     assert opt.calls == 1
+
+
+def test_build_prompt_trims_final_text():
+    records = [_record(1.0, summary="good", tests_passed=True, ts=1)]
+    engine = PromptEngine(
+        patch_retriever=DummyRetriever(records),
+        token_threshold=5,
+        confidence_threshold=-1.0,
+    )
+    long_context = "word " * 100
+    prompt = engine.build_prompt("desc", context=long_context)
+    assert str(prompt).endswith("...")


### PR DESCRIPTION
## Summary
- Allow SelfCodingEngine and PromptEngine to configure a token threshold (default 3500)
- Summarize large file contexts with `get_chunk_summaries` when threshold exceeded
- Trim final assembled prompts to stay within the token limit and add regression test

## Testing
- `python -m py_compile self_coding_engine.py prompt_engine.py tests/test_prompt_engine.py`
- `pytest tests/test_prompt_engine.py tests/test_prompt_chunking.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b655ce7560832eba7edd6365585079