### PR TITLE
Log skipped retries due to high failure fingerprint similarity

### DIFF
--- a/logs/audit_log.jsonl
+++ b/logs/audit_log.jsonl
@@ -2,3 +2,6 @@
 {"timestamp": "2025-07-17T05:08:43.956236", "event_type": "visual_agent_run_result", "event_id": "visual_agent_run_result-20250717050843956236-fnw1vj", "data": {"run_id": "visual_agent_run-20250717050613360951-zq6gkj", "outcome": "reverted"}}
 {"timestamp": "2025-07-17T06:47:16.837146", "event_type": "visual_agent_run", "event_id": "visual_agent_run-20250717064716837146-27xitw", "data": {"url": "http://127.0.0.1:8001", "prompt": "Improve Menace by enhancing error handling and modifying existing bots.\n\nWrite a Python function named auto_auto_debug that auto_debug. Use these snippets as reference:\n\n", "status": "started"}}
 {"timestamp": "2025-09-02T02:48:48.563763", "event_type": "prompt_style_reverted", "event_id": "prompt_style_reverted-20250902024848563695-1eob13", "data": {"reason": "missing_data"}}
+{"timestamp": "2025-09-03T00:31:28.471150", "event_type": "prompt_style_reverted", "event_id": "prompt_style_reverted-20250903003128471110-y28oj6", "data": {"reason": "missing_data"}}
+{"timestamp": "2025-09-03T00:31:28.671689", "event_type": "prompt_style_reverted", "event_id": "prompt_style_reverted-20250903003128671625-succ13", "data": {"reason": "missing_data"}}
+{"timestamp": "2025-09-03T00:31:28.695966", "event_type": "prompt_style_reverted", "event_id": "prompt_style_reverted-20250903003128695929-oz27zo", "data": {"reason": "missing_data"}}

--- a/tests/test_self_coding_engine_chunking.py
+++ b/tests/test_self_coding_engine_chunking.py
@@ -149,7 +149,7 @@ class _DummyBaselineTracker:
 
 _setmod(
     "self_improvement.baseline_tracker",
-    types.SimpleNamespace(BaselineTracker=_DummyBaselineTracker),
+    types.SimpleNamespace(BaselineTracker=_DummyBaselineTracker, TRACKER={}),
 )
 
 _setmod(


### PR DESCRIPTION
## Summary
- record fingerprint hash, similarity, cluster id and reason when retry skipped for similarity in self-coding engine
- audit and patch history capture skipped retry details in self-coding manager
- add tests ensuring skipped retries store fingerprint metadata

## Testing
- `pytest tests/test_failure_fingerprint_retry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b78aaeb368832e89d23b77d8b11355