### PR TITLE
Support line-aligned chunking for targeted regions

### DIFF
--- a/tests/test_chunking_split.py
+++ b/tests/test_chunking_split.py
@@ -87,3 +87,9 @@ def test_get_chunk_summaries_cache_invalidation(tmp_path, monkeypatch):
     cache_files = list(cache_dir.iterdir())
     assert len(cache_files) == 1  # file replaced
     assert first != second
+
+
+def test_split_respects_line_ranges() -> None:
+    code = "\n".join(f"print({i})" for i in range(1, 6))
+    chunks = pc.split_into_chunks(code, 100, line_ranges=[(2, 3)])
+    assert [(c.start_line, c.end_line) for c in chunks] == [(1, 1), (2, 3), (4, 5)]


### PR DESCRIPTION
## Summary
- allow split_into_chunks to accept explicit line ranges and keep chunk boundaries aligned
- ensure _build_file_context stitches multi-chunk target regions and summarizes others
- add tests for line range chunking and stitched target regions

## Testing
- `pytest tests/test_chunking_split.py tests/test_self_coding_engine_chunking.py::test_build_file_context_stitches_target_region tests/test_self_coding_engine_chunking.py::test_generate_helper_injects_chunk_summaries -q`
- `pytest -q` *(fails: ImportError: cannot import name 'Retriever' from 'vector_service')*


------
https://chatgpt.com/codex/tasks/task_e_68b8580c879c832e85b69c79ec8cdcb5