### PR TITLE
Add tests for self-improvement trigger and ROI logic

### DIFF
--- a/self_improvement/tests/test_trigger_and_encoding.py
+++ b/self_improvement/tests/test_trigger_and_encoding.py
@@ -1,0 +1,107 @@
+import ast
+import importlib.util
+import types
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+# Load BaselineTracker
+MODULE_DIR = Path(__file__).resolve().parents[1]
+BT_SPEC = importlib.util.spec_from_file_location(
+    "baseline_tracker", MODULE_DIR / "baseline_tracker.py"
+)
+baseline_mod = importlib.util.module_from_spec(BT_SPEC)
+assert BT_SPEC and BT_SPEC.loader
+BT_SPEC.loader.exec_module(baseline_mod)  # type: ignore[attr-defined]
+BaselineTracker = baseline_mod.BaselineTracker
+
+# Extract selected methods from engine.py
+ENG_PATH = MODULE_DIR / "engine.py"
+engine_src = ENG_PATH.read_text()
+engine_tree = ast.parse(engine_src)
+future = ast.ImportFrom(module="__future__", names=[ast.alias("annotations", None)], level=0)
+class_def = next(
+    n for n in engine_tree.body if isinstance(n, ast.ClassDef) and n.name == "SelfImprovementEngine"
+)
+should_trigger = next(
+    n for n in class_def.body if isinstance(n, ast.FunctionDef) and n.name == "_should_trigger"
+)
+check_stagnation = next(
+    n for n in class_def.body if isinstance(n, ast.FunctionDef) and n.name == "_check_roi_stagnation"
+)
+engine_module = ast.Module(
+    [future, ast.ClassDef("SelfImprovementEngine", [], [], [should_trigger, check_stagnation], [])],
+    type_ignores=[],
+)
+engine_module = ast.fix_missing_locations(engine_module)
+alerts: list[tuple] = []
+ns: Dict[str, Any] = {
+    "time": time,
+    "log_record": lambda **k: k,
+    "dispatch_alert": lambda *a, **k: alerts.append((a, k)),
+}
+exec(compile(engine_module, "<engine>", "exec"), ns)
+SelfImprovementEngine = ns["SelfImprovementEngine"]
+
+# Extract _should_encode from meta_planning.py
+MP_PATH = MODULE_DIR / "meta_planning.py"
+mp_src = MP_PATH.read_text()
+mp_tree = ast.parse(mp_src)
+should_encode_func = next(
+    n for n in mp_tree.body if isinstance(n, ast.FunctionDef) and n.name == "_should_encode"
+)
+mp_module = ast.Module([future, should_encode_func], type_ignores=[])
+mp_module = ast.fix_missing_locations(mp_module)
+mp_ns: Dict[str, Any] = {}
+exec(compile(mp_module, "<meta>", "exec"), mp_ns)
+_should_encode = mp_ns["_should_encode"]
+
+
+def test_should_trigger_respects_dynamic_baseline():
+    tracker = BaselineTracker(window=3)
+    for score in [0.4, 0.5, 0.6]:
+        tracker.update(score=score)
+    threshold = tracker.get("score") + tracker.std("score")
+    eng = SelfImprovementEngine.__new__(SelfImprovementEngine)
+    eng.baseline_tracker = tracker
+    eng.last_run = 0.0
+    eng.interval = 0.0
+    eng.delta_score_dev_multiplier = 1.0
+    eng.logger = types.SimpleNamespace(debug=lambda *a, **k: None)
+    eng._compute_delta_score = lambda: (threshold - 0.01, {"roi": 0.1})
+    assert not eng._should_trigger()
+    eng._compute_delta_score = lambda: (threshold + 0.01, {"roi": 0.1})
+    assert eng._should_trigger()
+
+
+def test_should_encode_uses_roi_delta_and_momentum():
+    tracker = BaselineTracker(window=3)
+    tracker.update(roi=1.0)
+    record = {"roi_gain": 1.2, "entropy": 0.4}
+    assert _should_encode(record, tracker, entropy_threshold=0.5)
+    record_neg = {"roi_gain": 0.8, "entropy": 0.4}
+    assert not _should_encode(record_neg, tracker, entropy_threshold=0.5)
+    tracker._success_history.clear()
+    tracker._success_history.extend([False] * tracker.window)
+    assert tracker.momentum == 0.0
+    assert not _should_encode(record, tracker, entropy_threshold=0.5)
+
+
+def test_urgency_escalates_after_three_non_positive_roi_deltas():
+    alerts.clear()
+    eng = SelfImprovementEngine.__new__(SelfImprovementEngine)
+    eng.baseline_tracker = BaselineTracker(window=5)
+    eng.urgency_tier = 0
+    eng.urgency_recovery_threshold = 0.05
+    eng.logger = types.SimpleNamespace(warning=lambda *a, **k: None, exception=lambda *a, **k: None)
+    eng.stagnation_cycles = 3
+    eng._stagnation_streak = 0
+    for roi in [1.0, 0.9]:
+        eng.baseline_tracker.update(roi=roi)
+        eng._check_roi_stagnation()
+        assert eng.urgency_tier == 0
+    eng.baseline_tracker.update(roi=0.8)
+    eng._check_roi_stagnation()
+    assert eng._stagnation_streak == 3
+    assert eng.urgency_tier == 1
+    assert alerts and alerts[0][0][0] == "roi_negative_trend"


### PR DESCRIPTION
## Summary
- add tests covering `_should_trigger` baseline threshold logic
- ensure `_should_encode` respects ROI delta and momentum
- verify urgency tier escalates after three non-positive ROI deltas

## Testing
- `pytest self_improvement/tests/test_trigger_and_encoding.py -q` *(fails: No module named 'sandbox_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68b7b36c0b5c832e98dca89dcd087b77