### PR TITLE
Use resolve_path for sandbox_data defaults

### DIFF
--- a/scripts/generate_module_map.py
+++ b/scripts/generate_module_map.py
@@ -8,6 +8,7 @@ import json
 from pathlib import Path
 
 from dynamic_module_mapper import build_module_map as _build_map
+from dynamic_path_router import resolve_path
 
 
 # ---------------------------------------------------------------------------
@@ -38,7 +39,9 @@ def generate_module_map(
 def main(args: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Build sandbox module map")
     parser.add_argument("repo", nargs="?", default=".", help="Repository path")
-    parser.add_argument("--output", default="sandbox_data/module_map.json")
+    parser.add_argument(
+        "--output", default=resolve_path("sandbox_data/module_map.json")
+    )
     parser.add_argument(
         "--algorithm",
         default="greedy",

--- a/synergy_tools.py
+++ b/synergy_tools.py
@@ -5,14 +5,11 @@ from __future__ import annotations
 import argparse
 import atexit
 import contextlib
-import json
 import os
 import signal
 import socket
 import sys
-import threading
 import time
-import urllib.request
 from pathlib import Path
 
 if os.getenv("SANDBOX_CENTRAL_LOGGING") is None:
@@ -24,6 +21,7 @@ from menace.audit_trail import AuditTrail
 from logging_utils import get_logger, setup_logging
 from synergy_monitor import ExporterMonitor
 from menace.metrics_exporter import start_metrics_server
+from dynamic_path_router import resolve_path
 
 
 logger = get_logger(__name__)
@@ -46,8 +44,6 @@ def _free_port() -> int:
         return sock.getsockname()[1]
 
 
-
-
 # ----------------------------------------------------------------------
 
 def main(argv: list[str] | None = None) -> None:
@@ -55,7 +51,7 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--sandbox-data-dir",
-        default="sandbox_data",
+        default=resolve_path("sandbox_data"),
         help="directory containing synergy data files",
     )
     args = parser.parse_args(argv)


### PR DESCRIPTION
## Summary
- ensure module map script resolves its default output path via `resolve_path`
- default sandbox data directory in synergy tools now resolved with `resolve_path`

## Testing
- `pre-commit run --files scripts/generate_module_map.py synergy_tools.py`
- `pytest tests/test_run_scenarios.py tests/test_workflow_synthesizer.py tests/integration/test_orphan_cluster_update.py` *(fails: ModuleNotFoundError: No module named 'pylint'; FileNotFoundError: 'sandbox_data/relevancy_metrics.json' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b82d48da7c832e953d4ae86457364f