### PR TITLE
Capture failing frames and add targeting helpers

### DIFF
--- a/self_improvement/targeting.py
+++ b/self_improvement/targeting.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import ast
+import pathlib
+import re
+# ``typing`` is intentionally minimal to keep this module lightweight.
+
+
+@dataclass
+class TargetRegion:
+    """Represents a contiguous region of source code.
+
+    Attributes
+    ----------
+    file: str
+        Absolute path to the source file containing the target.
+    start_line: int
+        First line number of the region (1-indexed).
+    end_line: int
+        Last line number of the region (1-indexed).
+    func_name: str
+        Name of the enclosing function or ``"<module>"`` when the code is at
+        module level.
+    """
+
+    file: str
+    start_line: int
+    end_line: int
+    func_name: str
+
+
+def region_from_frame(filename: str, lineno: int, func_name: str) -> TargetRegion:
+    """Return :class:`TargetRegion` for ``filename``/``lineno``.
+
+    The module is parsed using :mod:`ast` and the smallest function (or class)
+    enclosing ``lineno`` is returned.  If parsing fails or no suitable node is
+    found, a region spanning only ``lineno`` is returned.
+    """
+
+    path = pathlib.Path(filename)
+    try:
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+    except Exception:
+        return TargetRegion(file=str(path), start_line=lineno, end_line=lineno, func_name=func_name)
+
+    target: ast.AST | None = None
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            start = getattr(node, "lineno", None)
+            end = getattr(node, "end_lineno", start)
+            if start is None or end is None:
+                continue
+            if start <= lineno <= end:
+                # choose the innermost function/class containing the line
+                if target is None or start >= getattr(target, "lineno", 0):
+                    target = node
+    if target is not None:
+        start = getattr(target, "lineno", lineno)
+        end = getattr(target, "end_lineno", start)
+        name = getattr(target, "name", func_name)
+        return TargetRegion(file=str(path), start_line=start, end_line=end, func_name=name)
+
+    return TargetRegion(file=str(path), start_line=lineno, end_line=lineno, func_name=func_name)
+
+
+_FRAME_RE = re.compile(r'File "([^"]+)", line (\d+), in ([^\n]+)')
+
+
+def extract_target_region(trace: str) -> TargetRegion | None:
+    """Parse ``trace`` and return the innermost frame within the repo.
+
+    The stack trace is scanned for ``File ...`` entries.  The deepest frame whose
+    filename resides inside the repository root is returned as a
+    :class:`TargetRegion`.  ``None`` is returned when no such frame is found.
+    """
+
+    frames = _FRAME_RE.findall(trace)
+    if not frames:
+        return None
+
+    repo_root = pathlib.Path(__file__).resolve().parent.parent
+    for filename, lineno_str, func in reversed(frames):
+        try:
+            path = pathlib.Path(filename).resolve()
+        except Exception:
+            continue
+        try:
+            path.relative_to(repo_root)
+        except ValueError:
+            continue
+        return region_from_frame(str(path), int(lineno_str), func.strip())
+    return None
+
+
+__all__ = ["TargetRegion", "region_from_frame", "extract_target_region"]

--- a/tests/test_target_region.py
+++ b/tests/test_target_region.py
@@ -1,0 +1,45 @@
+import inspect
+import traceback
+from pathlib import Path
+
+from error_parser import extract_target_region
+from sandbox_runner.workflow_sandbox_runner import WorkflowSandboxRunner
+
+
+def _inner_fail():
+    raise RuntimeError("boom")
+
+
+def _outer_call():
+    _inner_fail()
+
+
+def test_extract_target_region_identifies_innermost_frame():
+    try:
+        _outer_call()
+    except Exception:
+        trace = traceback.format_exc()
+    region = extract_target_region(trace)
+    assert region is not None
+    assert Path(region.file) == Path(inspect.getsourcefile(_inner_fail))
+    src, start = inspect.getsourcelines(_inner_fail)
+    assert region.func_name == "_inner_fail"
+    assert region.start_line == start
+    assert region.end_line == start + len(src) - 1
+
+
+def failing_func():
+    raise ValueError("boom")
+
+
+def test_runner_records_traceback_frames():
+    runner = WorkflowSandboxRunner()
+    metrics = runner.run(failing_func, safe_mode=True)
+    mod = metrics.modules[0]
+    assert not mod.success
+    assert mod.frames
+    frame_file, frame_line, frame_func = mod.frames[-1]
+    assert frame_func == "failing_func"
+    assert Path(frame_file) == Path(inspect.getsourcefile(failing_func))
+    start = inspect.getsourcelines(failing_func)[1]
+    assert frame_line == start + 1


### PR DESCRIPTION
## Summary
- record traceback frames for failing modules in `WorkflowSandboxRunner`
- add `self_improvement.targeting` module to compute TargetRegion for stack frames
- expose `extract_target_region` via `error_parser`

## Testing
- `pre-commit run --files error_parser.py sandbox_runner/workflow_sandbox_runner.py self_improvement/targeting.py tests/test_target_region.py`
- `pytest tests/test_error_parser.py tests/test_failure_localization.py tests/test_target_region.py`


------
https://chatgpt.com/codex/tasks/task_e_68b85c2216b8832e9b576e7f9abf9d54