### PR TITLE
Use resolve_path for relevancy metrics file

### DIFF
--- a/evaluation_dashboard.py
+++ b/evaluation_dashboard.py
@@ -10,6 +10,11 @@ from typing import Any, Dict, List
 import types
 from relevancy_radar import flagged_modules
 
+try:  # pragma: no cover - allow running as script
+    from .dynamic_path_router import resolve_path  # type: ignore
+except Exception:  # pragma: no cover - fallback when executed directly
+    from dynamic_path_router import resolve_path  # type: ignore
+
 # optional CLI support
 import argparse
 
@@ -342,9 +347,7 @@ class EvaluationDashboard:
     def relevancy_radar_panel(self, threshold: int = 5) -> List[Dict[str, Any]]:
         """Return modules with low relevancy scores and annotations."""
 
-        metrics_path = (
-            Path(__file__).resolve().parent / "sandbox_data" / "relevancy_metrics.json"
-        )
+        metrics_path = Path(resolve_path("sandbox_data/relevancy_metrics.json"))
         if not metrics_path.exists():
             return []
         try:

--- a/metrics_dashboard.py
+++ b/metrics_dashboard.py
@@ -244,9 +244,7 @@ class MetricsDashboard:
 
             flags = rr_flagged()
             impacts: dict[str, float] = {}
-            metrics_path = (
-                Path(__file__).resolve().parent / "sandbox_data" / "relevancy_metrics.json"
-            )
+            metrics_path = Path(resolve_path("sandbox_data/relevancy_metrics.json"))
             try:
                 data = json.loads(metrics_path.read_text())
                 if isinstance(data, dict):

--- a/metrics_exporter.py
+++ b/metrics_exporter.py
@@ -11,6 +11,11 @@ from collections import Counter
 import json
 from pathlib import Path
 
+try:  # pragma: no cover - allow running as script
+    from .dynamic_path_router import resolve_path  # type: ignore
+except Exception:  # pragma: no cover - fallback when executed directly
+    from dynamic_path_router import resolve_path  # type: ignore
+
 logger = logging.getLogger(__name__)
 
 # Ensure this module is a single instance regardless of import path
@@ -391,7 +396,7 @@ def update_relevancy_metrics(
     if impacts is None:
         impacts = {}
         try:
-            path = Path(__file__).resolve().parent / "sandbox_data" / "relevancy_metrics.json"
+            path = Path(resolve_path("sandbox_data/relevancy_metrics.json"))
             data = json.loads(path.read_text())
             if isinstance(data, dict):
                 for mod, info in data.items():

--- a/relevancy_radar.py
+++ b/relevancy_radar.py
@@ -78,13 +78,17 @@ import functools
 import contextlib
 from metrics_exporter import update_relevancy_metrics
 from relevancy_metrics_db import RelevancyMetricsDB
+try:  # pragma: no cover - allow running as script
+    from .dynamic_path_router import resolve_path  # type: ignore
+except Exception:  # pragma: no cover - fallback when executed directly
+    from dynamic_path_router import resolve_path  # type: ignore
 
 # Path to the persistent usage statistics file.
 _BASE_DIR = Path(__file__).resolve().parent
 _MODULE_USAGE_FILE = _BASE_DIR / "sandbox_data" / "module_usage.json"
 _RELEVANCY_FLAGS_FILE = _BASE_DIR / "sandbox_data" / "relevancy_flags.json"
 # File used by :class:`RelevancyRadar` to persist detailed usage metrics.
-_RELEVANCY_METRICS_FILE = _BASE_DIR / "sandbox_data" / "relevancy_metrics.json"
+_RELEVANCY_METRICS_FILE = Path(resolve_path("sandbox_data/relevancy_metrics.json"))
 # Default location of the SQLite metrics store consumed by :func:`scan`.
 _RELEVANCY_METRICS_DB = _BASE_DIR / "sandbox_data" / "relevancy_metrics.db"
 # File used to persist the call graph between runs.


### PR DESCRIPTION
## Summary
- resolve sandbox data paths for relevancy metrics using `resolve_path`
- ensure evaluation and metrics dashboards, exporter, and radar share new path resolution

## Testing
- `pytest` *(fails: 440 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b8122ab9dc832ea395d3bc0a8e3ee4