### PR TITLE
Use resolve_path for sandbox data directory

### DIFF
--- a/menace_visual_agent_2.py
+++ b/menace_visual_agent_2.py
@@ -33,6 +33,10 @@ import json
 from pathlib import Path
 import atexit
 import psutil
+try:  # pragma: no cover - allow running as script
+    from .dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback for flat layout
+    from dynamic_path_router import resolve_path  # type: ignore
 try:
     from .visual_agent_queue import VisualAgentQueue
 except ImportError:  # pragma: no cover - allow running as script
@@ -298,7 +302,7 @@ def _cleanup_stale_files() -> None:
 # Queue management
 
 # Database paths
-DATA_DIR = Path(os.getenv("SANDBOX_DATA_DIR", "sandbox_data"))
+DATA_DIR = Path(os.getenv("SANDBOX_DATA_DIR") or resolve_path("sandbox_data"))
 QUEUE_FILE = DATA_DIR / "visual_agent_queue.jsonl"  # legacy path
 QUEUE_DB = DATA_DIR / "visual_agent_queue.db"
 RECOVERY_METRICS_FILE = DATA_DIR / "visual_agent_recovery.json"

--- a/sandbox_recovery_manager.py
+++ b/sandbox_recovery_manager.py
@@ -221,6 +221,7 @@ class SandboxRecoveryManager:
         errors—such as an open circuit or exceeding ``max_retries``—raise
         :class:`SandboxRecoveryError`.
         """
+        data_dir = Path(os.getenv("SANDBOX_DATA_DIR") or resolve_path("sandbox_data"))
         attempts = 0
         delay = self.retry_delay
         while True:
@@ -249,8 +250,7 @@ class SandboxRecoveryManager:
                 )
 
                 log_dir = Path(
-                    getattr(args, "sandbox_data_dir", None)
-                    or os.getenv("SANDBOX_DATA_DIR", "sandbox_data")
+                    getattr(args, "sandbox_data_dir", None) or data_dir
                 )
                 log_dir.mkdir(parents=True, exist_ok=True)
                 log_file = log_dir / "recovery.log"

--- a/visual_agent_client.py
+++ b/visual_agent_client.py
@@ -14,6 +14,11 @@ from typing import Iterable, Dict, Any, Callable, Deque, Tuple
 from pathlib import Path
 import json
 
+try:  # pragma: no cover - allow running as script
+    from .dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback for flat layout
+    from dynamic_path_router import resolve_path  # type: ignore
+
 from . import metrics_exporter
 
 from .audit_logger import log_event
@@ -128,7 +133,7 @@ class VisualAgentClient:
         self._worker = threading.Thread(target=self._worker_loop, daemon=True)
         self._worker.start()
         self._stop_event = threading.Event()
-        data_dir = Path(os.getenv("SANDBOX_DATA_DIR", "sandbox_data"))
+        data_dir = Path(os.getenv("SANDBOX_DATA_DIR") or resolve_path("sandbox_data"))
         self._local_queue = _LocalQueue(data_dir / "visual_agent_client_queue.jsonl")
         if self.queue_warning_threshold is not None and self.urls and requests:
             self._metrics_thread = threading.Thread(


### PR DESCRIPTION
## Summary
- use resolve_path with SANDBOX_DATA_DIR to locate sandbox data in VisualAgentClient
- centralize sandbox data path handling in menace_visual_agent_2
- compute data_dir once in SandboxRecoveryManager and reuse for log directory

## Testing
- `pytest tests/test_visual_agent_client.py::test_main_runs_single_worker tests/test_visual_agent_client.py::test_dataset_dir_env -q` (fails: RecursionError: maximum recursion depth exceeded while calling a Python object)
- `pytest tests/test_sandbox_recovery_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b858cfbe84832eae60c633d2cde9fb