### PR TITLE
Adapt delta score weights based on baseline variability

### DIFF
--- a/docs/sandbox_settings.md
+++ b/docs/sandbox_settings.md
@@ -38,6 +38,8 @@ settings = load_sandbox_settings("docs/sandbox_config.sample.yaml")
 - `pass_rate_weight`: `1.0`
 - `momentum_weight`: `1.0`
 - `entropy_weight`: `0.1`
+- `momentum_weight_scale`: `0.0`
+- `entropy_weight_scale`: `0.0`
 
 ## Synergy defaults
 - `threshold`: `null`

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -1516,6 +1516,22 @@ class SandboxSettings(BaseSettings):
     roi_weight: float = Field(1.0, env="ROI_WEIGHT")
     momentum_weight: float = Field(1.0, env="MOMENTUM_WEIGHT")
     pass_rate_weight: float = Field(1.0, env="PASS_RATE_WEIGHT")
+    entropy_weight_scale: float = Field(
+        0.0,
+        env="ENTROPY_WEIGHT_SCALE",
+        description=(
+            "Multiplier applied to the entropy standard deviation when "
+            "adapting the entropy weight."
+        ),
+    )
+    momentum_weight_scale: float = Field(
+        0.0,
+        env="MOMENTUM_WEIGHT_SCALE",
+        description=(
+            "Multiplier applied to the recent success ratio when "
+            "adapting the momentum weight."
+        ),
+    )
     min_integration_roi: float = Field(
         0.0,
         env="MIN_INTEGRATION_ROI",
@@ -1536,7 +1552,14 @@ class SandboxSettings(BaseSettings):
         description="confidence for variance tests; defaults to 0.95",
     )
 
-    @field_validator("roi_weight", "entropy_weight", "momentum_weight", "pass_rate_weight")
+    @field_validator(
+        "roi_weight",
+        "entropy_weight",
+        "momentum_weight",
+        "pass_rate_weight",
+        "entropy_weight_scale",
+        "momentum_weight_scale",
+    )
     def _validate_delta_weights(cls, v: float, info: Any) -> float:
         if v < 0:
             raise ValueError(f"{info.field_name} must be non-negative")

--- a/self_improvement/baseline_tracker.py
+++ b/self_improvement/baseline_tracker.py
@@ -31,11 +31,17 @@ class BaselineTracker:
                 hist.append(float(v))
 
     # ------------------------------------------------------------------
-    def update(self, **metrics: float) -> None:
+    def update(self, *, record_momentum: bool = True, **metrics: float) -> None:
         """Record new metric values.
 
         Parameters
         ----------
+        record_momentum:
+            When ``True`` (the default) the current momentum value is recorded
+            after processing ``metrics`` so that moving averages and deviations
+            can be computed for the momentum series.  Set to ``False`` when
+            adding auxiliary metrics that should not advance the momentum
+            history.
         **metrics:
             Mapping of metric name to numeric value.
 
@@ -60,12 +66,15 @@ class BaselineTracker:
                 self._success_history.append(delta > 0)
             hist.append(float(value))
 
-        # Record current momentum so moving averages and deviations can be
-        # computed like other metrics.  This is appended after processing the
-        # provided metrics so ``roi`` updates influence the momentum history in
-        # the same cycle.
-        momentum_hist = self._history.setdefault("momentum", deque(maxlen=self.window))
-        momentum_hist.append(self.momentum)
+        if record_momentum:
+            # Record current momentum so moving averages and deviations can be
+            # computed like other metrics.  This is appended after processing the
+            # provided metrics so ``roi`` updates influence the momentum history in
+            # the same cycle.
+            momentum_hist = self._history.setdefault(
+                "momentum", deque(maxlen=self.window)
+            )
+            momentum_hist.append(self.momentum)
 
     # ------------------------------------------------------------------
     def get(self, metric: str) -> float:


### PR DESCRIPTION
## Summary
- scale entropy and momentum weights in `_compute_delta_score` using tracker statistics
- record adaptive weight values in `BaselineTracker` for historical analysis
- expose `entropy_weight_scale` and `momentum_weight_scale` options in `SandboxSettings`

## Testing
- `pre-commit run --files self_improvement/baseline_tracker.py self_improvement/engine.py sandbox_settings.py docs/sandbox_settings.md`
- `pytest tests/test_self_improvement_engine.py::test_compute_delta_score_weights` *(skipped: SelfImprovementEngine unavailable)*
- `pytest self_improvement/tests/test_baseline_tracker.py tests/test_self_improvement_engine.py::test_compute_delta_score_weights` *(errors: ROISettings() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bf9ac4f8832e934d62df540b8f69