### PR TITLE
Use resolve_path for log file paths

### DIFF
--- a/invocation_tracker.py
+++ b/invocation_tracker.py
@@ -7,10 +7,16 @@ import json
 import os
 import time
 from datetime import datetime
+from pathlib import Path
+
+from dynamic_path_router import resolve_path
+
 from logging_utils import get_logger
 
 # Path for Security AI invocation logs
-INVOCATION_LOG = os.path.join("logs", "security_ai_invocations.jsonl")
+INVOCATION_LOG = Path(
+    os.environ.get("INVOCATION_LOG", resolve_path("logs/security_ai_invocations.jsonl"))
+)
 
 logger = get_logger(__name__)
 
@@ -25,17 +31,17 @@ def log_invocation(timestamp: float, action_id: str) -> None:
     action_id: str
         Identifier of the Menace action being evaluated.
     """
-    os.makedirs(os.path.dirname(INVOCATION_LOG), exist_ok=True)
+    INVOCATION_LOG.parent.mkdir(parents=True, exist_ok=True)
     entry = {"timestamp": timestamp, "action_id": action_id}
     try:
-        with open(INVOCATION_LOG, "a", encoding="utf-8") as fh:
+        with INVOCATION_LOG.open("a", encoding="utf-8") as fh:
             json.dump(entry, fh)
             fh.write("\n")
     except Exception as exc:
         logger.error("log_invocation failed: %s", exc)
-        tmp_path = INVOCATION_LOG + ".tmp"
+        tmp_path = INVOCATION_LOG.with_name(INVOCATION_LOG.name + ".tmp")
         try:
-            with open(tmp_path, "a", encoding="utf-8") as fh:
+            with tmp_path.open("a", encoding="utf-8") as fh:
                 json.dump(entry, fh)
                 fh.write("\n")
         except Exception as exc2:
@@ -46,10 +52,10 @@ def load_recent_invocations(window_seconds: int = 300) -> List[str]:
     """Return action ids logged within the last ``window_seconds``."""
     cutoff = time.time() - window_seconds
     action_ids: List[str] = []
-    if not os.path.exists(INVOCATION_LOG):
+    if not INVOCATION_LOG.exists():
         return action_ids
     try:
-        with open(INVOCATION_LOG, "r", encoding="utf-8") as fh:
+        with INVOCATION_LOG.open("r", encoding="utf-8") as fh:
             for line in fh:
                 line = line.strip()
                 if not line:
@@ -71,13 +77,14 @@ def load_recent_invocations(window_seconds: int = 300) -> List[str]:
     return action_ids
 
 
-def _load_action_log(path: str) -> List[str]:
+def _load_action_log(path: str | Path) -> List[str]:
     """Return list of action ids recorded in Menace log at *path*."""
+    p = Path(resolve_path(str(path)))
     ids: List[str] = []
-    if not os.path.exists(path):
+    if not p.exists():
         return ids
     try:
-        with open(path, "r", encoding="utf-8") as fh:
+        with p.open("r", encoding="utf-8") as fh:
             for line in fh:
                 line = line.strip()
                 if not line:
@@ -90,17 +97,23 @@ def _load_action_log(path: str) -> List[str]:
                 if isinstance(aid, str):
                     ids.append(aid)
     except Exception as exc:
-        logger.error("failed to load actions from %s: %s", path, exc)
+        logger.error("failed to load actions from %s: %s", p, exc)
     return ids
 
 
-def detect_missing_invocations(menace_action_log: str = "/mnt/shared/menace_logs/actions.jsonl", invocation_log: str = INVOCATION_LOG) -> List[str]:
+def detect_missing_invocations(
+    menace_action_log: str | Path | None = None,
+    invocation_log: Path | str = INVOCATION_LOG,
+) -> List[str]:
     """Compare Menace actions with Security AI invocations.
 
     Returns a list of action ids that were executed by Menace but never
     processed by Security AI.
     """
-    action_ids = set(_load_action_log(menace_action_log))
+    action_log = menace_action_log or os.environ.get(
+        "MENACE_ACTION_LOG", "/mnt/shared/menace_logs/actions.jsonl"
+    )
+    action_ids = set(_load_action_log(action_log))
     invoked = set(_load_action_log(invocation_log))
     missing = sorted(action_ids - invoked)
     return missing
@@ -114,7 +127,12 @@ def flag_avoidance_events(missing_ids: List[str]) -> dict[str, Any]:
         {"action_id": aid, "detected_at": timestamp, "severity": severity}
         for aid in missing_ids
     ]
-    return {"detected_at": timestamp, "missing": len(missing_ids), "events": events, "severity_score": severity}
+    return {
+        "detected_at": timestamp,
+        "missing": len(missing_ids),
+        "events": events,
+        "severity_score": severity,
+    }
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- route payout and invocation logs through dynamic_path_router.resolve_path
- allow PAYOUT_LOG_PATH, INVOCATION_LOG, and MENACE_ACTION_LOG env vars to override defaults

## Testing
- `pre-commit run --files finance_router_bot.py invocation_tracker.py`
- `pytest tests/test_finance_router_memory_subscribe.py`
- `pytest tests/test_autoscaler_invocation_logging.py tests/test_finance_router_bot.py tests/test_finance_router_memory_subscribe.py tests/test_event_integration.py` *(fails: ImportError: cannot import name 'RAISE_ERRORS' from 'menace')*

------
https://chatgpt.com/codex/tasks/task_e_68b8315ae7b8832e8ba2830db7f82d47