### PR TITLE
Resolve config path before loading sandbox settings

### DIFF
--- a/run_autonomous.py
+++ b/run_autonomous.py
@@ -2044,7 +2044,7 @@ def bootstrap(config_path: str = "config/bootstrap.yaml") -> None:
     import threading
 
     try:
-        settings = load_sandbox_settings(config_path)
+        settings = load_sandbox_settings(resolve_path(config_path))
     except ValidationError as exc:
         raise SystemExit(f"Invalid bootstrap configuration: {exc}") from exc
 

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -2215,10 +2215,11 @@ def load_sandbox_settings(path: str | None = None) -> SandboxSettings:
 
     data: dict[str, Any] = {}
     if path:
+        path = resolve_path(path)
         with open(path, "r", encoding="utf-8") as fh:
-            if path.endswith((".yml", ".yaml")):
+            if path.suffix in (".yml", ".yaml"):
                 data = yaml.safe_load(fh) or {}
-            elif path.endswith(".json"):
+            elif path.suffix == ".json":
                 data = json.load(fh)
             else:  # pragma: no cover - defensive
                 raise ValueError(f"Unsupported config format: {path}")


### PR DESCRIPTION
## Summary
- ensure run_autonomous resolves config path before loading settings
- load_sandbox_settings resolves paths before reading files

## Testing
- `python -m py_compile run_autonomous.py sandbox_settings.py`
- `pytest unit_tests/test_settings_env_overrides.py` *(fails: ImportError: attempted relative import with no known parent package)*
- `pytest unit_tests/test_settings_env_overrides.py::test_flakiness_runs_settings_override unit_tests/test_settings_env_overrides.py::test_orphan_retry_settings_override`
- `pytest tests/test_bootstrap_service_deps.py::test_missing_service_warns` *(fails: AttributeError: 'SandboxSettings' object has no attribute 'sandbox_required_db_files')*


------
https://chatgpt.com/codex/tasks/task_e_68b7fe8336c0832e9dcf59b396729678