### PR TITLE
Track patch success momentum

### DIFF
--- a/self_improvement_policy.py
+++ b/self_improvement_policy.py
@@ -857,7 +857,9 @@ class SelfImprovementPolicy:
         self.alpha = alpha
         self.gamma = gamma
         self.adaptive = adaptive
+        self.base_epsilon = epsilon
         self.epsilon = epsilon
+        self.urgency = 0.0
         self.temperature = temperature
         self.exploration = exploration
         self.epsilon_schedule = epsilon_schedule
@@ -886,6 +888,18 @@ class SelfImprovementPolicy:
         atexit.register(self._graceful_shutdown)
         if self.path:
             self.load(self.path)
+
+    # ------------------------------------------------------------------
+    def adjust_for_momentum(self, momentum: float) -> None:
+        """Adjust exploration and urgency based on momentum."""
+        if momentum < 0:
+            delta = -momentum
+            self.urgency = min(1.0, self.urgency + delta)
+            self.epsilon = min(1.0, self.base_epsilon + delta)
+        else:
+            delta = momentum
+            self.urgency = max(0.0, self.urgency - delta)
+            self.epsilon = max(self.base_epsilon, self.epsilon - delta)
 
     # ------------------------------------------------------------------
     def update(

--- a/tests/test_self_improvement_policy.py
+++ b/tests/test_self_improvement_policy.py
@@ -61,7 +61,14 @@ def test_convergence_simple_task():
 
 
 def test_policy_config_serialization(tmp_path):
-    cfg = PolicyConfig(alpha=0.3, gamma=0.8, epsilon=0.2, temperature=1.5, exploration="softmax", adaptive=True)
+    cfg = PolicyConfig(
+        alpha=0.3,
+        gamma=0.8,
+        epsilon=0.2,
+        temperature=1.5,
+        exploration="softmax",
+        adaptive=True,
+    )
     policy = SelfImprovementPolicy(config=cfg)
     path = tmp_path / "policy.json"
     policy.save_model(str(path))
@@ -83,3 +90,14 @@ def test_policy_config_defaults_from_settings():
     assert cfg.epsilon == settings.policy_epsilon
     assert cfg.temperature == settings.policy_temperature
     assert cfg.exploration == settings.policy_exploration
+
+
+def test_momentum_adjusts_urgency():
+    policy = SelfImprovementPolicy(epsilon=0.1)
+    policy.adjust_for_momentum(-0.3)
+    assert policy.urgency > 0.0
+    assert policy.epsilon > policy.base_epsilon
+    prev_urgency = policy.urgency
+    policy.adjust_for_momentum(0.2)
+    assert policy.urgency < prev_urgency
+    assert policy.epsilon >= policy.base_epsilon


### PR DESCRIPTION
## Summary
- maintain patch outcome history and compute momentum vs. long-term success
- react to falling momentum by boosting urgency and exploration
- test momentum-driven urgency adjustments in self-improvement policy

## Testing
- `pre-commit run --files self_debugger_sandbox.py self_improvement_policy.py tests/test_self_improvement_policy.py`
- `pytest tests/test_self_improvement_policy.py::test_momentum_adjusts_urgency -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6be1f3478832ea40174682fab03c9