### PR TITLE
Expose last prompt text and log failure fingerprints

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -348,7 +348,14 @@ class SelfCodingEngine:
         self._last_retry_trace: str | None = None
         self._failure_cache = FailureCache()
 
+    @property
+    def last_prompt_text(self) -> str:
+        """Return the text of the last prompt."""
+        prompt = self._last_prompt
+        return prompt.text if prompt else ""
+
     # ------------------------------------------------------------------
+
     def scan_repo(self) -> list["EnhancementSuggestion"]:
         """Run the enhancement classifier and queue suggestions."""
         classifier = getattr(self, "enhancement_classifier", None)
@@ -667,7 +674,7 @@ class SelfCodingEngine:
                 entry = summary_entries[chunk_index]
                 start = int(entry.get("start_line", 1))
                 end = int(entry.get("end_line", start))
-                selected = "\n".join(lines[start - 1 : end])
+                selected = "\n".join(lines[start - 1:end])
                 context = f"# Chunk {chunk_index} lines {start}-{end}\n{selected}"
                 summaries = [
                     f"Chunk {i}: {e.get('summary', '')}"
@@ -2160,7 +2167,8 @@ class SelfCodingEngine:
                     try:
                         conn = self.patch_db.router.get_connection("patch_history")
                         conn.execute(
-                            "INSERT INTO patch_history(filename, description, outcome) VALUES(?,?,?)",
+                            "INSERT INTO patch_history(filename, description, outcome) "
+                            "VALUES(?,?,?)",
                             (str(path), description, "retry_skipped"),
                         )
                         conn.commit()
@@ -2170,7 +2178,8 @@ class SelfCodingEngine:
             if matches:
                 prior = matches[0]
                 warning = (
-                    f"Previous similar failure '{prior.error_message}' in {prior.filename}:{prior.function_name}"
+                    f"Previous similar failure '{prior.error_message}' "
+                    f"in {prior.filename}:{prior.function_name}"
                 )
                 description = description + f"\n\nWARNING: {warning}"
                 try:
@@ -2181,7 +2190,8 @@ class SelfCodingEngine:
                     try:
                         conn = self.patch_db.router.get_connection("patch_history")
                         conn.execute(
-                            "INSERT INTO patch_history(filename, description, outcome) VALUES(?,?,?)",
+                            "INSERT INTO patch_history(filename, description, outcome) "
+                            "VALUES(?,?,?)",
                             (str(path), description, "retry_adjusted"),
                         )
                         conn.commit()


### PR DESCRIPTION
## Summary
- expose `SelfCodingEngine.last_prompt_text` for accessing last prompt sent to LLM
- record failure fingerprints using last prompt and stack traces before context rebuild in `SelfCodingManager.run_patch`

## Testing
- `pre-commit run --files self_coding_engine.py self_coding_manager.py`
- `pytest -q` *(fails: 411 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e4179694832e91daf3024db5d749