### PR TITLE
Resolve path literals via router

### DIFF
--- a/self_debugger_sandbox.py
+++ b/self_debugger_sandbox.py
@@ -562,7 +562,7 @@ class SelfDebuggerSandbox(AutomatedDebugger):
         test_paths = [path]
         tmp: Path | None = None
         self._last_test_log = None
-        sandbox_dir = Path(self._settings.sandbox_data_dir)
+        sandbox_dir = resolve_path(self._settings.sandbox_data_dir)
         sandbox_dir.mkdir(parents=True, exist_ok=True)
         try:
             logs = list(self._recent_logs())

--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -5889,9 +5889,7 @@ class SelfImprovementEngine:
         except Exception:
             self.logger.exception("relevancy evaluation failed")
         try:
-            metrics_db = Path(metrics_db_path)
-            if not metrics_db.is_absolute():
-                metrics_db = _repo_path() / metrics_db
+            metrics_db = resolve_path(metrics_db_path)
             scan_flags = radar_scan(metrics_db)
             if scan_flags:
                 flags.update(scan_flags)
@@ -6581,7 +6579,7 @@ class SelfImprovementEngine:
                         "applying helper patch",
                         extra=log_record(trending_topic=trending_topic),
                     )
-                    mod_path = resolve_path(".") / "auto_helpers.py"
+                    mod_path = resolve_path("auto_helpers.py")
                     start_patch = time.perf_counter()
                     patch_id, reverted, delta = self.self_coding_engine.apply_patch(
                         mod_path,
@@ -6874,7 +6872,7 @@ class SelfImprovementEngine:
                         try:
                             forecaster = UpgradeForecaster(self.foresight_tracker)
                             graph = WorkflowGraph()
-                            logger_obj = ForecastLogger("forecast_records/foresight.log")
+                            logger_obj = ForecastLogger(resolve_path("forecast_records/foresight.log"))
                             decision = is_foresight_safe_to_promote(
                                 workflow_id,
                                 str(patch_id) if patch_id is not None else "",


### PR DESCRIPTION
## Summary
- route sandbox data directory through resolve_path
- normalize self-improvement helper and metrics paths via resolve_path
- log foresight data using router-resolved forecast log file

## Testing
- `pytest self_improvement/tests/test_utils_cache_cleanup.py self_improvement/tests/test_synergy_weights_validation.py` *(fails: ImportError: attempted relative import with no known parent package)*
- `python -m py_compile self_debugger_sandbox.py self_improvement/engine.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7dde604cc832e8313241b0a65680e