### PR TITLE
feat: add momentum stagnation multiplier

### DIFF
--- a/docs/sandbox_settings.md
+++ b/docs/sandbox_settings.md
@@ -41,6 +41,10 @@ settings = load_sandbox_settings("docs/sandbox_config.sample.yaml")
 - `momentum_weight_scale`: `0.0`
 - `entropy_weight_scale`: `0.0`
 
+## Momentum defaults
+- `momentum_stagnation_dev_multiplier`: `1.0` – multiplier applied to the
+  momentum standard deviation when detecting stagnation.
+
 ## Synergy defaults
 - `threshold`: `null`
 - `confidence`: `null`

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -1550,6 +1550,14 @@ class SandboxSettings(BaseSettings):
             "adapting the momentum weight."
         ),
     )
+    momentum_stagnation_dev_multiplier: float = Field(
+        1.0,
+        env="MOMENTUM_STAGNATION_DEV_MULTIPLIER",
+        description=(
+            "Multiplier for the momentum standard deviation when "
+            "detecting stagnation."
+        ),
+    )
     min_integration_roi: float = Field(
         0.0,
         env="MIN_INTEGRATION_ROI",
@@ -1581,6 +1589,14 @@ class SandboxSettings(BaseSettings):
     def _validate_delta_weights(cls, v: float, info: Any) -> float:
         if v < 0:
             raise ValueError(f"{info.field_name} must be non-negative")
+        return v
+
+    @field_validator("momentum_stagnation_dev_multiplier")
+    def _momentum_stagnation_dev_multiplier_positive(
+        cls, v: float
+    ) -> float:
+        if v <= 0:
+            raise ValueError("momentum_stagnation_dev_multiplier must be positive")
         return v
 
     relevancy_threshold: int = Field(

--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -2181,15 +2181,20 @@ class SelfImprovementEngine:
         """Escalate urgency when momentum fails to improve."""
 
         delta = self.baseline_tracker.delta("momentum")
-        if delta <= 0:
+        momentum_threshold = (
+            self.baseline_tracker.std("momentum")
+            * settings.momentum_stagnation_dev_multiplier
+        )
+        if delta < -momentum_threshold:
             self._momentum_streak += 1
             if self._momentum_streak >= self.stagnation_cycles:
                 self.urgency_tier += 1
                 self.logger.warning(
-                    "momentum non-positive; increasing urgency tier",
+                    "momentum below threshold; increasing urgency tier",
                     extra=log_record(
                         tier=self.urgency_tier,
                         delta=delta,
+                        threshold=momentum_threshold,
                         streak=self._momentum_streak,
                     ),
                 )


### PR DESCRIPTION
## Summary
- make momentum urgency escalation respect baseline deviation via `momentum_stagnation_dev_multiplier`
- expose `momentum_stagnation_dev_multiplier` in SandboxSettings
- document new momentum stagnation multiplier and adjust tests

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_momentum_urgency.py tests/test_baseline_tracker_momentum.py tests/test_roi_stagnation_escalation.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7d49e6b3c832ebb496fdfccccbed6