### PR TITLE
Refactor scripts to use project path helpers

### DIFF
--- a/scripts/check_governed_embeddings.py
+++ b/scripts/check_governed_embeddings.py
@@ -12,6 +12,8 @@ from pathlib import Path
 import re
 import sys
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
 # Match ``SentenceTransformer(...).encode(`` or ``SentenceTransformer.encode(``
 # directly.  The ``.*`` is non-greedy so multi-line constructions are handled.
 DIRECT_ST_ENCODE = re.compile(
@@ -24,7 +26,9 @@ ENCODE_CALL = re.compile(r"\b(?!tokenizer\.)[A-Za-z_][A-Za-z0-9_]*\.encode\(")
 
 
 def main() -> int:
-    root = Path(__file__).resolve().parents[1]
+    from dynamic_path_router import get_project_root
+
+    root = get_project_root()
     offenders: list[str] = []
     this_file = Path(__file__).resolve()
     for path in root.rglob("*.py"):

--- a/scripts/check_governed_retrieval.py
+++ b/scripts/check_governed_retrieval.py
@@ -13,14 +13,17 @@ from pathlib import Path
 import re
 import sys
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
 # Match ``something.retrieve(``
 RETRIEVE_CALL = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\.retrieve\(")
 
 
 def main() -> int:
-    root = Path(__file__).resolve().parents[1]
+    from dynamic_path_router import get_project_root
+
+    root = get_project_root()
     offenders: list[str] = []
-    this_file = Path(__file__).resolve()
     for path in root.rglob("*.py"):
         if (
             "tests" in path.parts

--- a/scripts/discover_isolated_modules.py
+++ b/scripts/discover_isolated_modules.py
@@ -16,6 +16,8 @@ import json
 from pathlib import Path
 from typing import Iterable
 
+from dynamic_path_router import resolve_path
+
 from sandbox_runner.orphan_discovery import discover_recursive_orphans
 
 
@@ -29,7 +31,7 @@ def discover_isolated_modules(
     without orphan parents are returned.
     """
 
-    repo = Path(base_dir).resolve()
+    repo = resolve_path(str(base_dir))
     mapping = discover_recursive_orphans(str(repo))
 
     if not recursive:
@@ -59,10 +61,9 @@ def main(argv: Iterable[str] | None = None) -> None:  # pragma: no cover - CLI
     )
     args = parser.parse_args(list(argv) if argv is not None else None)
 
-    res = discover_isolated_modules(Path(args.path), recursive=args.recursive)
+    res = discover_isolated_modules(args.path, recursive=args.recursive)
     print(json.dumps(res, indent=2))
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point
     main()
-

--- a/scripts/find_orphan_modules.py
+++ b/scripts/find_orphan_modules.py
@@ -17,7 +17,7 @@ import logging
 from pathlib import Path
 from typing import Iterable, List
 
-from dynamic_path_router import resolve_path
+from dynamic_path_router import resolve_path, get_project_root
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -104,7 +104,7 @@ def main(argv: Iterable[str] | None = None) -> None:
         help="Repeat detection excluding discovered modules until stable",
     )
     args = parser.parse_args(list(argv) if argv is not None else None)
-    root = resolve_path(".")
+    root = get_project_root()
     orphan_paths = find_orphan_modules(
         root, excludes=args.exclude, recursive=args.recursive
     )


### PR DESCRIPTION
## Summary
- use `get_project_root` for scanning repositories in governance check scripts
- rely on `resolve_path`/`get_project_root` in orphan discovery utilities
- add `sys.path` bootstrap so scripts can import repo modules

## Testing
- `pre-commit run --files scripts/check_governed_retrieval.py scripts/check_governed_embeddings.py scripts/find_orphan_modules.py scripts/discover_isolated_modules.py`
- `python -m py_compile scripts/check_governed_retrieval.py scripts/check_governed_embeddings.py scripts/find_orphan_modules.py scripts/discover_isolated_modules.py`
- `pytest` *(fails: 432 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b8554a168c832e923f0bc596d16d84