### PR TITLE
Add entropy & diversity metrics to self-improvement

### DIFF
--- a/tests/test_self_improvement_metrics_module.py
+++ b/tests/test_self_improvement_metrics_module.py
@@ -7,8 +7,11 @@ metrics = pytest.importorskip("menace.self_improvement.metrics")
 def test_collect_metrics(tmp_path):
     sample = tmp_path / "sample.py"
     sample.write_text("def f():\n    return 1\n")
-    per_file, total, mi, test_count = metrics._collect_metrics([sample], tmp_path)
+    per_file, total, mi, test_count, ent, div = metrics._collect_metrics([sample], tmp_path)
     assert "sample.py" in per_file
     assert total >= 0
     assert mi >= 0
     assert test_count == 0
+    assert ent >= 0.0 and div >= 0.0
+    assert "token_entropy" in per_file["sample.py"]
+    assert "token_diversity" in per_file["sample.py"]


### PR DESCRIPTION
## Summary
- compute token entropy and diversity for each file in `_collect_metrics`
- record entropy and diversity with ROI tracker per cycle and compute composite trigger score blending ROI delta, entropy delta, and success momentum
- replace `_should_trigger` heuristics with ROI/entropy/success composite scoring

## Testing
- `pytest tests/test_self_improvement_metrics_module.py tests/test_metrics_maintainability.py -q`
- `pytest tests/test_self_improvement_engine.py::test_run_cycle -q` *(fails: AttributeError: type object 'Config' has no attribute 'model_validate')*

------
https://chatgpt.com/codex/tasks/task_e_68b6ac06ee0c832e9735310321a772a3