### PR TITLE
Use resolve_path for default DB paths

### DIFF
--- a/metrics_dashboard.py
+++ b/metrics_dashboard.py
@@ -28,9 +28,18 @@ try:  # pragma: no cover - allow running as script
 except Exception:  # pragma: no cover - fallback when executed directly
     from db_router import init_db_router  # type: ignore
 
+try:  # pragma: no cover - allow running as script
+    from .dynamic_path_router import resolve_path  # type: ignore
+except Exception:  # pragma: no cover - fallback when executed directly
+    from dynamic_path_router import resolve_path  # type: ignore
+
 MENACE_ID = uuid.uuid4().hex
-LOCAL_DB_PATH = os.getenv("MENACE_LOCAL_DB_PATH", f"./menace_{MENACE_ID}_local.db")
-SHARED_DB_PATH = os.getenv("MENACE_SHARED_DB_PATH", "./shared/global.db")
+LOCAL_DB_PATH = os.getenv(
+    "MENACE_LOCAL_DB_PATH", str(resolve_path(f"menace_{MENACE_ID}_local.db"))
+)
+SHARED_DB_PATH = os.getenv(
+    "MENACE_SHARED_DB_PATH", str(resolve_path("shared/global.db"))
+)
 GLOBAL_ROUTER = init_db_router(MENACE_ID, LOCAL_DB_PATH, SHARED_DB_PATH)
 
 router = GLOBAL_ROUTER

--- a/sandbox_dashboard.py
+++ b/sandbox_dashboard.py
@@ -20,10 +20,18 @@ from . import synergy_weight_cli
 from .alignment_dashboard import load_alignment_flag_records
 from .readiness_index import military_grade_readiness
 
+try:  # pragma: no cover - allow running as script
+    from .dynamic_path_router import resolve_path  # type: ignore
+except Exception:  # pragma: no cover - fallback when executed directly
+    from dynamic_path_router import resolve_path  # type: ignore
 
 MENACE_ID = uuid.uuid4().hex
-LOCAL_DB_PATH = os.getenv("MENACE_LOCAL_DB_PATH", f"./menace_{MENACE_ID}_local.db")
-SHARED_DB_PATH = os.getenv("MENACE_SHARED_DB_PATH", "./shared/global.db")
+LOCAL_DB_PATH = os.getenv(
+    "MENACE_LOCAL_DB_PATH", str(resolve_path(f"menace_{MENACE_ID}_local.db"))
+)
+SHARED_DB_PATH = os.getenv(
+    "MENACE_SHARED_DB_PATH", str(resolve_path("shared/global.db"))
+)
 GLOBAL_ROUTER = init_db_router(MENACE_ID, LOCAL_DB_PATH, SHARED_DB_PATH)
 
 

--- a/sandbox_runner.py
+++ b/sandbox_runner.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 
 from db_router import init_db_router
 from scope_utils import Scope, build_scope_clause, apply_scope
+from dynamic_path_router import resolve_path, repo_root
 
 # Initialise a router for this process with a unique menace_id so
 # ``GLOBAL_ROUTER`` becomes available to imported modules.  Import modules that
@@ -29,8 +30,12 @@ from scope_utils import Scope, build_scope_clause, apply_scope
 # legacy behaviour where sandbox utilities operate without a database connection
 # when possible. All DB access must go through the router.
 MENACE_ID = uuid.uuid4().hex
-LOCAL_DB_PATH = os.getenv("MENACE_LOCAL_DB_PATH", f"./menace_{MENACE_ID}_local.db")
-SHARED_DB_PATH = os.getenv("MENACE_SHARED_DB_PATH", "./shared/global.db")
+LOCAL_DB_PATH = os.getenv(
+    "MENACE_LOCAL_DB_PATH", str(resolve_path(f"menace_{MENACE_ID}_local.db"))
+)
+SHARED_DB_PATH = os.getenv(
+    "MENACE_SHARED_DB_PATH", str(resolve_path("shared/global.db"))
+)
 GLOBAL_ROUTER = init_db_router(MENACE_ID, LOCAL_DB_PATH, SHARED_DB_PATH)
 router = GLOBAL_ROUTER
 
@@ -173,8 +178,6 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, TYPE_CHECKING, Iterable
-from dynamic_path_router import resolve_path, repo_root
-
 from menace.unified_event_bus import UnifiedEventBus
 from menace.menace_orchestrator import MenaceOrchestrator
 from menace.self_improvement_policy import SelfImprovementPolicy


### PR DESCRIPTION
## Summary
- use dynamic_path_router.resolve_path for default menace and shared DB locations
- ensure sandbox_runner initialises router with resolved paths
- mirror resolved DB paths in sandbox_dashboard and metrics_dashboard

## Testing
- `pre-commit run --files sandbox_runner.py sandbox_dashboard.py metrics_dashboard.py`
- `pytest tests/test_sandbox_runner_metrics.py tests/test_repo_root_overrides.py` *(fails: FileNotFoundError and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b809534864832e8bbbe86ae31835e1