### PR TITLE
Track moving average deltas in baseline tracker

### DIFF
--- a/self_improvement/tests/test_moving_baseline_tracker.py
+++ b/self_improvement/tests/test_moving_baseline_tracker.py
@@ -1,7 +1,32 @@
-import importlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
 
-utils = importlib.import_module("menace.self_improvement.utils")
-baseline = importlib.import_module("menace.self_improvement.baseline_tracker")
+MODULE_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(MODULE_DIR.parent))
+
+root_pkg = types.ModuleType("menace")
+root_pkg.__path__ = [str(MODULE_DIR.parent)]
+sys.modules.setdefault("menace", root_pkg)
+
+sub_pkg = types.ModuleType("menace.self_improvement")
+sub_pkg.__path__ = [str(MODULE_DIR)]
+sys.modules.setdefault("menace.self_improvement", sub_pkg)
+sys.modules.setdefault("self_improvement", sub_pkg)
+
+utils_spec = importlib.util.spec_from_file_location(
+    "menace.self_improvement.utils", MODULE_DIR / "utils.py"
+)
+utils = importlib.util.module_from_spec(utils_spec)
+utils_spec.loader.exec_module(utils)
+
+baseline_spec = importlib.util.spec_from_file_location(
+    "menace.self_improvement.baseline_tracker", MODULE_DIR / "baseline_tracker.py"
+)
+baseline = importlib.util.module_from_spec(baseline_spec)
+baseline_spec.loader.exec_module(baseline)
+
 MovingBaselineTracker = utils.MovingBaselineTracker
 BaselineTracker = baseline.BaselineTracker
 
@@ -40,3 +65,21 @@ def test_momentum_history_recorded():
     assert len(hist) == 3
     assert hist[-1] == tracker.momentum
     assert tracker.get("momentum") == sum(hist) / len(hist)
+
+
+def test_roi_delta_and_success_history():
+    tracker = BaselineTracker(window=3)
+    tracker.update(roi=1.0)
+    tracker.update(roi=2.0)
+    tracker.update(roi=0.0)
+    assert tracker.delta_history("roi") == [1.0, 1.0, -1.5]
+    assert tracker.success_count == 2
+    assert tracker.cycle_count == 3
+
+
+def test_pass_rate_delta_from_moving_average():
+    tracker = BaselineTracker(window=3)
+    tracker.update(pass_rate=0.5)
+    tracker.update(pass_rate=1.0)
+    tracker.update(pass_rate=0.25)
+    assert tracker.delta_history("pass_rate") == [0.5, 0.5, -0.5]


### PR DESCRIPTION
## Summary
- Record `<metric>_delta` as the difference from the current moving average for all metrics
- Drive `success_history` off positive ROI deltas
- Test ROI and pass‑rate delta tracking

## Testing
- `cd self_improvement/tests && pytest --confcutdir=. test_moving_baseline_tracker.py`


------
https://chatgpt.com/codex/tasks/task_e_68b797fe65dc832e9b47d0aab4b7b855