### PR TITLE
Use resolve_path for module graph analyzer paths

### DIFF
--- a/tests/test_module_graph_analyzer.py
+++ b/tests/test_module_graph_analyzer.py
@@ -1,11 +1,10 @@
 import json
-from pathlib import Path
 
 from scripts.generate_module_map import generate_module_map
 from module_graph_analyzer import build_import_graph, cluster_modules
 
 
-def test_generate_module_map(tmp_path):
+def test_generate_module_map(tmp_path, monkeypatch):
     pkg = tmp_path / "pkg"
     pkg.mkdir()
     (pkg / "__init__.py").write_text("")
@@ -13,6 +12,9 @@ def test_generate_module_map(tmp_path):
     (pkg / "b.py").write_text("from .c import func_c\n\ndef func_b():\n    func_c()\n")
     (pkg / "c.py").write_text("def func_c():\n    pass\n")
     (tmp_path / "d.py").write_text("def d():\n    pass\n")
+
+    monkeypatch.setattr("orphan_analyzer.analyze_redundancy", lambda p: False)
+    monkeypatch.setattr("dynamic_module_mapper.analyze_redundancy", lambda p: False)
 
     out = tmp_path / "map.json"
     mapping = generate_module_map(out, root=tmp_path)


### PR DESCRIPTION
## Summary
- normalize module graph analyzer root with resolve_path
- read semantic analysis files via resolve_path
- patch module graph analyzer tests to bypass redundancy filtering

## Testing
- `pre-commit run --files module_graph_analyzer.py tests/test_module_graph_analyzer.py`
- `pytest tests/test_module_graph_analyzer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8c965c9d0832e8d97d1d99a65bad2