### PR TITLE
feat: add prompt chunk cache settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ configuration. The generated file includes stub values for critical settings:
 - `OPENAI_API_KEY` and `STRIPE_API_KEY` placeholders
 - `SANDBOX_DATA_DIR` defaults to `sandbox_data`
 - `SANDBOX_LOG_LEVEL` defaults to `INFO` (use `--log-level` to override)
-- `PROMPT_CHUNK_TOKEN_THRESHOLD` and `CHUNK_SUMMARY_CACHE_DIR` control code
+- `PROMPT_CHUNK_TOKEN_THRESHOLD` and `PROMPT_CHUNK_CACHE_DIR` control code
   chunking token limits and caching for large file summaries
 
 Bootstrap verifies these variables before launching and raises a clear error if

--- a/docs/prompt_engine.md
+++ b/docs/prompt_engine.md
@@ -46,8 +46,8 @@ Outcome: works (tests passed)
   included as context.
 * `chunk_token_threshold` – Token limit for individual code chunks when large files
   are summarised (defaults to `PROMPT_CHUNK_TOKEN_THRESHOLD`).
-* `chunk_summary_cache_dir` – Directory used to store cached summaries of
-  chunked code (`CHUNK_SUMMARY_CACHE_DIR`).
+* `prompt_chunk_cache_dir` – Directory used to store cached summaries of
+  chunked code (`PROMPT_CHUNK_CACHE_DIR`).
 * `success_header` and `failure_header` – control the section titles for
   successful and failing examples.  The defaults are
   `"Given the following pattern:"` and

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,7 +15,13 @@ This guide walks you through the common Menace workflows using the new `menace` 
    ```
    The command wraps `scripts/setup_autonomous.sh` and creates a basic `.env` file.
    This installs all required packages, including the `foresight_tracker`
-   module used for stability forecasting.
+   module used for stability forecasting. The generated file includes stub
+   values for critical settings:
+
+   - `DATABASE_URL` defaults to `sqlite:///menace.db`
+   - `SANDBOX_DATA_DIR` defaults to `sandbox_data`
+   - `PROMPT_CHUNK_TOKEN_THRESHOLD` and `PROMPT_CHUNK_CACHE_DIR` control code
+     chunking token limits and caching for large file summaries
 3. **Run the tests** (optional)
    ```bash
    menace test

--- a/docs/sandbox_config.sample.yaml
+++ b/docs/sandbox_config.sample.yaml
@@ -7,8 +7,8 @@ sandbox_required_db_files:
   - metrics.db
   - patch_history.db
   - visual_agent_queue.db
-prompt_chunk_token_threshold: 200
-chunk_summary_cache_dir: chunk_summary_cache
+prompt_chunk_token_threshold: 3500
+prompt_chunk_cache_dir: chunk_summary_cache
 roi:
   threshold: null
   confidence: null

--- a/docs/sandbox_settings.md
+++ b/docs/sandbox_settings.md
@@ -82,8 +82,8 @@ These weights influence the risk score produced by `_analyse_module`.
 - `prompt_failure_log_path`: `prompt_failure_log.json` (`PROMPT_FAILURE_LOG_PATH`)
 
 ## Prompt chunking defaults
-- `prompt_chunk_token_threshold`: `200` (`PROMPT_CHUNK_TOKEN_THRESHOLD`)
-- `chunk_summary_cache_dir`: `chunk_summary_cache` (`CHUNK_SUMMARY_CACHE_DIR`)
+- `prompt_chunk_token_threshold`: `3500` (`PROMPT_CHUNK_TOKEN_THRESHOLD`)
+- `prompt_chunk_cache_dir`: `chunk_summary_cache` (`PROMPT_CHUNK_CACHE_DIR`)
 
 These settings control token limits and caching for code chunk summaries.
 

--- a/docs/self_coding_engine.md
+++ b/docs/self_coding_engine.md
@@ -72,8 +72,8 @@ utilities so that callers can track environment issues.
 
 Large files are summarised in smaller chunks when their token count exceeds
 `prompt_chunk_token_threshold`. Chunk summaries are cached under
-`chunk_summary_cache_dir` to speed up subsequent runs. Both settings are
+`prompt_chunk_cache_dir` to speed up subsequent runs. Both settings are
 configurable through `SandboxSettings` or environment variables
-(`PROMPT_CHUNK_TOKEN_THRESHOLD` and `CHUNK_SUMMARY_CACHE_DIR`).
+(`PROMPT_CHUNK_TOKEN_THRESHOLD` and `PROMPT_CHUNK_CACHE_DIR`).
 
 

--- a/prompt_engine.py
+++ b/prompt_engine.py
@@ -164,10 +164,10 @@ class PromptEngine:
     chunk_token_threshold: int = field(
         default_factory=lambda: _SETTINGS.prompt_chunk_token_threshold
         if _SETTINGS
-        else 200
+        else 3500
     )
-    chunk_summary_cache_dir: Path = field(
-        default_factory=lambda: Path(_SETTINGS.chunk_summary_cache_dir)
+    prompt_chunk_cache_dir: Path = field(
+        default_factory=lambda: Path(_SETTINGS.prompt_chunk_cache_dir)
         if _SETTINGS
         else Path("chunk_summary_cache")
     )
@@ -259,8 +259,8 @@ class PromptEngine:
         try:
             import prompt_chunking as _pc
 
-            self.chunk_summary_cache_dir = Path(self.chunk_summary_cache_dir)
-            _pc.CACHE_DIR = self.chunk_summary_cache_dir
+            self.prompt_chunk_cache_dir = Path(self.prompt_chunk_cache_dir)
+            _pc.CACHE_DIR = self.prompt_chunk_cache_dir
         except Exception:
             pass
 

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -340,7 +340,10 @@ class SandboxSettings(BaseSettings):
         5 * 1024 * 1024,
         env="LOG_ROTATION_MAX_BYTES",
         ge=0,
-        description="Rotate logs when file exceeds this size in bytes; 0 disables size-based rotation.",
+        description=(
+            "Rotate logs when file exceeds this size in bytes; "
+            "0 disables size-based rotation."
+        ),
     )
     log_rotation_backup_count: int = Field(
         5,
@@ -587,14 +590,13 @@ class SandboxSettings(BaseSettings):
         description="Path for recording failed prompt executions.",
     )
     prompt_chunk_token_threshold: int = Field(
-        200,
+        3500,
         env="PROMPT_CHUNK_TOKEN_THRESHOLD",
-        description=
-        "Token limit for individual code chunks when summarizing large files.",
+        description="Token limit for individual code chunks when summarizing large files.",
     )
-    chunk_summary_cache_dir: str = Field(
-        "chunk_summary_cache",
-        env="CHUNK_SUMMARY_CACHE_DIR",
+    prompt_chunk_cache_dir: Path = Field(
+        Path("chunk_summary_cache"),
+        env="PROMPT_CHUNK_CACHE_DIR",
         description="Directory for cached summaries of code chunks.",
     )
     stub_timeout: float = Field(

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -194,7 +194,7 @@ class SelfCodingEngine:
         prompt_tone: str = "neutral",
         token_threshold: int = 3500,
         prompt_chunk_token_threshold: int | None = None,
-        chunk_summary_cache_dir: str | Path | None = None,
+        prompt_chunk_cache_dir: str | Path | None = None,
         **kwargs: Any,
     ) -> None:
         self.code_db = code_db
@@ -220,8 +220,8 @@ class SelfCodingEngine:
             if prompt_chunk_token_threshold is not None
             else _settings.prompt_chunk_token_threshold
         )
-        self.chunk_summary_cache_dir = Path(
-            chunk_summary_cache_dir or _settings.chunk_summary_cache_dir
+        self.prompt_chunk_cache_dir = Path(
+            prompt_chunk_cache_dir or _settings.prompt_chunk_cache_dir
         )
         self.safety_monitor = safety_monitor
         if llm_client is None:
@@ -315,7 +315,7 @@ class SelfCodingEngine:
             optimizer=self.prompt_optimizer,
             token_threshold=token_threshold,
             chunk_token_threshold=self.prompt_chunk_token_threshold,
-            chunk_summary_cache_dir=self.chunk_summary_cache_dir,
+            prompt_chunk_cache_dir=self.prompt_chunk_cache_dir,
         )
         if prompt_evolution_memory is None:
             try:

--- a/tests/test_prompt_chunk_settings.py
+++ b/tests/test_prompt_chunk_settings.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from sandbox_settings import SandboxSettings
+
+
+def test_defaults(monkeypatch):
+    monkeypatch.delenv("PROMPT_CHUNK_TOKEN_THRESHOLD", raising=False)
+    monkeypatch.delenv("PROMPT_CHUNK_CACHE_DIR", raising=False)
+    settings = SandboxSettings()
+    assert settings.prompt_chunk_token_threshold == 3500
+    assert settings.prompt_chunk_cache_dir == Path("chunk_summary_cache")
+
+
+def test_env_overrides(monkeypatch, tmp_path):
+    monkeypatch.setenv("PROMPT_CHUNK_TOKEN_THRESHOLD", "1234")
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("PROMPT_CHUNK_CACHE_DIR", str(cache_dir))
+    settings = SandboxSettings()
+    assert settings.prompt_chunk_token_threshold == 1234
+    assert settings.prompt_chunk_cache_dir == cache_dir


### PR DESCRIPTION
## Summary
- increase `prompt_chunk_token_threshold` default to 3500
- replace `chunk_summary_cache_dir` with `prompt_chunk_cache_dir` and support env overrides
- document prompt chunk settings

## Testing
- `pre-commit run --files README.md docs/prompt_engine.md docs/quickstart.md docs/sandbox_config.sample.yaml docs/sandbox_settings.md docs/self_coding_engine.md prompt_engine.py sandbox_settings.py self_coding_engine.py tests/test_prompt_chunk_settings.py`
- `pytest tests/test_prompt_chunk_settings.py tests/test_prompt_engine_chunk_summaries.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b66ea722c4832e97ba887633bd1b28