### PR TITLE
feat: configurable prompt chunking settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ configuration. The generated file includes stub values for critical settings:
 - `OPENAI_API_KEY` and `STRIPE_API_KEY` placeholders
 - `SANDBOX_DATA_DIR` defaults to `sandbox_data`
 - `SANDBOX_LOG_LEVEL` defaults to `INFO` (use `--log-level` to override)
+- `PROMPT_CHUNK_TOKEN_THRESHOLD` and `CHUNK_SUMMARY_CACHE_DIR` control code
+  chunking token limits and caching for large file summaries
 
 Bootstrap verifies these variables before launching and raises a clear error if
 any required value is missing or the model path does not exist.

--- a/docs/prompt_engine.md
+++ b/docs/prompt_engine.md
@@ -41,6 +41,13 @@ Outcome: works (tests passed)
   <trace>
   Please attempt a different solution.
   ```
+* `token_threshold` – Maximum number of tokens permitted for the assembled prompt.
+  Text exceeding this limit is trimmed and long files are summarised when
+  included as context.
+* `chunk_token_threshold` – Token limit for individual code chunks when large files
+  are summarised (defaults to `PROMPT_CHUNK_TOKEN_THRESHOLD`).
+* `chunk_summary_cache_dir` – Directory used to store cached summaries of
+  chunked code (`CHUNK_SUMMARY_CACHE_DIR`).
 * `success_header` and `failure_header` – control the section titles for
   successful and failing examples.  The defaults are
   `"Given the following pattern:"` and

--- a/docs/sandbox_config.sample.yaml
+++ b/docs/sandbox_config.sample.yaml
@@ -7,6 +7,8 @@ sandbox_required_db_files:
   - metrics.db
   - patch_history.db
   - visual_agent_queue.db
+prompt_chunk_token_threshold: 200
+chunk_summary_cache_dir: chunk_summary_cache
 roi:
   threshold: null
   confidence: null

--- a/docs/sandbox_settings.md
+++ b/docs/sandbox_settings.md
@@ -81,6 +81,12 @@ These weights influence the risk score produced by `_analyse_module`.
 - `prompt_success_log_path`: `prompt_success_log.json` (`PROMPT_SUCCESS_LOG_PATH`)
 - `prompt_failure_log_path`: `prompt_failure_log.json` (`PROMPT_FAILURE_LOG_PATH`)
 
+## Prompt chunking defaults
+- `prompt_chunk_token_threshold`: `200` (`PROMPT_CHUNK_TOKEN_THRESHOLD`)
+- `chunk_summary_cache_dir`: `chunk_summary_cache` (`CHUNK_SUMMARY_CACHE_DIR`)
+
+These settings control token limits and caching for code chunk summaries.
+
 See [`sandbox_config.sample.yaml`](sandbox_config.sample.yaml) for a complete
 example configuration file.
 

--- a/docs/self_coding_engine.md
+++ b/docs/self_coding_engine.md
@@ -68,4 +68,12 @@ with create_ephemeral_env(Path(".")) as (repo, run):
 Startup time and installation failures are logged via the sandbox logging
 utilities so that callers can track environment issues.
 
+## Prompt chunking and caching
+
+Large files are summarised in smaller chunks when their token count exceeds
+`prompt_chunk_token_threshold`. Chunk summaries are cached under
+`chunk_summary_cache_dir` to speed up subsequent runs. Both settings are
+configurable through `SandboxSettings` or environment variables
+(`PROMPT_CHUNK_TOKEN_THRESHOLD` and `CHUNK_SUMMARY_CACHE_DIR`).
+
 

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -586,6 +586,17 @@ class SandboxSettings(BaseSettings):
         env="PROMPT_FAILURE_LOG_PATH",
         description="Path for recording failed prompt executions.",
     )
+    prompt_chunk_token_threshold: int = Field(
+        200,
+        env="PROMPT_CHUNK_TOKEN_THRESHOLD",
+        description=
+        "Token limit for individual code chunks when summarizing large files.",
+    )
+    chunk_summary_cache_dir: str = Field(
+        "chunk_summary_cache",
+        env="CHUNK_SUMMARY_CACHE_DIR",
+        description="Directory for cached summaries of code chunks.",
+    )
     stub_timeout: float = Field(
         10.0,
         env="SANDBOX_STUB_TIMEOUT",


### PR DESCRIPTION
## Summary
- allow SandboxSettings to configure chunk summary caching and chunk token limits
- pass chunking settings through PromptEngine and SelfCodingEngine
- document prompt chunking configuration options

## Testing
- `pytest tests/test_prompt_chunking.py tests/test_prompt_engine.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b658101648832eae322ea9c9a29a6d