### PR TITLE
Add tests for targeting and escalation metrics

### DIFF
--- a/tests/integration/test_patch_escalation_metrics.py
+++ b/tests/integration/test_patch_escalation_metrics.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from tests import test_self_coding_engine_chunking as setup
+import types
+
+sce = setup.sce
+TargetRegion = sce.TargetRegion
+SelfCodingEngine = sce.SelfCodingEngine
+
+
+class DummyFP:
+    def __init__(self, filename, function_name, stack_trace, error_message, prompt_text, timestamp=0.0):
+        self.filename = filename
+        self.function_name = function_name
+        self.stack_trace = stack_trace
+        self.error_message = error_message
+        self.prompt_text = prompt_text
+        self.embedding = [0.0]
+        self.timestamp = timestamp
+
+    @classmethod
+    def from_failure(cls, filename, function_name, stack_trace, error_message, prompt_text):
+        return cls(filename, function_name, stack_trace, error_message, prompt_text)
+
+
+def test_escalation_metrics(monkeypatch, tmp_path):
+    gauge_calls: dict[tuple[tuple[str, str], ...], int] = {}
+
+    class DummyGauge:
+        def labels(self, **labels):
+            key = tuple(sorted(labels.items()))
+            class Child:
+                def inc(self, amount: float = 1.0):
+                    gauge_calls[key] = gauge_calls.get(key, 0) + amount
+            return Child()
+
+    monkeypatch.setattr(sce, "_PATCH_ATTEMPTS", DummyGauge())
+    monkeypatch.setattr(sce, "_PATCH_ESCALATIONS", DummyGauge())
+
+    engine = SelfCodingEngine(code_db=object(), memory_mgr=object())
+    engine.audit_trail = types.SimpleNamespace(record=lambda payload: None)
+    engine._build_retry_context = lambda desc, rep: {}
+    engine._failure_cache = types.SimpleNamespace(seen=lambda trace: False, add=lambda trace: None)
+    engine.failure_similarity_tracker = types.SimpleNamespace(update=lambda **k: None, get=lambda key: 0.0, std=lambda key: 1.0)
+    engine._save_state = lambda: None
+    monkeypatch.setattr(sce, "check_similarity_and_warn", lambda *a, **k: (a[3], False, 0.0, [], ""))
+    monkeypatch.setattr(sce, "FailureFingerprint", DummyFP)
+    monkeypatch.setattr(sce, "log_fingerprint", lambda fp: None)
+    monkeypatch.setattr(sce, "record_failure", lambda *a, **k: None)
+    monkeypatch.setattr(sce, "parse_failure", lambda trace: types.SimpleNamespace(trace=trace, tags=set()))
+
+    calls: list[TargetRegion | None] = []
+
+    def fake_apply(self, path, description, context_meta=None, target_region=None, **kwargs):
+        calls.append(target_region)
+        self._last_retry_trace = (
+            f'Traceback (most recent call last):\n'
+            f'  File "{path}", line 1, in {target_region.func_name if target_region else "<module>"}\n'
+            '    1/0\n'
+            'ZeroDivisionError: division by zero'
+        )
+        return None, False, 0.0
+
+    engine.apply_patch = types.MethodType(fake_apply, engine)
+
+    path = tmp_path / "mod.py"
+    path.write_text("def f():\n    a=1\n    b=2\n    return a+b\n")
+    region = TargetRegion(start_line=2, end_line=2, func_name="f")
+
+    engine.apply_patch_with_retry(path, "desc", max_attempts=5, target_region=region)
+
+    assert len(calls) == 5
+    assert calls[0].start_line == 2 and calls[0].end_line == 2
+    assert calls[1].start_line == 2 and calls[1].end_line == 2
+    assert calls[2].start_line == 1 and calls[2].end_line == 4
+    assert calls[3].start_line == 1 and calls[3].end_line == 4
+    assert calls[4] is None
+
+    assert gauge_calls[(('scope', 'line'),)] == 2
+    assert gauge_calls[(('scope', 'function'),)] == 2
+    assert gauge_calls[(('scope', 'module'),)] == 1
+    assert gauge_calls[(('level', 'function'),)] == 1
+    assert gauge_calls[(('level', 'module'),)] == 1

--- a/tests/self_improvement/test_target_region_patch.py
+++ b/tests/self_improvement/test_target_region_patch.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import sys
+import types
+import subprocess
+import shutil
+from pathlib import Path
+
+import pytest
+
+import self_improvement.targeting as targeting
+from tests.self_improvement.test_patch_application import _load_patch_module
+
+
+BUGGY_SRC = """\
+def divide(a, b):
+    result = a / 0
+    return result
+"""
+
+PATCH = """\
+diff --git a/buggy.py b/buggy.py
+--- a/buggy.py
++++ b/buggy.py
+@@ -1,3 +1,3 @@
+ def divide(a, b):
+-    result = a / 0
++    result = a / b
+     return result
+"""
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "you@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Your Name"], cwd=repo, check=True)
+    (repo / "buggy.py").write_text(BUGGY_SRC)
+    subprocess.run(["git", "add", "buggy.py"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True)
+    return repo
+
+
+def test_extract_target_region_and_patch(monkeypatch, tmp_path):
+    repo = _init_repo(tmp_path)
+
+    trace = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import buggy, traceback\n"
+            "try:\n buggy.divide(1,0)\n"
+            "except Exception:\n print(traceback.format_exc())",
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout
+
+    monkeypatch.setattr(targeting, "__file__", str(repo / "__init__.py"))
+    region = targeting.extract_target_region(trace)
+    assert region is not None
+    assert Path(region.file) == repo / "buggy.py"
+    assert region.func_name == "divide"
+    assert region.start_line == 1
+    assert region.end_line == 3
+
+    before = (repo / "buggy.py").read_text().splitlines()
+    pycache = repo / "__pycache__"
+    if pycache.exists():
+        shutil.rmtree(pycache)
+
+    mod = types.ModuleType("quick_fix_engine")
+    mod.fetch_patch = lambda patch_id: PATCH
+    monkeypatch.setitem(sys.modules, "quick_fix_engine", mod)
+    patch_module = _load_patch_module()
+    commit = patch_module.apply_patch(1, repo)
+    assert len(commit) == 40
+
+    after = (repo / "buggy.py").read_text().splitlines()
+    assert after[1] == "    result = a / b"
+    assert before[0] == after[0]
+    assert before[2] == after[2]


### PR DESCRIPTION
## Summary
- add unit test verifying `extract_target_region` locates failing function and `apply_patch` only updates intended lines
- add integration test covering region→function→module escalation with telemetry counts

## Testing
- `pytest tests/self_improvement/test_target_region_patch.py::test_extract_target_region_and_patch -q`
- `pytest tests/integration/test_patch_escalation_metrics.py::test_escalation_metrics -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8c83c5904832e8d523bcb0e575b6c