### PR TITLE
Handle best-effort failures explicitly

### DIFF
--- a/self_improvement/patch_generation.py
+++ b/self_improvement/patch_generation.py
@@ -6,10 +6,16 @@ import logging
 
 from .utils import _load_callable, _call_with_retries
 from ..sandbox_settings import SandboxSettings
+from ..metrics_exporter import self_improvement_failure_total
 
 try:  # pragma: no cover - simplified environments
     from ..logging_utils import log_record
-except Exception:  # pragma: no cover - best effort
+except (ImportError, AttributeError) as exc:  # pragma: no cover - best effort
+    logging.getLogger(__name__).warning(
+        "log_record unavailable", extra={"component": __name__}, exc_info=exc
+    )
+    self_improvement_failure_total.labels(reason="log_record_import").inc()
+
     def log_record(**fields: object) -> dict[str, object]:  # type: ignore
         return fields
 

--- a/unit_tests/test_failure_paths.py
+++ b/unit_tests/test_failure_paths.py
@@ -1,0 +1,47 @@
+import types
+import sys
+import importlib
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+class _DummyErrorLogger:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+sys.modules.setdefault("error_logger", types.SimpleNamespace(ErrorLogger=_DummyErrorLogger))
+sys.modules.setdefault("adaptive_roi_predictor", types.SimpleNamespace(load_training_data=lambda: None))
+
+menace_pkg = types.ModuleType("menace")
+menace_pkg.__path__ = [str(ROOT)]
+sys.modules.setdefault("menace", menace_pkg)
+
+sandbox_pkg = types.ModuleType("menace.sandbox_runner")
+sandbox_pkg.__path__ = [str(ROOT / "sandbox_runner")]
+sys.modules.setdefault("menace.sandbox_runner", sandbox_pkg)
+
+environment = importlib.import_module("menace.sandbox_runner.environment")
+
+
+def test_radar_worker_start_failure_propagates(monkeypatch):
+    class FailingThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(environment.threading, "Thread", FailingThread)
+    counter = types.SimpleNamespace(count=0)
+    monkeypatch.setattr(
+        environment,
+        "sandbox_crashes_total",
+        types.SimpleNamespace(inc=lambda: setattr(counter, "count", counter.count + 1)),
+    )
+    worker = environment._RadarWorker()
+    with pytest.raises(RuntimeError):
+        worker.__enter__()
+    assert counter.count == 1


### PR DESCRIPTION
## Summary
- log and track logging_utils import failures during patch generation
- tighten self-improvement config loading and report meta-planning reload errors
- surface radar worker failures with explicit metrics

## Testing
- `pytest unit_tests/test_failure_paths.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6750b8b48832eb66aa3f459c24a31