### PR TITLE
Make recent error window configurable

### DIFF
--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -7834,7 +7834,9 @@ class SelfImprovementEngine:
                 _entropy_mean,
                 _entropy_std,
             ) = meta_planning._recent_error_entropy(
-                self.error_bot, self.baseline_tracker
+                self.error_bot,
+                self.baseline_tracker,
+                getattr(SandboxSettings(), "error_window", 5),
             )
             error_count = float(error_count)
             critical_errors = any(

--- a/self_improvement/tests/test_cycle_evaluation.py
+++ b/self_improvement/tests/test_cycle_evaluation.py
@@ -55,6 +55,7 @@ def _load_cycle_funcs() -> dict[str, Any]:
                 critical_severity_threshold=75.0,
                 max_allowed_errors=0,
                 entropy_overfit_threshold=1.0,
+                error_window=5,
             )
         ),
     }
@@ -144,6 +145,7 @@ def _run_cycle(
                     entropy_overfit_threshold=1.0,
                     max_allowed_errors=0,
                     critical_severity_threshold=75.0,
+                    error_window=5,
                 )
             ),
             "BASELINE_TRACKER": tracker,
@@ -373,6 +375,7 @@ def test_cycle_logs_skip_on_stop_event():
                     overfitting_entropy_threshold=1.0,
                     entropy_overfit_threshold=1.0,
                     max_allowed_errors=0,
+                    error_window=5,
                 )
             ),
             "BASELINE_TRACKER": tracker,

--- a/tests/self_improvement/test_cycle.py
+++ b/tests/self_improvement/test_cycle.py
@@ -348,8 +348,21 @@ def _load_cycle_funcs():
         "datetime": datetime,
         "BASELINE_TRACKER": types.SimpleNamespace(),
         "_get_entropy_threshold": lambda cfg, tracker: 1.0,
+        "DEFAULT_SEVERITY_SCORE_MAP": {
+            "critical": 100.0,
+            "crit": 100.0,
+            "fatal": 100.0,
+            "high": 75.0,
+            "error": 75.0,
+            "warn": 50.0,
+            "warning": 50.0,
+            "medium": 50.0,
+            "low": 25.0,
+            "info": 0.0,
+        },
     }
     exec(compile(module, "<ast>", "exec"), ns)
+    ns["REQUIRED_METRICS"] = ("roi", "pass_rate", "entropy")
     return ns
 
 
@@ -432,9 +445,14 @@ def _run_cycle(
                     overfitting_entropy_threshold=1.0,
                     entropy_overfit_threshold=1.0,
                     max_allowed_errors=0,
+                    error_window=5,
                 )
             ),
             "BASELINE_TRACKER": tracker,
+            "_get_overfit_thresholds": lambda cfg, _tracker: (
+                getattr(cfg, "max_allowed_errors", 0),
+                getattr(cfg, "entropy_overfit_threshold", 1.0),
+            ),
         }
     )
 


### PR DESCRIPTION
## Summary
- allow `_recent_error_entropy` to use configurable history window
- pass configurable error window from self-improvement cycle and engine
- adjust tests for new configurable window size

## Testing
- `pytest self_improvement/tests/test_cycle_evaluation.py tests/self_improvement/test_cycle.py` *(fails: cannot import name 'RAISE_ERRORS')*
- `pytest tests/self_improvement/test_cycle.py` *(fails: assertion failure in test_cycle_overfitting_fallback_on_entropy_spike)*

------
https://chatgpt.com/codex/tasks/task_e_68b841b0c540832e9a427c5361680f21