### PR TITLE
Expose chunked prompt settings for self-coding

### DIFF
--- a/prompt_engine.py
+++ b/prompt_engine.py
@@ -166,8 +166,8 @@ class PromptEngine:
         if _SETTINGS
         else 3500
     )
-    prompt_chunk_cache_dir: Path = field(
-        default_factory=lambda: Path(_SETTINGS.prompt_chunk_cache_dir)
+    chunk_summary_cache_dir: Path = field(
+        default_factory=lambda: Path(_SETTINGS.chunk_summary_cache_dir)
         if _SETTINGS
         else Path("chunk_summary_cache")
     )
@@ -218,6 +218,17 @@ class PromptEngine:
     _optimizer_counter: int = field(default=0, init=False)
     _optimizer_applied: bool = field(default=False, init=False)
 
+    @property
+    def prompt_chunk_cache_dir(self) -> Path:  # pragma: no cover - backward compat
+        """Alias for :attr:`chunk_summary_cache_dir`.
+
+        The prompt engine historically exposed ``prompt_chunk_cache_dir``.  The
+        attribute is retained for compatibility but proxies to the new
+        :attr:`chunk_summary_cache_dir` setting.
+        """
+
+        return self.chunk_summary_cache_dir
+
     def __post_init__(self) -> None:  # pragma: no cover - lightweight setup
         if self.retriever is None:
             try:
@@ -259,8 +270,8 @@ class PromptEngine:
         try:
             import prompt_chunking as _pc
 
-            self.prompt_chunk_cache_dir = Path(self.prompt_chunk_cache_dir)
-            _pc.CACHE_DIR = self.prompt_chunk_cache_dir
+            self.chunk_summary_cache_dir = Path(self.chunk_summary_cache_dir)
+            _pc.CACHE_DIR = self.chunk_summary_cache_dir
         except Exception:
             pass
 

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -594,11 +594,6 @@ class SandboxSettings(BaseSettings):
         env="PROMPT_CHUNK_TOKEN_THRESHOLD",
         description="Token limit for individual code chunks when summarizing large files.",
     )
-    prompt_chunk_cache_dir: Path = Field(
-        Path("chunk_summary_cache"),
-        env="PROMPT_CHUNK_CACHE_DIR",
-        description="Directory for cached summaries of code chunks.",
-    )
     chunk_token_threshold: int = Field(
         3500,
         env="CHUNK_TOKEN_THRESHOLD",
@@ -606,9 +601,22 @@ class SandboxSettings(BaseSettings):
     )
     chunk_summary_cache_dir: Path = Field(
         Path("chunk_summary_cache"),
-        env="CHUNK_SUMMARY_CACHE_DIR",
+        env=["CHUNK_SUMMARY_CACHE_DIR", "PROMPT_CHUNK_CACHE_DIR"],
         description="Directory for cached summaries used in chunked prompting.",
     )
+
+    @property
+    def prompt_chunk_cache_dir(self) -> Path:  # pragma: no cover - backward compat
+        """Alias for :attr:`chunk_summary_cache_dir`.
+
+        Historically the settings exposed ``prompt_chunk_cache_dir`` which
+        matched the environment variable ``PROMPT_CHUNK_CACHE_DIR``.  The new
+        field :attr:`chunk_summary_cache_dir` supersedes it but this property is
+        retained so older code can continue to access the cache directory via
+        the previous attribute name.
+        """
+
+        return self.chunk_summary_cache_dir
     stub_timeout: float = Field(
         10.0,
         env="SANDBOX_STUB_TIMEOUT",

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -195,6 +195,7 @@ class SelfCodingEngine:
         prompt_tone: str = "neutral",
         token_threshold: int = 3500,
         prompt_chunk_token_threshold: int | None = None,
+        chunk_summary_cache_dir: str | Path | None = None,
         prompt_chunk_cache_dir: str | Path | None = None,
         **kwargs: Any,
     ) -> None:
@@ -223,10 +224,15 @@ class SelfCodingEngine:
         )
         # maintain backward compatibility
         self.prompt_chunk_token_threshold = self.chunk_token_threshold
-        self.prompt_chunk_cache_dir = Path(
-            prompt_chunk_cache_dir or _settings.prompt_chunk_cache_dir
+        cache_dir = (
+            chunk_summary_cache_dir
+            or prompt_chunk_cache_dir
+            or _settings.chunk_summary_cache_dir
         )
-        self.chunk_cache = ChunkSummaryCache(self.prompt_chunk_cache_dir)
+        self.chunk_summary_cache_dir = Path(cache_dir)
+        # backward compatibility
+        self.prompt_chunk_cache_dir = self.chunk_summary_cache_dir
+        self.chunk_cache = ChunkSummaryCache(self.chunk_summary_cache_dir)
         self.safety_monitor = safety_monitor
         if llm_client is None:
             try:
@@ -319,7 +325,7 @@ class SelfCodingEngine:
             optimizer=self.prompt_optimizer,
             token_threshold=token_threshold,
             chunk_token_threshold=self.chunk_token_threshold,
-            prompt_chunk_cache_dir=self.prompt_chunk_cache_dir,
+            chunk_summary_cache_dir=self.chunk_summary_cache_dir,
         )
         if prompt_evolution_memory is None:
             try:

--- a/tests/integration/test_chunked_patch_flow.py
+++ b/tests/integration/test_chunked_patch_flow.py
@@ -73,6 +73,7 @@ _setmod(
             va_prompt_prefix="",
             va_repo_layout_lines=0,
             prompt_chunk_token_threshold=20,
+            chunk_summary_cache_dir="cache",
             prompt_chunk_cache_dir="cache",
             audit_log_path="audit.log",
             audit_privkey=None,
@@ -106,7 +107,7 @@ def _setup_engine(tmp_path, monkeypatch):
         object(),
         llm_client=DummyLLM(),
         prompt_chunk_token_threshold=50,
-        prompt_chunk_cache_dir=tmp_path,
+        chunk_summary_cache_dir=tmp_path,
     )
     engine.data_bot = None
     engine.trend_predictor = None

--- a/tests/test_prompt_chunk_settings.py
+++ b/tests/test_prompt_chunk_settings.py
@@ -5,16 +5,19 @@ from sandbox_settings import SandboxSettings
 
 def test_defaults(monkeypatch):
     monkeypatch.delenv("PROMPT_CHUNK_TOKEN_THRESHOLD", raising=False)
+    monkeypatch.delenv("CHUNK_SUMMARY_CACHE_DIR", raising=False)
     monkeypatch.delenv("PROMPT_CHUNK_CACHE_DIR", raising=False)
     settings = SandboxSettings()
     assert settings.prompt_chunk_token_threshold == 3500
+    assert settings.chunk_summary_cache_dir == Path("chunk_summary_cache")
     assert settings.prompt_chunk_cache_dir == Path("chunk_summary_cache")
 
 
 def test_env_overrides(monkeypatch, tmp_path):
     monkeypatch.setenv("PROMPT_CHUNK_TOKEN_THRESHOLD", "1234")
     cache_dir = tmp_path / "cache"
-    monkeypatch.setenv("PROMPT_CHUNK_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("CHUNK_SUMMARY_CACHE_DIR", str(cache_dir))
     settings = SandboxSettings()
     assert settings.prompt_chunk_token_threshold == 1234
+    assert settings.chunk_summary_cache_dir == cache_dir
     assert settings.prompt_chunk_cache_dir == cache_dir

--- a/tests/test_self_coding_engine_chunking.py
+++ b/tests/test_self_coding_engine_chunking.py
@@ -86,6 +86,7 @@ _setmod(
             va_prompt_prefix="",
             va_repo_layout_lines=0,
             prompt_chunk_token_threshold=20,
+            chunk_summary_cache_dir="cache",
             prompt_chunk_cache_dir="cache",
             audit_log_path="audit.log",
             audit_privkey=None,
@@ -147,7 +148,7 @@ def test_generate_helper_injects_chunk_summaries(monkeypatch, tmp_path):
         object(),
         llm_client=DummyLLM(),
         prompt_chunk_token_threshold=50,
-        prompt_chunk_cache_dir=tmp_path,
+        chunk_summary_cache_dir=tmp_path,
     )
 
     monkeypatch.setattr(engine, "suggest_snippets", lambda desc, limit=3: [])


### PR DESCRIPTION
## Summary
- add `chunk_summary_cache_dir` setting alongside `prompt_chunk_token_threshold`
- update self-coding components to use the new cache directory and surface chunk token limits
- document backward-compatible aliases and refresh related tests

## Testing
- `pytest tests/test_prompt_chunk_settings.py tests/test_self_coding_engine_chunking.py tests/integration/test_chunked_patch_flow.py tests/integration/test_quick_fix_engine_chunked_patch.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b688a3f1f0832ea9c1b8f7b6b92f98