### PR TITLE
Use resolve_path for sandbox entry scripts

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,16 +13,14 @@ import logging
 import os
 import pkgutil
 import sys
-from pathlib import Path
 from typing import Iterable, List
 import uuid
 
 from db_router import init_db_router
+from dynamic_path_router import get_project_root
 
-# allow running directly from the package directory
-_pkg_dir = Path(__file__).resolve().parent
-if _pkg_dir.name == "menace" and str(_pkg_dir.parent) not in sys.path:
-    sys.path.insert(0, str(_pkg_dir.parent))
+# Ensure repository root on sys.path for direct execution
+sys.path.insert(0, str(get_project_root()))
 
 logger = logging.getLogger(__name__)
 
@@ -92,4 +90,3 @@ def cli(argv: Iterable[str] | None = None) -> None:
 
 if __name__ == "__main__":
     cli()
-

--- a/run_autonomous.py
+++ b/run_autonomous.py
@@ -32,7 +32,7 @@ import math
 import uuid
 from scipy.stats import t
 from db_router import init_db_router
-from dynamic_path_router import resolve_path
+from dynamic_path_router import resolve_path, get_project_root
 from sandbox_settings import SandboxSettings
 from sandbox_runner.bootstrap import (
     bootstrap_environment,
@@ -77,12 +77,9 @@ if settings.menace_mode.lower() == "production" and settings.database_url.starts
     os.environ["MENACE_MODE"] = "test"
     settings = SandboxSettings()
 
-# allow execution directly from the package directory
-_pkg_dir = resolve_path("run_autonomous.py").parent
-if _pkg_dir.name == "menace" and str(_pkg_dir.parent) not in sys.path:
-    sys.path.insert(0, str(_pkg_dir.parent))
-elif "menace" not in sys.modules:
-    import importlib.util
+# Ensure repository root on sys.path when running as a script
+if "menace" not in sys.modules:
+    sys.path.insert(0, str(get_project_root()))
 
 # Repository root used by background services like the RelevancyRadarService.
 # Default to ``SANDBOX_REPO_PATH`` when provided, otherwise fall back to the

--- a/scripts/launch_personal.py
+++ b/scripts/launch_personal.py
@@ -6,7 +6,8 @@ import os
 import subprocess
 import sys
 import time
-from pathlib import Path
+
+from dynamic_path_router import resolve_path
 
 import auto_env_setup
 import run_autonomous
@@ -17,7 +18,7 @@ _DEF_PORT = "8001"
 
 def _start_agent(env: dict[str, str]) -> subprocess.Popen[bytes]:
     """Spawn ``menace_visual_agent_2.py`` with ``env``."""
-    cmd = [sys.executable, str(Path(__file__).resolve().parents[1] / "menace_visual_agent_2.py")]
+    cmd = [sys.executable, str(resolve_path("menace_visual_agent_2.py"))]
     if env.get("VISUAL_AGENT_AUTO_RECOVER") == "1":
         cmd.append("--auto-recover")
     return subprocess.Popen(cmd, env=env)

--- a/scripts/run_personal_sandbox.py
+++ b/scripts/run_personal_sandbox.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 import os
-import sys
 import time
-from pathlib import Path
+
+from dynamic_path_router import resolve_path
 
 from visual_agent_manager import VisualAgentManager
 import run_autonomous
@@ -39,15 +39,13 @@ def _ensure_env() -> None:
     ensure_env(env_file)
 
 
-
 def main(argv: list[str] | None = None) -> None:
     """Start the visual agent if needed then run ``run_autonomous``."""
     _ensure_env()
     os.environ.setdefault("MENACE_AGENT_PORT", _DEF_PORT)
     os.environ.setdefault("VISUAL_AGENT_URLS", f"http://127.0.0.1:{_DEF_PORT}")
 
-    agent_path = Path(__file__).resolve().parents[1] / "menace_visual_agent_2.py"
-    manager = VisualAgentManager(str(agent_path))
+    manager = VisualAgentManager(str(resolve_path("menace_visual_agent_2.py")))
     started = _start_agent(manager)
     try:
         run_autonomous.main(argv)

--- a/visual_agent_manager.py
+++ b/visual_agent_manager.py
@@ -10,6 +10,8 @@ import time
 import json
 from pathlib import Path
 
+from dynamic_path_router import resolve_path
+
 try:
     from .visual_agent_queue import VisualAgentQueue
 except ImportError:  # pragma: no cover - allow running as script
@@ -29,7 +31,7 @@ class VisualAgentManager:
 
     def __init__(self, agent_script: str | None = None) -> None:
         self.agent_script = agent_script or str(
-            Path(__file__).with_name("menace_visual_agent_2.py")
+            resolve_path("menace_visual_agent_2.py")
         )
         self.pid_file = Path(
             os.getenv(
@@ -92,7 +94,10 @@ class VisualAgentManager:
                         status = data.get("status", {})
                         if isinstance(status, dict):
                             for tid, info in status.items():
-                                if isinstance(info, dict) and info.get("status") in {"queued", "running"}:
+                                if (
+                                    isinstance(info, dict)
+                                    and info.get("status") in {"queued", "running"}
+                                ):
                                     queue.append({
                                         "id": tid,
                                         "prompt": info.get("prompt", ""),


### PR DESCRIPTION
## Summary
- load project root via `get_project_root` instead of manual `_pkg_dir` logic
- locate sandbox and visual-agent scripts with `resolve_path`

## Testing
- `pre-commit run --files main.py run_autonomous.py scripts/launch_personal.py scripts/run_personal_sandbox.py visual_agent_manager.py`
- `pytest tests/test_visual_agent_watchdog.py`
- `pytest tests/test_run_autonomous.py::test_metrics_server_started` *(fails: ModuleNotFoundError: No module named 'sandbox_runner.bootstrap'; 'sandbox_runner' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b1049440832e8964f992dcdc8ce2