### PR TITLE
chore: standardize logging and metrics

### DIFF
--- a/metrics_exporter.py
+++ b/metrics_exporter.py
@@ -710,6 +710,15 @@ sandbox_memory_mb = Gauge(
 sandbox_crashes_total = Gauge(
     "sandbox_crashes_total", "Total sandbox cycle crashes"
 )
+stub_generation_requests_total = Gauge(
+    "stub_generation_requests_total", "Total stub generation requests"
+)
+stub_generation_failures_total = Gauge(
+    "stub_generation_failures_total", "Total stub generation failures"
+)
+stub_generation_retries_total = Gauge(
+    "stub_generation_retries_total", "Total stub generation retries"
+)
 environment_failure_total = Gauge(
     "environment_failure_total",
     "Total number of sandbox environment failures",
@@ -906,6 +915,9 @@ __all__ = [
     "sandbox_cpu_percent",
     "sandbox_memory_mb",
     "sandbox_crashes_total",
+    "stub_generation_requests_total",
+    "stub_generation_failures_total",
+    "stub_generation_retries_total",
     "cleanup_idle",
     "cleanup_unhealthy",
     "cleanup_lifetime",

--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -6971,9 +6971,18 @@ class SelfImprovementEngine:
                 extra=log_record(roi=roi_realish, predicted_roi=pred_realish),
             )
             return result
+        except Exception:
+            self_improvement_failure_total.labels(reason="run_cycle").inc()
+            self.logger.exception(
+                "cycle failure", extra=log_record(event="failure")
+            )
+            raise
         finally:
             self._cycle_running = False
             set_correlation_id(None)
+            self.logger.info(
+                "cycle shutdown", extra=log_record(event="shutdown")
+            )
 
     async def _schedule_loop(self, energy: int = 1) -> None:
         while not self._stop_event.is_set():

--- a/start_autonomous_sandbox.py
+++ b/start_autonomous_sandbox.py
@@ -8,9 +8,11 @@ capturing startup exceptions and allowing the log level to be configured via
 from __future__ import annotations
 
 import argparse
-import logging
 import sys
+import time
+import uuid
 
+from logging_utils import get_logger, setup_logging, set_correlation_id, log_record
 from sandbox_settings import SandboxSettings
 from sandbox_runner.bootstrap import (
     bootstrap_environment,
@@ -18,6 +20,18 @@ from sandbox_runner.bootstrap import (
     sandbox_health,
     shutdown_autonomous_sandbox,
 )
+try:  # pragma: no cover - allow package relative import
+    from metrics_exporter import (
+        sandbox_restart_total,
+        sandbox_crashes_total,
+        sandbox_last_failure_ts,
+    )
+except Exception:  # pragma: no cover - fallback when run as a module
+    from .metrics_exporter import (  # type: ignore
+        sandbox_restart_total,
+        sandbox_crashes_total,
+        sandbox_last_failure_ts,
+    )
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -46,20 +60,31 @@ def main(argv: list[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
-    # Configure logging; errors are always shown but the level can be raised
-    # for debugging during initialization.
-    logging.basicConfig(level=getattr(logging, str(args.log_level).upper(), None))
+    setup_logging(level=args.log_level)
+    cid = f"sas-{uuid.uuid4()}"
+    set_correlation_id(cid)
+    logger = get_logger(__name__)
+    sandbox_restart_total.labels(service="start_autonomous", reason="launch").inc()
+    logger.info("sandbox start", extra=log_record(event="start"))
 
     try:
         if args.health_check:
             bootstrap_environment()
-            logging.info("Sandbox health: %s", sandbox_health())
+            logger.info(
+                "sandbox health", extra=log_record(health=sandbox_health())
+            )
             shutdown_autonomous_sandbox()
+            logger.info("sandbox shutdown", extra=log_record(event="shutdown"))
             return
         launch_sandbox()
+        logger.info("sandbox shutdown", extra=log_record(event="shutdown"))
     except Exception:  # pragma: no cover - defensive catch
-        logging.exception("Failed to launch sandbox")
+        sandbox_crashes_total.inc()
+        sandbox_last_failure_ts.set(time.time())
+        logger.exception("sandbox failure", extra=log_record(event="failure"))
         sys.exit(1)
+    finally:
+        set_correlation_id(None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- unify logging across sandbox entry points and engine using `logging_utils.get_logger`
- add correlation IDs and Prometheus counters for sandbox lifecycle and stub generation
- improve retry and shutdown logging for stub provider and bootstrap helpers

## Testing
- `pytest sandbox_runner/tests/test_start_autonomous_noninteractive.py::test_start_autonomous_sandbox_noninteractive -q`
- `pytest tests/test_generative_stub_provider.py::test_generate_stubs_cache -q`
- `pytest sandbox_runner/tests/test_shutdown_cleanup.py::test_shutdown_cleans_caches -q` *(fails: TypeError: object() takes no arguments)*


------
https://chatgpt.com/codex/tasks/task_e_68b6886b1448832ea2159c8b06368765