### PR TITLE
Use resolve_path for prompt builders

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -19,6 +19,10 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from .code_database import CodeDB, CodeRecord, PatchHistoryDB, PatchRecord
 from .unified_event_bus import UnifiedEventBus
 from .trend_predictor import TrendPredictor
+try:  # pragma: no cover - allow flat imports
+    from .dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback for flat layout
+    from dynamic_path_router import resolve_path  # type: ignore
 from gpt_memory_interface import GPTMemoryInterface
 from .safety_monitor import SafetyMonitor
 from .advanced_error_management import FormalVerifier
@@ -245,7 +249,7 @@ class SelfCodingEngine:
             or prompt_chunk_cache_dir
             or _settings.chunk_summary_cache_dir
         )
-        self.chunk_summary_cache_dir = Path(cache_dir)
+        self.chunk_summary_cache_dir = resolve_path(cache_dir)
         # backward compatibility
         self.prompt_chunk_cache_dir = self.chunk_summary_cache_dir
         self._failure_similarity_threshold = failure_similarity_threshold
@@ -700,7 +704,7 @@ class SelfCodingEngine:
     @staticmethod
     def _get_repo_layout(limit: int) -> str:
         """Return a short list of top-level Python files in the repo."""
-        root = Path(__file__).resolve().parent
+        root = resolve_path(".")
         files = sorted(p.name for p in root.glob("*.py"))
         lines = files[:limit]
         if len(files) > limit:
@@ -814,7 +818,7 @@ class SelfCodingEngine:
         self._last_prompt_metadata = meta
         if VA_PROMPT_TEMPLATE:
             try:
-                text = Path(VA_PROMPT_TEMPLATE).read_text()
+                text = resolve_path(VA_PROMPT_TEMPLATE).read_text()
             except Exception:
                 text = VA_PROMPT_TEMPLATE
             data = {
@@ -1155,7 +1159,7 @@ class SelfCodingEngine:
 
         def workflow() -> bool:
             ok = True
-            target = Path(file_name) if file_name else Path(".")
+            target = Path(file_name) if file_name else resolve_path(".")
             if self.formal_verifier and path is not None:
                 try:
                     if not self.formal_verifier.verify(target):

--- a/self_coding_scheduler.py
+++ b/self_coding_scheduler.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Iterable, Optional, List, Dict, TYPE_CHECKING
 
 import yaml
+from dynamic_path_router import resolve_path
 
 from sandbox_runner.workflow_sandbox_runner import WorkflowSandboxRunner
 
@@ -66,7 +67,7 @@ class SelfCodingScheduler:
             if error_increase is not None
             else self.settings.self_coding_error_increase
         )
-        self.patch_path = patch_path or Path("auto_helpers.py")
+        self.patch_path = patch_path or (resolve_path(".") / "auto_helpers.py")
         self.description = description
         self.last_roi = self.data_bot.roi(self.manager.bot_name)
         self.last_errors = 0.0
@@ -107,7 +108,7 @@ class SelfCodingScheduler:
     def _record_cycle_metrics(self, success: bool, retries: int) -> None:
         """Persist outcome of a self-coding cycle to ``sandbox_metrics.yaml``."""
 
-        path = Path("sandbox_metrics.yaml")
+        path = resolve_path("sandbox_metrics.yaml")
         data: Dict[str, Dict[str, float]] = {}
         try:
             if path.exists():


### PR DESCRIPTION
## Summary
- Resolve prompt template and weight paths relative to repo root
- Load/save prompt memory trainer state via resolve_path
- Resolve repo layout and templates in self-coding helpers for dynamic context
- Use resolve_path for self-coding scheduler outputs

## Testing
- `pytest tests/test_prompt_engine.py tests/test_prompt_memory_trainer_incremental.py -q`
- `pytest tests/test_prompt_engine.py tests/test_prompt_memory_trainer_incremental.py tests/test_self_coding_engine.py tests/test_self_coding_scheduler.py -q` *(fails: ImportError and AttributeError)*


------
https://chatgpt.com/codex/tasks/task_e_68b7938c8220832ea02d4631b8843b16