### PR TITLE
feat: derive adaptive thresholds

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -1323,6 +1323,8 @@ class SandboxSettings(BaseSettings):
         "test_run_timeout",
         "side_effect_dev_multiplier",
         "synergy_dev_multiplier",
+        "roi_threshold_k",
+        "synergy_threshold_k",
     )
     def _validate_positive_float(cls, v: float, info: Any) -> float:
         if v <= 0:
@@ -1419,6 +1421,8 @@ class SandboxSettings(BaseSettings):
     )
     roi_threshold: float | None = Field(None, env="ROI_THRESHOLD")
     synergy_threshold: float | None = Field(None, env="SYNERGY_THRESHOLD")
+    roi_threshold_k: float = Field(1.0, env="ROI_THRESHOLD_K")
+    synergy_threshold_k: float = Field(1.0, env="SYNERGY_THRESHOLD_K")
     roi_confidence: float | None = Field(
         None,
         env="ROI_CONFIDENCE",


### PR DESCRIPTION
## Summary
- compute ROI and synergy thresholds from tracker averages and variance when none are supplied
- expose standard deviation multipliers via CLI flags and sandbox settings

## Testing
- `pytest tests/test_cli_full_autonomous_run.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7c92eff6c832ebf6b5a9779e09cb0