### PR TITLE
Log all sandbox DB health check failures

### DIFF
--- a/sandbox_runner/tests/test_start_autonomous_health.py
+++ b/sandbox_runner/tests/test_start_autonomous_health.py
@@ -122,6 +122,7 @@ def test_sandbox_health_and_artifacts(tmp_path, monkeypatch):
     assert health == {
         "self_improvement_thread_alive": True,
         "databases_accessible": True,
+        "database_errors": {},
         "stub_generator_initialized": True,
     }
 


### PR DESCRIPTION
## Summary
- Continue sandbox database health checks after failures and log each failing file with its exception
- Return aggregated database error details as part of sandbox health report
- Cover multiple database failure scenarios in tests and update existing health tests

## Testing
- `pytest tests/test_sandbox_health_databases.py sandbox_runner/tests/test_start_autonomous_health.py::test_sandbox_health_and_artifacts -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6683e0d20832e9224bd1d2c3a08ec