### PR TITLE
Add dynamic path resolution helper

### DIFF
--- a/tests/test_resolve_path_nested_repo.py
+++ b/tests/test_resolve_path_nested_repo.py
@@ -1,4 +1,5 @@
 import importlib.util
+import os
 import shutil
 from pathlib import Path
 
@@ -27,13 +28,13 @@ def test_resolve_path_in_nested_clone(monkeypatch, tmp_path):
     monkeypatch.chdir(repo / "nested" / "deep")
 
     calls = []
-    original_rglob = Path.rglob
+    original_walk = os.walk
 
-    def tracking_rglob(self, pattern):
-        calls.append(pattern)
-        return original_rglob(self, pattern)
+    def tracking_walk(*args, **kwargs):
+        calls.append(args[0])
+        return original_walk(*args, **kwargs)
 
-    monkeypatch.setattr(Path, "rglob", tracking_rglob)
+    monkeypatch.setattr(os, "walk", tracking_walk)
 
     assert dr.resolve_path("sandbox_runner.py") == (repo / "sandbox_runner.py").resolve()
     assert dr.resolve_path("patch_provenance.py") == (
@@ -43,4 +44,4 @@ def test_resolve_path_in_nested_clone(monkeypatch, tmp_path):
         repo / "prompts" / "prompt_engine.py"
     ).resolve()
 
-    assert len(calls) >= 2
+    assert calls


### PR DESCRIPTION
## Summary
- Introduce `dynamic_path_router` with environment override, git-based root detection, and cached path resolution
- Provide utilities to clear cache and list cached files
- Update nested repository test to track `os.walk`

## Testing
- `pytest tests/test_dynamic_path_router.py tests/test_resolve_path_nested_repo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7ad9bf648832eaccde8601ffff215