### PR TITLE
feat: track failing regions and escalation state

### DIFF
--- a/failure_fingerprint.py
+++ b/failure_fingerprint.py
@@ -63,6 +63,8 @@ class FailureFingerprint:
     embedding_metadata: Dict[str, Any] = field(default_factory=dict)
     timestamp: float = field(default_factory=lambda: time())
     count: int = 1
+    target_region: str | None = None
+    escalation_level: int = 0
 
     # ``function`` is used by ``FailureFingerprintStore``; keep ``function_name`` for
     # backwards compatibility with existing callers.

--- a/failure_fingerprint_store.py
+++ b/failure_fingerprint_store.py
@@ -247,6 +247,8 @@ class FailureFingerprintStore:
                         "function": existing.function,
                         "embedding_meta": existing.embedding_metadata,
                         "count": existing.count,
+                        "target_region": existing.target_region,
+                        "escalation_level": existing.escalation_level,
                     },
                 )
             except Exception:  # pragma: no cover - best effort
@@ -267,6 +269,8 @@ class FailureFingerprintStore:
                 "function": fingerprint.function,
                 "embedding_meta": fingerprint.embedding_metadata,
                 "count": fingerprint.count,
+                "target_region": fingerprint.target_region,
+                "escalation_level": fingerprint.escalation_level,
             },
         )
         self._cache[record_id] = fingerprint
@@ -364,6 +368,8 @@ class FailureFingerprintStore:
                         "filename": fp.filename,
                         "function": fp.function,
                         "embedding_meta": fp.embedding_metadata,
+                        "target_region": fp.target_region,
+                        "escalation_level": fp.escalation_level,
                     },
                 )
         except Exception:  # pragma: no cover - best effort
@@ -378,6 +384,8 @@ class FailureFingerprintStore:
                             "filename": fp.filename,
                             "function": fp.function,
                             "embedding_meta": fp.embedding_metadata,
+                            "target_region": fp.target_region,
+                            "escalation_level": fp.escalation_level,
                         },
                     )
                 except Exception:

--- a/failure_region_cli.py
+++ b/failure_region_cli.py
@@ -1,0 +1,49 @@
+"""CLI for summarising failure regions and escalation levels."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+from typing import Iterable
+
+from failure_fingerprint_store import FailureFingerprintStore
+
+
+def cli(argv: Iterable[str] | None = None) -> int:
+    """Entry point for command line execution."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--path",
+        default="failure_fingerprints.jsonl",
+        help="Path to failure fingerprint log",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    store = FailureFingerprintStore(path=args.path)
+    region_counts: Counter[str] = Counter()
+    escalation: dict[str, int] = defaultdict(int)
+    for fp in store._cache.values():
+        region = fp.target_region or "unknown"
+        region_counts[region] += fp.count
+        if fp.escalation_level > escalation[region]:
+            escalation[region] = fp.escalation_level
+
+    if not region_counts:
+        print("No failures recorded.")
+        return 0
+
+    print("region\tcount\tescalation")
+    for region, count in sorted(region_counts.items(), key=lambda x: x[1], reverse=True):
+        print(f"{region}\t{count}\t{escalation.get(region, 0)}")
+    return 0
+
+
+def main(argv: Iterable[str] | None = None) -> None:  # pragma: no cover - CLI glue
+    import sys
+
+    sys.exit(cli(argv))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/tests/test_failure_region_cli.py
+++ b/tests/test_failure_region_cli.py
@@ -1,0 +1,51 @@
+from failure_fingerprint_store import FailureFingerprint, FailureFingerprintStore
+from failure_region_cli import cli
+from .test_failure_fingerprint_store import DummyVectorService
+
+
+def test_region_cli_counts(tmp_path, capsys):
+    svc = DummyVectorService()
+    store = FailureFingerprintStore(
+        path=tmp_path / "fps.jsonl",
+        vector_service=svc,
+        similarity_threshold=0.9,
+        compact_interval=0,
+    )
+    store.add(
+        FailureFingerprint(
+            "a.py",
+            "f",
+            "e",
+            "trace one",
+            "p",
+            target_region="us",
+            escalation_level=1,
+        )
+    )
+    store.add(
+        FailureFingerprint(
+            "b.py",
+            "g",
+            "e",
+            "trace two",
+            "p",
+            target_region="us",
+            escalation_level=2,
+        )
+    )
+    store.add(
+        FailureFingerprint(
+            "c.py",
+            "h",
+            "e",
+            "trace three",
+            "p",
+            target_region="eu",
+            escalation_level=0,
+        )
+    )
+    cli(["--path", str(store.path)])
+    out = capsys.readouterr().out.strip().splitlines()
+    assert out[0] == "region\tcount\tescalation"
+    assert out[1] == "us\t2\t2"
+    assert out[2] == "eu\t1\t0"


### PR DESCRIPTION
## Summary
- store target region and escalation level on failure fingerprints
- expose CLI to summarise failing regions and escalation levels

## Testing
- `pytest tests/test_failure_fingerprint_store.py tests/test_failure_region_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68b856371848832e9fbde232945fe741