### PR TITLE
feat: incorporate code entropy into self-improvement cycle

### DIFF
--- a/self_improvement/baseline_tracker.py
+++ b/self_improvement/baseline_tracker.py
@@ -43,6 +43,12 @@ class BaselineTracker:
                     "roi_delta", deque(maxlen=self.window)
                 )
                 delta_hist.append(float(value) - prev)
+            elif name == "entropy":
+                avg = sum(hist) / len(hist) if hist else 0.0
+                delta_hist = self._history.setdefault(
+                    "entropy_delta", deque(maxlen=self.window)
+                )
+                delta_hist.append(float(value) - avg)
             hist.append(float(value))
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- compute per-cycle code entropy from complexity and maintainability metrics
- track entropy deltas in baseline tracker and ROIResultsDB for historical analysis
- weigh entropy delta alongside ROI delta in cycle triggers and meta-planning heuristics

## Testing
- `pytest tests/test_roi_results_db.py -q`
- `pytest self_improvement/tests/test_minimal_workflow.py tests/test_roi_results_db.py -q` *(fails: ImportError: cannot import name 'RAISE_ERRORS' from 'menace')*


------
https://chatgpt.com/codex/tasks/task_e_68b6c9b89bb4832e95cbd55ac76e9873