### PR TITLE
feat: track module relevancy baselines

### DIFF
--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -5604,7 +5604,7 @@ class SelfImprovementEngine:
             auto_process = True
             metrics_db_path = "sandbox_data/relevancy_metrics.db"
 
-        for counts in getattr(self.relevancy_radar, "_metrics", {}).values():
+        for mod, counts in getattr(self.relevancy_radar, "_metrics", {}).items():
             impact_val = float(counts.get("impact", 0.0)) + float(
                 counts.get("output_impact", 0.0)
             )
@@ -5613,7 +5613,8 @@ class SelfImprovementEngine:
                 + float(counts.get("executions", 0.0))
                 + impact_val
             )
-            self.baseline_tracker.update(relevancy=score)
+            metric_name = f"relevancy:{mod}"
+            self.baseline_tracker.update(relevancy=score, **{metric_name: score})
 
         avg = self.baseline_tracker.get("relevancy")
         std = self.baseline_tracker.std("relevancy")


### PR DESCRIPTION
## Summary
- track per-module relevancy scores in BaselineTracker
- derive relevancy flags from moving baseline averages and deviations
- document dynamic thresholding in relevancy evaluation

## Testing
- `pytest tests/test_relevancy_thresholds.py -q`
- `pytest tests/test_relevancy_retirement_flow.py -q` *(fails: ImportError: cannot import name 'load_sandbox_settings' from 'sandbox_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68b77b2d9fc0832e8ac4961fa1321fdc