### PR TITLE
Handle meta planner errors to keep cycle running

### DIFF
--- a/self_improvement/meta_planning.py
+++ b/self_improvement/meta_planning.py
@@ -1131,8 +1131,11 @@ async def self_improvement_cycle(
             if not outcome_logged:
                 _debug_cycle("skipped")
         except Exception as exc:  # pragma: no cover - planner is best effort
+            _debug_cycle("error", reason=str(exc))
             logger.debug("error", extra=log_record(err=str(exc)))
             logger.exception("meta planner execution failed", exc_info=exc)
+            await asyncio.sleep(interval)
+            continue
 
         for chain in list(active):
             planner.cluster_map.pop(tuple(chain), None)


### PR DESCRIPTION
## Summary
- log meta planner errors with `_debug_cycle("error")`
- continue the self-improvement cycle after planner errors

## Testing
- `pre-commit run --files self_improvement/meta_planning.py`
- `PYTHONPATH=. pytest self_improvement/tests/test_cycle_evaluation.py` *(fails: ImportError while importing test module '/workspace/menace_sandbox/self_improvement/__init__.py')*


------
https://chatgpt.com/codex/tasks/task_e_68b80bd49810832ea8a0b4a793d1f57b