### PR TITLE
refactor: resolve sandbox_runner path dynamically

### DIFF
--- a/run_autonomous.py
+++ b/run_autonomous.py
@@ -32,6 +32,7 @@ import math
 import uuid
 from scipy.stats import t
 from db_router import init_db_router
+from dynamic_path_router import resolve_path
 from sandbox_settings import SandboxSettings
 from sandbox_runner.bootstrap import (
     bootstrap_environment,
@@ -210,7 +211,7 @@ if not hasattr(sandbox_runner, "_sandbox_main"):
     import importlib.util
 
     spec = importlib.util.spec_from_file_location(
-        "sandbox_runner", _pkg_dir / "sandbox_runner.py"
+        "sandbox_runner", resolve_path("sandbox_runner.py")
     )
     sr_mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(sr_mod)

--- a/scripts/start_sandbox.sh
+++ b/scripts/start_sandbox.sh
@@ -3,5 +3,5 @@
 "$(dirname "$0")/../setup_env.sh"
 
 # Launch sandbox runner with metrics dashboard
-python sandbox_runner.py full-autonomous-run --preset-count 3 --dashboard-port 8002 "$@"
+python $(python -c 'from dynamic_path_router import resolve_path; print(resolve_path("sandbox_runner.py"))') full-autonomous-run --preset-count 3 --dashboard-port 8002 "$@"
 


### PR DESCRIPTION
## Summary
- resolve sandbox_runner.py through dynamic_path_router in run_autonomous
- replace hard-coded sandbox_runner.py strings in environment subprocess calls
- compute sandbox_runner.py path at runtime in start_sandbox.sh

## Testing
- `pre-commit run --files run_autonomous.py sandbox_runner/environment.py scripts/start_sandbox.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b790ef7804832eb09bf1bd17e24e9a