### PR TITLE
Use resolve_path for .py paths

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -2390,8 +2390,9 @@ class SelfCodingEngine:
         if not bot:
             return
         root_path = resolve_path(str(root_dir))
-        path = root_path / f"{bot}.py"
-        if not path.exists():
+        try:
+            path = resolve_path(root_path / f"{bot}.py")
+        except FileNotFoundError:
             return
         self.apply_patch(path, "refactor", reason="refactor", trigger="refactor_worst_bot")
 

--- a/self_debugger_sandbox.py
+++ b/self_debugger_sandbox.py
@@ -1377,6 +1377,7 @@ class SelfDebuggerSandbox(AutomatedDebugger):
                     with create_ephemeral_env(repo_src) as (repo, run):
                         test_path = repo / "test_auto.py"
                         test_path.write_text(code)
+                        test_path = resolve_path(test_path)
                         env = os.environ.copy()
                         env["PYTHONPATH"] = str(repo)
                         try:
@@ -1481,6 +1482,7 @@ class SelfDebuggerSandbox(AutomatedDebugger):
 
                     root_test = resolve_path(".") / f"test_auto_{idx}.py"
                     root_test.write_text(code)
+                    root_test = resolve_path(root_test)
                     result = "failed"
                     before_cov = after_cov = None
                     before_runtime = after_runtime = 0.0
@@ -1683,6 +1685,7 @@ class SelfDebuggerSandbox(AutomatedDebugger):
                 code = best["code"]
                 root_test = resolve_path(".") / "test_auto.py"
                 root_test.write_text(code)
+                root_test = resolve_path(root_test)
                 code_hash: str | None = None
                 try:
                     with open(root_test, "rb") as fh:

--- a/tests/test_quick_fix_engine.py
+++ b/tests/test_quick_fix_engine.py
@@ -54,7 +54,7 @@ sys.modules.setdefault("vector_service.patch_logger", types.SimpleNamespace(Patc
 # Load QuickFixEngine without importing the full package
 spec = importlib.util.spec_from_file_location(
     "menace.quick_fix_engine",
-    str(dynamic_path_router.resolve_path("quick_fix_engine.py")),
+    dynamic_path_router.path_for_prompt("quick_fix_engine.py"),
 )
 quick_fix = importlib.util.module_from_spec(spec)
 sys.modules["menace.quick_fix_engine"] = quick_fix

--- a/tests/test_self_coding_engine.py
+++ b/tests/test_self_coding_engine.py
@@ -228,7 +228,7 @@ sys.modules.setdefault(
 
 spec = importlib.util.spec_from_file_location(
     "menace.self_coding_engine",
-    str(dynamic_path_router.resolve_path("self_coding_engine.py")),
+    dynamic_path_router.path_for_prompt("self_coding_engine.py"),
 )
 sce = importlib.util.module_from_spec(spec)
 sys.modules["menace.self_coding_engine"] = sce

--- a/tests/test_self_debugger_sandbox.py
+++ b/tests/test_self_debugger_sandbox.py
@@ -147,7 +147,7 @@ sys.modules.setdefault(
 
 rt_spec = importlib.util.spec_from_file_location(
     "menace.roi_tracker",
-    str(dynamic_path_router.resolve_path("roi_tracker.py")),
+    dynamic_path_router.path_for_prompt("roi_tracker.py"),
 )
 rt = importlib.util.module_from_spec(rt_spec)
 assert rt_spec.loader is not None
@@ -252,7 +252,7 @@ from pathlib import Path as _P
 
 _spec = importlib.util.spec_from_file_location(
     "menace.self_debugger_sandbox",
-    str(dynamic_path_router.resolve_path("self_debugger_sandbox.py")),
+    dynamic_path_router.path_for_prompt("self_debugger_sandbox.py"),
 )
 sds = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(sds)


### PR DESCRIPTION
## Summary
- use `resolve_path` for bot files in SelfCodingEngine
- ensure sandbox-generated test files are resolved before execution
- load engine modules in tests via `path_for_prompt`

## Testing
- `pytest tests/test_self_coding_engine.py::test_repo_layout tests/test_quick_fix_engine.py::test_spec_load tests/test_self_debugger_sandbox.py::test_run_tests_includes_telemetry -q` *(failed: ImportError, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d770e2a8832e8e451196af2b6ca1