### PR TITLE
Use resolve_path in sandbox runner tests

### DIFF
--- a/sandbox_runner/tests/test_minimal_cycle.py
+++ b/sandbox_runner/tests/test_minimal_cycle.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
+from dynamic_path_router import resolve_path  # noqa: E402
 from sandbox_settings import SandboxSettings  # noqa: E402
 
 
@@ -123,13 +124,15 @@ def test_cycle_generates_patch_and_metrics(tmp_path, monkeypatch):
     sys.modules["menace.meta_workflow_planner"] = types.SimpleNamespace(MetaWorkflowPlanner=None)
 
     init_module = _load_module(
-        "menace.self_improvement.init", Path("self_improvement/init.py")
+        "menace.self_improvement.init", resolve_path("self_improvement/init.py")
     )
     meta_planning = _load_module(
-        "menace.self_improvement.meta_planning", Path("self_improvement/meta_planning.py")
+        "menace.self_improvement.meta_planning",
+        resolve_path("self_improvement/meta_planning.py"),
     )
     patch_generation = _load_module(
-        "menace.self_improvement.patch_generation", Path("self_improvement/patch_generation.py")
+        "menace.self_improvement.patch_generation",
+        resolve_path("self_improvement/patch_generation.py"),
     )
 
     monkeypatch.setattr(meta_planning, "ROIResultsDB", InMemoryROIResultsDB)

--- a/sandbox_runner/tests/test_self_improvement_flow.py
+++ b/sandbox_runner/tests/test_self_improvement_flow.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
+from dynamic_path_router import resolve_path  # noqa: E402
 from sandbox_settings import SandboxSettings  # noqa: E402
 
 
@@ -54,7 +55,7 @@ def test_init_creates_and_clamps_synergy_weights(tmp_path, monkeypatch):
     sys.modules["menace.self_improvement.meta_planning"] = meta_stub
 
     init_module = _load_module(
-        "menace.self_improvement.init", Path("self_improvement/init.py")
+        "menace.self_improvement.init", resolve_path("self_improvement/init.py")
     )
 
     settings = SandboxSettings()
@@ -106,10 +107,11 @@ def test_start_self_improvement_cycle_thread(tmp_path, monkeypatch, in_memory_db
     sys.modules["menace.sandbox_settings"] = sandbox_settings_module
 
     init_module = _load_module(
-        "menace.self_improvement.init", Path("self_improvement/init.py")
+        "menace.self_improvement.init", resolve_path("self_improvement/init.py")
     )
     meta_planning = _load_module(
-        "menace.self_improvement.meta_planning", Path("self_improvement/meta_planning.py")
+        "menace.self_improvement.meta_planning",
+        resolve_path("self_improvement/meta_planning.py"),
     )
 
     settings = SandboxSettings()


### PR DESCRIPTION
## Summary
- replace hard-coded Path literals with resolve_path for self_improvement modules in sandbox runner tests
- import resolve_path from dynamic_path_router for test modules

## Testing
- `pytest sandbox_runner/tests/test_minimal_cycle.py sandbox_runner/tests/test_self_improvement_flow.py -q` *(fails: ModuleNotFoundError: No module named 'menace.error_logger'; RuntimeError: Missing dependencies for self-improvement)*

------
https://chatgpt.com/codex/tasks/task_e_68b854271b9c832eb0977c372366b197