### PR TITLE
Use dynamic path resolution for sandbox runner package

### DIFF
--- a/sandbox_runner.py
+++ b/sandbox_runner.py
@@ -243,7 +243,7 @@ except Exception:  # pragma: no cover - optional dependency
 if TYPE_CHECKING:  # pragma: no cover
     from menace.roi_tracker import ROITracker
 
-__path__ = [os.path.join(os.path.dirname(__file__), "sandbox_runner")]
+__path__ = [resolve_path("sandbox_runner").as_posix()]
 logger = get_logger(__name__)
 
 def _get_local_knowledge() -> LocalKnowledgeModule:


### PR DESCRIPTION
## Summary
- use `resolve_path` to set `sandbox_runner` package `__path__`

## Testing
- `pytest sandbox_runner/tests/test_minimal_cycle.py` *(fails: No module named 'pylint')*
- `python -m py_compile sandbox_runner.py`


------
https://chatgpt.com/codex/tasks/task_e_68b83b809884832e8ed0060343684a58