### PR TITLE
Use moving-average momentum for urgency escalation

### DIFF
--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -2007,23 +2007,23 @@ class SelfImprovementEngine:
 
     # ------------------------------------------------------------------
     def _check_momentum(self) -> None:
-        """Escalate urgency when momentum stays below baseline."""
+        """Escalate urgency when momentum trails the moving average."""
 
-        current_momentum = self.momentum_coefficient
-        base = self.baseline_tracker.get("momentum")
-        std = self.baseline_tracker.std("momentum")
-        threshold = base - self.momentum_dev_multiplier * std
+        current_momentum = self.baseline_tracker.momentum
+        moving_avg = self.baseline_tracker.get("momentum")
+        deviation = self.momentum_dev_multiplier * self.baseline_tracker.std("momentum")
+        threshold = moving_avg - deviation
         if current_momentum < threshold:
             self._momentum_streak += 1
             if self._momentum_streak >= self.stagnation_cycles:
                 self.urgency_tier += 1
                 self.logger.warning(
-                    "momentum below baseline; increasing urgency tier",
+                    "momentum below moving average; increasing urgency tier",
                     extra=log_record(
                         tier=self.urgency_tier,
                         momentum=current_momentum,
-                        base=base,
-                        std=std,
+                        moving_avg=moving_avg,
+                        deviation=deviation,
                         streak=self._momentum_streak,
                     ),
                 )

--- a/tests/test_momentum_urgency.py
+++ b/tests/test_momentum_urgency.py
@@ -27,12 +27,10 @@ SelfImprovementEngine = ns["SelfImprovementEngine"]
 
 def _make_engine():
     eng = SelfImprovementEngine.__new__(SelfImprovementEngine)
-    eng.success_history = [False, False, True, False]
-    eng.momentum_window = 4
     eng.urgency_tier = 0
     eng.logger = types.SimpleNamespace(warning=lambda *a, **k: None)
     eng.baseline_tracker = types.SimpleNamespace(
-        get=lambda m: 0.75, std=lambda m: 0.05
+        get=lambda m: 0.75, std=lambda m: 0.05, momentum=0.25
     )
     eng.momentum_dev_multiplier = 1.0
     eng.stagnation_cycles = 2


### PR DESCRIPTION
## Summary
- derive current momentum from BaselineTracker and compare to moving average
- trigger urgency only when momentum falls below moving average by configured deviation
- update momentum urgency test for new baseline tracking

## Testing
- `pre-commit run --files self_improvement/engine.py tests/test_momentum_urgency.py`
- `pytest tests/test_momentum_urgency.py`


------
https://chatgpt.com/codex/tasks/task_e_68b779c450d0832e8dcf249be38243a9