### PR TITLE
refactor: centralize sandbox path resolution

### DIFF
--- a/sandbox_runner/cycle.py
+++ b/sandbox_runner/cycle.py
@@ -23,6 +23,7 @@ from log_tags import FEEDBACK, IMPROVEMENT_PATH, INSIGHT, ERROR_FIX
 from foresight_tracker import ForesightTracker
 from db_router import GLOBAL_ROUTER, init_db_router
 from alert_dispatcher import dispatch_alert
+from dynamic_path_router import resolve_path
 
 
 # ``vector_service`` is an essential dependency but importing it at module load
@@ -444,7 +445,7 @@ def run_workflow_scenarios(
 
     from task_handoff_bot import WorkflowDB
 
-    wf_db = WorkflowDB(Path(workflow_db))
+    wf_db = WorkflowDB(resolve_path(str(workflow_db)))
     workflows = wf_db.fetch(limit=1000)
     report: Dict[str, Dict[str, float]] = {}
 
@@ -459,7 +460,7 @@ def run_workflow_scenarios(
         wf_id = str(getattr(wf, "wid", getattr(wf, "id", "")))
         report[wf_id] = deltas
 
-    out_path = Path(data_dir) / "scenario_deltas.json"
+    out_path = resolve_path(str(data_dir)) / "scenario_deltas.json"
     try:
         out_path.parent.mkdir(parents=True, exist_ok=True)
         with out_path.open("w", encoding="utf-8") as fh:
@@ -1103,7 +1104,7 @@ def _sandbox_cycle_runner(
         )
         flexibility = float(len(mods)) / float(total_mods)
 
-        cov_path = ctx.repo / ".coverage"
+        cov_path = resolve_path(".coverage")
         if cov_path.exists():
             try:
                 from coverage import CoverageData
@@ -2013,9 +2014,9 @@ def _sandbox_cycle_runner(
     try:
         load_training_data(
             tracker,
-            evolution_path=ctx.repo / "evolution_history.db",
-            roi_events_path=ctx.repo / "roi_events.db",
-            output_path=ctx.repo / "sandbox_data/adaptive_roi.csv",
+            evolution_path=resolve_path("evolution_history.db"),
+            roi_events_path=resolve_path("roi_events.db"),
+            output_path=resolve_path("sandbox_data/adaptive_roi.csv"),
             router=router,
         )
     except Exception:
@@ -2056,7 +2057,7 @@ def _sandbox_cycle_runner(
                 settings.relevancy_radar_compress_ratio,
                 settings.relevancy_radar_replace_ratio,
             )
-            flag_path = ctx.repo / "sandbox_data" / "relevancy_flags.json"
+            flag_path = resolve_path("sandbox_data/relevancy_flags.json")
             flag_path.parent.mkdir(parents=True, exist_ok=True)
             with flag_path.open("w", encoding="utf-8") as fh:
                 json.dump(flags, fh, indent=2, sort_keys=True)

--- a/sandbox_runner/orphan_discovery.py
+++ b/sandbox_runner/orphan_discovery.py
@@ -8,6 +8,8 @@ import os
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
 
+from dynamic_path_router import resolve_path
+
 try:  # pragma: no cover - executed during import
     import orphan_analyzer
 except ModuleNotFoundError as exc:  # pragma: no cover - import-time guard
@@ -809,7 +811,7 @@ def discover_recursive_orphans(
 
     repo = Path(repo_path).resolve()
     if module_map is None:
-        module_map = repo / "sandbox_data" / "module_map.json"
+        module_map = resolve_path("sandbox_data/module_map.json")
 
     known: set[str] = set()
     if module_map and Path(module_map).exists():

--- a/sandbox_runner/orphan_integration.py
+++ b/sandbox_runner/orphan_integration.py
@@ -11,6 +11,7 @@ from datetime import datetime
 import yaml
 
 from logging_utils import get_logger
+from dynamic_path_router import resolve_path
 
 if TYPE_CHECKING:  # pragma: no cover - heavy import for type checking only
     from roi_tracker import ROITracker
@@ -89,7 +90,7 @@ def integrate_and_graph_orphans(
             from module_synergy_grapher import ModuleSynergyGrapher, load_graph
 
             grapher = ModuleSynergyGrapher(root=repo)
-            graph_path = repo / "sandbox_data" / "module_synergy_graph.json"
+            graph_path = resolve_path("sandbox_data/module_synergy_graph.json")
             if graph_path.exists():
                 try:
                     grapher.graph = load_graph(graph_path)
@@ -111,7 +112,7 @@ def integrate_and_graph_orphans(
             from intent_clusterer import IntentClusterer
 
             clusterer = IntentClusterer()
-            clusterer.index_modules([repo / m for m in added])
+            clusterer.index_modules([resolve_path(m) for m in added])
             cluster_ok = True
         except Exception:  # pragma: no cover - best effort
             log.warning("intent clustering update failed", exc_info=True)
@@ -132,7 +133,7 @@ def integrate_and_graph_orphans(
         retry = list(added)
         tested["retry"] = retry
 
-    log_path = repo / "sandbox_data" / "orphan_integration.log"
+    log_path = resolve_path("sandbox_data/orphan_integration.log")
     record = {
         "timestamp": datetime.utcnow().isoformat(),
         "modules": added,
@@ -171,7 +172,7 @@ def _record_orphan_metrics(
         Logger used for diagnostic messages.
     """
 
-    path = repo / "sandbox_metrics.yaml"
+    path = resolve_path("sandbox_metrics.yaml")
     data: Dict[str, Dict[str, float]] = {}
     try:
         if path.exists():


### PR DESCRIPTION
## Summary
- use resolve_path for sandbox_runner path defaults and systemd assets
- delegate workflow and reporting paths through resolve_path
- resolve orphan integration artifacts via resolve_path

## Testing
- `pytest sandbox_runner/tests` *(fails: ModuleNotFoundError, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_68b7edbee004832e9afde7779c254f81