### PR TITLE
Prepend target region instructions

### DIFF
--- a/tests/test_build_visual_agent_prompt.py
+++ b/tests/test_build_visual_agent_prompt.py
@@ -94,6 +94,7 @@ sys.modules.setdefault(
 )
 roi_mod = types.ModuleType("vector_service.roi_tags")
 
+
 class _RoiTag:
     HIGH_ROI = types.SimpleNamespace(value="high-ROI")
     SUCCESS = types.SimpleNamespace(value="success")
@@ -105,6 +106,7 @@ class _RoiTag:
     @classmethod
     def validate(cls, value):
         return cls.SUCCESS
+
 
 roi_mod.RoiTag = _RoiTag
 sys.modules.setdefault("vector_service.roi_tags", roi_mod)
@@ -126,7 +128,13 @@ def test_build_visual_agent_prompt_basic(monkeypatch):
     captured: dict[str, str | None] = {}
 
     def fake_build_prompt(
-        self, description, *, context="", retrieval_context="", retry_trace=None
+        self,
+        description,
+        *,
+        context="",
+        retrieval_context="",
+        retry_trace=None,
+        target_region=None,
     ):
         captured.update(
             description=description,
@@ -170,7 +178,13 @@ def test_build_visual_agent_prompt_layout(monkeypatch):
     captured = {}
 
     def fake_build_prompt(
-        self, description, *, context="", retrieval_context="", retry_trace=None
+        self,
+        description,
+        *,
+        context="",
+        retrieval_context="",
+        retry_trace=None,
+        target_region=None,
     ):
         captured["context"] = context
         return "PROMPT"
@@ -187,7 +201,13 @@ def test_build_visual_agent_prompt_retrieval_context(monkeypatch):
     captured = {}
 
     def fake_build_prompt(
-        self, description, *, context="", retrieval_context="", retry_trace=None
+        self,
+        description,
+        *,
+        context="",
+        retrieval_context="",
+        retry_trace=None,
+        target_region=None,
     ):
         captured["retrieval_context"] = retrieval_context
         return "PROMPT"

--- a/tests/test_prompt_engine.py
+++ b/tests/test_prompt_engine.py
@@ -422,7 +422,9 @@ def test_prompt_engine_includes_target_region_metadata():
     region.original_lines = ["    pass"]
     prompt = engine.build_prompt("desc", context=context, target_region=region)
     text = str(prompt)
-    assert "Modify only lines 3-5 within function func" in text
+    assert text.splitlines()[0].startswith(
+        "Modify only lines 3-5 within function func"
+    )
     assert "# start" in text and "# end" in text
     assert prompt.metadata["target_region"]["func_name"] == "func"
     assert prompt.metadata["target_region"]["signature"] == "def func(a, b):"


### PR DESCRIPTION
## Summary
- Prepend explicit target-region scope instructions in prompts
- Pass TargetRegion through visual agent prompts
- Test prompt metadata and visual agent prompt builder updates

## Testing
- `pre-commit run --files prompt_engine.py self_coding_engine.py tests/test_build_visual_agent_prompt.py tests/test_prompt_engine.py`
- `pytest tests/test_prompt_engine.py::test_prompt_engine_includes_target_region_metadata -q`
- `pytest tests/test_build_visual_agent_prompt.py::test_build_visual_agent_prompt_basic -q` *(fails: ImportError: cannot import name 'CodeDB' from 'code_database')*


------
https://chatgpt.com/codex/tasks/task_e_68b8cd97dbb8832e8ed3a7e2a1282fc5