### PR TITLE
Track scenario pass-rate delta in self-improvement engine

### DIFF
--- a/tests/test_scenario_metric_remediation.py
+++ b/tests/test_scenario_metric_remediation.py
@@ -97,6 +97,7 @@ def test_scenario_metric_degradation_triggers_actions(monkeypatch):
     assert patches
     assert engine._force_rerun
     assert engine._scenario_pass_rate < 0
+    assert engine._pass_rate_delta == engine.baseline_tracker.get("pass_rate_delta")
     captured = {}
     def fake_update(roi_delta, deltas, extra=None):
         captured["extra"] = extra


### PR DESCRIPTION
## Summary
- track pass-rate delta in `SelfImprovementEngine` and include it in delta scoring
- update scenario metric evaluation to record pass-rate and pass-rate delta
- assert pass-rate delta is recorded in scenario metric remediation test

## Testing
- `pytest tests/test_self_improvement_engine.py::test_compute_delta_score_weights -q` *(skipped)*
- `pytest tests/test_self_improvement_engine.py::test_compute_delta_score_weights tests/test_scenario_metric_remediation.py::test_scenario_metric_degradation_triggers_actions -q` *(import error: cannot import name 'load_presets' due to circular import)*

------
https://chatgpt.com/codex/tasks/task_e_68b796809230832eac9aea0dec70f2e9