### PR TITLE
Add chunked patch generation to quick_fix_engine

### DIFF
--- a/tests/integration/test_quick_fix_engine_chunked_patch.py
+++ b/tests/integration/test_quick_fix_engine_chunked_patch.py
@@ -1,0 +1,72 @@
+import sys
+import types
+import importlib.util
+from pathlib import Path
+
+# Ensure repository root is on sys.path so quick_fix_engine dependencies resolve
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+# Lightweight stubs to load quick_fix_engine without heavy dependencies
+package = types.ModuleType("menace_sandbox")
+package.__path__ = [str(ROOT)]
+sys.modules["menace_sandbox"] = package
+
+error_bot = types.ModuleType("menace_sandbox.error_bot")
+error_bot.ErrorDB = object
+sys.modules["menace_sandbox.error_bot"] = error_bot
+
+scm = types.ModuleType("menace_sandbox.self_coding_manager")
+scm.SelfCodingManager = object
+sys.modules["menace_sandbox.self_coding_manager"] = scm
+
+kg = types.ModuleType("menace_sandbox.knowledge_graph")
+kg.KnowledgeGraph = object
+sys.modules["menace_sandbox.knowledge_graph"] = kg
+
+vec = types.ModuleType("vector_service")
+vec.ContextBuilder = object
+vec.Retriever = object
+vec.FallbackResult = object
+vec.EmbeddingBackfill = object
+sys.modules["vector_service"] = vec
+
+pp = types.ModuleType("patch_provenance")
+pp.PatchLogger = object
+sys.modules["patch_provenance"] = pp
+
+spec = importlib.util.spec_from_file_location(
+    "menace_sandbox.quick_fix_engine",
+    ROOT / "quick_fix_engine.py",
+)
+quick_fix = importlib.util.module_from_spec(spec)
+sys.modules["menace_sandbox.quick_fix_engine"] = quick_fix
+spec.loader.exec_module(quick_fix)
+
+def test_chunked_patch_generation(tmp_path, monkeypatch):
+    path = tmp_path / "big.py"
+    lines = ["def big():"] + ["    pass" for _ in range(4000)]
+    path.write_text("\n".join(lines) + "\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(quick_fix, "generate_code_diff", lambda *a, **k: {})
+    monkeypatch.setattr(quick_fix, "flag_risky_changes", lambda *a, **k: [])
+
+    class Engine:
+        prompt_chunk_token_threshold = 1000
+
+        def __init__(self):
+            self.calls = []
+
+        def apply_patch(self, p, desc, **kw):
+            self.calls.append(desc)
+            with open(p, "a", encoding="utf-8") as fh:
+                fh.write(f"# patch {len(self.calls)}\n")
+            return len(self.calls), False, ""
+
+    engine = Engine()
+
+    pid = quick_fix.generate_patch(str(path), engine)
+    assert len(engine.calls) > 1
+    assert pid == len(engine.calls)
+    lines = path.read_text().strip().splitlines()
+    assert lines[-len(engine.calls):] == [f"# patch {i}" for i in range(1, len(engine.calls) + 1)]


### PR DESCRIPTION
## Summary
- process quick fixes chunk-by-chunk using cached summaries for large files
- assemble per-chunk patches into a final patch, preserving order
- test chunked patching against a >3500-token file

## Testing
- `pytest menace_sandbox/tests/test_quick_fix_engine.py::test_generate_patch_blocks_risky menace_sandbox/tests/integration/test_quick_fix_engine_chunked_patch.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b672171028832e8f8a06bd711e390d