### PR TITLE
Use resolve_path for sandbox_data references

### DIFF
--- a/adaptive_roi_dataset.py
+++ b/adaptive_roi_dataset.py
@@ -37,6 +37,11 @@ from .evolution_history_db import EvolutionHistoryDB
 from .evaluation_history_db import EvaluationHistoryDB
 from .roi_tracker import ROITracker
 
+try:  # pragma: no cover - allow running as script
+    from .dynamic_path_router import resolve_path  # type: ignore
+except Exception:  # pragma: no cover - fallback when executed directly
+    from dynamic_path_router import resolve_path  # type: ignore
+
 __all__ = ["load_adaptive_roi_dataset", "build_dataset"]
 
 
@@ -445,7 +450,7 @@ def build_dataset(
     ema_span: int | None = 3,
     selected_features: Sequence[str] | None = None,
     return_feature_names: bool = False,
-    export_path: str | Path | None = "sandbox_data/adaptive_roi.csv",
+    export_path: str | Path | None = resolve_path("sandbox_data") / "adaptive_roi.csv",
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray] | Tuple[np.ndarray, np.ndarray, np.ndarray, list[str]]:
     """Assemble a training dataset combining evolution, ROI and evaluation data.
 
@@ -515,7 +520,7 @@ def build_dataset(
 
     if selected_features is None:
         try:
-            meta_path = Path("sandbox_data/adaptive_roi.meta.json")
+            meta_path = resolve_path("sandbox_data") / "adaptive_roi.meta.json"
             if meta_path.exists():
                 meta = json.loads(meta_path.read_text())
                 sel = meta.get("selected_features")

--- a/environment_bootstrap.py
+++ b/environment_bootstrap.py
@@ -30,6 +30,11 @@ from .external_dependency_provisioner import ExternalDependencyProvisioner
 from . import startup_checks
 from .vector_service.embedding_scheduler import start_scheduler_from_env
 
+try:  # pragma: no cover - allow running as script
+    from .dynamic_path_router import resolve_path  # type: ignore
+except Exception:  # pragma: no cover - fallback when executed directly
+    from dynamic_path_router import resolve_path  # type: ignore
+
 
 class EnvironmentBootstrapper:
     """Bootstrap dependencies and infrastructure on startup."""
@@ -253,7 +258,7 @@ class EnvironmentBootstrapper:
             except Exception as exc:  # pragma: no cover - log only
                 self.logger.warning("VectorMetricsDB bootstrap failed: %s", exc)
 
-            hist = Path("sandbox_data/roi_history.json")
+            hist = resolve_path("sandbox_data") / "roi_history.json"
             if not hist.exists():
                 try:
                     hist.parent.mkdir(parents=True, exist_ok=True)

--- a/evaluation_dashboard.py
+++ b/evaluation_dashboard.py
@@ -53,7 +53,7 @@ from .telemetry_backend import TelemetryBackend
 from .violation_logger import load_persisted_alignment_warnings
 from .scope_utils import Scope
 
-GOVERNANCE_LOG = Path("sandbox_data/governance_outcomes.jsonl")
+GOVERNANCE_LOG = resolve_path("sandbox_data") / "governance_outcomes.jsonl"
 
 
 def append_governance_result(

--- a/lineage_tracker.py
+++ b/lineage_tracker.py
@@ -22,9 +22,13 @@ except Exception:  # pragma: no cover - gracefully degrade
     def get_patch_provenance(patch_id: int) -> List[dict]:
         return []
 
+try:  # pragma: no cover - allow running as script
+    from .dynamic_path_router import resolve_path  # type: ignore
+except Exception:  # pragma: no cover - fallback when executed directly
+    from dynamic_path_router import resolve_path  # type: ignore
 
 _SUMMARY_STORE = Path(
-    os.environ.get("WORKFLOW_SUMMARY_STORE", Path("sandbox_data") / "workflows")
+    os.environ.get("WORKFLOW_SUMMARY_STORE", str(resolve_path("sandbox_data") / "workflows"))
 )
 
 

--- a/meta_workflow_planner.py
+++ b/meta_workflow_planner.py
@@ -21,6 +21,11 @@ from vector_utils import persist_embedding, cosine_similarity
 from cache_utils import get_cached_chain, set_cached_chain
 from logging_utils import get_logger
 
+try:  # pragma: no cover - allow running as script
+    from .dynamic_path_router import resolve_path  # type: ignore
+except Exception:  # pragma: no cover - fallback when executed directly
+    from dynamic_path_router import resolve_path  # type: ignore
+
 logger = get_logger(__name__)
 
 # Decay factor applied when persisting/loading cluster metrics to favor recent runs
@@ -2086,7 +2091,7 @@ class MetaWorkflowPlanner:
     def _save_cluster_map(self) -> None:
         """Persist ``cluster_map`` to ``sandbox_data/meta_clusters.json``."""
 
-        path = Path("sandbox_data/meta_clusters.json")
+        path = resolve_path("sandbox_data") / "meta_clusters.json"
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -2136,7 +2141,7 @@ class MetaWorkflowPlanner:
     def _load_cluster_map(self) -> None:
         """Load ``cluster_map`` from persistence layers if present."""
 
-        path = Path("sandbox_data/meta_clusters.json")
+        path = resolve_path("sandbox_data") / "meta_clusters.json"
         if path.exists():
             try:
                 data = json.loads(path.read_text())

--- a/sandbox_dashboard.py
+++ b/sandbox_dashboard.py
@@ -42,8 +42,8 @@ class SandboxDashboard(MetricsDashboard):
         self,
         history_file: str | Path = "roi_history.json",
         weights_log: str | Path = synergy_weight_cli.LOG_PATH,
-        summary_file: str | Path = Path("sandbox_data") / "scenario_summary.json",
-        alignment_flags_file: str | Path = Path("sandbox_data") / "alignment_flags.jsonl",
+        summary_file: str | Path = resolve_path("sandbox_data") / "scenario_summary.json",
+        alignment_flags_file: str | Path = resolve_path("sandbox_data") / "alignment_flags.jsonl",
         auth: Callable[[Request], bool] | None = None,
     ) -> None:
         super().__init__(history_file)
@@ -203,12 +203,12 @@ def cli(argv: List[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Sandbox dashboard")
     parser.add_argument(
         '--file',
-        default=str(Path('sandbox_data') / 'roi_history.json'),
+        default=str(resolve_path('sandbox_data') / 'roi_history.json'),
         help='Path to roi_history.json'
     )
     parser.add_argument(
         '--summary-file',
-        default=str(Path('sandbox_data') / 'scenario_summary.json'),
+        default=str(resolve_path('sandbox_data') / 'scenario_summary.json'),
         help='Path to scenario_summary.json'
     )
     parser.add_argument('--port', type=int, default=8002, help='HTTP port')

--- a/sandbox_recovery_manager.py
+++ b/sandbox_recovery_manager.py
@@ -53,6 +53,11 @@ except ImportError as exc:  # pragma: no cover - module may not be a package
     )
     from sandbox_settings import SandboxSettings  # type: ignore
 
+try:  # pragma: no cover - allow running as script
+    from .dynamic_path_router import resolve_path  # type: ignore
+except Exception:  # pragma: no cover - fallback when executed directly
+    from dynamic_path_router import resolve_path  # type: ignore
+
 recovery_failure_total = Gauge(
     "sandbox_recovery_failure_total",
     "Total number of sandbox recovery failures by severity",
@@ -317,7 +322,7 @@ def cli(argv: List[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=cli.__doc__)
     parser.add_argument(
         "--file",
-        default=str(Path("sandbox_data") / "recovery.json"),
+        default=str(resolve_path("sandbox_data") / "recovery.json"),
         help="Path to recovery.json",
     )
     args = parser.parse_args(argv)

--- a/scripts/autonomous_setup.py
+++ b/scripts/autonomous_setup.py
@@ -9,6 +9,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from dynamic_path_router import resolve_path
+
 from auto_env_setup import ensure_env, interactive_setup
 from auto_resource_setup import ensure_proxies, ensure_accounts
 from setup_dependencies import check_and_install
@@ -77,8 +79,9 @@ def main() -> None:
     logger.info("generating presets")
     presets = generate_presets()
     presets = adapt_presets(ROITracker(), presets)
-    Path("sandbox_data").mkdir(exist_ok=True)
-    Path("sandbox_data/latest_presets.json").write_text(
+    data_dir = resolve_path("sandbox_data")
+    data_dir.mkdir(exist_ok=True)
+    (data_dir / "latest_presets.json").write_text(
         json.dumps(presets, indent=2)
     )
 

--- a/self_services_config.py
+++ b/self_services_config.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+try:  # pragma: no cover - allow running as script
+    from .dynamic_path_router import resolve_path  # type: ignore
+except Exception:  # pragma: no cover - fallback when executed directly
+    from dynamic_path_router import resolve_path  # type: ignore
+
 try:  # pragma: no cover - compatibility with pydantic v1/v2
     from pydantic_settings import BaseSettings, SettingsConfigDict
     PYDANTIC_V2 = True
@@ -70,12 +75,12 @@ class SelfTestConfig(BaseSettings):
     """Configuration for the self-test service."""
 
     lock_file: Path = Field(
-        default=Path("sandbox_data/self_test.lock"),
+        default=resolve_path("sandbox_data") / "self_test.lock",
         validation_alias="SELF_TEST_LOCK_FILE",
         description="File used to serialise self-test runs.",
     )
     report_dir: Path = Field(
-        default=Path("sandbox_data/self_test_reports"),
+        default=resolve_path("sandbox_data") / "self_test_reports",
         validation_alias="SELF_TEST_REPORT_DIR",
         description="Directory used to store self-test reports.",
     )

--- a/workflow_evolution_manager.py
+++ b/workflow_evolution_manager.py
@@ -21,6 +21,10 @@ from . import workflow_run_summary
 from . import sandbox_runner
 from .workflow_synergy_comparator import WorkflowSynergyComparator
 from .meta_workflow_planner import MetaWorkflowPlanner
+try:  # pragma: no cover - allow running as script
+    from .dynamic_path_router import resolve_path  # type: ignore
+except Exception:  # pragma: no cover - fallback when executed directly
+    from dynamic_path_router import resolve_path  # type: ignore
 try:  # pragma: no cover - optional dependency
     from vector_service.retriever import Retriever  # type: ignore
 except Exception:  # pragma: no cover - allow running without retriever
@@ -52,7 +56,7 @@ def consume_planner_suggestions(chains: Iterable[Sequence[str]]) -> None:
     """Persist planner-suggested chains for later evaluation."""
     for idx, chain in enumerate(chains, start=1):
         try:
-            path = Path("sandbox_data") / f"planner_chain_{idx}.workflow.json"
+            path = resolve_path("sandbox_data") / f"planner_chain_{idx}.workflow.json"
             save_workflow([{"module": m} for m in chain], path)
         except Exception:
             logger.exception("failed to save planner suggestion", extra={"chain": chain})

--- a/workflow_run_summary.py
+++ b/workflow_run_summary.py
@@ -7,6 +7,11 @@ import json
 import os
 from typing import Dict, List
 
+try:  # pragma: no cover - allow running as script
+    from .dynamic_path_router import resolve_path  # type: ignore
+except Exception:  # pragma: no cover - fallback when executed directly
+    from dynamic_path_router import resolve_path  # type: ignore
+
 from .workflow_graph import WorkflowGraph
 from . import workflow_spec
 
@@ -26,7 +31,7 @@ _HISTORY_PATH = Path(
 # Default location for saved workflow summaries.  Individual tests can override
 # via the ``WORKFLOW_SUMMARY_STORE`` environment variable.
 _SUMMARY_STORE = Path(
-    os.environ.get("WORKFLOW_SUMMARY_STORE", Path("sandbox_data") / "workflows")
+    os.environ.get("WORKFLOW_SUMMARY_STORE", str(resolve_path("sandbox_data") / "workflows"))
 )
 
 

--- a/workflow_synthesizer.py
+++ b/workflow_synthesizer.py
@@ -52,6 +52,11 @@ from typing import (
     get_type_hints,
 )
 
+try:  # pragma: no cover - allow running as script
+    from .dynamic_path_router import resolve_path  # type: ignore
+except Exception:  # pragma: no cover - fallback when executed directly
+    from dynamic_path_router import resolve_path  # type: ignore
+
 try:  # pragma: no cover - support running as a package
     from .fcntl_compat import flock, LOCK_EX, LOCK_SH, LOCK_UN
 except Exception:  # pragma: no cover - allow running as script
@@ -88,7 +93,7 @@ except Exception:  # pragma: no cover - gracefully degrade
 
 logger = logging.getLogger(__name__)
 
-WINNING_SEQUENCES_PATH = Path("sandbox_data/winning_sequences.json")
+WINNING_SEQUENCES_PATH = resolve_path("sandbox_data") / "winning_sequences.json"
 
 
 def record_winning_sequence(sequence: List[str]) -> None:
@@ -180,7 +185,7 @@ class WorkflowStep:
 class ModuleIOAnalyzer:
     """Analyze modules to determine their IO signatures with caching."""
 
-    def __init__(self, cache_path: Path = Path("sandbox_data/io_signatures.json")) -> None:
+    def __init__(self, cache_path: Path = resolve_path("sandbox_data") / "io_signatures.json") -> None:
         self.cache_path = cache_path
         self._cache: Dict[str, Dict[str, Any]] = {}
         try:
@@ -359,7 +364,7 @@ class WorkflowSynthesizer:
         self.synergy_graph_path = (
             Path(synergy_graph_path)
             if synergy_graph_path is not None
-            else Path("sandbox_data/module_synergy_graph.json")
+            else resolve_path("sandbox_data") / "module_synergy_graph.json"
         )
 
         # Load synergy graph if available
@@ -1345,7 +1350,7 @@ class WorkflowSynthesizer:
         self.workflow_scores = []
         self.generated_workflows = []
         self.workflow_score_details = []
-        out_dir = Path("sandbox_data/generated_workflows")
+        out_dir = resolve_path("sandbox_data") / "generated_workflows"
         out_dir.mkdir(parents=True, exist_ok=True)
         for idx, (score, wf, syn, intent, penalty) in enumerate(entries[:limit]):
             details: Dict[str, Any] = {
@@ -1418,7 +1423,7 @@ class WorkflowSynthesizer:
         """
 
         data = self.to_dict()
-        base = Path(path) if path is not None else Path("sandbox_data/generated_workflows")
+        base = Path(path) if path is not None else resolve_path("sandbox_data") / "generated_workflows"
         if base.suffix:
             out_dir = base.parent
             stem = base.stem
@@ -1656,7 +1661,7 @@ def consume_planner_suggestions(chains: Iterable[Sequence[str]]) -> List[Path]:
     paths: List[Path] = []
     for idx, chain in enumerate(chains, start=1):
         steps = [WorkflowStep(module=str(m)) for m in chain]
-        path = Path("sandbox_data") / f"planner_chain_{idx}.workflow.json"
+        path = resolve_path("sandbox_data") / f"planner_chain_{idx}.workflow.json"
         try:
             save_workflow(steps, path)
             paths.append(path)

--- a/workflow_synthesizer_cli.py
+++ b/workflow_synthesizer_cli.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 
 import argparse
 import sys
-from pathlib import Path
+
+from dynamic_path_router import resolve_path
 
 from workflow_synthesizer import (
     WorkflowSynthesizer,
@@ -38,7 +39,7 @@ def run(args: argparse.Namespace) -> int:
     """
 
     if getattr(args, "list", False):
-        directory = Path("sandbox_data/generated_workflows")
+        directory = resolve_path("sandbox_data") / "generated_workflows"
         if directory.exists():
             for path in sorted(directory.glob("*.workflow.json")):
                 print(path.name)
@@ -118,7 +119,7 @@ def run(args: argparse.Namespace) -> int:
     elif args.save is not None:
         name = args.save or args.start
         safe = "".join(c if c.isalnum() or c in ("-", "_") else "_" for c in name)
-        directory = Path("sandbox_data/generated_workflows")
+        directory = resolve_path("sandbox_data") / "generated_workflows"
         directory.mkdir(parents=True, exist_ok=True)
         path = directory / f"{safe}.workflow.json"
         save_workflow(chosen, path)


### PR DESCRIPTION
## Summary
- import `resolve_path` and resolve sandbox_data files, including GOVERNANCE_LOG
- update constructors and CLIs to compute sandbox_data paths via resolve_path
- adjust self-test config defaults to use resolved paths

## Testing
- `pytest tests/test_environment_bootstrap.py tests/test_workflow_synthesizer.py tests/test_self_services_config.py tests/test_workflow_evolution_manager.py tests/test_sandbox_recovery_manager.py tests/test_adaptive_roi_dataset.py -q` *(fail: assertion failures in workflow_synthesizer and adaptive_roi_dataset tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b82aaf07d4832e8295b482a9272c5d