### PR TITLE
Resolve path for relevancy metrics database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1100,7 +1100,7 @@ missing. Notable defaults include:
 - `SYNERGY_WEIGHTS_PATH=sandbox_data/synergy_weights.json`
 - `ALIGNMENT_FLAGS_PATH=sandbox_data/alignment_flags.jsonl`
 - `MODULE_SYNERGY_GRAPH_PATH=sandbox_data/module_synergy_graph.json`
-- `RELEVANCY_METRICS_DB_PATH=sandbox_data/relevancy_metrics.db`
+- `RELEVANCY_METRICS_DB_PATH=/path/to/relevancy_metrics.db`
 - `RUN_CYCLES=0`
 - `RUN_UNTIL=`
  - `METRICS_PORT=8001`  # same as `--metrics-port`

--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -115,6 +115,7 @@ try:
     import neurosales  # noqa: F401
 except ImportError as exc:  # pragma: no cover - fail fast when dependency missing
     raise RuntimeError("neurosales dependency is required") from exc
+DEFAULT_RELEVANCY_METRICS_DB = Path("sandbox_data") / "relevancy_metrics.db"
 from alert_dispatcher import dispatch_alert
 import json
 import inspect
@@ -5985,14 +5986,18 @@ class SelfImprovementEngine:
             auto_process = getattr(
                 settings, "auto_process_relevancy_flags", True
             )
-            metrics_db_path = getattr(
-                settings, "relevancy_metrics_db_path", "sandbox_data/relevancy_metrics.db"
+            metrics_db_path = resolve_path(
+                getattr(
+                    settings,
+                    "relevancy_metrics_db_path",
+                    DEFAULT_RELEVANCY_METRICS_DB,
+                )
             )
         except Exception:
             k = 1.0
             min_history = 0
             auto_process = True
-            metrics_db_path = "sandbox_data/relevancy_metrics.db"
+            metrics_db_path = resolve_path(DEFAULT_RELEVANCY_METRICS_DB)
 
         for mod, counts in getattr(self.relevancy_radar, "_metrics", {}).items():
             impact_val = float(counts.get("impact", 0.0)) + float(


### PR DESCRIPTION
## Summary
- default relevancy metrics database path built from `Path("sandbox_data") / "relevancy_metrics.db"`
- call `resolve_path` when reading or falling back to metrics DB path
- document configurable `RELEVANCY_METRICS_DB_PATH` without baked-in sandbox path

## Testing
- `python -m py_compile self_improvement/engine.py`
- `pytest --collect-only self_improvement/tests/test_baseline_tracker.py` *(fails: requires transformers and exited with KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b83a6eba68832e90c18c1e21d621c6