### PR TITLE
docs: document chunking pipeline and summary cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ configuration. The generated file includes stub values for critical settings:
 - `PROMPT_CHUNK_TOKEN_THRESHOLD` and `PROMPT_CHUNK_CACHE_DIR` control code
   chunking token limits and caching for large file summaries
 
+### Chunking pipeline
+
+Large modules are split and summarised before prompting so the LLM never sees
+more than the configured token budget. The pipeline consists of:
+
+1. `chunk_code` – walks a module and produces token‑bounded chunks.
+2. `summarize_code` – generates a short natural‑language blurb for each chunk.
+3. `get_chunk_summaries` – stores the code and summary in
+   `chunk_summary_cache/` keyed by a SHA256 hash of the chunk. Cached entries are
+   reused until the source changes.
+
+`PROMPT_CHUNK_TOKEN_THRESHOLD` sets the maximum tokens per chunk and
+`PROMPT_CHUNK_CACHE_DIR` relocates the cache directory.
+
 Bootstrap verifies these variables before launching and raises a clear error if
 any required value is missing or the model path does not exist.
 

--- a/docs/prompt_chunking.md
+++ b/docs/prompt_chunking.md
@@ -19,3 +19,21 @@ folder. On subsequent runs the hash is used to look up an existing summary. If
 it matches the current chunk the cached summary is reused; otherwise a new
 summary is generated and written back to the cache. The cache makes repeated
 prompt generation faster and now logs when cache hits or misses occur.
+
+## Developer notes
+
+The default `summarize_code` helper uses a tiny diff model and simply returns the
+original code if the model is unavailable. To target other languages or LLMs you
+can drop in a custom implementation:
+
+```python
+from my_llm import client
+
+def summarize_code(code: str) -> str:
+    return client.summarize(code, language="rust")
+```
+
+Monkeypatching `prompt_chunking.summarize_code` or providing an alternative
+`code_summarizer.summarize_code` allows the cache to store summaries from any
+backend. Summaries should remain short and deterministic so cache hits stay
+reliable across runs.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -60,6 +60,33 @@ menace new-db demo
 
 `retrieve` caches results on disk and reuses them until the underlying databases change. When the vector retriever raises an error, database-specific full-text helpers are consulted as a fallback.
 
+### Precomputing summaries
+
+Populate the summary cache ahead of time to avoid first‑run latency:
+
+```python
+from pathlib import Path
+from prompt_chunking import get_chunk_summaries
+
+# Writes JSON files into chunk_summary_cache/
+get_chunk_summaries(Path("bots/example.py"), 800)
+```
+
+When building prompts the self‑coding engine loads these summaries and passes
+them to the prompt engine:
+
+```python
+from prompt_chunking import get_chunk_summaries
+from prompt_engine import PromptEngine
+
+engine = PromptEngine()
+chunks = get_chunk_summaries(Path("bots/example.py"), 800)
+prompt = engine.build_prompt(
+    "refactor helper",
+    summaries=[c["summary"] for c in chunks],
+)
+```
+
 ### Recursive module discovery
 
 Passing modules are merged into the sandbox automatically and a simple


### PR DESCRIPTION
## Summary
- outline chunking pipeline and configuration in README
- show how to precompute summaries and pass them to prompts in quickstart guide
- add developer notes on extending `summarize_code` for other languages and LLMs

## Testing
- `pytest tests/test_prompt_chunking.py tests/test_prompt_chunker.py tests/test_prompt_engine_chunk_summaries.py tests/test_prompt_chunk_settings.py`

------
https://chatgpt.com/codex/tasks/task_e_68b674557bcc832e8f5e6e2747daa7ed