### PR TITLE
Add code chunking utilities and tests

### DIFF
--- a/chunking.py
+++ b/chunking.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+"""Code chunking utilities with token-aware grouping and summarisation."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from llm_interface import LLMClient
+import ast
+import hashlib
+
+try:  # Optional dependency for accurate token counting
+    import tiktoken  # type: ignore
+except Exception:  # pragma: no cover - tiktoken may be missing
+    tiktoken = None  # type: ignore
+
+_ENCODER = None
+if tiktoken is not None:  # pragma: no branch - simple import logic
+    try:  # pragma: no cover - defensive
+        _ENCODER = tiktoken.get_encoding("cl100k_base")
+    except Exception:  # pragma: no cover - encoder creation failed
+        _ENCODER = None
+
+
+def _count_tokens(text: str) -> int:
+    """Return number of tokens in *text* using best available tokenizer."""
+
+    if _ENCODER is not None:
+        try:  # pragma: no cover - defensive
+            return len(_ENCODER.encode(text))
+        except Exception:
+            pass
+    return len(text.split())
+
+
+@dataclass
+class CodeChunk:
+    """Representation of a contiguous code block."""
+
+    start_line: int
+    end_line: int
+    text: str
+    hash: str
+
+
+def chunk_file(path: Path, max_tokens: int) -> List[CodeChunk]:
+    """Return token limited ``CodeChunk`` objects for ``path``.
+
+    The file is parsed using :mod:`ast` and split at top-level ``FunctionDef``
+    and ``ClassDef`` boundaries. Nodes are grouped together while ensuring the
+    accumulated token count does not exceed ``max_tokens``. Individual nodes
+    larger than ``max_tokens`` are emitted as their own chunk.
+    """
+
+    source = path.read_text()
+    lines = source.splitlines()
+    try:
+        module = ast.parse(source)
+    except SyntaxError:  # pragma: no cover - syntax error fallback
+        text = source.rstrip()
+        h = hashlib.sha256(text.encode("utf-8")).hexdigest()
+        return [CodeChunk(1, len(lines), text, h)]
+
+    segments: List[tuple[int, int, str]] = []
+    prev_end = 1
+    for node in module.body:
+        if not hasattr(node, "lineno"):
+            continue
+        start = node.lineno
+        end = getattr(node, "end_lineno", start)
+        if start > prev_end:
+            filler = "\n".join(lines[prev_end - 1:start - 1]).rstrip()
+            if filler:
+                segments.append((prev_end, start - 1, filler))
+        block = "\n".join(lines[start - 1:end]).rstrip()
+        segments.append((start, end, block))
+        prev_end = end + 1
+    if prev_end <= len(lines):
+        filler = "\n".join(lines[prev_end - 1:]).rstrip()
+        if filler:
+            segments.append((prev_end, len(lines), filler))
+
+    chunks: List[CodeChunk] = []
+    current: List[str] = []
+    current_start = 1
+    current_end = 1
+    token_total = 0
+
+    for start, end, text in segments:
+        count = _count_tokens(text)
+        if current and token_total + count > max_tokens:
+            chunk_text = "\n".join(current).rstrip()
+            h = hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
+            chunks.append(CodeChunk(current_start, current_end, chunk_text, h))
+            current = [text]
+            current_start = start
+            current_end = end
+            token_total = count
+        else:
+            if not current:
+                current_start = start
+            current.append(text)
+            current_end = end
+            token_total += count
+
+    if current:
+        chunk_text = "\n".join(current).rstrip()
+        h = hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
+        chunks.append(CodeChunk(current_start, current_end, chunk_text, h))
+    return chunks
+
+
+def summarize_code(text: str, llm: LLMClient | None) -> str:
+    """Return a short summary for ``text`` using ``llm`` when available."""
+
+    if llm is not None:
+        from prompt_types import Prompt
+        prompt = Prompt(
+            system="Summarise the following code snippet in one sentence.",
+            user=text,
+        )
+        try:  # pragma: no cover - llm failures
+            result = llm.generate(prompt)
+            if result.text.strip():
+                return result.text.strip()
+        except Exception:
+            pass
+    for line in text.strip().splitlines():
+        line = line.strip()
+        if line:
+            return line[:80]
+    return ""
+
+
+__all__ = ["CodeChunk", "chunk_file", "summarize_code"]

--- a/unit_tests/test_chunking.py
+++ b/unit_tests/test_chunking.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import tiktoken  # noqa: E402
+from chunking import chunk_file, summarize_code  # noqa: E402
+
+
+def test_token_counting_respects_limit(tmp_path):
+    code = (
+        'def foo():\n'
+        '    x = 1\n'
+        '    return x\n\n'
+        'def bar():\n'
+        '    y = 2\n'
+        '    return y\n'
+    )
+    path = tmp_path / 'sample.py'
+    path.write_text(code)
+    enc = tiktoken.get_encoding('cl100k_base')
+    limit = 20
+    chunks = chunk_file(path, limit)
+    assert len(chunks) == 2
+    for chunk in chunks:
+        assert len(enc.encode(chunk.text)) <= limit
+
+
+def test_ast_boundary_accuracy(tmp_path):
+    code = (
+        'def foo():\n'
+        '    x = 1\n'
+        '    return x\n\n'
+        'def bar():\n'
+        '    y = 2\n'
+        '    return y\n'
+    )
+    path = tmp_path / 'code.py'
+    path.write_text(code)
+    chunks = chunk_file(path, 20)
+    assert (chunks[0].start_line, chunks[0].end_line) == (1, 3)
+    assert (chunks[1].start_line, chunks[1].end_line) == (5, 7)
+
+
+def test_summarize_code_fallback():
+    code = 'def foo():\n    pass\n'
+    summary = summarize_code(code, None)
+    assert summary.startswith('def foo():')


### PR DESCRIPTION
## Summary
- add `chunking` module for AST-aware, token-limited code splitting
- provide simple LLM-backed `summarize_code` with heuristic fallback
- include tests for token counting, AST boundary handling, and summarization fallback

## Testing
- `pre-commit run --files chunking.py unit_tests/test_chunking.py`
- `pytest unit_tests/test_chunking.py`


------
https://chatgpt.com/codex/tasks/task_e_68b67602d0c8832e9a379042a59cb047