### PR TITLE
test: cover moving baselines and urgency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1391,6 +1391,13 @@ raises a `RuntimeError` with installation guidance when they are missing.
 - `AUTO_TRAIN_INTERVAL`, `SYNERGY_TRAIN_INTERVAL`, `ADAPTIVE_ROI_RETRAIN_INTERVAL`
   – control retraining frequency
 - `ENABLE_META_PLANNER` – require meta-planning support when set to ``true``
+- `BASELINE_WINDOW` – number of recent scores used for the moving average baseline
+- `STAGNATION_ITERS` – cycles with no improvement before the baseline resets
+- `DELTA_MARGIN` – minimum positive delta over baseline needed to accept a patch
+
+Self-improvement compares ROI gains against this moving baseline and escalates
+an internal urgency tier when momentum stalls, encouraging more aggressive
+mutations.
 
 #### Example workflow
 

--- a/docs/sandbox_self_improvement.md
+++ b/docs/sandbox_self_improvement.md
@@ -27,6 +27,9 @@ to run self-improvement cycles inside the sandbox.
 - `AUTO_TRAIN_INTERVAL`, `SYNERGY_TRAIN_INTERVAL`,
   `ADAPTIVE_ROI_RETRAIN_INTERVAL` – control retraining frequency.
 - `ENABLE_META_PLANNER` – require meta-planning support when set to `true`.
+- `BASELINE_WINDOW` – number of recent scores used for the moving average baseline.
+- `STAGNATION_ITERS` – cycles with no improvement before the baseline resets.
+- `DELTA_MARGIN` – minimum positive delta over baseline needed to accept a patch.
 
 ## Example workflows
 
@@ -46,6 +49,13 @@ engine = SelfImprovementEngine(bot_name="alpha",
                                pipeline=ModelAutomationPipeline())
 engine.run_cycle()
 ```
+
+## Adaptive strategy
+
+Recent cycle scores are compared against a moving baseline. The window size is
+configurable via `BASELINE_WINDOW`. When ROI deltas fail to beat this baseline
+for `STAGNATION_ITERS` iterations or fall short by more than `DELTA_MARGIN`,
+the engine escalates its urgency tier to explore more aggressive mutations.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- extend self-improvement cycle tests with moving baseline checks and urgency tiers
- document baseline window, stagnation, and delta margin settings
- explain adaptive strategy and urgency escalation in README and docs

## Testing
- `pre-commit run --files tests/self_improvement/test_cycle.py tests/integration/test_self_improvement_cycle.py docs/sandbox_self_improvement.md README.md`
- `pytest tests/self_improvement/test_cycle.py tests/integration/test_self_improvement_cycle.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6e39455b8832ebd4ee9e5acfb8be5