### PR TITLE
Track ROI delta history and escalate on stagnation

### DIFF
--- a/tests/test_roi_stagnation_escalation.py
+++ b/tests/test_roi_stagnation_escalation.py
@@ -1,0 +1,71 @@
+import ast
+import importlib.util
+import types
+from pathlib import Path
+from typing import Any, Dict
+
+_BT_PATH = Path(__file__).resolve().parents[1] / "self_improvement" / "baseline_tracker.py"
+spec = importlib.util.spec_from_file_location("baseline_tracker", _BT_PATH)
+baseline_tracker = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(baseline_tracker)  # type: ignore[attr-defined]
+BaselineTracker = baseline_tracker.BaselineTracker
+
+ENG_PATH = Path(__file__).resolve().parents[1] / "self_improvement" / "engine.py"
+src = ENG_PATH.read_text()
+tree = ast.parse(src)
+future = ast.ImportFrom(module="__future__", names=[ast.alias("annotations", None)], level=0)
+sie_cls = next(
+    n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "SelfImprovementEngine"
+)
+method = next(
+    n for n in sie_cls.body if isinstance(n, ast.FunctionDef)
+    and n.name == "_check_roi_stagnation"
+)
+engine_module = ast.Module(
+    [future, ast.ClassDef("SelfImprovementEngine", [], [], [method], [])],
+    type_ignores=[],
+)
+engine_module = ast.fix_missing_locations(engine_module)
+alerts: list[tuple] = []
+ns: Dict[str, Any] = {
+    "BaselineTracker": BaselineTracker,
+    "dispatch_alert": lambda *a, **k: alerts.append((a, k)),
+    "log_record": lambda **k: k,
+}
+exec(compile(engine_module, "<engine>", "exec"), ns)
+SelfImprovementEngine = ns["SelfImprovementEngine"]
+
+
+def _make_engine():
+    eng = SelfImprovementEngine.__new__(SelfImprovementEngine)
+    eng.baseline_tracker = BaselineTracker(window=5)
+    eng.urgency_tier = 0
+    eng.urgency_recovery_threshold = 0.05
+    eng.logger = types.SimpleNamespace(warning=lambda *a, **k: None, exception=lambda *a, **k: None)
+    return eng
+
+
+def test_roi_stagnation_escalates():
+    alerts.clear()
+    eng = _make_engine()
+    for roi in [1.0, 0.9, 0.8]:
+        eng.baseline_tracker.update(roi=roi)
+        eng._check_roi_stagnation()
+        assert eng.urgency_tier == 0
+    eng.baseline_tracker.update(roi=0.8)
+    eng._check_roi_stagnation()
+    assert eng.urgency_tier == 1
+    assert alerts and alerts[0][0][0] == "roi_negative_trend"
+
+
+def test_roi_recovery_resets():
+    alerts.clear()
+    eng = _make_engine()
+    for roi in [1.0, 0.9, 0.8, 0.8]:
+        eng.baseline_tracker.update(roi=roi)
+        eng._check_roi_stagnation()
+    assert eng.urgency_tier == 1
+    eng.baseline_tracker.update(roi=0.9)
+    eng._check_roi_stagnation()
+    assert eng.urgency_tier == 0


### PR DESCRIPTION
## Summary
- track ROI change per cycle in baseline tracker
- escalate urgency tier when ROI stagnates for 3 cycles and reset on recovery
- test ROI stagnation escalation and recovery

## Testing
- `pre-commit run --files self_improvement/baseline_tracker.py self_improvement/engine.py tests/test_roi_stagnation_escalation.py`
- `pytest tests/test_roi_stagnation_escalation.py tests/test_chain_roi_escalation.py`

------
https://chatgpt.com/codex/tasks/task_e_68b6c70a20a4832e8758f1e16b218215