### PR TITLE
Use dynamic path resolver for sandbox data files

### DIFF
--- a/adaptive_roi_cli.py
+++ b/adaptive_roi_cli.py
@@ -22,6 +22,7 @@ from .truth_adapter import TruthAdapter
 from .composite_workflow_scorer import CompositeWorkflowScorer
 from .roi_results_db import ROIResultsDB
 import db_router
+from .dynamic_path_router import resolve_path
 
 
 # ---------------------------------------------------------------------------
@@ -324,7 +325,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--model",
-        default="sandbox_data/adaptive_roi.pkl",
+        default=str(Path(resolve_path("sandbox_data")) / "adaptive_roi.pkl"),
         help="Model path",
     )
     parser.add_argument("--slope-threshold", type=float, default=None, help="Slope threshold")
@@ -381,10 +382,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     p_refresh.add_argument("--evaluation-db", default="evaluation_history.db")
     p_refresh.add_argument("--roi-events-db", default="roi_events.db")
     p_refresh.add_argument(
-        "--history", default="sandbox_data/roi_history.json", help="Tracker history path"
+        "--history",
+        default=str(Path(resolve_path("sandbox_data")) / "roi_history.json"),
+        help="Tracker history path",
     )
     p_refresh.add_argument(
-        "--output-csv", default="sandbox_data/adaptive_roi.csv", help="CSV dump path"
+        "--output-csv",
+        default=str(Path(resolve_path("sandbox_data")) / "adaptive_roi.csv"),
+        help="CSV dump path",
     )
     p_refresh.add_argument(
         "--interval", type=int, default=3600, help="Seconds between refresh"
@@ -400,7 +405,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Comma separated scenario names; defaults to standard presets",
     )
     p_card.add_argument(
-        "--history", default="sandbox_data/roi_history.json", help="Tracker history path"
+        "--history",
+        default=str(Path(resolve_path("sandbox_data")) / "roi_history.json"),
+        help="Tracker history path",
     )
     p_card.add_argument("--output", default=None, help="Write scorecard JSON to file")
     p_card.set_defaults(func=_scorecard)
@@ -425,10 +432,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     p_sched.add_argument("--evaluation-db", default="evaluation_history.db")
     p_sched.add_argument("--roi-events-db", default="roi_events.db")
     p_sched.add_argument(
-        "--history", default="sandbox_data/roi_history.json", help="Tracker history path"
+        "--history",
+        default=str(Path(resolve_path("sandbox_data")) / "roi_history.json"),
+        help="Tracker history path",
     )
     p_sched.add_argument(
-        "--output-csv", default="sandbox_data/adaptive_roi.csv", help="CSV dump path"
+        "--output-csv",
+        default=str(Path(resolve_path("sandbox_data")) / "adaptive_roi.csv"),
+        help="CSV dump path",
     )
     p_sched.add_argument(
         "--interval", type=int, default=3600, help="Seconds between retraining"
@@ -447,7 +458,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     p_sched.add_argument(
         "--log-path",
-        default="sandbox_data/adaptive_roi_schedule.log",
+        default=str(Path(resolve_path("sandbox_data")) / "adaptive_roi_schedule.log"),
         help="Log file path",
     )
     p_sched.set_defaults(func=_schedule)

--- a/auto_env_setup.py
+++ b/auto_env_setup.py
@@ -12,6 +12,7 @@ from typing import Dict, Iterable
 from . import config_discovery as cd
 from .secrets_manager import SecretsManager
 from .vault_secret_provider import VaultSecretProvider
+from .dynamic_path_router import resolve_path
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +43,7 @@ DEFAULT_VARS: Dict[str, str] = {
     "OVERRIDE_UPDATE_INTERVAL": "600",
     "AUTO_BACKUP": "0",
     "MAINTENANCE_DB": "maintenance.db",
-    "SANDBOX_DATA_DIR": "sandbox_data",
+    "SANDBOX_DATA_DIR": str(resolve_path("sandbox_data")),
     "SELF_TEST_DISABLE_ORPHANS": "0",
     "SELF_TEST_DISCOVER_ORPHANS": "1",
     "SELF_TEST_RECURSIVE_ORPHANS": "1",

--- a/borderline_bucket.py
+++ b/borderline_bucket.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Tuple
 
 from filelock import FileLock
+from dynamic_path_router import resolve_path
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +30,11 @@ class BorderlineBucket:
     """Persist borderline workflow information to a JSONL file."""
 
     def __init__(self, path: str | Path | None = None) -> None:
-        self.path = Path(path) if path else Path("sandbox_data/borderline_bucket.jsonl")
+        self.path = (
+            Path(path)
+            if path
+            else Path(resolve_path("sandbox_data")) / "borderline_bucket.jsonl"
+        )
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self.lock = FileLock(str(self.path) + ".lock")
         self._load()

--- a/composite_workflow_scorer.py
+++ b/composite_workflow_scorer.py
@@ -26,6 +26,7 @@ from .roi_tracker import ROITracker
 from .roi_calculator import ROICalculator
 from .roi_results_db import ROIResultsDB
 from . import sandbox_runner
+from .dynamic_path_router import resolve_path
 from .workflow_scorer_core import (
     ROIScorer as BaseROIScorer,
     EvaluationResult,
@@ -46,7 +47,7 @@ try:  # pragma: no cover - runtime failures should not break scoring
 except Exception:  # pragma: no cover - defensive fallback
     PATCH_SUCCESS_RATE = 1.0
 
-WINNING_SEQUENCES_PATH = Path("sandbox_data/winning_sequences.json")
+WINNING_SEQUENCES_PATH = Path(resolve_path("sandbox_data")) / "winning_sequences.json"
 
 
 # ---------------------------------------------------------------------------

--- a/dynamic_module_mapper.py
+++ b/dynamic_module_mapper.py
@@ -8,6 +8,7 @@ from typing import Dict, Iterable
 from orphan_analyzer import analyze_redundancy
 
 from module_graph_analyzer import build_import_graph, cluster_modules
+from dynamic_path_router import resolve_path
 
 
 def discover_module_groups(
@@ -71,7 +72,7 @@ def build_module_map(
                 pass
             filtered[mod] = grp
         mapping = filtered
-    out = root / "sandbox_data" / "module_map.json"
+    out = Path(resolve_path("sandbox_data")) / "module_map.json"
     out.parent.mkdir(parents=True, exist_ok=True)
     with open(out, "w", encoding="utf-8") as fh:
         json.dump(mapping, fh, indent=2)

--- a/relevancy_radar_cli.py
+++ b/relevancy_radar_cli.py
@@ -13,8 +13,10 @@ import json
 from pathlib import Path
 from typing import Iterable
 
+from dynamic_path_router import resolve_path
+
 # Path to the relevancy metrics file produced by :class:`RelevancyRadar`.
-_METRICS_FILE = Path(__file__).resolve().parent / "sandbox_data" / "relevancy_metrics.json"
+_METRICS_FILE = Path(resolve_path("sandbox_data")) / "relevancy_metrics.json"
 
 
 # ---------------------------------------------------------------------------

--- a/synergy_weight_cli.py
+++ b/synergy_weight_cli.py
@@ -19,8 +19,9 @@ from menace.metrics_exporter import (
     synergy_weight_update_alerts_total,
 )
 from alert_dispatcher import dispatch_alert
+from dynamic_path_router import resolve_path
 
-LOG_PATH = Path("sandbox_data/synergy_weights.log")
+LOG_PATH = Path(resolve_path("sandbox_data")) / "synergy_weights.log"
 
 
 def _load_engine(path: str | None):

--- a/truth_adapter.py
+++ b/truth_adapter.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Tuple
 
 from .logging_utils import get_logger, log_record
+from .dynamic_path_router import resolve_path
 
 import numpy as np
 from numpy.typing import NDArray
@@ -41,7 +42,8 @@ class TruthAdapter:
 
     def __init__(
         self,
-        model_path: str | Path = "sandbox_data/truth_adapter.pkl",
+        model_path: str | Path = Path(resolve_path("sandbox_data"))
+        / "truth_adapter.pkl",
         model_type: str = "ridge",
         ridge_params: dict[str, Any] | None = None,
         xgb_params: dict[str, Any] | None = None,


### PR DESCRIPTION
## Summary
- ensure `SANDBOX_DATA_DIR` and related paths resolve via `dynamic_path_router.resolve_path`
- update CLI tools and utilities to wrap sandbox data files with `Path(resolve_path(...))`
- centralize sandbox data file handling for scoring and training modules

## Testing
- `pytest tests/test_synergy_weight_cli.py -q` *(fails: ModuleNotFoundError: No module named 'menace.self_improvement.engine'; 'menace.self_improvement' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e7bff878832eb7731747781ba2d2