### PR TITLE
Refine target region context for prompt generation

### DIFF
--- a/prompt_engine.py
+++ b/prompt_engine.py
@@ -813,17 +813,20 @@ class PromptEngine:
             lines.append("")
 
         if target_region is not None:
-            file_name = (
-                Path(getattr(target_region, "path", "")).name
-                if getattr(target_region, "path", None)
-                else "the file"
-            )
-            lines.append(
-                f"Change only lines {target_region.start_line}-{target_region.end_line} of {file_name} unless adjacent logic is required."
-            )
+            func = getattr(target_region, "func_name", None)
+            if func:
+                lines.append(
+                    f"Modify only lines {target_region.start_line}-{target_region.end_line} "
+                    f"within function {func} unless surrounding logic is causally required."
+                )
+            else:
+                lines.append(
+                    f"Modify only lines {target_region.start_line}-{target_region.end_line} "
+                    f"unless surrounding logic is causally required."
+                )
         else:
             lines.append(
-                "Change only the provided lines unless adjacent logic is required."
+                "Modify only the provided lines unless surrounding logic is causally required."
             )
         lines.append(f"Given the following pattern, {task}")
         lines.append("")
@@ -842,6 +845,10 @@ class PromptEngine:
                 "start_line": target_region.start_line,
                 "end_line": target_region.end_line,
                 "func_name": getattr(target_region, "func_name", ""),
+                "signature": getattr(
+                    target_region, "func_signature", getattr(target_region, "signature", "")
+                ),
+                "original_lines": getattr(target_region, "original_lines", []),
             }
             meta["target_region"] = region_meta
             try:


### PR DESCRIPTION
## Summary
- include function signature and explicit start/end markers when building target region context
- tighten prompt instructions to modify only specific lines within a function
- track signature and original lines in prompt metadata and adjust tests

## Testing
- `pre-commit run --files self_coding_engine.py prompt_engine.py tests/test_prompt_engine.py`
- `pytest tests/test_prompt_engine.py::test_prompt_engine_includes_target_region_metadata tests/test_prompt_engine.py::test_build_prompt_trims_final_text tests/test_prompt_engine.py::test_prompt_engine_uses_optimizer_preferences tests/test_self_coding_engine_chunking.py::test_build_file_context_stitches_target_region`


------
https://chatgpt.com/codex/tasks/task_e_68b8c46a927c832e84474b30a2943ccb