### PR TITLE
Resolve module-mapper paths

### DIFF
--- a/module_graph_analyzer.py
+++ b/module_graph_analyzer.py
@@ -19,8 +19,9 @@ except Exception:  # pragma: no cover - optional dependency
 
 # ---------------------------------------------------------------------------
 
-def _iter_py_files(root: Path, ignore: Iterable[str] | None = None) -> Iterable[Path]:
+def _iter_py_files(root: str | Path, ignore: Iterable[str] | None = None) -> Iterable[Path]:
     """Yield all ``.py`` files under ``root`` skipping ignored paths."""
+    root = Path(resolve_path(root))
     ignore = set(ignore or [])
     for path in root.rglob("*.py"):
         if not path.is_file():

--- a/module_mapper.py
+++ b/module_mapper.py
@@ -14,8 +14,9 @@ from dynamic_path_router import resolve_path
 
 # ---------------------------------------------------------------------------
 
-def _iter_py_files(root: Path, ignore: Iterable[str] | None = None) -> Iterable[Path]:
+def _iter_py_files(root: str | Path, ignore: Iterable[str] | None = None) -> Iterable[Path]:
     """Yield all ``.py`` files under ``root`` skipping ignored paths."""
+    root = Path(resolve_path(root))
     ignore = set(ignore or [])
     for path in root.rglob("*.py"):
         if not path.is_file():


### PR DESCRIPTION
## Summary
- ensure module-mapper utilities resolve repository paths before scanning
- expand `_iter_py_files` helpers to operate from canonical repo roots

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_module_mapper.py tests/test_dynamic_module_mapper.py tests/test_module_graph_analyzer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8cb197f38832ead6ebda31b4ac492