### PR TITLE
Deduplicate failure fingerprints and track counts

### DIFF
--- a/failure_fingerprint.py
+++ b/failure_fingerprint.py
@@ -62,6 +62,7 @@ class FailureFingerprint:
     embedding: List[float] = field(default_factory=list)
     embedding_metadata: Dict[str, Any] = field(default_factory=dict)
     timestamp: float = field(default_factory=lambda: time())
+    count: int = 1
 
     # ``function`` is used by ``FailureFingerprintStore``; keep ``function_name`` for
     # backwards compatibility with existing callers.

--- a/failure_fingerprint_store.py
+++ b/failure_fingerprint_store.py
@@ -138,6 +138,32 @@ class FailureFingerprintStore:
         fingerprint.cluster_id = best_id
         return best_id
 
+    def _persist_update(self, record_id: str, fingerprint: FailureFingerprint) -> None:
+        """Rewrite the JSONL entry for ``record_id`` with updated data."""
+
+        tmp_path = self.path.with_suffix(".tmp")
+        data = asdict(fingerprint)
+        data["id"] = record_id
+        new_line = json.dumps(data) + "\n"
+        try:
+            with self.path.open("r", encoding="utf-8") as src, tmp_path.open(
+                "w", encoding="utf-8"
+            ) as dst:
+                for line in src:
+                    try:
+                        obj = json.loads(line)
+                    except json.JSONDecodeError:
+                        dst.write(line)
+                        continue
+                    if obj.get("id") == record_id:
+                        dst.write(new_line)
+                    else:
+                        dst.write(line)
+        except FileNotFoundError:  # pragma: no cover - best effort
+            with tmp_path.open("w", encoding="utf-8") as dst:
+                dst.write(new_line)
+        tmp_path.replace(self.path)
+
     # ----------------------------------------------------------------- public
     def cluster_fingerprints(self) -> None:
         """Cluster all fingerprints currently in the store."""
@@ -155,6 +181,28 @@ class FailureFingerprintStore:
 
         self._ensure_embedding(fingerprint)
         record_id = self._id_for(fingerprint)
+        existing = self._cache.get(record_id)
+        if existing is not None:
+            existing.count += 1
+            existing.timestamp = fingerprint.timestamp
+            existing.embedding_metadata = fingerprint.embedding_metadata
+            self._persist_update(record_id, existing)
+            try:
+                self.vector_service.vector_store.add(
+                    "failure_fingerprint",
+                    record_id,
+                    existing.embedding,
+                    metadata={
+                        "filename": existing.filename,
+                        "function": existing.function,
+                        "embedding_meta": existing.embedding_metadata,
+                        "count": existing.count,
+                    },
+                )
+            except Exception:  # pragma: no cover - best effort
+                pass
+            return
+
         self._assign_cluster(record_id, fingerprint)
         data = asdict(fingerprint)
         data["id"] = record_id
@@ -168,6 +216,7 @@ class FailureFingerprintStore:
                 "filename": fingerprint.filename,
                 "function": fingerprint.function,
                 "embedding_meta": fingerprint.embedding_metadata,
+                "count": fingerprint.count,
             },
         )
         self._cache[record_id] = fingerprint

--- a/prompt_optimizer.py
+++ b/prompt_optimizer.py
@@ -404,7 +404,8 @@ class PromptOptimizer:
                         feats["has_bullets"],
                         has_system,
                     )
-                    counts[key] += 1
+                    count_val = int(data.get("count", 1))
+                    counts[key] += count_val
             for key, count in counts.items():
                 stat = self.stats.get(key)
                 if not stat:
@@ -475,8 +476,9 @@ class PromptOptimizer:
                         has_system=has_system,
                     )
                     self.stats[key] = stat
-                stat.total += 1
-                counts[key] += 1
+                occurrences = getattr(fp, "count", 1)
+                stat.total += occurrences
+                counts[key] += occurrences
         for key, count in counts.items():
             stat = self.stats.get(key)
             if not stat:


### PR DESCRIPTION
## Summary
- Avoid storing duplicate failure fingerprints by tracking a `count` for each record
- Update vector store metadata in place and rewrite JSONL entries on repeat failures
- Adjust prompt optimizer to respect fingerprint counts when applying penalties

## Testing
- `pytest tests/test_failure_fingerprint_store.py::test_duplicate_increments_count -q`
- `pytest tests/test_prompt_optimizer_penalty.py -q`
- `pytest tests/test_failure_fingerprint_store.py tests/test_prompt_optimizer_penalty.py tests/test_failure_fingerprinting.py tests/test_failure_fingerprint_manager.py -q` *(fails: ImportError and AttributeError during broader test run)*

------
https://chatgpt.com/codex/tasks/task_e_68b7807da13c832eb827c6255e14b63a