### PR TITLE
Incorporate ROI and pass-rate deltas into schedule loop

### DIFF
--- a/self_improvement/baseline_tracker.py
+++ b/self_improvement/baseline_tracker.py
@@ -55,6 +55,12 @@ class BaselineTracker:
                 delta = float(value) - prev
                 delta_hist.append(delta)
                 self._success_history.append(delta > 0)
+            elif name == "pass_rate":
+                prev = hist[-1] if hist else 0.0
+                delta_hist = self._history.setdefault(
+                    "pass_rate_delta", deque(maxlen=self.window)
+                )
+                delta_hist.append(float(value) - prev)
             elif name == "entropy":
                 avg = sum(hist) / len(hist) if hist else 0.0
                 delta_hist = self._history.setdefault(


### PR DESCRIPTION
## Summary
- track pass-rate delta in `BaselineTracker`
- use ROI and pass-rate deltas to decide whether to run a cycle, escalate urgency, or skip in scheduling loop

## Testing
- `pytest tests/test_self_improvement_engine_adaptive_roi.py tests/test_roi_stagnation_escalation.py tests/test_momentum_urgency.py tests/test_chain_roi_escalation.py tests/test_self_improvement_run_cycle.py tests/test_self_improvement_policy.py` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68b78ddf6710832eb8d1085098b4a477