### PR TITLE
Scale prompt penalties by failure clusters

### DIFF
--- a/docs/prompt_optimizer.md
+++ b/docs/prompt_optimizer.md
@@ -8,8 +8,9 @@ runtime improvements to suggest high-performing configurations.
 
 Pass a path to `failure_fingerprints.jsonl` via the
 `failure_fingerprints_path` argument when constructing `PromptOptimizer`.
-Fingerprints are grouped by their prompt text and counted. If the number of
-fingerprints associated with a prompt configuration exceeds the
-`fingerprint_threshold`, the optimiser reduces that configuration's recorded
-successes accordingly. This allows repeated failures to bias the success rate
-without needing corresponding log entries.
+Fingerprints are grouped into similarity clusters. For each cluster whose size
+exceeds `fingerprint_threshold`, the optimiser deducts the cluster size from the
+configuration's successes and scales its score by `1 / (1 + size -
+fingerprint_threshold)`. Larger clusters therefore impose heavier penalties,
+allowing repeated failures to bias the success rate without needing
+corresponding log entries.

--- a/failure_fingerprint_store.py
+++ b/failure_fingerprint_store.py
@@ -180,6 +180,31 @@ class FailureFingerprintStore:
             self._ensure_embedding(fp)
             self._assign_cluster(record_id, fp)
 
+    def cluster_stats(self) -> Dict[int, Dict[str, Any]]:
+        """Return basic statistics about all known clusters.
+
+        The returned mapping contains one entry per cluster ID with the total
+        number of fingerprints assigned to that cluster (respecting the
+        ``count`` field of each fingerprint) and a representative example
+        fingerprint.
+        """
+
+        stats: Dict[int, Dict[str, Any]] = {}
+        for cid, ids in self._clusters.items():
+            example = None
+            size = 0
+            for rid in ids:
+                fp = self._cache.get(rid)
+                if fp is None:
+                    continue
+                if example is None:
+                    example = fp
+                size += fp.count
+            if example is None:
+                continue
+            stats[cid] = {"size": size, "example": example}
+        return stats
+
     def similarity_stats(self, window: int = 50) -> tuple[float, float]:
         """Return moving average and deviation of recent similarities."""
 


### PR DESCRIPTION
## Summary
- expose `cluster_stats()` from `FailureFingerprintStore` to report cluster sizes and an example fingerprint
- weight `PromptOptimizer` scores by fingerprint clusters, penalizing configurations appearing in large failure groups
- document cluster-based penalty scaling

## Testing
- `pre-commit run --files failure_fingerprint_store.py prompt_optimizer.py docs/prompt_optimizer.md`
- `pytest tests/test_prompt_optimizer_penalty.py::test_failure_fingerprints_penalize tests/test_prompt_optimizer_penalty.py::test_failure_fingerprints_reduce_score -q`
- `pytest tests/test_prompt_optimizer_penalty.py::test_failure_fingerprints_penalize tests/test_prompt_optimizer_penalty.py::test_failure_fingerprints_reduce_score tests/test_failure_fingerprint_scenarios.py::test_prompt_optimizer_penalizes_from_fingerprint_log -q` *(fails: ImportError: cannot import name 'TRACKER' from '<unknown module name>')*

------
https://chatgpt.com/codex/tasks/task_e_68b788b97634832e85ad908a8b0660d7