### PR TITLE
Use resolve_path for module files

### DIFF
--- a/quick_fix_engine.py
+++ b/quick_fix_engine.py
@@ -373,8 +373,9 @@ class QuickFixEngine:
         etype, module, mods, count = info
         if count < self.threshold:
             return
-        path = Path(f"{module}.py")
-        if not path.exists():
+        try:
+            path = resolve_path(f"{module}.py")
+        except FileNotFoundError:
             return
         context_meta = {"error_type": etype, "module": module, "bot": bot}
         builder = self.context_builder
@@ -474,8 +475,9 @@ class QuickFixEngine:
                 module, risk = item, 1.0
             if risk < thresh:
                 continue
-            path = Path(f"{module}.py")
-            if not path.exists():
+            try:
+                path = resolve_path(f"{module}.py")
+            except FileNotFoundError:
                 continue
             meta = {"module": module, "reason": "preemptive_patch"}
             builder = self.context_builder

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -2389,7 +2389,8 @@ class SelfCodingEngine:
         bot = data_bot.worst_bot("errors")
         if not bot:
             return
-        path = Path(root_dir) / f"{bot}.py"
+        root_path = resolve_path(str(root_dir))
+        path = root_path / f"{bot}.py"
         if not path.exists():
             return
         self.apply_patch(path, "refactor", reason="refactor", trigger="refactor_worst_bot")

--- a/self_debugger_sandbox.py
+++ b/self_debugger_sandbox.py
@@ -1474,7 +1474,7 @@ class SelfDebuggerSandbox(AutomatedDebugger):
                                     self.logger.exception("record failed strategy failed")
                             return None
 
-                    root_test = Path(f"test_auto_{idx}.py")
+                    root_test = resolve_path(".") / f"test_auto_{idx}.py"
                     root_test.write_text(code)
                     result = "failed"
                     before_cov = after_cov = None

--- a/tests/test_self_coding_engine_logging.py
+++ b/tests/test_self_coding_engine_logging.py
@@ -2,6 +2,7 @@ import logging
 import sys
 import types
 from pathlib import Path
+import dynamic_path_router
 
 from llm_interface import LLMResult
 
@@ -146,7 +147,7 @@ def test_knowledge_service_logging(monkeypatch, caplog):
     )
     caplog.set_level(logging.WARNING)
     caplog.clear()
-    engine.generate_helper("desc", path=Path("a.py"))
+    engine.generate_helper("desc", path=dynamic_path_router.resolve_path(".") / "a.py")
     messages = [record.message for record in caplog.records]
     assert any("recent_feedback" in m for m in messages)
     assert any("recent_improvement_path" in m for m in messages)

--- a/tests/test_self_coding_engine_patch_logger.py
+++ b/tests/test_self_coding_engine_patch_logger.py
@@ -2,6 +2,7 @@ import importlib.util
 import sys
 import types
 from pathlib import Path
+import dynamic_path_router
 
 import pytest
 
@@ -109,7 +110,7 @@ def load_engine_module():
             pass
 
     add_stub("prompt_engine", types.SimpleNamespace(PromptEngine=DummyPromptEngine))
-    path = Path(__file__).resolve().parents[1] / "self_coding_engine.py"
+    path = dynamic_path_router.resolve_path("self_coding_engine.py")
     spec = importlib.util.spec_from_file_location("menace.self_coding_engine", path)
     module = importlib.util.module_from_spec(spec)
     sys.modules["menace.self_coding_engine"] = module

--- a/tests/test_self_debugger_sandbox.py
+++ b/tests/test_self_debugger_sandbox.py
@@ -7,6 +7,7 @@ import pytest
 import json
 import asyncio
 import time
+import dynamic_path_router
 
 sys.modules.setdefault("cryptography", types.ModuleType("cryptography"))
 sys.modules.setdefault("cryptography.hazmat", types.ModuleType("hazmat"))
@@ -113,8 +114,40 @@ sys.modules.setdefault("menace", menace_pkg)
 import logging_utils as _logging_utils
 sys.modules.setdefault("menace.logging_utils", _logging_utils)
 
+cfg_stub = types.SimpleNamespace(
+    get_impact_severity=lambda *a, **k: {},
+    impact_severity_map=lambda *a, **k: {},
+)
+sys.modules.setdefault("menace.config_loader", cfg_stub)
+sys.modules.setdefault("config_loader", cfg_stub)
+sys.modules.setdefault(
+    "menace.workflow_run_summary",
+    types.SimpleNamespace(record_run=lambda *a, **k: None, save_all_summaries=lambda *a, **k: None),
+)
+sys.modules.setdefault(
+    "workflow_run_summary",
+    types.SimpleNamespace(record_run=lambda *a, **k: None, save_all_summaries=lambda *a, **k: None),
+)
+sys.modules.setdefault("menace.telemetry_backend", types.SimpleNamespace(TelemetryBackend=object))
+sys.modules.setdefault("telemetry_backend", types.SimpleNamespace(TelemetryBackend=object))
+sys.modules.setdefault("menace.borderline_bucket", types.SimpleNamespace(BorderlineBucket=object))
+sys.modules.setdefault("borderline_bucket", types.SimpleNamespace(BorderlineBucket=object))
+sys.modules.setdefault("menace.truth_adapter", types.SimpleNamespace(TruthAdapter=object))
+sys.modules.setdefault("truth_adapter", types.SimpleNamespace(TruthAdapter=object))
+sys.modules.setdefault(
+    "menace.roi_calculator", types.SimpleNamespace(ROICalculator=object, propose_fix=lambda *a, **k: None)
+)
+sys.modules.setdefault(
+    "roi_calculator", types.SimpleNamespace(ROICalculator=object, propose_fix=lambda *a, **k: None)
+)
+sys.modules.setdefault("menace.readiness_index", types.SimpleNamespace(compute_readiness=lambda *a, **k: 0.0))
+sys.modules.setdefault(
+    "readiness_index", types.SimpleNamespace(compute_readiness=lambda *a, **k: 0.0)
+)
+
 rt_spec = importlib.util.spec_from_file_location(
-    "menace.roi_tracker", Path(__file__).resolve().parents[1] / "roi_tracker.py"
+    "menace.roi_tracker",
+    str(dynamic_path_router.resolve_path("roi_tracker.py")),
 )
 rt = importlib.util.module_from_spec(rt_spec)
 assert rt_spec.loader is not None
@@ -219,7 +252,7 @@ from pathlib import Path as _P
 
 _spec = importlib.util.spec_from_file_location(
     "menace.self_debugger_sandbox",
-    _P(__file__).resolve().parents[1] / "self_debugger_sandbox.py",
+    str(dynamic_path_router.resolve_path("self_debugger_sandbox.py")),
 )
 sds = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(sds)


### PR DESCRIPTION
## Summary
- resolve Python helper paths with `resolve_path` to remove layout assumptions
- update unit tests to work with dynamic repository paths

## Testing
- `pytest tests/test_self_coding_engine.py tests/test_self_coding_engine_logging.py tests/test_self_coding_engine_patch_logger.py tests/test_quick_fix_engine.py tests/test_self_debugger_sandbox.py -q` *(fails: missing test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ab184b50832e9ce30a3f424de75e