### PR TITLE
Add chunk summary support for prompt generation

### DIFF
--- a/tests/test_build_prompt_summaries.py
+++ b/tests/test_build_prompt_summaries.py
@@ -1,0 +1,36 @@
+from typing import Any, Dict, List
+
+from prompt_engine import PromptEngine
+
+
+class DummyRetriever:
+    def __init__(self, records: List[Dict[str, Any]] | None = None) -> None:
+        self.records = records or []
+
+    def search(self, query: str, top_k: int):
+        return self.records
+
+
+def test_build_prompt_includes_summaries():
+    records = [{"score": 0.9, "metadata": {"summary": "irrelevant", "tests_passed": True}}]
+    engine = PromptEngine(
+        retriever=DummyRetriever(records),
+        patch_retriever=DummyRetriever(records),
+        confidence_threshold=-1.0,
+    )
+    prompt = engine.build_prompt("do things", summaries=["sumA", "sumB"])
+    text = str(prompt)
+    assert "sumA" in text and "sumB" in text
+
+
+def test_build_prompt_skips_summaries_when_absent():
+    records = [{"score": 0.9, "metadata": {"summary": "irrelevant", "tests_passed": True}}]
+    engine = PromptEngine(
+        retriever=DummyRetriever(records),
+        patch_retriever=DummyRetriever(records),
+        confidence_threshold=-1.0,
+    )
+    prompt = engine.build_prompt("do things")
+    text = str(prompt)
+    assert "irrelevant" in text
+    assert "sumA" not in text and "sumB" not in text


### PR DESCRIPTION
## Summary
- compute chunk summaries in `generate_helper` for large files and pass them to the prompt engine
- allow `PromptEngine.build_prompt` to accept optional summaries and prepend them to prompts
- add regression tests to ensure summaries are included only when provided

## Testing
- `pytest tests/test_build_prompt_summaries.py tests/test_prompt_engine_chunk_summaries.py -q`
- `pre-commit run --files prompt_engine.py self_coding_engine.py tests/test_build_prompt_summaries.py`

------
https://chatgpt.com/codex/tasks/task_e_68b668568c30832eaa64e7fda3a1ce4e