### PR TITLE
Integrate pass rate into baseline tracker and scoring

### DIFF
--- a/self_improvement/baseline_tracker.py
+++ b/self_improvement/baseline_tracker.py
@@ -41,8 +41,9 @@ class BaselineTracker:
 
         Notes
         -----
-        Updating the ``roi`` metric also records the delta from the previous
-        value under ``roi_delta`` to provide a history of per-cycle ROI changes.
+        Updating the ``roi`` or ``pass_rate`` metrics also records the delta
+        from the previous value under ``roi_delta`` or ``pass_rate_delta`` to
+        provide a history of per-cycle changes.
         """
 
         for name, value in metrics.items():
@@ -60,7 +61,8 @@ class BaselineTracker:
                 delta_hist = self._history.setdefault(
                     "pass_rate_delta", deque(maxlen=self.window)
                 )
-                delta_hist.append(float(value) - prev)
+                delta = float(value) - prev
+                delta_hist.append(delta)
             elif name == "entropy":
                 avg = sum(hist) / len(hist) if hist else 0.0
                 delta_hist = self._history.setdefault(

--- a/tests/test_self_improvement_engine.py
+++ b/tests/test_self_improvement_engine.py
@@ -1555,18 +1555,25 @@ def test_compute_delta_score_weights():
     eng.roi_delta_ema = 1.0
     eng.entropy_delta_ema = 0.5
     eng.entropy_dev_multiplier = 0.0
-    eng.baseline_tracker = types.SimpleNamespace(std=lambda metric: 0.0)
+    eng.pass_rate_dev_multiplier = 0.0
+    eng.baseline_tracker = types.SimpleNamespace(
+        std=lambda metric: 0.0,
+        get=lambda name: 0.3 if name == "pass_rate_delta" else 0.0,
+    )
     eng._metric_delta = lambda metric: 0.2
     eng.roi_weight = 2.0
     eng.momentum_weight = 3.0
     eng.entropy_weight = 4.0
+    eng.pass_rate_weight = 5.0
     score, components = sie.SelfImprovementEngine._compute_delta_score(eng)
-    assert score == pytest.approx(2.0 * 1.0 + 3.0 * 0.2 - 4.0 * 0.5)
+    assert score == pytest.approx(2.0 * 1.0 + 5.0 * 0.3 + 3.0 * 0.2 - 4.0 * 0.5)
     assert components == {
         "roi_delta": 1.0,
+        "pass_rate_delta": 0.3,
         "entropy_delta": 0.5,
         "momentum_delta": 0.2,
         "roi_component": 2.0,
+        "pass_rate_component": 1.5,
         "momentum_component": 0.6,
         "entropy_component": -2.0,
     }


### PR DESCRIPTION
## Summary
- record pass-rate deltas in BaselineTracker
- include pass-rate metrics in SelfImprovementEngine scoring and scheduling
- test delta score weighting with pass-rate component

## Testing
- `pytest tests/test_baseline_tracker_momentum.py -q`
- `pytest tests/test_self_improvement_engine.py::test_compute_delta_score_weights -q` *(skipped: SelfImprovementEngine unavailable)*
- `pytest tests/test_self_improvement_engine_adaptive_roi.py::test_growth_class_alters_action_selection -q` *(fail: FileNotFoundError: [Errno 2] No such file or directory: '/workspace/menace_sandbox/tests/../self_improvement.py')*

------
https://chatgpt.com/codex/tasks/task_e_68b78ef828e4832ea9b11ae6f7c05713