### PR TITLE
Refactor workflow sandbox runner path resolution

### DIFF
--- a/dynamic_path_router.py
+++ b/dynamic_path_router.py
@@ -143,6 +143,33 @@ def resolve_path(name: str | Path) -> Path:
     raise FileNotFoundError(f"Unable to resolve path: {name}")
 
 
+def resolve_dir(name: str | Path) -> Path:
+    """Resolve *name* to a directory within the repository.
+
+    Parameters
+    ----------
+    name:
+        Directory to locate. Accepts the same forms as :func:`resolve_path`.
+
+    Returns
+    -------
+    pathlib.Path
+        Normalised absolute path to the located directory.
+
+    Raises
+    ------
+    NotADirectoryError
+        If the resolved path is not a directory.
+    FileNotFoundError
+        If the target cannot be located.
+    """
+
+    path = resolve_path(name)
+    if not path.is_dir():
+        raise NotADirectoryError(f"Expected directory: {name}")
+    return path
+
+
 def clear_cache() -> None:
     """Clear internal caches used by this module."""
 

--- a/tests/integration/test_full_self_improvement_cycle.py
+++ b/tests/integration/test_full_self_improvement_cycle.py
@@ -3,17 +3,18 @@ import asyncio
 import importlib.util
 import sys
 import types
-from pathlib import Path
 from typing import Any, Callable, Mapping
 
 import pytest
 
+from dynamic_path_router import resolve_dir, resolve_path, repo_root
 
-ROOT = Path(__file__).resolve().parent.parent.parent
+
+ROOT = repo_root()
 
 
 def _load_meta_planning():
-    src = (ROOT / "self_improvement" / "meta_planning.py").read_text()
+    src = resolve_path("self_improvement/meta_planning.py").read_text()
     tree = ast.parse(src)
     wanted = {"_get_entropy_threshold", "_should_encode", "self_improvement_cycle"}
     nodes = [
@@ -49,12 +50,12 @@ def _load_meta_planning():
 
 
 # Dynamically load WorkflowSandboxRunner without importing the full package
-package_path = ROOT / "sandbox_runner"
+package_path = resolve_dir("sandbox_runner")
 package = types.ModuleType("sandbox_runner")
 package.__path__ = [str(package_path)]
 sys.modules["sandbox_runner"] = package
 spec = importlib.util.spec_from_file_location(
-    "sandbox_runner.workflow_sandbox_runner", package_path / "workflow_sandbox_runner.py"
+    "sandbox_runner.workflow_sandbox_runner", resolve_path("workflow_sandbox_runner.py")
 )
 wsr = importlib.util.module_from_spec(spec)
 assert spec.loader

--- a/tests/integration/test_workflow_policy_integration.py
+++ b/tests/integration/test_workflow_policy_integration.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from pathlib import Path
 import sqlite3
 import pytest
 import urllib.request
@@ -8,20 +7,21 @@ import tempfile
 import importlib.util
 import types
 
+from dynamic_path_router import resolve_dir, resolve_path, repo_root
+
 os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
 
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = repo_root()
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 # Dynamically load WorkflowSandboxRunner without importing the heavy package
-package_path = ROOT / "sandbox_runner"
+package_path = resolve_dir("sandbox_runner")
 package = types.ModuleType("sandbox_runner")
 package.__path__ = [str(package_path)]
 sys.modules["sandbox_runner"] = package
 spec = importlib.util.spec_from_file_location(
-    "sandbox_runner.workflow_sandbox_runner",
-    package_path / "workflow_sandbox_runner.py",
+    "sandbox_runner.workflow_sandbox_runner", resolve_path("workflow_sandbox_runner.py")
 )
 wsr = importlib.util.module_from_spec(spec)
 assert spec.loader

--- a/tests/test_memory_limit_no_psutil.py
+++ b/tests/test_memory_limit_no_psutil.py
@@ -1,13 +1,14 @@
 import importlib.util
-import pathlib
 import sys
 
 import pytest
 
-# Ensure repository root on path for sandbox_settings import
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from dynamic_path_router import resolve_path, repo_root
 
-module_path = pathlib.Path(__file__).resolve().parents[1] / "sandbox_runner" / "workflow_sandbox_runner.py"
+# Ensure repository root on path for sandbox_settings import
+sys.path.append(str(repo_root()))
+
+module_path = resolve_path("workflow_sandbox_runner.py")
 spec = importlib.util.spec_from_file_location("workflow_sandbox_runner", module_path)
 workflow_sandbox_runner = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = workflow_sandbox_runner

--- a/tests/test_meta_workflow_planner_transitions.py
+++ b/tests/test_meta_workflow_planner_transitions.py
@@ -1,15 +1,14 @@
 import sys
 import types
 import importlib.util
-from pathlib import Path
 
 import pytest
 
+from dynamic_path_router import resolve_path
 from meta_workflow_planner import MetaWorkflowPlanner
 
 spec = importlib.util.spec_from_file_location(
-    "workflow_sandbox_runner",
-    Path(__file__).resolve().parent.parent / "sandbox_runner" / "workflow_sandbox_runner.py",
+    "workflow_sandbox_runner", resolve_path("workflow_sandbox_runner.py")
 )
 wsr = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
 assert spec.loader is not None

--- a/tests/test_workflow_sandbox_runner.py
+++ b/tests/test_workflow_sandbox_runner.py
@@ -4,9 +4,9 @@ import os
 import sys
 import tempfile
 import types
-from pathlib import Path
 import builtins
 import logging
+from pathlib import Path
 
 import urllib.request
 import shutil
@@ -15,22 +15,23 @@ import multiprocessing
 import pytest
 import time
 
+from dynamic_path_router import resolve_dir, resolve_path, repo_root
+
 os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
 
-ROOT = Path(__file__).resolve().parent.parent
+ROOT = repo_root()
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 # ---------------------------------------------------------------------------
 # Dynamically load WorkflowSandboxRunner without importing the heavy package
-package_path = Path(__file__).resolve().parent.parent / "sandbox_runner"
+package_path = resolve_dir("sandbox_runner")
 package = types.ModuleType("sandbox_runner")
 package.__path__ = [str(package_path)]
 sys.modules["sandbox_runner"] = package
 
 spec = importlib.util.spec_from_file_location(
-    "sandbox_runner.workflow_sandbox_runner",
-    package_path / "workflow_sandbox_runner.py",
+    "sandbox_runner.workflow_sandbox_runner", resolve_path("workflow_sandbox_runner.py")
 )
 wsr = importlib.util.module_from_spec(spec)
 assert spec.loader

--- a/tests/test_workflow_sandbox_runner_isolation.py
+++ b/tests/test_workflow_sandbox_runner_isolation.py
@@ -8,17 +8,19 @@ import shutil
 
 import pytest
 
+from dynamic_path_router import resolve_dir, resolve_path
+
 
 @pytest.fixture(scope="module")
 def WorkflowSandboxRunner():
-    package_path = Path(__file__).resolve().parent.parent / "sandbox_runner"
+    package_path = resolve_dir("sandbox_runner")
     package = types.ModuleType("sandbox_runner")
     package.__path__ = [str(package_path)]
     sys.modules["sandbox_runner"] = package
 
     spec = importlib.util.spec_from_file_location(
         "sandbox_runner.workflow_sandbox_runner",
-        package_path / "workflow_sandbox_runner.py",
+        resolve_path("workflow_sandbox_runner.py"),
     )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None

--- a/tests/test_workflow_sandbox_runner_security.py
+++ b/tests/test_workflow_sandbox_runner_security.py
@@ -4,18 +4,20 @@ import contextlib
 import os
 import sys
 import types
-from pathlib import Path
 import urllib.request
+from pathlib import Path
 
 import pytest
 
+from dynamic_path_router import resolve_dir, resolve_path, repo_root
+
 os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
 
-ROOT = Path(__file__).resolve().parent.parent
+ROOT = repo_root()
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-package_path = ROOT / "sandbox_runner"
+package_path = resolve_dir("sandbox_runner")
 package = types.ModuleType("sandbox_runner")
 package.__path__ = [str(package_path)]
 sys.modules["sandbox_runner"] = package
@@ -24,8 +26,7 @@ env_stub = types.ModuleType("sandbox_runner.environment")
 env_stub._patched_imports = contextlib.nullcontext  # type: ignore[attr-defined]
 sys.modules["sandbox_runner.environment"] = env_stub
 spec = importlib.util.spec_from_file_location(
-    "sandbox_runner.workflow_sandbox_runner",
-    package_path / "workflow_sandbox_runner.py",
+    "sandbox_runner.workflow_sandbox_runner", resolve_path("workflow_sandbox_runner.py")
 )
 wsr = importlib.util.module_from_spec(spec)
 assert spec.loader

--- a/unit_tests/test_workflow_sandbox_runner_resolve.py
+++ b/unit_tests/test_workflow_sandbox_runner_resolve.py
@@ -1,19 +1,20 @@
 import importlib.util
 import sys
 import types
-from pathlib import Path
 
 import pytest
 
+from dynamic_path_router import resolve_dir, resolve_path, repo_root
 
-ROOT = Path(__file__).resolve().parent.parent
-package_path = ROOT / "sandbox_runner"
+
+ROOT = repo_root()
+package_path = resolve_dir("sandbox_runner")
 package = types.ModuleType("sandbox_runner")
 package.__path__ = [str(package_path)]
 sys.modules["sandbox_runner"] = package
 
 spec = importlib.util.spec_from_file_location(
-    "sandbox_runner.workflow_sandbox_runner", package_path / "workflow_sandbox_runner.py"
+    "sandbox_runner.workflow_sandbox_runner", resolve_path("workflow_sandbox_runner.py")
 )
 wsr = importlib.util.module_from_spec(spec)
 assert spec.loader


### PR DESCRIPTION
## Summary
- use `resolve_path`/`resolve_dir` to locate `workflow_sandbox_runner` modules in tests
- add `resolve_dir` helper for directory lookups

## Testing
- `pytest unit_tests/test_workflow_sandbox_runner_resolve.py tests/test_memory_limit_no_psutil.py tests/integration/test_workflow_policy_integration.py tests/integration/test_full_self_improvement_cycle.py tests/test_workflow_sandbox_runner_security.py tests/test_workflow_sandbox_runner.py tests/test_workflow_sandbox_runner_isolation.py tests/test_meta_workflow_planner_transitions.py -q` *(failed: 5 failed, KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b7926a03b4832e9e33a13127977eac