### PR TITLE
Ensure patch dispatchers resolve script paths

### DIFF
--- a/quick_fix_engine.py
+++ b/quick_fix_engine.py
@@ -14,6 +14,10 @@ import uuid
 from typing import Tuple, Iterable, Dict, Any, List, TYPE_CHECKING
 
 from codebase_diff_checker import generate_code_diff, flag_risky_changes
+try:  # pragma: no cover - allow flat imports
+    from .dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback for flat layout
+    from dynamic_path_router import resolve_path  # type: ignore
 try:  # pragma: no cover - optional dependency
     from .error_cluster_predictor import ErrorClusterPredictor
 except Exception:  # pragma: no cover - optional dependency
@@ -92,10 +96,10 @@ def generate_patch(
     """
 
     logger = logging.getLogger("QuickFixEngine")
-    path = Path(module)
-    if path.suffix == "":
-        path = path.with_suffix(".py")
-    if not path.exists():
+    mod_str = module if module.endswith(".py") else f"{module}.py"
+    try:
+        path = resolve_path(mod_str)
+    except FileNotFoundError:
         logger.error("module not found: %s", module)
         return None
 

--- a/self_debugger_sandbox.py
+++ b/self_debugger_sandbox.py
@@ -41,6 +41,10 @@ except Exception:  # pragma: no cover - test fallback
 
     def _hash_code(data: bytes) -> str:
         return "x"
+try:  # pragma: no cover - allow flat imports
+    from .dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback for flat layout
+    from dynamic_path_router import resolve_path  # type: ignore
 from .self_improvement_policy import SelfImprovementPolicy
 from .roi_tracker import ROITracker
 from .error_cluster_predictor import ErrorClusterPredictor
@@ -1672,7 +1676,7 @@ class SelfDebuggerSandbox(AutomatedDebugger):
                     break
 
                 code = best["code"]
-                root_test = Path("test_auto.py")
+                root_test = resolve_path(".") / "test_auto.py"
                 root_test.write_text(code)
                 code_hash: str | None = None
                 try:

--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -61,6 +61,10 @@ from .init import (
     _atomic_write,
     get_default_synergy_weights,
 )
+try:  # pragma: no cover - allow flat imports
+    from ..dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback for flat layout
+    from dynamic_path_router import resolve_path  # type: ignore
 from ..metrics_exporter import (
     synergy_weight_updates_total,
     synergy_weight_update_failures_total,
@@ -6495,7 +6499,7 @@ class SelfImprovementEngine:
                         "applying helper patch",
                         extra=log_record(trending_topic=trending_topic),
                     )
-                    mod_path = Path("auto_helpers.py")
+                    mod_path = resolve_path(".") / "auto_helpers.py"
                     start_patch = time.perf_counter()
                     patch_id, reverted, delta = self.self_coding_engine.apply_patch(
                         mod_path,


### PR DESCRIPTION
## Summary
- use `resolve_path` in quick_fix_engine, self_improvement engine, and self_debugger_sandbox to resolve script locations
- test that quick_fix_engine dispatcher locates modules even when working directory changes

## Testing
- `pytest tests/test_quick_fix_engine.py::test_generate_patch_resolves_module_path -q`


------
https://chatgpt.com/codex/tasks/task_e_68b79f544f68832e8e5c4893cc60c245