### PR TITLE
Use dynamic path for sandbox runner

### DIFF
--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -1924,7 +1924,12 @@ def _prune_networks() -> int:
 
 
 def purge_leftovers() -> None:
-    """Remove stale sandbox containers and leftover QEMU overlay files."""
+    """Remove stale sandbox containers and leftover QEMU overlay files.
+
+    Container commands are matched using :func:`resolve_path` to locate
+    ``sandbox_runner.py`` dynamically, ensuring cleanup works even if the
+    repository layout changes.
+    """
     global _STALE_CONTAINERS_REMOVED
     with _PURGE_FILE_LOCK:
         try:


### PR DESCRIPTION
## Summary
- document dynamic sandbox runner resolution in leftover purge helper
- ensure cleanup test uses resolve_path for sandbox runner path

## Testing
- `pytest tests/test_unlabeled_container_cleanup.py sandbox_runner/tests/test_environment_resolver.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7da326ae4832e8b66a30e763013f7