### PR TITLE
docs: recommend resolve_path for sandbox data

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,24 @@ PY
 )" --help
 ```
 
+Environment variables influence path resolution. Setting `MENACE_ROOT` or
+`SANDBOX_REPO_PATH` overrides the repository root:
+
+```bash
+SANDBOX_REPO_PATH=/alt/clone python - <<'PY'
+from dynamic_path_router import resolve_path
+print(resolve_path('configs/foresight_templates.yaml'))
+PY
+```
+
+Combine `SANDBOX_DATA_DIR` with `resolve_path` to locate runtime data files:
+
+```python
+import os
+from dynamic_path_router import resolve_path
+roi_history = resolve_path(f"{os.getenv('SANDBOX_DATA_DIR', 'sandbox_data')}/roi_history.json")
+```
+
 The router enables experimenting with alternative directory structures without
 breaking tooling, and nested clones can share the same lookup logic.
 When adding new scripts or documentation, resolve paths with
@@ -32,7 +50,8 @@ configuration. The generated file includes stub values for critical settings:
 - `DATABASE_URL` defaults to `sqlite:///menace.db`
 - `MODELS` resolves to the bundled `micro_models` directory when set to `demo`
 - `OPENAI_API_KEY` and `STRIPE_API_KEY` placeholders
-- `SANDBOX_DATA_DIR` defaults to `sandbox_data`
+- `SANDBOX_DATA_DIR` defaults to `sandbox_data` (use `resolve_path` when
+  referencing files under this directory)
 - `SANDBOX_LOG_LEVEL` defaults to `INFO` (use `--log-level` to override)
 - `PROMPT_CHUNK_TOKEN_THRESHOLD` and `CHUNK_SUMMARY_CACHE_DIR` control code
   chunking token limits and caching for large file summaries (see
@@ -81,7 +100,7 @@ message if installation fails.
 - ROI foresight with `ForesightTracker.predict_roi_collapse`, projecting trends,
   classifying risk (Stable, Slow decay, Volatile, Immediate collapse risk) and
   flagging brittle workflows. Baseline curves live in
-  `configs/foresight_templates.yaml` with keys `profiles`, `trajectories`,
+  `resolve_path('configs/foresight_templates.yaml')` with keys `profiles`, `trajectories`,
   `entropy_profiles`, `risk_profiles`, `entropy_trajectories` and
   `risk_trajectories`
 - Self-coding manager applies patches then deploys via the automation pipeline

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -19,9 +19,21 @@ This guide walks you through the common Menace workflows using the new `menace` 
    values for critical settings:
 
    - `DATABASE_URL` defaults to `sqlite:///menace.db`
-   - `SANDBOX_DATA_DIR` defaults to `sandbox_data`
+   - `SANDBOX_DATA_DIR` defaults to `sandbox_data` (use `resolve_path` when referencing files)
    - `PROMPT_CHUNK_TOKEN_THRESHOLD` and `PROMPT_CHUNK_CACHE_DIR` control code
      chunking token limits and caching for large file summaries
+
+   Resolve paths with `dynamic_path_router.resolve_path` so configurations
+   remain portable:
+
+   ```python
+   import os
+   from dynamic_path_router import resolve_path
+   data_dir = resolve_path(os.getenv("SANDBOX_DATA_DIR", "sandbox_data"))
+   ```
+
+   Setting `MENACE_ROOT` or `SANDBOX_REPO_PATH` will change the root used by
+   `resolve_path`, allowing the CLI to target alternative checkouts.
 3. **Run the tests** (optional)
    ```bash
    menace test

--- a/docs/sandbox_environment.md
+++ b/docs/sandbox_environment.md
@@ -14,6 +14,20 @@ The sandbox expects a few variables to be set before launch:
 Run `auto_env_setup.ensure_env()` to generate a `.env` file with these variables when
 missing. Values may also be supplied via the shell environment.
 
+Use `dynamic_path_router.resolve_path` for all repository file lookups so paths
+remain portable. Combine it with `SANDBOX_DATA_DIR` when accessing runtime
+artifacts:
+
+```python
+import os
+from dynamic_path_router import resolve_path
+data_dir = resolve_path(os.getenv("SANDBOX_DATA_DIR", "sandbox_data"))
+```
+
+Setting `MENACE_ROOT` or `SANDBOX_REPO_PATH` changes the repository root used by
+`resolve_path`, allowing alternate checkouts to be targeted without modifying
+code.
+
 ## Prompt logging variables
 
 These optional variables control where prompt execution results are stored:

--- a/docs/synergy_learning.md
+++ b/docs/synergy_learning.md
@@ -1,6 +1,14 @@
 # Synergy learning
 
-This page explains how synergy weights are learned and how predictions feed into ROI calculations. Synergy history is persisted in `synergy_history.db` within the sandbox data directory. If a legacy `synergy_history.json` exists it is migrated automatically at startup.
+This page explains how synergy weights are learned and how predictions feed into ROI calculations. Synergy history is persisted in `synergy_history.db` under the sandbox data directory. Resolve the path dynamically to respect environment overrides:
+
+```python
+import os
+from dynamic_path_router import resolve_path
+history = resolve_path(f"{os.getenv('SANDBOX_DATA_DIR', 'sandbox_data')}/synergy_history.db")
+```
+
+If a legacy `synergy_history.json` exists it is migrated automatically at startup.
 
 ## SynergyWeightLearner
 


### PR DESCRIPTION
## Summary
- document using `dynamic_path_router.resolve_path` for sandbox data and template paths
- add examples showing `SANDBOX_REPO_PATH` and `SANDBOX_DATA_DIR` environment variables influencing path lookups

## Testing
- `pre-commit run --files README.md docs/sandbox_environment.md docs/quickstart.md docs/synergy_learning.md`
- `pytest` *(fails: 445 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f4a16bf8832ea9759d8bc1871295