### PR TITLE
Refactor path references to dynamic resolver

### DIFF
--- a/menace_master.py
+++ b/menace_master.py
@@ -28,6 +28,7 @@ from pathlib import Path
 import sys
 import logging
 from logging_utils import log_record
+from dynamic_path_router import resolve_path
 
 # Logger for this module
 logger = logging.getLogger(__name__)
@@ -252,7 +253,7 @@ def _start_dependency_watchdog(
 
 
 def _install_user_systemd() -> None:
-    service_file = Path("systemd/menace.service")
+    service_file = resolve_path("systemd/menace.service")
     target = Path.home() / ".config" / "systemd" / "user" / "menace.service"
     target.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy(service_file, target)
@@ -262,7 +263,7 @@ def _install_user_systemd() -> None:
 
 def _install_task_scheduler() -> None:
     exe = sys.executable
-    script = Path(__file__).resolve().parent / "service_supervisor.py"
+    script = resolve_path("service_supervisor.py")
     cmd = [
         "schtasks",
         "/Create",

--- a/service_installer.py
+++ b/service_installer.py
@@ -2,20 +2,22 @@
 
 from __future__ import annotations
 
+import argparse
 import os
 import platform
 import shutil
 import subprocess
 import sys
-from pathlib import Path
-import argparse
 import textwrap
+from pathlib import Path
+
+from dynamic_path_router import resolve_path
 
 SERVICE_NAME = "menace"
 
 
 def _install_systemd() -> None:
-    service_file = Path("systemd/menace.service")
+    service_file = resolve_path("systemd/menace.service")
     target = Path("/etc/systemd/system/menace.service")
     if os.geteuid() != 0:
         print("Systemd installation requires root privileges")
@@ -31,7 +33,7 @@ def _install_systemd() -> None:
 
 def _install_windows() -> None:
     exe = sys.executable
-    script = Path(__file__).resolve().parent / "service_supervisor.py"
+    script = resolve_path("service_supervisor.py")
     cmd = [
         "sc",
         "create",


### PR DESCRIPTION
## Summary
- use `resolve_path` for systemd and supervisor scripts in service installer
- resolve service script paths in `menace_master`
- leverage dynamic path router for `menace_master.py` executable in autoscaler

## Testing
- `python -m py_compile service_installer.py menace_master.py autoscaler.py`
- `pytest -q` *(fails: KeyboardInterrupt during heavy dependency import)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f85dffbc832eae46a7b761d58242