### PR TITLE
Add weighting parameters to self-improvement scoring

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -1490,6 +1490,8 @@ class SandboxSettings(BaseSettings):
     )
     entropy_window: int = Field(5, env="ENTROPY_WINDOW")
     entropy_weight: float = Field(0.1, env="ENTROPY_WEIGHT")
+    roi_weight: float = Field(1.0, env="ROI_WEIGHT")
+    momentum_weight: float = Field(1.0, env="MOMENTUM_WEIGHT")
     min_integration_roi: float = Field(
         0.0,
         env="MIN_INTEGRATION_ROI",
@@ -1509,6 +1511,12 @@ class SandboxSettings(BaseSettings):
         env="SYNERGY_VARIANCE_CONFIDENCE",
         description="confidence for variance tests; defaults to 0.95",
     )
+
+    @field_validator("roi_weight", "entropy_weight", "momentum_weight")
+    def _validate_delta_weights(cls, v: float, info: Any) -> float:
+        if v < 0:
+            raise ValueError(f"{info.field_name} must be non-negative")
+        return v
 
     relevancy_threshold: int = Field(
         20,


### PR DESCRIPTION
## Summary
- allow SandboxSettings to configure ROI, entropy, and momentum weights
- combine metric deltas using configurable weights in self-improvement engine
- exercise weighted scoring in tests

## Testing
- `pytest tests/test_self_improvement_engine.py::test_compute_delta_score_weights -q`


------
https://chatgpt.com/codex/tasks/task_e_68b788bc778c832e947273e7b37b30d7