### PR TITLE
feat: track moving baseline in debugger sandbox

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,5 +7,25 @@ sandbox_runner_pkg = types.ModuleType("sandbox_runner")
 sandbox_runner_pkg.__path__ = [str(Path(__file__).resolve().parent / "sandbox_runner")]
 sys.modules.setdefault("sandbox_runner", sandbox_runner_pkg)
 
+# Stub menace package to avoid heavy imports during tests
+root_pkg = types.ModuleType("menace")
+root_pkg.__path__ = [str(Path(__file__).resolve().parent)]
+sys.modules.setdefault("menace", root_pkg)
+sub_pkg = types.ModuleType("menace.self_improvement")
+sub_pkg.__path__ = [str(Path(__file__).resolve().parent / "self_improvement")]
+sys.modules.setdefault("menace.self_improvement", sub_pkg)
+sys.modules.setdefault("self_improvement", sub_pkg)
+metric_stub = types.SimpleNamespace(
+    labels=lambda **k: types.SimpleNamespace(inc=lambda: None)
+)
+sys.modules.setdefault(
+    "menace.metrics_exporter",
+    types.SimpleNamespace(self_improvement_failure_total=metric_stub),
+)
+sys.modules.setdefault(
+    "menace.sandbox_settings",
+    types.SimpleNamespace(SandboxSettings=lambda: types.SimpleNamespace()),
+)
+
 os.environ.setdefault("VISUAL_AGENT_URLS", "http://127.0.0.1:8001")
 os.environ.setdefault("VISUAL_AGENT_TOKEN", "test-token")

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -1763,10 +1763,15 @@ class SandboxSettings(BaseSettings):
     )
 
     # self debugger scoring configuration
-    score_threshold: float = Field(
-        0.5,
-        env="SCORE_THRESHOLD",
-        description="Minimum composite score required for patch acceptance.",
+    baseline_window: int = Field(
+        5,
+        env="BASELINE_WINDOW",
+        description="Number of recent scores used for moving average baseline.",
+    )
+    delta_margin: float = Field(
+        0.0,
+        env="DELTA_MARGIN",
+        description="Minimum positive delta over baseline required for patch acceptance.",
     )
     score_weights: tuple[float, float, float, float, float, float] = Field(
         (1.0, 1.0, 1.0, 1.0, 1.0, 1.0),
@@ -1774,10 +1779,16 @@ class SandboxSettings(BaseSettings):
         description="Weights for coverage, errors, ROI, complexity, synergy ROI and efficiency.",
     )
 
-    @field_validator("score_threshold")
-    def _check_score_threshold(cls, v: float) -> float:
+    @field_validator("baseline_window")
+    def _check_baseline_window(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("baseline_window must be a positive integer")
+        return v
+
+    @field_validator("delta_margin")
+    def _check_delta_margin(cls, v: float) -> float:
         if not 0 <= v <= 1:
-            raise ValueError("score_threshold must be between 0 and 1")
+            raise ValueError("delta_margin must be between 0 and 1")
         return v
 
     @field_validator(

--- a/self_improvement/tests/test_moving_baseline_tracker.py
+++ b/self_improvement/tests/test_moving_baseline_tracker.py
@@ -1,0 +1,30 @@
+import importlib
+
+utils = importlib.import_module("menace.self_improvement.utils")
+MovingBaselineTracker = utils.MovingBaselineTracker
+
+
+def _apply(tracker: MovingBaselineTracker, score: float, margin: float = 0.0) -> tuple[bool, float]:
+    """Helper returning acceptance decision and delta."""
+
+    avg, _ = tracker.stats()
+    delta = score - avg
+    tracker.update(score)
+    return delta >= margin, delta
+
+
+def test_accept_on_positive_delta():
+    tracker = MovingBaselineTracker(3)
+    tracker.update(0.2)
+    tracker.update(0.4)
+    accepted, delta = _apply(tracker, 0.6)
+    assert accepted and delta > 0
+
+
+def test_reject_and_persist_on_negative_delta():
+    tracker = MovingBaselineTracker(3)
+    tracker.update(0.8)
+    tracker.update(0.7)
+    accepted, delta = _apply(tracker, 0.6)
+    assert not accepted and delta < 0
+    assert tracker.composite_history[-1] == 0.6

--- a/self_improvement/tests/test_utils_cache_cleanup.py
+++ b/self_improvement/tests/test_utils_cache_cleanup.py
@@ -1,4 +1,6 @@
-from self_improvement import utils
+import importlib
+
+utils = importlib.import_module("menace.self_improvement.utils")
 
 
 def test_remove_import_cache_files(tmp_path):


### PR DESCRIPTION
## Summary
- add `MovingBaselineTracker` for rolling score averages
- base sandbox patch decisions on delta vs moving baseline
- expose baseline window and delta margin settings

## Testing
- `pre-commit run --files sandbox_settings.py self_improvement/utils.py self_debugger_sandbox.py self_improvement/tests/test_moving_baseline_tracker.py self_improvement/tests/test_utils_cache_cleanup.py conftest.py`
- `pytest self_improvement/tests/test_moving_baseline_tracker.py self_improvement/tests/test_utils_cache_cleanup.py` *(fails: No module named 'sandbox_settings')*


------
https://chatgpt.com/codex/tasks/task_e_68b6b11263b0832eb66cc2c64968f4f9