### PR TITLE
Log fallback overfitting cycle

### DIFF
--- a/self_improvement/meta_planning.py
+++ b/self_improvement/meta_planning.py
@@ -1052,6 +1052,7 @@ async def self_improvement_cycle(
                     ),
                 )
                 decision = "run"
+                _debug_cycle("fallback", reason="overfitting")
             else:
                 _debug_cycle("skipped", reason=info.get("reason"))
                 await asyncio.sleep(interval)


### PR DESCRIPTION
## Summary
- Log a debug cycle record when a skip decision falls back to run due to overfitting
- Extend cycle evaluation tests to simulate recent error entropy and verify overfitting fallback logging

## Testing
- `PYTHONPATH=/workspace/menace_sandbox pytest -q self_improvement/tests/test_cycle_evaluation.py::test_cycle_overfitting_fallback_logs_before_planner -vv` *(fails: ImportError: cannot import name 'RAISE_ERRORS' from 'menace')*


------
https://chatgpt.com/codex/tasks/task_e_68b808b26e94832e828cbf328518655f