### PR TITLE
Add token-bounded code summarizer

### DIFF
--- a/code_summarizer.py
+++ b/code_summarizer.py
@@ -1,0 +1,99 @@
+"""Lightweight helper to summarise code snippets.
+
+The function tries multiple local approaches in order of preference:
+
+1. :mod:`micro_models.diff_summarizer` – a fine tuned model specialised in
+   code diffs.  The code is passed as the ``after`` portion of a synthetic diff
+   with an empty ``before``.  The ``max_summary_tokens`` parameter is forwarded
+   to the underlying model to cap the length of the generated summary.
+2. :class:`llm_interface.LLMClient` – if a local LLM server compatible with the
+   :mod:`local_client` helpers is available the code is summarised via a normal
+   language model call.
+3. Heuristic fallback – as a last resort the first non-empty line of the code
+   is returned, truncated to ``max_summary_tokens`` token-like units.
+
+All returned summaries are truncated to ``max_summary_tokens`` to avoid runaway
+outputs when model limits are ignored or unavailable.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imported for typing only
+    from llm_interface import LLMClient  # noqa: F401
+
+
+def _truncate_tokens(text: str, limit: int) -> str:
+    """Return ``text`` truncated to at most ``limit`` whitespace tokens."""
+
+    tokens = text.split()
+    if len(tokens) <= limit:
+        return text.strip()
+    return " ".join(tokens[:limit]).strip()
+
+
+def _heuristic_summary(code: str, limit: int) -> str:
+    """Return a simple summary derived from the first non-empty line."""
+
+    lines = [ln.strip() for ln in code.splitlines() if ln.strip()]
+    if not lines:
+        return ""
+    return _truncate_tokens(lines[0], limit)
+
+
+def summarize_code(code: str, *, max_summary_tokens: int = 128) -> str:
+    """Return a short description of ``code``.
+
+    The function attempts several local summarisation strategies before falling
+    back to a simple heuristic based on the first line of the snippet.
+    ``max_summary_tokens`` bounds the returned summary length to avoid runaway
+    outputs.
+    """
+
+    code = code.strip()
+    if not code:
+        return ""
+
+    # ------------------------------------------------------------------
+    # 1) Try the fine-tuned micro model
+    try:  # pragma: no cover - optional dependency
+        from micro_models.diff_summarizer import summarize_diff as _summ
+    except Exception:  # pragma: no cover - summariser may be missing
+        _summ = None
+    if _summ is not None:
+        try:  # pragma: no cover - defensive against runtime failures
+            summary = _summ("", code, max_new_tokens=max_summary_tokens)
+            if summary:
+                return _truncate_tokens(summary, max_summary_tokens)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # 2) Fallback to a local LLM client
+    try:  # pragma: no cover - optional dependency
+        from local_client import OllamaClient
+        from prompt_types import Prompt
+    except Exception:  # pragma: no cover - client may be missing
+        OllamaClient = None  # type: ignore[assignment]
+        Prompt = None  # type: ignore[assignment]
+    if OllamaClient is not None and Prompt is not None:
+        try:  # pragma: no cover - defensive against runtime failures
+            client = OllamaClient()  # type: ignore[call-arg]
+            prompt = Prompt(
+                text=f"Summarize the following code:\n{code}\nSummary:",
+                metadata={"small_task": True},
+            )
+            result = client.generate(prompt)
+            summary = getattr(result, "text", "").strip()
+            if summary:
+                return _truncate_tokens(summary, max_summary_tokens)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # 3) Heuristic fallback
+    return _heuristic_summary(code, max_summary_tokens)
+
+
+__all__ = ["summarize_code"]

--- a/tests/test_code_summarizer.py
+++ b/tests/test_code_summarizer.py
@@ -1,0 +1,48 @@
+import types
+
+from code_summarizer import summarize_code
+
+
+def test_summarize_code_micro_model(monkeypatch):
+    """Ensure the micro-model path is used and honours token limits."""
+
+    def fake_summarize_diff(before: str, after: str, max_new_tokens: int = 128) -> str:
+        assert before == ""
+        assert after == "print('hi')"
+        return "one two three four five six seven"
+
+    monkeypatch.setattr(
+        "micro_models.diff_summarizer.summarize_diff", fake_summarize_diff
+    )
+
+    class DummyClient:
+        def __init__(self, *a, **kw):  # pragma: no cover - should not be called
+            raise AssertionError("LLM client should not be used")
+
+    monkeypatch.setattr("local_client.OllamaClient", DummyClient)
+
+    summary = summarize_code("print('hi')", max_summary_tokens=5)
+    assert summary.split() == ["one", "two", "three", "four", "five"]
+
+
+def test_summarize_code_llm_client(monkeypatch):
+    """Fallback to a local LLM when the micro model is unavailable."""
+
+    monkeypatch.setattr(
+        "micro_models.diff_summarizer.summarize_diff", lambda *a, **k: ""
+    )
+
+    class DummyResult(types.SimpleNamespace):
+        text: str = "alpha beta gamma delta epsilon zeta eta"
+
+    class DummyClient:
+        def __init__(self, *a, **k):
+            pass
+
+        def generate(self, prompt):  # pragma: no cover - trivial
+            return DummyResult()
+
+    monkeypatch.setattr("local_client.OllamaClient", DummyClient)
+
+    summary = summarize_code("print('hi')", max_summary_tokens=5)
+    assert summary.split() == ["alpha", "beta", "gamma", "delta", "epsilon"]


### PR DESCRIPTION
## Summary
- add `summarize_code` utility to describe code using local models with token limits
- support micro model and local LLM fallbacks with heuristic summary when unavailable
- test summarizer paths and enforce maximum token counts

## Testing
- `pre-commit run --files code_summarizer.py tests/test_code_summarizer.py`
- `pytest tests/test_code_summarizer.py`


------
https://chatgpt.com/codex/tasks/task_e_68b66003cbbc832e82204ec39c0a40c0