### PR TITLE
Add AST-aware prompt chunker with token fallback

### DIFF
--- a/prompt_chunker.py
+++ b/prompt_chunker.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""Utilities for splitting code into token-limited chunks respecting AST boundaries."""
+
+from typing import List
+import ast
+
+try:  # Optional dependency for accurate token counts
+    import tiktoken  # type: ignore
+except Exception:  # pragma: no cover - tiktoken may be missing
+    tiktoken = None  # type: ignore
+
+_encoder = None
+if tiktoken is not None:  # pragma: no branch - simple import logic
+    try:  # pragma: no cover - defensive
+        _encoder = tiktoken.get_encoding("cl100k_base")
+    except Exception:  # pragma: no cover - encoder creation failed
+        _encoder = None
+
+
+def _count_tokens(text: str) -> int:
+    """Return number of tokens in *text* using best available tokenizer."""
+
+    if _encoder is not None:
+        try:  # pragma: no cover - defensive
+            return len(_encoder.encode(text))
+        except Exception:
+            pass
+    return len(text.split())
+
+
+def _split_by_line(code: str, limit: int) -> List[str]:
+    """Split *code* by lines ensuring each chunk stays under *limit* tokens."""
+
+    if _count_tokens(code) <= limit:
+        return [code]
+
+    out: List[str] = []
+    current: List[str] = []
+    for line in code.splitlines():
+        tentative = "\n".join(current + [line])
+        if _count_tokens(tentative) <= limit or not current:
+            current.append(line)
+        else:
+            out.append("\n".join(current))
+            current = [line]
+    if current:
+        out.append("\n".join(current))
+    return out
+
+
+def split_into_chunks(code: str, max_tokens: int) -> List[str]:
+    """Split *code* into chunks under *max_tokens* respecting AST boundaries.
+
+    Parsing failures (syntax errors) fall back to simple line-based splitting.
+    """
+
+    try:
+        module = ast.parse(code)
+    except SyntaxError:  # pragma: no cover - error path tested separately
+        return _split_by_line(code, max_tokens)
+
+    lines = code.splitlines()
+    chunks: List[str] = []
+    prev_end = 1
+    for node in module.body:
+        if not hasattr(node, "lineno"):
+            continue
+        start = node.lineno
+        end = getattr(node, "end_lineno", start)
+        if start > prev_end:
+            segment = "\n".join(lines[prev_end - 1 : start - 1]).rstrip()
+            if segment:
+                chunks.extend(_split_by_line(segment, max_tokens))
+        block = "\n".join(lines[start - 1 : end]).rstrip()
+        if block:
+            chunks.extend(_split_by_line(block, max_tokens))
+        prev_end = end + 1
+    if prev_end <= len(lines):
+        segment = "\n".join(lines[prev_end - 1 :]).rstrip()
+        if segment:
+            chunks.extend(_split_by_line(segment, max_tokens))
+    return chunks
+
+
+__all__ = ["split_into_chunks"]

--- a/tests/test_prompt_chunker.py
+++ b/tests/test_prompt_chunker.py
@@ -1,0 +1,50 @@
+import prompt_chunker as pc
+import textwrap
+
+try:
+    import tiktoken  # type: ignore
+except Exception:  # pragma: no cover - tiktoken may be missing
+    tiktoken = None  # type: ignore
+
+if tiktoken is not None:  # pragma: no branch - simple import logic
+    _ENC = tiktoken.get_encoding("cl100k_base")
+else:
+    _ENC = None
+
+
+def _count_tokens(text: str) -> int:
+    if _ENC is not None:
+        return len(_ENC.encode(text))
+    return len(text.split())
+
+
+def test_token_counting_respects_limit() -> None:
+    code = "\n".join(f"print({i})" for i in range(50))
+    chunks = pc.split_into_chunks(code, 30)
+    assert len(chunks) > 1
+    for chunk in chunks:
+        assert _count_tokens(chunk) <= 30
+
+
+def test_ast_boundaries_preserved() -> None:
+    code = textwrap.dedent(
+        """
+        def a():
+            return 1
+
+        def b():
+            return 2
+        """
+    )
+    chunks = pc.split_into_chunks(code, 20)
+    assert len(chunks) == 2
+    assert chunks[0].lstrip().startswith("def a")
+    assert chunks[1].lstrip().startswith("def b")
+
+
+def test_syntax_error_fallback() -> None:
+    code = "def bad(:\n    pass"  # invalid syntax
+    chunks = pc.split_into_chunks(code, 5)
+    assert chunks  # returns something
+    for chunk in chunks:
+        assert _count_tokens(chunk) <= 5


### PR DESCRIPTION
## Summary
- Add `split_into_chunks` utility to split code into token-limited chunks using AST boundaries
- Use `tiktoken` when available with whitespace fallback
- Test chunking token limits, AST boundaries, and syntax-error handling

## Testing
- `pytest tests/test_prompt_chunker.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b65e43aad4832e8d2da27bead0d27d