### PR TITLE
Use path_for_prompt for prompt file paths

### DIFF
--- a/dynamic_path_router.py
+++ b/dynamic_path_router.py
@@ -135,7 +135,7 @@ def resolve_dir(dirname: str) -> Path:
 def path_for_prompt(name: str) -> str:
     """Return a normalised string path suitable for inclusion in prompts."""
 
-    return str(resolve_path(name))
+    return resolve_path(name).as_posix()
 
 
 def clear_cache() -> None:

--- a/run_autonomous.py
+++ b/run_autonomous.py
@@ -32,7 +32,7 @@ import math
 import uuid
 from scipy.stats import t
 from db_router import init_db_router
-from dynamic_path_router import resolve_path, get_project_root
+from dynamic_path_router import resolve_path, get_project_root, path_for_prompt
 from sandbox_settings import SandboxSettings
 from sandbox_runner.bootstrap import (
     bootstrap_environment,
@@ -133,7 +133,7 @@ def _visual_agent_running(urls: str) -> bool:
 
 
 spec = importlib.util.spec_from_file_location(
-    "menace", str(resolve_path("__init__.py"))
+    "menace", path_for_prompt("__init__.py")
 )
 menace_pkg = importlib.util.module_from_spec(spec)
 sys.modules["menace"] = menace_pkg
@@ -210,7 +210,7 @@ if not hasattr(sandbox_runner, "_sandbox_main"):
     import importlib.util
 
     spec = importlib.util.spec_from_file_location(
-        "sandbox_runner", str(resolve_path("sandbox_runner.py"))
+        "sandbox_runner", path_for_prompt("sandbox_runner.py")
     )
     sr_mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(sr_mod)
@@ -1675,7 +1675,7 @@ def main(argv: List[str] | None = None) -> None:
     if autostart:
         from visual_agent_manager import VisualAgentManager
 
-        agent_mgr = VisualAgentManager(str(resolve_path("menace_visual_agent_2.py")))
+        agent_mgr = VisualAgentManager(path_for_prompt("menace_visual_agent_2.py"))
         if not _visual_agent_running(settings.visual_agent_urls):
             try:
                 logger.info("starting visual agent")

--- a/scripts/launch_personal.py
+++ b/scripts/launch_personal.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import time
 
-from dynamic_path_router import resolve_path
+from dynamic_path_router import resolve_path, path_for_prompt
 
 import auto_env_setup
 import run_autonomous
@@ -18,7 +18,7 @@ _DEF_PORT = "8001"
 
 def _start_agent(env: dict[str, str]) -> subprocess.Popen[bytes]:
     """Spawn ``menace_visual_agent_2.py`` with ``env``."""
-    cmd = [sys.executable, str(resolve_path("menace_visual_agent_2.py"))]
+    cmd = [sys.executable, path_for_prompt("menace_visual_agent_2.py")]
     if env.get("VISUAL_AGENT_AUTO_RECOVER") == "1":
         cmd.append("--auto-recover")
     return subprocess.Popen(cmd, env=env)

--- a/scripts/run_personal_sandbox.py
+++ b/scripts/run_personal_sandbox.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 import time
 
-from dynamic_path_router import resolve_path
+from dynamic_path_router import resolve_path, path_for_prompt
 
 from visual_agent_manager import VisualAgentManager
 import run_autonomous
@@ -45,7 +45,7 @@ def main(argv: list[str] | None = None) -> None:
     os.environ.setdefault("MENACE_AGENT_PORT", _DEF_PORT)
     os.environ.setdefault("VISUAL_AGENT_URLS", f"http://127.0.0.1:{_DEF_PORT}")
 
-    manager = VisualAgentManager(str(resolve_path("menace_visual_agent_2.py")))
+    manager = VisualAgentManager(path_for_prompt("menace_visual_agent_2.py"))
     started = _start_agent(manager)
     try:
         run_autonomous.main(argv)


### PR DESCRIPTION
## Summary
- Normalize prompt file paths with `path_for_prompt`
- Replace hard coded `str(resolve_path(...))` usages with `path_for_prompt`

## Testing
- `python -m pytest unit_tests/test_prompt_path_resolution.py tests/test_resolve_path_nested_repo.py -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e00026b4832e9eff86c2eb7da06b