### PR TITLE
Use ChunkSummaryCache for chunk summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ more than the configured token budget. The pipeline consists of:
 
 1. `chunk_file` – walks a module and produces token‑bounded chunks.
 2. `summarize_code` – generates a short natural‑language blurb for each chunk.
-3. `get_chunk_summaries` – stores the code and summary in
-   `chunk_summary_cache/` keyed by a SHA256 hash of the chunk. Cached entries are
-   reused until the source changes.
+3. `get_chunk_summaries` – uses a disk-backed cache to persist chunk summaries
+   and automatically invalidates them when the source file changes.
 
 `PROMPT_CHUNK_TOKEN_THRESHOLD` sets the maximum tokens per chunk and
 `PROMPT_CHUNK_CACHE_DIR` relocates the cache directory.

--- a/docs/chunking.md
+++ b/docs/chunking.md
@@ -13,12 +13,11 @@ none is available.
 
 ## Cache semantics
 
-`get_chunk_summaries(path, token_limit)` hashes each chunk and stores a JSON
-record containing the chunk and its summary inside the `chunk_summary_cache/`
-folder. On subsequent runs the hash is used to look up an existing summary. If
-it matches the current chunk the cached summary is reused; otherwise a new
-summary is generated and written back to the cache. The cache makes repeated
-prompt generation faster and now logs when cache hits or misses occur.
+`get_chunk_summaries(path, token_limit)` uses :class:`chunk_summary_cache.ChunkSummaryCache`
+to persist summaries for each file.  The cache tracks the file's content hash and
+automatically invalidates entries when the source changes.  Subsequent calls for
+unchanged files reuse the stored summaries, making repeated prompt generation
+faster without manual file-hash bookkeeping.
 
 ## Developer notes
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -68,7 +68,7 @@ Populate the summary cache ahead of time to avoid first‑run latency:
 from pathlib import Path
 from chunking import get_chunk_summaries
 
-# Writes JSON files into chunk_summary_cache/
+# Populate chunk_summary_cache/ with summaries
 get_chunk_summaries(Path("bots/example.py"), 800)
 ```
 

--- a/prompt_engine.py
+++ b/prompt_engine.py
@@ -269,9 +269,12 @@ class PromptEngine:
         self.apply_optimizer_format(__name__, "build_prompt")
         try:
             import chunking as _pc
+            from chunk_summary_cache import ChunkSummaryCache
 
             self.chunk_summary_cache_dir = Path(self.chunk_summary_cache_dir)
-            _pc.CACHE_DIR = self.chunk_summary_cache_dir
+            cache = getattr(_pc, "CHUNK_CACHE", None)
+            if not cache or getattr(cache, "cache_dir", None) != self.chunk_summary_cache_dir:
+                _pc.CHUNK_CACHE = ChunkSummaryCache(self.chunk_summary_cache_dir)
         except Exception:
             pass
 

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -234,6 +234,12 @@ class SelfCodingEngine:
         # backward compatibility
         self.prompt_chunk_cache_dir = self.chunk_summary_cache_dir
         self.chunk_cache = ChunkSummaryCache(self.chunk_summary_cache_dir)
+        try:
+            import chunking as _pc
+
+            _pc.CHUNK_CACHE = self.chunk_cache
+        except Exception:
+            pass
         self.safety_monitor = safety_monitor
         if llm_client is None:
             try:
@@ -774,7 +780,11 @@ class SelfCodingEngine:
                             cached_summaries.append(entry)
                             cache_map[ch_hash] = entry
                             updated = True
-                        elif entry.get("summary") != summary_text or entry.get("start_line") != ch.start_line or entry.get("end_line") != ch.end_line:
+                        elif (
+                            entry.get("summary") != summary_text
+                            or entry.get("start_line") != ch.start_line
+                            or entry.get("end_line") != ch.end_line
+                        ):
                             entry.update(
                                 {
                                     "start_line": ch.start_line,

--- a/tests/test_chunking_split.py
+++ b/tests/test_chunking_split.py
@@ -1,3 +1,4 @@
+from chunk_summary_cache import ChunkSummaryCache
 import chunking as pc
 import textwrap
 
@@ -50,14 +51,14 @@ def test_get_chunk_summaries_cache_hit(tmp_path, monkeypatch):
     monkeypatch.setattr(pc, "summarize_code", fake_summary)
     cache_dir = tmp_path / "cache"
     cache_dir.mkdir()
-    monkeypatch.setattr(pc, "CACHE_DIR", cache_dir)
+    monkeypatch.setattr(pc, "CHUNK_CACHE", ChunkSummaryCache(cache_dir))
 
     first = pc.get_chunk_summaries(file, 50)
     assert calls["n"] == len(first)
 
     second = pc.get_chunk_summaries(file, 50)
     assert second == first
-    assert calls["n"] == len(first) * 2  # summaries recomputed
+    assert calls["n"] == len(first)  # cache hit
 
 
 def test_get_chunk_summaries_cache_invalidation(tmp_path, monkeypatch):
@@ -73,16 +74,16 @@ def test_get_chunk_summaries_cache_invalidation(tmp_path, monkeypatch):
     cache_dir = tmp_path / "cache"
     cache_dir.mkdir()
     monkeypatch.setattr(pc, "summarize_code", fake_summary)
-    monkeypatch.setattr(pc, "CACHE_DIR", cache_dir)
+    monkeypatch.setattr(pc, "CHUNK_CACHE", ChunkSummaryCache(cache_dir))
 
     first = pc.get_chunk_summaries(file, 50)
     assert calls["n"] == len(first)
     first_files = list(cache_dir.iterdir())
     assert len(first_files) == 1
 
-    file.write_text("def a():\n    return 2\n")  # change content -> new hash
+    file.write_text("def a():\n    return 2\n")  # change content -> cache invalidated
     second = pc.get_chunk_summaries(file, 50)
     assert calls["n"] == len(first) + len(second)
     cache_files = list(cache_dir.iterdir())
-    assert len(cache_files) == 2  # old + new cache files
+    assert len(cache_files) == 1  # file replaced
     assert first != second


### PR DESCRIPTION
## Summary
- route chunk summary lookups through `ChunkSummaryCache`
- thread-safe cache hits and invalidation via per-path locks
- let `PromptEngine` and `SelfCodingEngine` share cache directory from settings
- document new cache semantics and add regression tests

## Testing
- `pre-commit run --files chunking.py prompt_engine.py self_coding_engine.py tests/test_chunking_cache.py tests/test_chunking_split.py docs/chunking.md docs/quickstart.md README.md`
- `pytest tests/test_prompt_chunk_settings.py`
- `pytest tests/test_chunking_cache.py tests/test_chunking_split.py tests/test_chunk_summary_cache.py tests/test_prompt_engine_chunk_summaries.py tests/test_chunk_workflow.py tests/test_self_coding_engine_chunking.py tests/integration/test_chunked_patch_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6b4624d38832ea70725610c9a6131