### PR TITLE
Track ROI stagnation cycles

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -52,6 +52,7 @@ class ROISettings(BaseModel):
     entropy_ceiling_consecutive: int | None = None
     baseline_window: int = 5
     deviation_tolerance: float = 0.0
+    stagnation_cycles: int = 3
 
     @field_validator(
         "threshold",
@@ -76,6 +77,12 @@ class ROISettings(BaseModel):
     def _check_positive(cls, v: int | None, info: Any) -> int | None:
         if v is not None and v <= 0:
             raise ValueError(f"{info.field_name} must be a positive integer")
+        return v
+
+    @field_validator("stagnation_cycles")
+    def _check_stagnation(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("stagnation_cycles must be a positive integer")
         return v
 
 
@@ -315,6 +322,12 @@ class SandboxSettings(BaseSettings):
     def _roi_baseline_window_positive(cls, v: int) -> int:
         if v <= 0:
             raise ValueError("roi_baseline_window must be positive")
+        return v
+
+    @field_validator("roi_stagnation_cycles")
+    def _roi_stagnation_cycles_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("roi_stagnation_cycles must be positive")
         return v
 
     @field_validator(
@@ -1522,6 +1535,7 @@ class SandboxSettings(BaseSettings):
     roi_ema_alpha: float = Field(0.1, env="ROI_EMA_ALPHA")
     roi_compounding_weight: float = Field(1.0, env="ROI_COMPOUNDING_WEIGHT")
     roi_baseline_window: int = Field(5, env="ROI_BASELINE_WINDOW")
+    roi_stagnation_cycles: int = Field(3, env="ROI_STAGNATION_CYCLES")
     sandbox_score_db: str = Field("score_history.db", env="SANDBOX_SCORE_DB")
     synergy_weights_lr: float = Field(
         0.1,
@@ -1921,6 +1935,7 @@ class SandboxSettings(BaseSettings):
             ema_alpha=self.roi_ema_alpha,
             compounding_weight=self.roi_compounding_weight,
             baseline_window=self.roi_baseline_window,
+            stagnation_cycles=self.roi_stagnation_cycles,
             min_integration_roi=self.min_integration_roi,
             entropy_threshold=self.entropy_threshold,
             entropy_plateau_threshold=self.entropy_plateau_threshold,

--- a/tests/test_roi_stagnation_escalation.py
+++ b/tests/test_roi_stagnation_escalation.py
@@ -43,6 +43,8 @@ def _make_engine():
     eng.urgency_tier = 0
     eng.urgency_recovery_threshold = 0.05
     eng.logger = types.SimpleNamespace(warning=lambda *a, **k: None, exception=lambda *a, **k: None)
+    eng.stagnation_cycles = 3
+    eng._stagnation_streak = 0
     return eng
 
 
@@ -55,6 +57,7 @@ def test_roi_stagnation_escalates():
         assert eng.urgency_tier == 0
     eng.baseline_tracker.update(roi=0.8)
     eng._check_roi_stagnation()
+    assert eng._stagnation_streak == 3
     assert eng.urgency_tier == 1
     assert alerts and alerts[0][0][0] == "roi_negative_trend"
 
@@ -65,7 +68,9 @@ def test_roi_recovery_resets():
     for roi in [1.0, 0.9, 0.8, 0.8]:
         eng.baseline_tracker.update(roi=roi)
         eng._check_roi_stagnation()
+    assert eng._stagnation_streak == 3
     assert eng.urgency_tier == 1
     eng.baseline_tracker.update(roi=0.9)
     eng._check_roi_stagnation()
+    assert eng._stagnation_streak == 0
     assert eng.urgency_tier == 0


### PR DESCRIPTION
## Summary
- Track consecutive non-improving ROI cycles and escalate urgency tier on stagnation
- Make ROI stagnation threshold configurable via `roi_settings.stagnation_cycles`
- Test ROI stagnation escalation and recovery logic

## Testing
- `pre-commit run --files self_improvement/engine.py sandbox_settings.py tests/test_roi_stagnation_escalation.py`
- `pytest tests/test_roi_stagnation_escalation.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6da38d004832e94a8f3e69f20250c