### PR TITLE
Use resolve_path for workflow stability file

### DIFF
--- a/workflow_stability_db.py
+++ b/workflow_stability_db.py
@@ -5,6 +5,15 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, Tuple
 import json
+try:  # pragma: no cover - allow package and flat imports
+    from .dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback for flat layout
+    from dynamic_path_router import resolve_path  # type: ignore
+
+try:  # pragma: no cover - compute default path via resolve_path
+    _DEFAULT_PATH = resolve_path("sandbox_data/stable_workflows.json")
+except FileNotFoundError:  # pragma: no cover - directory exists but file may not
+    _DEFAULT_PATH = resolve_path("sandbox_data") / "stable_workflows.json"
 
 
 class WorkflowStabilityDB:
@@ -15,7 +24,7 @@ class WorkflowStabilityDB:
     ``threshold`` the workflow is automatically cleared from the stable set.
     """
 
-    def __init__(self, path: str | Path = "sandbox_data/stable_workflows.json") -> None:
+    def __init__(self, path: str | Path = _DEFAULT_PATH) -> None:
         self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._load()


### PR DESCRIPTION
## Summary
- import resolve_path and compute default stability database path

## Testing
- `python -m py_compile workflow_stability_db.py`
- `pytest tests/test_meta_workflow_planner_failures.py::test_validate_chain_multi_run_aggregation -q`


------
https://chatgpt.com/codex/tasks/task_e_68b815221ab0832ea93099f36bb23f3c