### PR TITLE
Resolve Menace CLI scaffold script paths dynamically

### DIFF
--- a/menace_cli.py
+++ b/menace_cli.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import uuid
 
+from dynamic_path_router import resolve_path
 from db_router import init_db_router
 
 # Expose a DBRouter for CLI operations early so imported modules can rely on
@@ -94,14 +95,16 @@ def _normalise_hits(hits, origin=None):
 
 def handle_new_db(args: argparse.Namespace) -> int:
     """Handle ``new-db`` command."""
-    return _run([sys.executable, "scripts/new_db_template.py", args.name])
+    script_path = str(resolve_path("scripts/new_db_template.py"))
+    return _run([sys.executable, script_path, args.name])
 
 
 def handle_new_vector(args: argparse.Namespace) -> int:
     """Handle ``new-vector`` command."""
+    script_path = str(resolve_path("scripts/new_vector_module.py"))
     cmd = [
         sys.executable,
-        "scripts/new_vector_module.py",
+        script_path,
         args.name,
     ]
     if args.root:

--- a/tests/test_menace_cli_resolve_path.py
+++ b/tests/test_menace_cli_resolve_path.py
@@ -1,0 +1,78 @@
+import argparse
+import sys
+import types
+from pathlib import Path
+
+
+# Stub modules required by menace_cli imports
+def _auto_link(*a, **k):
+    def decorator(func):
+        return func
+
+    return decorator
+
+
+sys.modules.setdefault("auto_link", types.SimpleNamespace(auto_link=_auto_link))
+sys.modules.setdefault("unified_event_bus", types.SimpleNamespace(UnifiedEventBus=object))
+sys.modules.setdefault(
+    "retry_utils",
+    types.SimpleNamespace(
+        publish_with_retry=lambda *a, **k: None,
+        with_retry=lambda *a, **k: None,
+    ),
+)
+sys.modules.setdefault(
+    "alert_dispatcher",
+    types.SimpleNamespace(send_discord_alert=lambda *a, **k: None, CONFIG={}),
+)
+sys.modules.setdefault("menace.plugins", types.SimpleNamespace(load_plugins=lambda *a, **k: None))
+
+import menace_cli
+
+
+def _capture_run(store):
+    def runner(cmd):
+        store["cmd"] = cmd
+        return 0
+
+    return runner
+
+
+def test_handle_new_db_uses_resolved_path(monkeypatch):
+    store = {}
+
+    def fake_resolve(path):
+        store["resolved"] = path
+        return Path("/tmp/db_script.py")
+
+    monkeypatch.setattr(menace_cli, "resolve_path", fake_resolve)
+    monkeypatch.setattr(menace_cli, "_run", _capture_run(store))
+
+    args = argparse.Namespace(name="demo")
+    rc = menace_cli.handle_new_db(args)
+    assert rc == 0
+    assert store["resolved"] == "scripts/new_db_template.py"
+    assert store["cmd"][1] == "/tmp/db_script.py"
+
+
+def test_handle_new_vector_uses_resolved_path(monkeypatch):
+    store = {}
+
+    def fake_resolve(path):
+        store["resolved"] = path
+        return Path("/tmp/vector_script.py")
+
+    monkeypatch.setattr(menace_cli, "resolve_path", fake_resolve)
+    monkeypatch.setattr(menace_cli, "_run", _capture_run(store))
+
+    args = argparse.Namespace(
+        name="demo",
+        root=None,
+        register_router=False,
+        create_migration=False,
+    )
+    rc = menace_cli.handle_new_vector(args)
+    assert rc == 0
+    assert store["resolved"] == "scripts/new_vector_module.py"
+    assert store["cmd"][1] == "/tmp/vector_script.py"
+


### PR DESCRIPTION
## Summary
- resolve Menace CLI scaffold script paths using `resolve_path`
- cover `handle_new_db` and `handle_new_vector` handlers with tests using the resolved paths

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_menace_cli_resolve_path.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7f6775e38832e90f9859a3054bb07