### PR TITLE
Refine trigger logic with metric deltas and error severity checks

### DIFF
--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -3267,30 +3267,102 @@ class SelfImprovementEngine:
     def _should_trigger(self) -> bool:
         """Return ``True`` when a new improvement cycle should run."""
 
-        trigger = False
         if getattr(self, "_force_rerun", False):
             self._force_rerun = False
-            trigger = True
-        else:
-            if time.time() - self.last_run >= self.interval:
-                score, components = self._compute_delta_score()
-                baseline = self.baseline_tracker.get("score")
-                deviation = self.baseline_tracker.std("score")
-                self.logger.debug(
-                    "delta score evaluation",
-                    extra=log_record(
-                        delta_score=score,
-                        delta_score_baseline=baseline,
-                        delta_score_std=deviation,
-                        **components,
-                    ),
+            return True
+
+        if time.time() - self.last_run < self.interval:
+            self.logger.debug(
+                "skipping self-improvement cycle",
+                extra=log_record(metrics={}, reason="interval_not_elapsed"),
+            )
+            return False
+
+        # Gather per-metric deltas from the baseline tracker
+        history = self.baseline_tracker.to_dict()
+        metrics: dict[str, float] = {}
+        for name in history.keys():
+            if name.endswith("_delta"):
+                continue
+            try:
+                metrics[name] = float(self.baseline_tracker.delta(name))
+            except Exception:
+                continue
+
+        # Include any available ROI tracker deltas
+        roi_tracker = getattr(self, "roi_tracker", None)
+        if roi_tracker and hasattr(roi_tracker, "get_scenario_metrics_delta"):
+            try:
+                metrics.update(
+                    roi_tracker.get_scenario_metrics_delta("overall")
                 )
-                if all(v == 0.0 for v in components.values()):
-                    trigger = True
-                else:
-                    threshold = baseline + self.delta_score_dev_multiplier * deviation
-                    trigger = score > threshold
-        return trigger
+            except Exception:
+                pass
+
+        # Fetch recent errors and check for critical severity
+        events = None
+        try:
+            eb = getattr(self, "error_bot", None)
+            if eb is not None:
+                if hasattr(eb, "recent_errors"):
+                    events = eb.recent_errors(limit=5)
+                elif hasattr(eb, "recent_events"):
+                    events = eb.recent_events(limit=5)
+                elif hasattr(getattr(eb, "db", None), "recent_errors"):
+                    events = eb.db.recent_errors(limit=5)  # type: ignore[attr-defined]
+        except Exception:
+            events = None
+
+        threshold = getattr(settings, "critical_severity_threshold", 75.0)
+
+        def _severity_to_score(sev: object) -> float | None:
+            mapping = {
+                "critical": 100.0,
+                "crit": 100.0,
+                "fatal": 100.0,
+                "high": 75.0,
+                "error": 75.0,
+                "warn": 50.0,
+                "warning": 50.0,
+                "medium": 50.0,
+                "low": 25.0,
+                "info": 0.0,
+            }
+            if isinstance(sev, str):
+                s = sev.lower()
+                if s in mapping:
+                    return mapping[s]
+                try:
+                    sev = float(sev)
+                except ValueError:
+                    return None
+            if isinstance(sev, (int, float)):
+                val = float(sev)
+                if 0 <= val <= 1:
+                    return val * 100
+                if 0 <= val <= 5:
+                    return val * 20
+                if 0 <= val <= 10:
+                    return val * 10
+                return val
+            return None
+
+        critical_error = False
+        for ev in events or []:
+            sev = getattr(getattr(ev, "error_type", None), "severity", None)
+            score = _severity_to_score(sev)
+            if score is not None and score >= threshold:
+                critical_error = True
+                break
+
+        if metrics and all(v > 0 for v in metrics.values()) and not critical_error:
+            self.logger.debug(
+                "skipping self-improvement cycle",
+                extra=log_record(metrics=metrics, reason="all_deltas_positive"),
+            )
+            return False
+
+        return True
 
     def _record_state(self) -> None:
         """Store metrics and discrepancies as research items."""


### PR DESCRIPTION
## Summary
- evaluate individual metric deltas and recent errors when deciding to trigger a self-improvement cycle
- log metrics and reasons when skipping cycles
- update trigger tests for the new logic

## Testing
- `python - <<'PY'
import types, sys, pytest

sandbox_runner_pkg = types.ModuleType('sandbox_runner')
bootstrap_stub = types.ModuleType('sandbox_runner.bootstrap')
bootstrap_stub.initialize_autonomous_sandbox = lambda *a, **k: None
sandbox_runner_pkg.bootstrap = bootstrap_stub
sys.modules['sandbox_runner'] = sandbox_runner_pkg
sys.modules['sandbox_runner.bootstrap'] = bootstrap_stub

ss = types.ModuleType('sandbox_settings')
ss.SandboxSettings = object
ss.load_sandbox_settings = lambda *a, **k: None
sys.modules['sandbox_settings'] = ss

db_router = types.ModuleType('db_router')
db_router.DBRouter = object
db_router.GLOBAL_ROUTER = None
db_router.init_db_router = lambda *a, **k: None
db_router.LOCAL_TABLES = set()
sys.modules['db_router'] = db_router

sys.path.insert(0, '..')

pytest.main(['test_trigger_and_encoding.py::test_should_trigger_skips_only_on_positive_deltas_and_no_critical_errors', '-q'])
PY` *(fails: No module named 'audit')*

------
https://chatgpt.com/codex/tasks/task_e_68b82ea7d754832e94162ff3a73eca07