### PR TITLE
feat: adapt overfitting limits to baseline stats

### DIFF
--- a/self_improvement/tests/test_cycle_evaluation.py
+++ b/self_improvement/tests/test_cycle_evaluation.py
@@ -41,7 +41,8 @@ def _load_cycle_funcs() -> dict[str, Any]:
         "_init": types.SimpleNamespace(
             settings=types.SimpleNamespace(
                 critical_severity_threshold=75.0,
-                entropy_z_threshold=1.0,
+                max_allowed_errors=0,
+                entropy_overfit_threshold=1.0,
             )
         ),
     }
@@ -129,7 +130,6 @@ def _run_cycle(
                     meta_domain_penalty=0.0,
                     overfitting_entropy_threshold=1.0,
                     entropy_overfit_threshold=1.0,
-                    entropy_z_threshold=1.0,
                     max_allowed_errors=0,
                     critical_severity_threshold=75.0,
                 )
@@ -306,7 +306,6 @@ def test_cycle_logs_skip_on_stop_event():
                     meta_domain_penalty=0.0,
                     overfitting_entropy_threshold=1.0,
                     entropy_overfit_threshold=1.0,
-                    entropy_z_threshold=1.0,
                     max_allowed_errors=0,
                 )
             ),

--- a/tests/self_improvement/test_cycle.py
+++ b/tests/self_improvement/test_cycle.py
@@ -432,7 +432,6 @@ def _run_cycle(
                     meta_domain_penalty=0.0,
                     overfitting_entropy_threshold=1.0,
                     entropy_overfit_threshold=1.0,
-                    entropy_z_threshold=1.0,
                     max_allowed_errors=0,
                 )
             ),

--- a/tests/self_improvement/test_meta_planning_logging.py
+++ b/tests/self_improvement/test_meta_planning_logging.py
@@ -39,7 +39,6 @@ class _SandboxSettings:
     meta_search_depth = 1
     meta_beam_width = 1
     max_allowed_errors = 0
-    entropy_z_threshold = 3.0
     overfitting_entropy_threshold = 1.0
 sandbox_settings_mod.SandboxSettings = _SandboxSettings
 sys.modules["menace.sandbox_settings"] = sandbox_settings_mod
@@ -104,7 +103,6 @@ def _setup(monkeypatch):
         meta_roi_weight=1.0,
         meta_domain_penalty=1.0,
         max_allowed_errors=0,
-        entropy_z_threshold=3.0,
         overfitting_entropy_threshold=1.0,
     )
     monkeypatch.setattr(mp, "_init", SimpleNamespace(settings=cfg))


### PR DESCRIPTION
## Summary
- derive dynamic error and entropy thresholds from BaselineTracker statistics
- apply recalculated thresholds during meta-planning skip checks
- verify thresholds shift when baseline metrics change

## Testing
- `pytest unit_tests/test_meta_planning.py::test_overfit_thresholds_adjust_with_baseline unit_tests/test_meta_planning.py::test_cycle_uses_fallback_planner_when_missing`


------
https://chatgpt.com/codex/tasks/task_e_68b8264c91e4832e9c39853232b43897