### PR TITLE
feat: add adaptive baseline tracker for self-improvement

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -293,7 +293,31 @@ class SandboxSettings(BaseSettings):
     )
     roi_cycles: int | None = Field(None, env="ROI_CYCLES")
     synergy_cycles: int | None = Field(None, env="SYNERGY_CYCLES")
+    baseline_window: int = Field(10, env="BASELINE_WINDOW")
+    mae_deviation: float = Field(1.0, env="MAE_DEVIATION")
+    acc_deviation: float = Field(1.0, env="ACC_DEVIATION")
+    energy_deviation: float = Field(1.0, env="ENERGY_DEVIATION")
+    roi_deviation: float = Field(1.0, env="ROI_DEVIATION")
+    entropy_deviation: float = Field(1.0, env="ENTROPY_DEVIATION")
     save_synergy_history: bool | None = Field(None, env="SAVE_SYNERGY_HISTORY")
+
+    @field_validator("baseline_window")
+    def _baseline_window_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("baseline_window must be positive")
+        return v
+
+    @field_validator(
+        "mae_deviation",
+        "acc_deviation",
+        "energy_deviation",
+        "roi_deviation",
+        "entropy_deviation",
+    )
+    def _baseline_non_negative(cls, v: float, info: Any) -> float:
+        if v < 0:
+            raise ValueError(f"{info.field_name} must be non-negative")
+        return v
     menace_env_file: str = Field(".env", env="MENACE_ENV_FILE")
     sandbox_data_dir: str = Field("sandbox_data", env="SANDBOX_DATA_DIR")
     sandbox_env_presets: str | None = Field(None, env="SANDBOX_ENV_PRESETS")

--- a/self_improvement/baseline_tracker.py
+++ b/self_improvement/baseline_tracker.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import math
+from collections import deque
+from typing import Deque, Dict, Iterable
+
+
+class BaselineTracker:
+    """Maintain rolling statistics for numeric metrics.
+
+    Metrics are tracked using fixed-size deques so both the moving average and
+    variance can be computed efficiently for recent values.  The tracker is
+    metric-agnostic and will automatically create histories for new metric
+    names on first update.
+    """
+
+    def __init__(self, window: int = 10, metrics: Iterable[str] | None = None) -> None:
+        self.window = window
+        self._history: Dict[str, Deque[float]] = {
+            m: deque(maxlen=window) for m in (metrics or [])
+        }
+
+    # ------------------------------------------------------------------
+    def update(self, **metrics: float) -> None:
+        """Record new metric values.
+
+        Parameters
+        ----------
+        **metrics:
+            Mapping of metric name to numeric value.
+        """
+
+        for name, value in metrics.items():
+            hist = self._history.setdefault(name, deque(maxlen=self.window))
+            hist.append(float(value))
+
+    # ------------------------------------------------------------------
+    def get(self, metric: str) -> float:
+        """Return the moving average for *metric*."""
+        hist = self._history.get(metric)
+        if not hist:
+            return 0.0
+        return sum(hist) / len(hist)
+
+    # ------------------------------------------------------------------
+    def variance(self, metric: str) -> float:
+        """Return the population variance for *metric*."""
+        hist = self._history.get(metric)
+        if not hist:
+            return 0.0
+        mean = self.get(metric)
+        return sum((x - mean) ** 2 for x in hist) / len(hist)
+
+    # ------------------------------------------------------------------
+    def std(self, metric: str) -> float:
+        """Return the standard deviation for *metric*."""
+        return math.sqrt(self.variance(metric))
+
+    # ------------------------------------------------------------------
+    def to_dict(self) -> Dict[str, list[float]]:
+        """Expose raw metric histories (primarily for testing)."""
+        return {k: list(v) for k, v in self._history.items()}
+
+
+# Shared tracker used across self-improvement modules
+TRACKER = BaselineTracker()


### PR DESCRIPTION
## Summary
- introduce shared BaselineTracker with moving average & variance
- derive ROI predictor, energy gating, and borderline checks from tracker stats
- expose baseline window and deviation multipliers in SandboxSettings

## Testing
- `pytest tests/self_improvement/test_cycle.py::test_self_improvement_cycle_runs -q` *(fails: Missing dependencies for self-improvement: error_logger, telemetry_feedback, telemetry_backend; Version mismatches: quick_fix_engine, sandbox_runner)*
- `pytest self_improvement/tests/test_moving_baseline_tracker.py -q` *(fails: ModuleNotFoundError: No module named 'sandbox_settings')*


------
https://chatgpt.com/codex/tasks/task_e_68b6c3329bc4832eaca385c0e828e034