### PR TITLE
feat: cluster failure fingerprints

### DIFF
--- a/failure_fingerprint.py
+++ b/failure_fingerprint.py
@@ -25,6 +25,7 @@ class FailureFingerprint:
     error_message: str
     stack_trace: str
     prompt_text: str
+    cluster_id: int | None = None
     hash: str = field(init=False)
     embedding: List[float] = field(default_factory=list)
     embedding_metadata: Dict[str, Any] = field(default_factory=dict)


### PR DESCRIPTION
## Summary
- add optional cluster_id to FailureFingerprint
- cluster fingerprints by cosine similarity and expose helpers to retrieve cluster contents
- test cluster assignment in FailureFingerprintStore

## Testing
- `pre-commit run --files failure_fingerprint.py failure_fingerprint_store.py tests/test_failure_fingerprint_store.py tests/test_failure_fingerprinting.py`
- `pytest tests/test_failure_fingerprint_store.py tests/test_failure_fingerprinting.py` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f73ee264832eb9f02a8a345f3fd5