### PR TITLE
feat: route stub generation through configurable LLM backend

### DIFF
--- a/docs/environment_generator.md
+++ b/docs/environment_generator.md
@@ -271,9 +271,9 @@ tighten resource limits while negative ones relax them. The RL agent also
 consumes `synergy_roi` alongside ROI history so improvements in these metrics
 directly influence the policy update step.
 
-## OpenAI stub generation
+## LLM stub generation
 
-When `SANDBOX_STUB_MODEL=openai` and `OPENAI_API_KEY` are set the sandbox
-generates input stubs via the OpenAI Completion API. Generated objects are cached
-alongside locally produced stubs under `SANDBOX_STUB_CACHE`. This fallback is
-used whenever the `transformers` pipeline cannot be loaded.
+Set `SANDBOX_STUB_MODEL` to a model name understood by the configured backend
+to enable language-model driven stub creation. Generated objects are cached
+alongside locally produced stubs under `SANDBOX_STUB_CACHE`. When no model is
+configured the sandbox falls back to a deterministic rule-based strategy.

--- a/docs/sandbox_runner.md
+++ b/docs/sandbox_runner.md
@@ -505,6 +505,8 @@ The generative stub provider exposes several knobs via environment variables:
 - `SANDBOX_STUB_RETRY_BASE` – initial delay for exponential back-off in seconds.
 - `SANDBOX_STUB_RETRY_MAX` – ceiling for the back-off delay.
 - `SANDBOX_STUB_CACHE_MAX` – maximum number of cached stub responses.
+- `SANDBOX_STUB_MODEL` – model name used for stub generation. When unset a
+  deterministic rule-based strategy is used.
 - `SANDBOX_STUB_FALLBACK_MODEL` – model name used when the preferred provider is unavailable.
 
 The `concurrency_spike` failure mode starts bursts of threads and async tasks. The sandbox records how many threads and tasks were spawned in the metrics.

--- a/sandbox_runner/tests/test_generative_stub_backends.py
+++ b/sandbox_runner/tests/test_generative_stub_backends.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 
-
 sys.modules.setdefault(
     "db_router",
     types.SimpleNamespace(GLOBAL_ROUTER=None, init_db_router=lambda *a, **k: None),
@@ -25,95 +24,37 @@ class _StubSettings:
         self.stub_cache_max = 1
         self.stub_fallback_model = os.getenv("SANDBOX_STUB_FALLBACK_MODEL", "distilgpt2")
         self.sandbox_stub_model = os.getenv("SANDBOX_STUB_MODEL")
-        self.huggingface_token = os.getenv("HUGGINGFACE_API_TOKEN")
-        self.stub_models = []
+        self.llm_backend = os.getenv("LLM_BACKEND", "openai")
 
 
 def _reset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(gsp, "_GENERATOR", None)
     monkeypatch.setattr(gsp, "_SETTINGS", None)
     monkeypatch.setattr(gsp, "_CONFIG", None)
-    monkeypatch.setattr(gsp, "pipeline", None)
-    monkeypatch.setattr(gsp, "openai", None)
     monkeypatch.setattr(gsp, "SandboxSettings", _StubSettings)
 
 
-def test_transformers_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_llm_client_used(monkeypatch: pytest.MonkeyPatch) -> None:
     _reset(monkeypatch)
-    monkeypatch.setenv("SANDBOX_ENABLE_TRANSFORMERS", "1")
     monkeypatch.setenv("SANDBOX_STUB_MODEL", "foo")
-    monkeypatch.setenv("SANDBOX_HUGGINGFACE_TOKEN", "tok")
-    monkeypatch.setenv("HUGGINGFACE_API_TOKEN", "tok")
-    monkeypatch.delenv("SANDBOX_ENABLE_OPENAI", raising=False)
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
-    sentinel = object()
+    class DummyClient:
+        model = "foo"
 
-    def fake_pipeline(task: str, model: str, use_auth_token: str):
-        assert task == "text-generation"
-        assert model == "foo"
-        assert use_auth_token == "tok"
-        return sentinel
+        def generate(self, prompt):
+            from llm_interface import LLMResult
 
-    monkeypatch.setattr(gsp, "pipeline", fake_pipeline)
-    monkeypatch.setattr(gsp, "_seed_generator_from_history", lambda gen: None)
-    settings = gsp.get_settings(refresh=True)
-    assert settings.huggingface_token == "tok"
-    cfg = gsp.get_config(refresh=True)
-    assert cfg.enabled_backends[0] == "transformers"
-    gen = gsp._load_generator(cfg)
-    assert gen is sentinel
+            return LLMResult(text="{\"a\": 1}")
+
+    monkeypatch.setattr(gsp, "get_client", lambda name, **kw: DummyClient())
+    result = gsp.generate_stubs([{}], {"target": None})
+    assert result == [{"a": 1}]
 
 
-def test_openai_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_rule_based_when_no_model(monkeypatch: pytest.MonkeyPatch) -> None:
     _reset(monkeypatch)
-    monkeypatch.setenv("SANDBOX_ENABLE_OPENAI", "1")
-    monkeypatch.setenv("OPENAI_API_KEY", "key")
-    monkeypatch.delenv("SANDBOX_ENABLE_TRANSFORMERS", raising=False)
-
-    sentinel = object()
-
-    async def fake_openai():
-        return sentinel
-
-    monkeypatch.setattr(gsp, "_load_openai_generator", fake_openai)
-    cfg = gsp.get_config(refresh=True)
-    assert cfg.enabled_backends == ("openai",)
-    gen = gsp._load_generator(cfg)
-    assert gen is sentinel
-
-
-def test_fallback_backend(monkeypatch: pytest.MonkeyPatch) -> None:
-    _reset(monkeypatch)
-    monkeypatch.setenv("SANDBOX_ENABLE_TRANSFORMERS", "1")
-    monkeypatch.setenv("SANDBOX_STUB_FALLBACK_MODEL", "stub")
     monkeypatch.delenv("SANDBOX_STUB_MODEL", raising=False)
-    monkeypatch.delenv("SANDBOX_HUGGINGFACE_TOKEN", raising=False)
-    monkeypatch.delenv("SANDBOX_ENABLE_OPENAI", raising=False)
-
-    sentinel = object()
-
-    async def fake_fallback(cfg):
-        assert cfg.fallback_model == "stub"
-        return sentinel
-
-    monkeypatch.setattr(gsp, "_load_fallback_pipeline", fake_fallback)
-    cfg = gsp.get_config(refresh=True)
-    assert cfg.enabled_backends == ("fallback",)
-    gen = gsp._load_generator(cfg)
-    assert gen is sentinel
-
-
-def test_no_backend_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    _reset(monkeypatch)
-    monkeypatch.delenv("SANDBOX_ENABLE_TRANSFORMERS", raising=False)
-    monkeypatch.delenv("SANDBOX_ENABLE_OPENAI", raising=False)
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("SANDBOX_STUB_MODEL", raising=False)
-    monkeypatch.delenv("SANDBOX_HUGGINGFACE_TOKEN", raising=False)
-
-    cfg = gsp.get_config(refresh=True)
-    assert cfg.enabled_backends == ()
-    with pytest.raises(RuntimeError):
-        gsp._load_generator(cfg)
-
+    sentinel = {"x": 1}
+    monkeypatch.setattr(gsp, "_rule_based_stub", lambda s, f: sentinel)
+    result = gsp.generate_stubs([{}], {"target": None})
+    assert result == [sentinel]


### PR DESCRIPTION
## Summary
- load stub generation client from `SANDBOX_STUB_MODEL` and selected backend
- fall back to rule-based stubs only when no model is configured
- document new `SANDBOX_STUB_MODEL` setting and update tests

## Testing
- `pre-commit run --files sandbox_runner/generative_stub_provider.py sandbox_runner/tests/test_generative_stub_backends.py tests/test_generative_stub_provider.py`
- `pytest sandbox_runner/tests/test_generative_stub_backends.py tests/test_generative_stub_provider.py::test_stub_generation_aborts_on_model_error tests/test_generative_stub_provider.py::test_env_reload_updates_retries`


------
https://chatgpt.com/codex/tasks/task_e_68b65da1448c832ebb4c8b003cfeefb3