### PR TITLE
use resolve_path for dynamic imports

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -145,22 +145,22 @@ sys.modules.setdefault("menace.alert_dispatcher", _alert_dispatcher)
 _readiness_index = importlib.import_module(__name__ + ".readiness_index")
 sys.modules.setdefault("readiness_index", _readiness_index)
 sys.modules.setdefault("menace.readiness_index", _readiness_index)
+from .dynamic_path_router import resolve_path, get_project_root
 
-_pkg_dir = os.path.dirname(__file__)
-_sk_dir = os.path.join(_pkg_dir, "sklearn")
-_extra_dir = os.path.join(_pkg_dir, "menace")
-if os.path.isdir(_extra_dir) and _extra_dir not in __path__:
-    __path__.append(_extra_dir)
-if "sklearn" not in sys.modules and os.path.isdir(_sk_dir):
+_sk_dir = get_project_root() / "sklearn"
+_extra_dir = get_project_root() / "menace"
+if _extra_dir.is_dir() and str(_extra_dir) not in __path__:
+    __path__.append(str(_extra_dir))
+if "sklearn" not in sys.modules and _sk_dir.is_dir():
     spec = importlib.util.spec_from_file_location(
-        "sklearn", os.path.join(_sk_dir, "__init__.py")
+        "sklearn", str(resolve_path("sklearn/__init__.py"))
     )
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     sys.modules["sklearn"] = mod
     for sub in ["feature_extraction", "linear_model", "pipeline"]:
         spec_sub = importlib.util.spec_from_file_location(
-            f"sklearn.{sub}", os.path.join(_sk_dir, sub, "__init__.py")
+            f"sklearn.{sub}", str(resolve_path(f"sklearn/{sub}/__init__.py"))
         )
         mod_sub = importlib.util.module_from_spec(spec_sub)
         spec_sub.loader.exec_module(mod_sub)

--- a/run_autonomous.py
+++ b/run_autonomous.py
@@ -132,7 +132,9 @@ def _visual_agent_running(urls: str) -> bool:
     return False
 
 
-spec = importlib.util.spec_from_file_location("menace", resolve_path("__init__.py"))
+spec = importlib.util.spec_from_file_location(
+    "menace", str(resolve_path("__init__.py"))
+)
 menace_pkg = importlib.util.module_from_spec(spec)
 sys.modules["menace"] = menace_pkg
 spec.loader.exec_module(menace_pkg)
@@ -208,7 +210,7 @@ if not hasattr(sandbox_runner, "_sandbox_main"):
     import importlib.util
 
     spec = importlib.util.spec_from_file_location(
-        "sandbox_runner", resolve_path("sandbox_runner.py")
+        "sandbox_runner", str(resolve_path("sandbox_runner.py"))
     )
     sr_mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(sr_mod)


### PR DESCRIPTION
## Summary
- use resolve_path when dynamically importing sandbox_runner and menace modules
- remove manual _pkg_dir path handling in package init in favor of get_project_root

## Testing
- `python -m py_compile run_autonomous.py __init__.py`
- `pytest tests/test_visual_agent_monitor.py::test_monitor_restarts_when_status_fails -q` *(fails: NameError: name 'resolve_path' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b7dc1e7e84832e9cd08e2f89e00f4f