### PR TITLE
Use resolve_path for sandbox paths

### DIFF
--- a/patch_branch_manager.py
+++ b/patch_branch_manager.py
@@ -9,6 +9,11 @@ import logging
 import json
 
 try:  # pragma: no cover - fallback for flat layout
+    from .dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback
+    from dynamic_path_router import resolve_path  # type: ignore
+
+try:  # pragma: no cover - fallback for flat layout
     from .audit_trail import AuditTrail
 except Exception:  # pragma: no cover - fallback
     from audit_trail import AuditTrail  # type: ignore
@@ -26,7 +31,7 @@ class PatchBranchManager:
         audit_trail: AuditTrail | None = None,
         main_branch: str = "main",
     ) -> None:
-        self.repo = Path(repo)
+        self.repo = resolve_path(str(repo))
         self.audit_trail = audit_trail
         self.main_branch = main_branch
 

--- a/self_debugger_sandbox.py
+++ b/self_debugger_sandbox.py
@@ -406,10 +406,11 @@ class SelfDebuggerSandbox(AutomatedDebugger):
                     tempfile.TemporaryDirectory() as before_dir,
                     tempfile.TemporaryDirectory() as after_dir,
                 ):
-                    src = Path(mod)
-                    if src.suffix == "":
-                        src = src.with_suffix(".py")
-                    rel = src.name if src.is_absolute() else src
+                    orig = Path(mod)
+                    rel = orig.name if orig.is_absolute() else orig
+                    src = resolve_path(
+                        f"{orig}.py" if orig.suffix == "" else str(orig)
+                    )
                     before_target = Path(before_dir) / rel
                     before_target.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(src, before_target)
@@ -1372,7 +1373,7 @@ class SelfDebuggerSandbox(AutomatedDebugger):
                 best: dict[str, object] | None = None
 
                 async def _eval_candidate(idx: int, code: str) -> dict[str, object] | None:
-                    repo_src = Path(self._settings.sandbox_repo_path or ".")
+                    repo_src = resolve_path(self._settings.sandbox_repo_path or ".")
                     with create_ephemeral_env(repo_src) as (repo, run):
                         test_path = repo / "test_auto.py"
                         test_path.write_text(code)

--- a/self_improvement/init.py
+++ b/self_improvement/init.py
@@ -38,6 +38,11 @@ from sandbox_settings import SandboxSettings, load_sandbox_settings
 from sandbox_runner.bootstrap import initialize_autonomous_sandbox
 from ..metrics_exporter import self_improvement_failure_total
 
+try:  # pragma: no cover - fallback for flat layout
+    from ..dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback
+    from dynamic_path_router import resolve_path  # type: ignore
+
 try:
     from ..logging_utils import get_logger, setup_logging, log_record
 except (ImportError, AttributeError) as exc:  # pragma: no cover - simplified environments
@@ -393,7 +398,7 @@ def _load_initial_synergy_weights() -> None:
     normalisation is logged and the sanitized result written back to disk.
     """
 
-    default_path = Path(getattr(settings, "sandbox_data_dir", ".")) / "synergy_weights.json"
+    default_path = resolve_path(getattr(settings, "sandbox_data_dir", ".")) / "synergy_weights.json"
     path = Path(
         getattr(
             settings,

--- a/self_improvement/patch_application.py
+++ b/self_improvement/patch_application.py
@@ -18,6 +18,11 @@ from .patch_generation import generate_patch
 from .utils import _load_callable, _call_with_retries
 from ..sandbox_settings import SandboxSettings
 
+try:  # pragma: no cover - fallback for flat layout
+    from ..dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback
+    from dynamic_path_router import resolve_path  # type: ignore
+
 _settings = SandboxSettings()
 
 
@@ -54,7 +59,7 @@ def apply_patch(
     if not patch_data:
         logger.error("quick_fix_engine returned no patch data")
         raise RuntimeError("quick_fix_engine did not return patch data")
-    repo_path = Path(repo_path)
+    repo_path = resolve_path(str(repo_path))
     status = subprocess.run(
         ["git", "status", "--porcelain"],
         cwd=str(repo_path),


### PR DESCRIPTION
## Summary
- route patch branch repo and sandbox paths through resolve_path
- resolve temporary test and module paths via router for self-improvement utilities

## Testing
- `pytest tests/test_patch_branch_manager.py -q`
- `pytest tests/test_patch_branch_manager.py tests/test_self_debugger_sandbox.py tests/integration/test_full_self_improvement_cycle.py -q` *(fails: BaselineTracker import and other dependency issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b2d4d50c832ea0be5419aa1ed7d9