### PR TITLE
Integrate momentum into self‑improvement metrics

### DIFF
--- a/tests/test_baseline_tracker_momentum.py
+++ b/tests/test_baseline_tracker_momentum.py
@@ -1,0 +1,19 @@
+import importlib.util
+from pathlib import Path
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "baseline_tracker", Path(__file__).resolve().parents[1] / "self_improvement" / "baseline_tracker.py"
+)
+baseline_tracker = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(baseline_tracker)  # type: ignore[attr-defined]
+BaselineTracker = baseline_tracker.BaselineTracker
+
+def test_momentum_tracking():
+    bt = BaselineTracker(window=5)
+    for roi in [1.0, 1.1, 0.9, 1.0]:
+        bt.update(roi=roi)
+    assert bt.success_count == 3
+    assert bt.cycle_count == 4
+    assert bt.momentum == pytest.approx(3 / 5)


### PR DESCRIPTION
## Summary
- track per-cycle ROI successes and expose momentum via `BaselineTracker`
- weight energy scheduling and ROI thresholds by momentum with logging
- add coverage for momentum tracking and adjust engine tests

## Testing
- `pytest tests/test_baseline_tracker_momentum.py tests/test_roi_stagnation_escalation.py`
- `pytest tests/test_self_improvement_engine.py tests/test_self_improvement_engine_adaptive_roi.py` *(fails: module 'menace.self_improvement' missing attributes / connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ce7fa7dc832e8633e5f24118eba0