### PR TITLE
Use resolve_path for vector asset paths

### DIFF
--- a/environment_bootstrap.py
+++ b/environment_bootstrap.py
@@ -227,9 +227,8 @@ class EnvironmentBootstrapper:
         try:
             from .vector_service import download_model as _dm
 
-            dest = (
-                Path(_dm.__file__).with_name("minilm")
-                / "tiny-distilroberta-base.tar.xz"
+            dest = resolve_path(
+                "vector_service/minilm/tiny-distilroberta-base.tar.xz"
             )
             if not dest.exists():
                 _dm.bundle(dest)
@@ -237,10 +236,8 @@ class EnvironmentBootstrapper:
             self.logger.warning("embedding model download failed: %s", exc)
 
         try:
-            reg_path = (
-                Path(__file__).resolve().parent
-                / "vector_service"
-                / "embedding_registry.json"
+            reg_path = resolve_path(
+                "vector_service/embedding_registry.json"
             )
             with open(reg_path, "r", encoding="utf-8") as fh:
                 names = list(json.load(fh).keys())


### PR DESCRIPTION
## Summary
- import resolve_path and use it to locate vector-service assets
- update bootstrap paths to use resolve_path

## Testing
- `pre-commit run --files environment_bootstrap.py`
- `pytest environment_bootstrap.py` *(fails: ModuleNotFoundError: No module named 'retrieval_cache')*

------
https://chatgpt.com/codex/tasks/task_e_68b83e40bb60832eb4a242ebdf92acbe