### PR TITLE
Resolve module paths with dynamic resolver

### DIFF
--- a/module_mapper.py
+++ b/module_mapper.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Dict, Iterable, Mapping, Tuple, List
 
 import networkx as nx
+from dynamic_path_router import resolve_path
 
 
 # ---------------------------------------------------------------------------
@@ -46,7 +47,7 @@ def build_module_graph(
 
     logger = logging.getLogger(__name__)
 
-    root = Path(repo_path)
+    root = Path(resolve_path(repo_path))
     graph = nx.DiGraph()
     modules: Dict[str, Path] = {}
     for file in _iter_py_files(root, ignore=ignore):

--- a/scripts/generate_module_map.py
+++ b/scripts/generate_module_map.py
@@ -40,7 +40,8 @@ def main(args: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Build sandbox module map")
     parser.add_argument("repo", nargs="?", default=".", help="Repository path")
     parser.add_argument(
-        "--output", default=resolve_path("sandbox_data/module_map.json")
+        "--output",
+        default=Path(resolve_path("sandbox_data")) / "module_map.json",
     )
     parser.add_argument(
         "--algorithm",


### PR DESCRIPTION
## Summary
- resolve repo roots via `resolve_path` for dynamic and static mappers
- safely resolve module file paths when filtering
- write module map JSON under resolved `sandbox_data`

## Testing
- `pytest tests/test_dynamic_module_mapper.py tests/test_build_module_map_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_68b8c7ca327c832ebfa261b321b63d61