### PR TITLE
feat: track integration metrics with baseline

### DIFF
--- a/tests/integration/test_orphan_pipeline_metrics.py
+++ b/tests/integration/test_orphan_pipeline_metrics.py
@@ -233,7 +233,7 @@ def test_side_effect_metric_increments(monkeypatch, tmp_path):
     env = importlib.import_module("sandbox_runner.environment")
 
     res = env.try_integrate_into_workflows(
-        [str(mod)], side_effects={"skip.py": 11}, side_effect_threshold=10
+        [str(mod)], side_effects={"skip.py": 11}
     )
 
     assert res == []

--- a/tests/test_workflow_update.py
+++ b/tests/test_workflow_update.py
@@ -223,7 +223,6 @@ def test_try_integrate_intent_synergy(tmp_path, monkeypatch):
         ["b.py"],
         workflows_db=db_path,
         intent_clusterer=clusterer,
-        intent_threshold=0.5,
     )
     recs = {r.wid: r for r in wf_db.fetch(limit=10)}
     assert wid in updated


### PR DESCRIPTION
## Summary
- use BaselineTracker to track side effects, intent similarity, and synergy
- integrate modules using dynamic thresholds derived from moving averages
- update tests for new integration threshold multipliers

## Testing
- `pytest tests/test_workflow_update.py::test_try_integrate_into_workflows -q` *(fails: error_logger is required)*
- `pytest tests/integration/test_orphan_pipeline_metrics.py::test_side_effect_metric_increments -q` *(fails: ImportError: cannot import name 'RAISE_ERRORS')*


------
https://chatgpt.com/codex/tasks/task_e_68b7b5541094832e9f3bb3cd93d0ba90