### PR TITLE
Use resolve_path for unit test file paths

### DIFF
--- a/unit_tests/test_async_track_usage_logging.py
+++ b/unit_tests/test_async_track_usage_logging.py
@@ -1,6 +1,6 @@
-from pathlib import Path
 import ast
 import types
+from dynamic_path_router import resolve_path
 
 
 class DummyLogger:
@@ -29,7 +29,7 @@ class DummyQueue:
 
 
 def _load_async_track_usage():
-    src = Path("sandbox_runner/cycle.py").read_text()
+    src = resolve_path("sandbox_runner/cycle.py").read_text()
     tree = ast.parse(src)
     async_fn = next(
         n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "_async_track_usage"

--- a/unit_tests/test_evolve_workflows.py
+++ b/unit_tests/test_evolve_workflows.py
@@ -1,5 +1,6 @@
 import ast
 from pathlib import Path
+from dynamic_path_router import resolve_path
 import os
 from types import SimpleNamespace
 
@@ -42,7 +43,7 @@ def test_evolve_workflows_calls_evolver():
         "os": os,
     }
 
-    src = Path("self_improvement.py").read_text()
+    src = resolve_path("self_improvement.py").read_text()
     tree = ast.parse(src)
     class_node = next(
         n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "SelfImprovementEngine"
@@ -107,7 +108,7 @@ def test_evolve_workflows_skips_flagged_workflow():
         "os": os,
     }
 
-    src = Path("self_improvement.py").read_text()
+    src = resolve_path("self_improvement.py").read_text()
     tree = ast.parse(src)
     class_node = next(
         n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "SelfImprovementEngine"

--- a/unit_tests/test_fallback_planner.py
+++ b/unit_tests/test_fallback_planner.py
@@ -6,6 +6,7 @@ import ast
 from pathlib import Path
 from statistics import fmean
 from typing import Any, Callable, Mapping, Sequence
+from dynamic_path_router import resolve_path
 
 import pytest
 
@@ -68,7 +69,7 @@ class DummyLogger:
 
 
 def _load_fallback_planner():
-    src = Path("self_improvement/meta_planning.py").read_text()
+    src = resolve_path("self_improvement/meta_planning.py").read_text()
     tree = ast.parse(src)
     nodes = [n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "_FallbackPlanner"]
     module = ast.Module(nodes, type_ignores=[])

--- a/unit_tests/test_meta_planning.py
+++ b/unit_tests/test_meta_planning.py
@@ -6,13 +6,14 @@ import threading
 import time
 import types
 from pathlib import Path
+from dynamic_path_router import resolve_path
 from typing import Any, Callable, Mapping, Sequence
 from self_improvement.baseline_tracker import BaselineTracker
 import pytest
 
 
 def _load_meta_planning():
-    src = Path("self_improvement/meta_planning.py").read_text()
+    src = resolve_path("self_improvement/meta_planning.py").read_text()
     tree = ast.parse(src)
     wanted = {
         "_get_entropy_threshold",
@@ -215,7 +216,7 @@ def test_cycle_fails_when_enabled_but_missing():
 def test_cycle_thread_logs_cancellation(monkeypatch, caplog):
     import importlib.util
 
-    path = Path("self_improvement/meta_planning.py")
+    path = resolve_path("self_improvement/meta_planning.py")
     spec = importlib.util.spec_from_file_location(
         "menace_sandbox.self_improvement.meta_planning", path
     )

--- a/unit_tests/test_metrics_logging_failures.py
+++ b/unit_tests/test_metrics_logging_failures.py
@@ -3,6 +3,7 @@ import json
 import types
 import sys
 from pathlib import Path
+from dynamic_path_router import resolve_path
 import pytest
 
 
@@ -21,7 +22,7 @@ class DummyLogger:
 
 
 def _load_integrator(repo: Path, data_dir: Path):
-    src = Path("self_improvement.py").read_text()
+    src = resolve_path("self_improvement.py").read_text()
     tree = ast.parse(src)
     cls = next(
         n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "SelfImprovementEngine"

--- a/unit_tests/test_missing_module_failure.py
+++ b/unit_tests/test_missing_module_failure.py
@@ -2,12 +2,12 @@ import ast
 import importlib
 import logging
 import types
-from pathlib import Path
 from typing import Callable
+from dynamic_path_router import resolve_path
 
 
 def _load_build_callable():
-    src = Path("workflow_evolution_manager.py").read_text()
+    src = resolve_path("workflow_evolution_manager.py").read_text()
     tree = ast.parse(src)
     func_node = next(
         n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "_build_callable"

--- a/unit_tests/test_self_coding_engine.py
+++ b/unit_tests/test_self_coding_engine.py
@@ -1,12 +1,13 @@
 import ast
 import logging
 from pathlib import Path
+from dynamic_path_router import resolve_path
 
 import pytest
 
 
 def _build_check_permission():
-    src = Path("self_coding_engine.py").read_text()
+    src = resolve_path("self_coding_engine.py").read_text()
     tree = ast.parse(src)
     class_node = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "SelfCodingEngine")
     method = next(m for m in class_node.body if isinstance(m, ast.FunctionDef) and m.name == "_check_permission")
@@ -15,7 +16,7 @@ def _build_check_permission():
     module = ast.fix_missing_locations(module)
 
     import importlib.util, sys
-    spec = importlib.util.spec_from_file_location("menace", Path("__init__.py"))
+    spec = importlib.util.spec_from_file_location("menace", resolve_path("__init__.py"))
     menace = importlib.util.module_from_spec(spec)
     menace.__path__ = [str(Path().resolve())]
     sys.modules.setdefault("menace", menace)

--- a/unit_tests/test_self_improvement_engine_metrics.py
+++ b/unit_tests/test_self_improvement_engine_metrics.py
@@ -1,9 +1,10 @@
 import ast
 from pathlib import Path
+from dynamic_path_router import resolve_path
 
 
 def _load_data_dir(sandbox_dir):
-    src = Path("self_improvement/__init__.py").read_text()
+    src = resolve_path("self_improvement/__init__.py").read_text()
     tree = ast.parse(src)
     fn = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "_data_dir")
     module = ast.Module([fn], type_ignores=[])

--- a/unit_tests/test_self_improvement_engine_utils.py
+++ b/unit_tests/test_self_improvement_engine_utils.py
@@ -2,8 +2,8 @@ import ast
 import importlib
 import logging
 import time
-from pathlib import Path
 from unittest.mock import patch
+from dynamic_path_router import resolve_path
 from typing import Callable, Any, Awaitable
 import types
 import asyncio
@@ -19,7 +19,7 @@ import pytest
 
 
 def _load_utils():
-    src = Path("self_improvement/utils.py").read_text()
+    src = resolve_path("self_improvement/utils.py").read_text()
     tree = ast.parse(src)
     wanted_funcs = {"_load_callable", "_call_with_retries", "_import_callable"}
     wanted_assigns = {"_diagnostics_lock", "_diagnostics"}

--- a/unit_tests/test_self_improvement_utils.py
+++ b/unit_tests/test_self_improvement_utils.py
@@ -3,7 +3,7 @@ import importlib
 import logging
 import time
 import types
-from pathlib import Path
+from dynamic_path_router import resolve_path
 from typing import Any, Callable, Awaitable
 from unittest.mock import patch
 import asyncio
@@ -19,7 +19,7 @@ import pytest
 
 
 def _load_utils():
-    src = Path("self_improvement/utils.py").read_text()
+    src = resolve_path("self_improvement/utils.py").read_text()
     tree = ast.parse(src)
     wanted_funcs = {
         "_load_callable",

--- a/unit_tests/test_self_learning_coordinator.py
+++ b/unit_tests/test_self_learning_coordinator.py
@@ -1,10 +1,10 @@
 import ast
 import asyncio
+from dynamic_path_router import resolve_path
 
 
 def _build_coordinator():
-    from pathlib import Path
-    src = Path("self_learning_coordinator.py").read_text()
+    src = resolve_path("self_learning_coordinator.py").read_text()
     tree = ast.parse(src)
     class_node = next(
         n
@@ -145,9 +145,8 @@ def test_train_record_restarts_failed_tasks(tmp_path):
     import asyncio
     import ast
     import logging
-    from pathlib import Path
 
-    src = Path("self_learning_coordinator.py").read_text()
+    src = resolve_path("self_learning_coordinator.py").read_text()
     tree = ast.parse(src)
     class_node = next(
         n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "SelfLearningCoordinator"


### PR DESCRIPTION
## Summary
- replace direct `Path("*.py")` file lookups in unit tests with `resolve_path()`
- import `resolve_path` from `dynamic_path_router` across affected tests

## Testing
- `pytest unit_tests/test_async_track_usage_logging.py unit_tests/test_missing_module_failure.py unit_tests/test_evolve_workflows.py unit_tests/test_meta_planning.py unit_tests/test_self_improvement_utils.py unit_tests/test_self_improvement_engine_utils.py unit_tests/test_self_improvement_engine_metrics.py unit_tests/test_metrics_logging_failures.py unit_tests/test_self_learning_coordinator.py unit_tests/test_fallback_planner.py unit_tests/test_self_coding_engine.py` *(fails: 11 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b850bad1d4832e92f5ac2ef60bd36d