### PR TITLE
Track patch region escalation with metrics

### DIFF
--- a/tests/test_patch_retry_escalation.py
+++ b/tests/test_patch_retry_escalation.py
@@ -1,0 +1,81 @@
+from . import test_self_coding_engine_chunking as setup  # reuse stub environment
+import types
+
+sce = setup.sce
+
+TargetRegion = sce.TargetRegion
+SelfCodingEngine = sce.SelfCodingEngine
+
+
+class DummyFP:
+    def __init__(self, filename, function_name, stack_trace, error_message, prompt_text, timestamp=0.0):
+        self.filename = filename
+        self.function_name = function_name
+        self.stack_trace = stack_trace
+        self.error_message = error_message
+        self.prompt_text = prompt_text
+        self.embedding = [0.0]
+        self.timestamp = timestamp
+
+    @classmethod
+    def from_failure(cls, filename, function_name, stack_trace, error_message, prompt_text):
+        return cls(filename, function_name, stack_trace, error_message, prompt_text)
+
+
+def test_region_escalation(monkeypatch, tmp_path):
+    gauge_calls = {}
+
+    class DummyGauge:
+        def labels(self, **labels):
+            key = tuple(sorted(labels.items()))
+            class Child:
+                def inc(self, amount=1.0):
+                    gauge_calls[key] = gauge_calls.get(key, 0) + amount
+            return Child()
+
+    monkeypatch.setattr(sce, "_PATCH_ATTEMPTS", DummyGauge())
+    monkeypatch.setattr(sce, "_PATCH_ESCALATIONS", DummyGauge())
+
+    engine = SelfCodingEngine(code_db=object(), memory_mgr=object())
+    engine.audit_trail = types.SimpleNamespace(record=lambda payload: None)
+    engine._build_retry_context = lambda desc, rep: {}
+    engine._failure_cache = types.SimpleNamespace(seen=lambda trace: False, add=lambda trace: None)
+    engine.failure_similarity_tracker = types.SimpleNamespace(
+        update=lambda **k: None, get=lambda key: 0.0, std=lambda key: 1.0
+    )
+    engine._save_state = lambda: None
+    monkeypatch.setattr(sce, "check_similarity_and_warn", lambda *a, **k: (a[3], False, 0.0, [], ""))
+    monkeypatch.setattr(sce, "FailureFingerprint", DummyFP)
+    monkeypatch.setattr(sce, "log_fingerprint", lambda fp: None)
+    monkeypatch.setattr(sce, "record_failure", lambda *a, **k: None)
+    monkeypatch.setattr(sce, "parse_failure", lambda trace: types.SimpleNamespace(trace=trace, tags=set()))
+
+    calls = []
+
+    def fake_apply(self, path, description, context_meta=None, target_region=None, **kwargs):
+        calls.append(target_region)
+        self._last_retry_trace = (
+            f'Traceback (most recent call last):\n'
+            f'  File "{path}", line 1, in {target_region.func_name if target_region else "<module>"}\n'
+            '    1/0\n'
+            'ZeroDivisionError: division by zero'
+        )
+        return None, False, 0.0
+
+    engine.apply_patch = types.MethodType(fake_apply, engine)
+
+    path = tmp_path / "mod.py"
+    path.write_text("def f():\n    a=1\n    b=2\n    return a+b\n")
+    region = TargetRegion(start_line=2, end_line=2, func_name="f")
+
+    engine.apply_patch_with_retry(path, "desc", max_attempts=5, target_region=region)
+
+    assert len(calls) == 5
+    assert calls[0].start_line == 2 and calls[0].end_line == 2
+    assert calls[1].start_line == 2 and calls[1].end_line == 2
+    assert calls[2].start_line == 1 and calls[2].end_line == 4
+    assert calls[3].start_line == 1 and calls[3].end_line == 4
+    assert calls[4] is None
+
+    assert gauge_calls[(('level', 'function'),)] == 1
+    assert gauge_calls[(('level', 'module'),)] == 1


### PR DESCRIPTION
## Summary
- track patch attempts and escalation with new metrics gauges
- expand failing line ranges to functions and then modules after repeated failures
- log escalation events and verify behavior in new tests

## Testing
- `pytest tests/test_patch_retry_escalation.py -q`
- `pytest -q` *(fails: missing vector_service, starlette, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c6529008832eafdad692425b93cd