### PR TITLE
Add nested clone path resolution test

### DIFF
--- a/tests/test_resolve_path_nested_repo.py
+++ b/tests/test_resolve_path_nested_repo.py
@@ -1,0 +1,46 @@
+import importlib.util
+import shutil
+from pathlib import Path
+
+
+def test_resolve_path_in_nested_clone(monkeypatch, tmp_path):
+    project_root = Path(__file__).resolve().parents[1]
+
+    repo = tmp_path / "clone" / "menace"
+    (repo / "patches").mkdir(parents=True)
+    (repo / "prompts").mkdir()
+    (repo / "nested" / "deep").mkdir(parents=True)
+
+    shutil.copy(project_root / "dynamic_path_router.py", repo / "dynamic_path_router.py")
+    shutil.copy(project_root / "sandbox_runner.py", repo / "sandbox_runner.py")
+    shutil.copy(project_root / "patch_provenance.py", repo / "patches" / "patch_provenance.py")
+    shutil.copy(project_root / "prompt_engine.py", repo / "prompts" / "prompt_engine.py")
+
+    spec = importlib.util.spec_from_file_location("dynamic_path_router", repo / "dynamic_path_router.py")
+    dr = importlib.util.module_from_spec(spec)
+    assert spec.loader
+    spec.loader.exec_module(dr)
+
+    monkeypatch.setenv("SANDBOX_REPO_PATH", str(repo))
+    dr.clear_cache()
+
+    monkeypatch.chdir(repo / "nested" / "deep")
+
+    calls = []
+    original_rglob = Path.rglob
+
+    def tracking_rglob(self, pattern):
+        calls.append(pattern)
+        return original_rglob(self, pattern)
+
+    monkeypatch.setattr(Path, "rglob", tracking_rglob)
+
+    assert dr.resolve_path("sandbox_runner.py") == (repo / "sandbox_runner.py").resolve()
+    assert dr.resolve_path("patch_provenance.py") == (
+        repo / "patches" / "patch_provenance.py"
+    ).resolve()
+    assert dr.resolve_path("prompt_engine.py") == (
+        repo / "prompts" / "prompt_engine.py"
+    ).resolve()
+
+    assert len(calls) >= 2


### PR DESCRIPTION
## Summary
- test resolving sandbox, patch, and prompt files in a simulated clone without git metadata

## Testing
- `pytest tests/test_resolve_path_nested_repo.py -q`
- `pytest tests/test_dynamic_path_router.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7a3dbc494832eabe355d4745835bd