### PR TITLE
test: cover chunk summary cache races

### DIFF
--- a/docs/chunked_prompting.md
+++ b/docs/chunked_prompting.md
@@ -26,3 +26,21 @@ rm -rf chunk_summary_cache
 
 The directory is recreated automatically on demand. Periodic cleanup prevents stale summaries from accumulating.
 
+### Cleaning utilities for CI and local runs
+
+Continuous integration jobs should start from a clean cache to avoid reusing
+stale summaries.  Removing the directory is sufficient:
+
+```bash
+rm -rf chunk_summary_cache
+```
+
+Developers can use the same command locally when forcing regeneration.  The
+retrieval cache maintained by the CLI can be cleared with:
+
+```bash
+menace cache clear
+```
+
+Both operations are safe and the caches are recreated on demand.
+

--- a/tests/test_chunk_summary_cache.py
+++ b/tests/test_chunk_summary_cache.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+import threading
 
 from chunk_summary_cache import ChunkSummaryCache
+import chunking as pc
 
 
 def test_roundtrip_and_invalidation(tmp_path: Path) -> None:
@@ -29,3 +31,63 @@ def test_roundtrip_and_invalidation(tmp_path: Path) -> None:
     file.write_text("print('changed')\n")
     assert cache.get(path_hash) is None
     assert not (cache_dir / f"{path_hash}.json").exists()
+
+
+def test_file_change_invalidates_cache_via_chunking(tmp_path: Path, monkeypatch) -> None:
+    """Changing a source file triggers cache invalidation on access."""
+
+    file = tmp_path / "sample.py"
+    file.write_text("def a():\n    return 1\n")
+
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr(pc, "CHUNK_CACHE", ChunkSummaryCache(cache_dir))
+
+    calls: list[str] = []
+
+    def fake_sum(code: str, llm=None) -> str:
+        calls.append(code)
+        return "sum"
+
+    monkeypatch.setattr(pc, "summarize_code", fake_sum)
+
+    first = pc.get_chunk_summaries(file, 20)
+    assert len(calls) == len(first)
+
+    # Modify file so cached entry becomes stale
+    file.write_text("def a():\n    return 2\n")
+    second = pc.get_chunk_summaries(file, 20)
+
+    # Cache was invalidated -> summaries recomputed
+    assert len(second) == len(first)
+    assert len(calls) == len(first) * 2
+
+
+def test_concurrent_requests_use_per_path_lock(tmp_path: Path, monkeypatch) -> None:
+    """Parallel summary requests for the same file only compute once."""
+
+    file = tmp_path / "sample.py"
+    file.write_text("def a():\n    return 1\n")
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr(pc, "CHUNK_CACHE", ChunkSummaryCache(cache_dir))
+
+    calls: list[str] = []
+
+    def fake_sum(code: str, llm=None) -> str:
+        calls.append(code)
+        return "sum"
+
+    monkeypatch.setattr(pc, "summarize_code", fake_sum)
+
+    def worker() -> None:
+        pc.get_chunk_summaries(file, 20)
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # summarizer invoked only once per chunk despite concurrent callers
+    assert len(calls) == len(pc.chunk_file(file, 20))


### PR DESCRIPTION
## Summary
- test ChunkSummaryCache invalidation when source files change
- ensure per-path locks serialize concurrent summarization requests
- document cache cleaning for CI and local runs

## Testing
- `pre-commit run --files docs/chunked_prompting.md tests/test_chunk_summary_cache.py`
- `pytest tests/test_chunk_summary_cache.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6c8ecc6f0832eb07045ab5c0d1e33