### PR TITLE
Use dynamic side effect thresholds

### DIFF
--- a/tests/test_recursive_orphans.py
+++ b/tests/test_recursive_orphans.py
@@ -46,7 +46,7 @@ def _load_methods():
         "Iterable": __import__("typing").Iterable,
         "math": __import__("math"),
         "SandboxSettings": lambda: types.SimpleNamespace(
-            side_effect_threshold=0.0, test_redundant_modules=False
+            test_redundant_modules=False
         ),
         "classify_module": lambda path, include_meta=True: ("candidate", {}),
         "build_module_map": lambda repo, ignore=None: {},

--- a/tests/test_self_improvement_run_cycle.py
+++ b/tests/test_self_improvement_run_cycle.py
@@ -26,7 +26,7 @@ def _load_test_method():
         "Path": Path,
         "Iterable": __import__("typing").Iterable,
         "SandboxSettings": lambda: types.SimpleNamespace(
-            side_effect_threshold=0.0, test_redundant_modules=False
+            test_redundant_modules=False
         ),
         "classify_module": lambda path, include_meta=True: ("candidate", {}),
         "analyze_redundancy": lambda p: False,


### PR DESCRIPTION
## Summary
- derive side-effect threshold from baseline stats even with minimal history
- seed baseline on first observation and drop fixed threshold fallback
- adjust tests to work with dynamic side-effect thresholds

## Testing
- `pytest tests/test_side_effect_threshold.py::test_engine_skips_heavy_side_effects -q` *(fails: ImportError: cannot import name 'RAISE_ERRORS')*
- `pytest tests/test_self_improvement_run_cycle.py::test_module_fails_bad_scenario -q` *(fails: FileNotFoundError: /workspace/menace_sandbox/self_improvement.py)*
- `pytest tests/test_recursive_orphans.py::test_update_orphan_modules_recursive -q` *(fails: FileNotFoundError: /workspace/menace_sandbox/self_improvement.py)*
- `pytest tests/test_self_improvement_error_handling.py::test_try_integrate_failure_logged_and_raised -q` *(fails: TypeError: cannot unpack non-iterable NoneType object)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b7438938832ebdb6e4334b1cd655