### PR TITLE
feat: track side-effect metrics with dynamic thresholds

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -1298,7 +1298,7 @@ class SandboxSettings(BaseSettings):
             raise ValueError(f"{info.field_name} must be a positive integer")
         return v
 
-    @field_validator("weight_update_interval", "test_run_timeout")
+    @field_validator("weight_update_interval", "test_run_timeout", "side_effect_dev_multiplier")
     def _validate_positive_float(cls, v: float, info: Any) -> float:
         if v <= 0:
             raise ValueError(f"{info.field_name} must be positive")
@@ -1310,6 +1310,9 @@ class SandboxSettings(BaseSettings):
         description="Integrate modules classified as redundant after validation.",
     )
     side_effect_threshold: int = Field(10, env="SANDBOX_SIDE_EFFECT_THRESHOLD")
+    side_effect_dev_multiplier: float = Field(
+        1.0, env="SANDBOX_SIDE_EFFECT_DEV_MULTIPLIER"
+    )
     auto_patch_high_risk: bool = Field(
         True,
         env="AUTO_PATCH_HIGH_RISK",


### PR DESCRIPTION
## Summary
- track side-effect metrics with BaselineTracker and compute deviation-based thresholds
- allow tuning via new `side_effect_dev_multiplier` setting
- gate module integration using dynamic side-effect limits across engine and environment

## Testing
- `pytest tests/test_self_improvement_error_handling.py tests/test_self_improvement_run_cycle.py tests/test_recursive_orphans.py tests/integration/test_orphan_pipeline_metrics.py` *(fails: FileNotFoundError for self_improvement.py; AttributeError: sandbox_central_logging)*

------
https://chatgpt.com/codex/tasks/task_e_68b78b50f774832eb82ae48292b07748