### PR TITLE
Allow configuring delta score component weights

### DIFF
--- a/docs/sandbox_settings.md
+++ b/docs/sandbox_settings.md
@@ -33,6 +33,12 @@ settings = load_sandbox_settings("docs/sandbox_config.sample.yaml")
 - `entropy_ceiling_threshold`: `null`
 - `entropy_ceiling_consecutive`: `null`
 
+## Delta weight defaults
+- `roi_weight`: `1.0`
+- `pass_rate_weight`: `1.0`
+- `momentum_weight`: `1.0`
+- `entropy_weight`: `0.1`
+
 ## Synergy defaults
 - `threshold`: `null`
 - `confidence`: `null`

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -1495,6 +1495,7 @@ class SandboxSettings(BaseSettings):
     entropy_weight: float = Field(0.1, env="ENTROPY_WEIGHT")
     roi_weight: float = Field(1.0, env="ROI_WEIGHT")
     momentum_weight: float = Field(1.0, env="MOMENTUM_WEIGHT")
+    pass_rate_weight: float = Field(1.0, env="PASS_RATE_WEIGHT")
     min_integration_roi: float = Field(
         0.0,
         env="MIN_INTEGRATION_ROI",
@@ -1515,7 +1516,7 @@ class SandboxSettings(BaseSettings):
         description="confidence for variance tests; defaults to 0.95",
     )
 
-    @field_validator("roi_weight", "entropy_weight", "momentum_weight")
+    @field_validator("roi_weight", "entropy_weight", "momentum_weight", "pass_rate_weight")
     def _validate_delta_weights(cls, v: float, info: Any) -> float:
         if v < 0:
             raise ValueError(f"{info.field_name} must be non-negative")

--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -492,6 +492,9 @@ class SelfImprovementEngine:
         roi_compounding_weight: float | None = None,
         entropy_window: int | None = None,
         entropy_weight: float | None = None,
+        roi_weight: float | None = None,
+        pass_rate_weight: float | None = None,
+        momentum_weight: float | None = None,
         synergy_weights_path: Path | str | None = None,
         synergy_weights_lr: float | None = None,
         synergy_learner_cls: Type[SynergyWeightLearner] = SynergyWeightLearner,
@@ -540,9 +543,19 @@ class SelfImprovementEngine:
         )
         self.baseline_tracker = GLOBAL_BASELINE_TRACKER
         self.baseline_tracker.window = self.baseline_window
-        self.roi_weight = getattr(settings, "roi_weight", 1.0)
-        self.momentum_weight = getattr(settings, "momentum_weight", 1.0)
-        self.pass_rate_weight = getattr(settings, "pass_rate_weight", 1.0)
+        self.roi_weight = (
+            roi_weight if roi_weight is not None else getattr(settings, "roi_weight", 1.0)
+        )
+        self.momentum_weight = (
+            momentum_weight
+            if momentum_weight is not None
+            else getattr(settings, "momentum_weight", 1.0)
+        )
+        self.pass_rate_weight = (
+            pass_rate_weight
+            if pass_rate_weight is not None
+            else getattr(settings, "pass_rate_weight", 1.0)
+        )
         self.momentum_window = getattr(
             getattr(cfg, "roi", None), "momentum_window", self.baseline_window
         )


### PR DESCRIPTION
## Summary
- add configurable ROI, pass-rate, momentum and entropy weights
- include pass-rate weight in sandbox settings with validation and docs
- combine component deltas using these weights when computing the delta score

## Testing
- `pytest tests/test_self_improvement_engine.py::test_compute_delta_score_weights -q` *(fails: skipped; SelfImprovementEngine unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b7950ddcf4832ebee526a2df4de0ff