### PR TITLE
feat: adapt fingerprint similarity threshold

### DIFF
--- a/self_coding_manager.py
+++ b/self_coding_manager.py
@@ -307,9 +307,14 @@ class SelfCodingManager:
                             sim = 0.0
                         if sim > best:
                             best = sim
-                    threshold = getattr(
-                        self.engine, "failure_similarity_threshold", self.skip_similarity or 0.95
-                    )
+                    threshold = getattr(self.engine, "failure_similarity_threshold", None)
+                    if threshold is None and self.failure_store is not None:
+                        try:
+                            threshold = self.failure_store.adaptive_threshold()
+                        except Exception:
+                            threshold = None
+                    if threshold is None:
+                        threshold = self.skip_similarity or 0.95
                     if self.skip_similarity is not None:
                         threshold = max(threshold, self.skip_similarity)
                     if best >= threshold:


### PR DESCRIPTION
## Summary
- track historical fingerprint similarities and derive an adaptive similarity threshold
- use adaptive threshold instead of fixed 0.95 when checking for repeated failures

## Testing
- `pytest tests/test_failure_fingerprint_store.py -q`
- `pytest tests/test_failure_fingerprinting.py::test_run_patch_skips_on_high_similarity tests/test_failure_fingerprinting.py::test_run_patch_warns_on_low_similarity tests/test_failure_fingerprinting.py::test_provisional_fingerprint_skips tests/test_failure_fingerprinting.py::test_provisional_fingerprint_warns -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68b7803174c0832ea446cc5bc20643f6