### PR TITLE
Track ROI momentum to adjust urgency

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -53,6 +53,7 @@ class ROISettings(BaseModel):
     entropy_ceiling_threshold: float | None = None
     entropy_ceiling_consecutive: int | None = None
     baseline_window: int = 5
+    momentum_window: int = 5
     deviation_tolerance: float = 0.0
     stagnation_cycles: int = 3
 
@@ -96,6 +97,12 @@ class ROISettings(BaseModel):
     def _check_stagnation(cls, v: int) -> int:
         if v <= 0:
             raise ValueError("stagnation_cycles must be a positive integer")
+        return v
+
+    @field_validator("momentum_window")
+    def _check_momentum_window(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("momentum_window must be a positive integer")
         return v
 
 
@@ -335,6 +342,12 @@ class SandboxSettings(BaseSettings):
     def _roi_baseline_window_positive(cls, v: int) -> int:
         if v <= 0:
             raise ValueError("roi_baseline_window must be positive")
+        return v
+
+    @field_validator("roi_momentum_window")
+    def _roi_momentum_window_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("roi_momentum_window must be positive")
         return v
 
     @field_validator("roi_stagnation_cycles")
@@ -1550,6 +1563,7 @@ class SandboxSettings(BaseSettings):
     roi_ema_alpha: float = Field(0.1, env="ROI_EMA_ALPHA")
     roi_compounding_weight: float = Field(1.0, env="ROI_COMPOUNDING_WEIGHT")
     roi_baseline_window: int = Field(5, env="ROI_BASELINE_WINDOW")
+    roi_momentum_window: int = Field(5, env="ROI_MOMENTUM_WINDOW")
     roi_stagnation_cycles: int = Field(3, env="ROI_STAGNATION_CYCLES")
     sandbox_score_db: str = Field("score_history.db", env="SANDBOX_SCORE_DB")
     synergy_weights_lr: float = Field(
@@ -1952,6 +1966,7 @@ class SandboxSettings(BaseSettings):
             entropy_window=self.entropy_window,
             entropy_weight=self.entropy_weight,
             baseline_window=self.roi_baseline_window,
+            momentum_window=self.roi_momentum_window,
             stagnation_cycles=self.roi_stagnation_cycles,
             min_integration_roi=self.min_integration_roi,
             entropy_threshold=self.entropy_threshold,

--- a/tests/test_momentum_urgency.py
+++ b/tests/test_momentum_urgency.py
@@ -1,0 +1,37 @@
+import ast
+import types
+from pathlib import Path
+from typing import Any, Dict
+
+ENG_PATH = Path(__file__).resolve().parents[1] / "self_improvement" / "engine.py"
+src = ENG_PATH.read_text()
+tree = ast.parse(src)
+future = ast.ImportFrom(module="__future__", names=[ast.alias("annotations", None)], level=0)
+sie_cls = next(
+    n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "SelfImprovementEngine"
+)
+methods = [
+    n
+    for n in sie_cls.body
+    if isinstance(n, ast.FunctionDef) and n.name in ("_check_momentum", "momentum_coefficient")
+]
+engine_module = ast.Module([future, ast.ClassDef("SelfImprovementEngine", [], [], methods, [])], type_ignores=[])
+engine_module = ast.fix_missing_locations(engine_module)
+ns: Dict[str, Any] = {"log_record": lambda **k: k}
+exec(compile(engine_module, "<engine>", "exec"), ns)
+SelfImprovementEngine = ns["SelfImprovementEngine"]
+
+
+def _make_engine():
+    eng = SelfImprovementEngine.__new__(SelfImprovementEngine)
+    eng.success_history = [False, False, True, False]
+    eng.momentum_window = 4
+    eng.urgency_tier = 0
+    eng.logger = types.SimpleNamespace(warning=lambda *a, **k: None)
+    return eng
+
+
+def test_low_momentum_escalates():
+    eng = _make_engine()
+    eng._check_momentum()
+    assert eng.urgency_tier == 1


### PR DESCRIPTION
## Summary
- add `momentum_window` to ROI settings with environment support
- track cycle success history and compute momentum for scheduling
- escalate urgency and adjust policy based on low momentum

## Testing
- `pytest tests/test_baseline_tracker_momentum.py tests/test_self_improvement_policy.py tests/test_momentum_urgency.py`

------
https://chatgpt.com/codex/tasks/task_e_68b6dfa2b3d4832e9058fad8788bf18a