### PR TITLE
feat: auto configure sandbox environment

### DIFF
--- a/start_autonomous_sandbox.py
+++ b/start_autonomous_sandbox.py
@@ -1,13 +1,15 @@
 """Entry point for launching the autonomous sandbox.
 
-This small wrapper adds a bit of resiliency around the sandbox bootstrap by
-capturing startup exceptions and allowing the log level to be configured via
-``SandboxSettings`` or overridden on the command line.
+This wrapper bootstraps the environment and model paths automatically before
+starting the sandbox. It captures startup exceptions and allows the log level
+to be configured via ``SandboxSettings`` or overridden on the command line
+without requiring any manual post-launch edits.
 """
 
 from __future__ import annotations
 
 import argparse
+import logging
 import sys
 import time
 import uuid
@@ -15,6 +17,7 @@ import uuid
 from logging_utils import get_logger, setup_logging, set_correlation_id, log_record
 from sandbox_settings import SandboxSettings
 from sandbox_runner.bootstrap import (
+    auto_configure_env,
     bootstrap_environment,
     launch_sandbox,
     sandbox_health,
@@ -45,6 +48,11 @@ def main(argv: list[str] | None = None) -> None:
     """
 
     settings = SandboxSettings()
+    # Automatically configure the environment before proceeding so the caller
+    # does not need to pre-populate configuration files or model paths.
+    auto_configure_env(settings)
+    # Reload settings to pick up any values written by ``auto_configure_env``.
+    settings = SandboxSettings()
 
     parser = argparse.ArgumentParser(description="Launch the autonomous sandbox")
     parser.add_argument(
@@ -60,7 +68,11 @@ def main(argv: list[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
-    setup_logging(level=args.log_level)
+    root_logger = logging.getLogger()
+    if not root_logger.handlers:
+        setup_logging(level=args.log_level)
+    else:
+        root_logger.setLevel(getattr(logging, str(args.log_level).upper(), logging.INFO))
     cid = f"sas-{uuid.uuid4()}"
     set_correlation_id(cid)
     logger = get_logger(__name__)
@@ -71,7 +83,7 @@ def main(argv: list[str] | None = None) -> None:
         if args.health_check:
             bootstrap_environment()
             logger.info(
-                "sandbox health", extra=log_record(health=sandbox_health())
+                "Sandbox health", extra=log_record(health=sandbox_health())
             )
             shutdown_autonomous_sandbox()
             logger.info("sandbox shutdown", extra=log_record(event="shutdown"))
@@ -81,7 +93,7 @@ def main(argv: list[str] | None = None) -> None:
     except Exception:  # pragma: no cover - defensive catch
         sandbox_crashes_total.inc()
         sandbox_last_failure_ts.set(time.time())
-        logger.exception("sandbox failure", extra=log_record(event="failure"))
+        logger.exception("Failed to launch sandbox", extra=log_record(event="failure"))
         sys.exit(1)
     finally:
         set_correlation_id(None)


### PR DESCRIPTION
## Summary
- add `auto_configure_env` to populate missing environment vars and model path
- initialize sandbox using automatic configuration
- launch script now relies on automated setup and preserves logging for tests

## Testing
- `pytest sandbox_runner/tests/test_start_autonomous_noninteractive.py sandbox_runner/tests/test_start_autonomous_health.py sandbox_runner/tests/test_start_autonomous_launch.py sandbox_runner/tests/test_start_autonomous_failure.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b68c2f198c832eb5db8d6b9a47b0e8