### PR TITLE
feat: track entropy history for meta planning

### DIFF
--- a/tests/test_metrics_entropy_history.py
+++ b/tests/test_metrics_entropy_history.py
@@ -1,0 +1,38 @@
+import yaml
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+repo = Path(__file__).resolve().parents[1]
+metrics_path = repo / "self_improvement" / "metrics.py"
+spec = importlib.util.spec_from_file_location(
+    "menace.self_improvement.metrics", metrics_path
+)
+metrics = importlib.util.module_from_spec(spec)
+pkg = sys.modules.setdefault("menace", types.ModuleType("menace"))
+pkg.__path__ = [str(repo)]  # type: ignore[attr-defined]
+sys.modules[spec.name] = metrics
+spec.loader.exec_module(metrics)  # type: ignore[union-attr]
+
+record_entropy = metrics.record_entropy
+_update_alignment_baseline = metrics._update_alignment_baseline
+
+
+def test_record_entropy(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_text("print('hi')\n")
+    monkeypatch.setenv("SANDBOX_REPO_PATH", str(repo))
+
+    baseline = tmp_path / "baseline.yaml"
+    settings = SimpleNamespace(alignment_baseline_metrics_path=str(baseline))
+    record_entropy(0.2, 0.4, roi=1.0, settings=settings)
+    record_entropy(0.4, 0.6, roi=0.5, settings=settings)
+    data = yaml.safe_load(baseline.read_text())
+    assert len(data["entropy_history"]) == 2
+    assert data["entropy_history"][0]["roi"] == 1.0
+    _update_alignment_baseline(settings)
+    data2 = yaml.safe_load(baseline.read_text())
+    assert "entropy_history" in data2 and len(data2["entropy_history"]) == 2


### PR DESCRIPTION
## Summary
- record per-cycle entropy values and persist history with baseline ROI metrics
- derive entropy gating from moving average history and compute delta entropy
- add tests for entropy history persistence and dynamic thresholds

## Testing
- `pre-commit run --files self_improvement/metrics.py self_improvement/meta_planning.py tests/test_meta_planning_entropy.py tests/test_metrics_entropy_history.py`
- `pytest -q tests/test_meta_planning_entropy.py tests/test_metrics_entropy_history.py`


------
https://chatgpt.com/codex/tasks/task_e_68b69e6017b4832e891db1f44c7e47d1