### PR TITLE
Add overfitting entropy fallback

### DIFF
--- a/docs/sandbox_config.sample.yaml
+++ b/docs/sandbox_config.sample.yaml
@@ -1,4 +1,5 @@
 meta_entropy_threshold: 0.2
+overfitting_entropy_threshold: 0.2
 enable_meta_planner: false
 optional_service_versions:
   relevancy_radar: "1.0.0"

--- a/docs/sandbox_settings.md
+++ b/docs/sandbox_settings.md
@@ -20,6 +20,7 @@ settings = load_sandbox_settings("docs/sandbox_config.sample.yaml")
 - `meta_roi_weight`: `1.0`
 - `meta_domain_penalty`: `1.0`
 - `meta_entropy_threshold`: `0.2`
+- `overfitting_entropy_threshold`: `0.2`
 
 ## ROI defaults
 - `threshold`: `null`

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -984,6 +984,11 @@ class SandboxSettings(BaseSettings):
         env="META_DOMAIN_PENALTY",
         description="Penalty for domain transitions in meta planning.",
     )
+    overfitting_entropy_threshold: float = Field(
+        0.2,
+        env="OVERFITTING_ENTROPY_THRESHOLD",
+        description="Entropy delta triggering overfitting fallback.",
+    )
     meta_entropy_threshold: float | None = Field(
         0.2,
         env="META_ENTROPY_THRESHOLD",
@@ -1270,6 +1275,12 @@ class SandboxSettings(BaseSettings):
     def _validate_meta_entropy_threshold(cls, v: float | None) -> float | None:
         if v is not None and not 0 <= v <= 1:
             raise ValueError("meta_entropy_threshold must be between 0 and 1")
+        return v
+
+    @field_validator("overfitting_entropy_threshold")
+    def _validate_overfitting_entropy_threshold(cls, v: float) -> float:
+        if v < 0:
+            raise ValueError("overfitting_entropy_threshold must be non-negative")
         return v
 
     @field_validator("meta_entropy_weight")


### PR DESCRIPTION
## Summary
- guard against overfitting in meta planning by checking entropy shift before skipping
- add `overfitting_entropy_threshold` setting and document it
- cover overfitting fallback with unit test

## Testing
- `pre-commit run --files docs/sandbox_config.sample.yaml docs/sandbox_settings.md sandbox_settings.py self_improvement/meta_planning.py unit_tests/test_meta_planning.py`
- `pytest unit_tests/test_meta_planning.py`

------
https://chatgpt.com/codex/tasks/task_e_68b7dbe28ad8832e915b11a82be1653e