### PR TITLE
Use moving average baselines for metric thresholds

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -51,6 +51,7 @@ class ROISettings(BaseModel):
     entropy_ceiling_threshold: float | None = None
     entropy_ceiling_consecutive: int | None = None
     baseline_window: int = 5
+    deviation_tolerance: float = 0.0
 
     @field_validator(
         "threshold",
@@ -65,7 +66,7 @@ class ROISettings(BaseModel):
             raise ValueError(f"{info.field_name} must be between 0 and 1")
         return v
 
-    @field_validator("compounding_weight", "min_integration_roi")
+    @field_validator("compounding_weight", "min_integration_roi", "deviation_tolerance")
     def _check_non_negative(cls, v: float, info: Any) -> float:
         if v < 0:
             raise ValueError(f"{info.field_name} must be non-negative")
@@ -76,6 +77,7 @@ class ROISettings(BaseModel):
         if v is not None and v <= 0:
             raise ValueError(f"{info.field_name} must be a positive integer")
         return v
+
 
 class SynergySettings(BaseModel):
     """Settings for module synergy calculations."""
@@ -109,6 +111,7 @@ class SynergySettings(BaseModel):
     target_sync: int = 10
     python_fallback: bool = True
     python_max_replay: int = 1000
+    deviation_tolerance: float = 0.0
 
     @field_validator(
         "threshold",
@@ -151,6 +154,7 @@ class SynergySettings(BaseModel):
         "weight_throughput",
         "weights_lr",
         "noise",
+        "deviation_tolerance",
     )
     def _synergy_non_negative(cls, v: float, info: Any) -> float:
         if v < 0:

--- a/self_improvement/meta_planning.py
+++ b/self_improvement/meta_planning.py
@@ -384,7 +384,9 @@ class _FallbackPlanner:
                     )
                     stable = True
 
-            if delta_roi <= 0.0 or not stable:
+            roi_base = BASELINE_TRACKER.get("roi_delta")
+            roi_tol = getattr(getattr(_init.settings, "roi", None), "deviation_tolerance", 0.0)
+            if delta_roi < roi_base - roi_tol or not stable:
                 self.logger.debug(
                     "rejecting chain %s", "->".join(chain), extra=log_record(workflow_id=wid)
                 )


### PR DESCRIPTION
## Summary
- Add deviation tolerance settings for ROI and synergy metrics
- Compare ROI metrics against moving-average baselines with configured tolerance in engine and meta-planner
- Autoscale registry decisions using baseline deviations rather than hard thresholds

## Testing
- `pre-commit run --files sandbox_settings.py self_improvement/engine.py self_improvement/meta_planning.py self_improvement/registry.py`
- `pytest` *(fails: 411 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d8213328832eb0592bbf0f6eee41