### PR TITLE
feat: add region-level rollback

### DIFF
--- a/tests/test_rollback_manager.py
+++ b/tests/test_rollback_manager.py
@@ -11,3 +11,15 @@ def test_register_and_rollback(tmp_path):
     mgr.rollback("p1")
     patches = mgr.applied_patches()
     assert not patches
+
+
+def test_region_register_and_rollback(tmp_path):
+    db_path = tmp_path / "rb.db"
+    mgr = rm.RollbackManager(str(db_path))
+    mgr.register_region_patch("p2", "nodeB", "file.txt", 10, 20)
+    patches = mgr.applied_region_patches()
+    assert len(patches) == 1
+    assert patches[0].file == "file.txt"
+    mgr.rollback_region("file.txt", 10, 20)
+    patches = mgr.applied_region_patches()
+    assert not patches

--- a/tests/test_rollback_manager_rpc.py
+++ b/tests/test_rollback_manager_rpc.py
@@ -49,3 +49,29 @@ def test_rpc_server(tmp_path):
     conn.getresponse().read()
     assert not mgr.applied_patches()
     mgr.stop_rpc_server()
+
+
+def test_rpc_server_region(tmp_path):
+    mgr = RollbackManager(str(tmp_path / "r.db"))
+    mgr.start_rpc_server(port=0)
+    port = mgr._server.server_address[1]
+
+    conn = http.client.HTTPConnection("localhost", port)
+    body = json.dumps(
+        {"patch_id": "p2", "node": "n", "file": "f", "start_line": 1, "end_line": 2}
+    )
+    conn.request("POST", "/register_region", body, {"Content-Type": "application/json"})
+    conn.getresponse().read()
+
+    patches = mgr.applied_region_patches()
+    assert patches and patches[0].file == "f"
+
+    conn.request(
+        "POST",
+        "/rollback_region",
+        json.dumps({"file": "f", "start_line": 1, "end_line": 2}),
+        {"Content-Type": "application/json"},
+    )
+    conn.getresponse().read()
+    assert not mgr.applied_region_patches()
+    mgr.stop_rpc_server()


### PR DESCRIPTION
## Summary
- allow rolling back patches for specific file line ranges
- track region-level patches and expose region RPC endpoints

## Testing
- `pytest tests/test_rollback_manager.py tests/test_rollback_manager_rpc.py`


------
https://chatgpt.com/codex/tasks/task_e_68b85afe9bf4832e888526a4f6a3aa84