### PR TITLE
Use resolve_path for event log path

### DIFF
--- a/config_loader.py
+++ b/config_loader.py
@@ -9,6 +9,7 @@ from types import MappingProxyType
 from typing import Any, Mapping
 
 import yaml
+from dynamic_path_router import resolve_path
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +33,7 @@ _CONFIG_PATH: str | None = None
 def _create_template(path: str) -> None:
     """Create a template configuration file at *path* if missing."""
     template = {
-        "log_paths": {"events": "./logs/events.log"},
+        "log_paths": {"events": str(resolve_path("logs/events.log"))},
         "risk_thresholds": {"low": 0.2, "high": 0.8},
         "forbidden_domains": ["example.com"],
         "domain_risk_map": {"example.com": 1.0},


### PR DESCRIPTION
## Summary
- ensure default event log path uses resolve_path

## Testing
- `python -m py_compile config_loader.py`
- `pytest -q -x` *(fails: No module named 'sqlalchemy.orm'; 'sqlalchemy' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68b80aa7c968832e929075e20333d473