### PR TITLE
Use dynamic synergy threshold

### DIFF
--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -7298,7 +7298,7 @@ def try_integrate_into_workflows(
     if side_effect_k is None:
         side_effect_k = getattr(settings, "side_effect_dev_multiplier", 1.0)
     if synergy_k is None:
-        synergy_k = 1.0
+        synergy_k = getattr(settings, "synergy_dev_multiplier", 1.0)
     for m in modules:
         p = Path(m)
         if p.is_absolute():
@@ -7404,7 +7404,7 @@ def try_integrate_into_workflows(
             expanded = {dotted}
             if _USE_MODULE_SYNERGY:
                 try:
-                    base_thr = getattr(settings, "synergy_threshold", 0.7)
+                    base_thr = tracker.get("synergy") + synergy_k * tracker.std("synergy")
                     cluster = get_synergy_cluster(dotted, base_thr)
                     hist = tracker.to_dict().get("synergy", [])
                     avg_s = tracker.get("synergy")

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -1318,7 +1318,12 @@ class SandboxSettings(BaseSettings):
             raise ValueError(f"{info.field_name} must be a positive integer")
         return v
 
-    @field_validator("weight_update_interval", "test_run_timeout", "side_effect_dev_multiplier")
+    @field_validator(
+        "weight_update_interval",
+        "test_run_timeout",
+        "side_effect_dev_multiplier",
+        "synergy_dev_multiplier",
+    )
     def _validate_positive_float(cls, v: float, info: Any) -> float:
         if v <= 0:
             raise ValueError(f"{info.field_name} must be positive")
@@ -1332,6 +1337,9 @@ class SandboxSettings(BaseSettings):
     side_effect_threshold: int = Field(10, env="SANDBOX_SIDE_EFFECT_THRESHOLD")
     side_effect_dev_multiplier: float = Field(
         1.0, env="SANDBOX_SIDE_EFFECT_DEV_MULTIPLIER"
+    )
+    synergy_dev_multiplier: float = Field(
+        1.0, env="SANDBOX_SYNERGY_DEV_MULTIPLIER"
     )
     auto_patch_high_risk: bool = Field(
         True,


### PR DESCRIPTION
## Summary
- compute module synergy threshold dynamically from tracker mean and deviation
- add `synergy_dev_multiplier` setting with default 1.0
- wire dynamic threshold into module intent expansion while keeping tracker updates before evaluation

## Testing
- `PYTHONPATH=. pytest sandbox_runner/tests/test_orphan_cycle_integration.py -q`
- `PYTHONPATH=. pytest tests/test_cli_synergy.py::test_synergy_converged -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7c36a5348832ea22f3c1b2141ed1c