### PR TITLE
feat: baseline-driven scenario remediation

### DIFF
--- a/docs/sandbox_settings.md
+++ b/docs/sandbox_settings.md
@@ -69,6 +69,11 @@ settings = load_sandbox_settings("docs/sandbox_config.sample.yaml")
 - `improvement_failure_threshold`: `0.9`
 - `baseline_metrics_path`: `sandbox_metrics.yaml`
 
+## Scenario deviation defaults
+- `scenario_alert_dev_multiplier`: `1.0` (`SCENARIO_ALERT_DEV_MULTIPLIER`)
+- `scenario_patch_dev_multiplier`: `2.0` (`SCENARIO_PATCH_DEV_MULTIPLIER`)
+- `scenario_rerun_dev_multiplier`: `3.0` (`SCENARIO_RERUN_DEV_MULTIPLIER`)
+
 ## Policy defaults
 - `alpha`: `0.5`
 - `gamma`: `0.9`

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -330,8 +330,14 @@ class SandboxSettings(BaseSettings):
     energy_deviation: float = Field(1.0, env="ENERGY_DEVIATION")
     roi_deviation: float = Field(1.0, env="ROI_DEVIATION")
     entropy_deviation: float = Field(1.0, env="ENTROPY_DEVIATION")
-    scenario_deviation_multiplier: float = Field(
-        1.0, env="SCENARIO_DEVIATION_MULTIPLIER"
+    scenario_alert_dev_multiplier: float = Field(
+        1.0, env="SCENARIO_ALERT_DEV_MULTIPLIER"
+    )
+    scenario_patch_dev_multiplier: float = Field(
+        2.0, env="SCENARIO_PATCH_DEV_MULTIPLIER"
+    )
+    scenario_rerun_dev_multiplier: float = Field(
+        3.0, env="SCENARIO_RERUN_DEV_MULTIPLIER"
     )
     save_synergy_history: bool | None = Field(None, env="SAVE_SYNERGY_HISTORY")
 
@@ -382,7 +388,9 @@ class SandboxSettings(BaseSettings):
         "roi_deviation",
         "entropy_deviation",
         "relevancy_deviation_multiplier",
-        "scenario_deviation_multiplier",
+        "scenario_alert_dev_multiplier",
+        "scenario_patch_dev_multiplier",
+        "scenario_rerun_dev_multiplier",
     )
     def _baseline_non_negative(cls, v: float, info: Any) -> float:
         if v < 0:


### PR DESCRIPTION
## Summary
- use baseline tracker deviations to determine scenario remediation actions
- add per-action deviation multipliers to settings and docs
- test scenario remediation against dynamic thresholds

## Testing
- `pytest tests/test_scenario_metric_remediation.py::test_scenario_metric_degradation_triggers_actions -q` *(fails: module 'menace.self_improvement' has no attribute 'SelfImprovementEngine')*

------
https://chatgpt.com/codex/tasks/task_e_68b799ccc990832ea5f5793276af30f7