### PR TITLE
Resolve repository paths with resolve_path

### DIFF
--- a/intent_clusterer.py
+++ b/intent_clusterer.py
@@ -970,7 +970,7 @@ class IntentClusterer:
     def index_repository(self, repo_path: str | Path) -> None:
         """Embed modules under ``repo_path`` using incremental updates."""
 
-        root = Path(repo_path)
+        root = Path(resolve_path(repo_path))
         paths = list(root.rglob("*.py"))
         if not paths:
             return
@@ -1050,7 +1050,7 @@ class IntentClusterer:
         if watch is None:
             raise RuntimeError("watchfiles is required for watch_repository")
 
-        repo_path = Path(repo_path)
+        repo_path = Path(resolve_path(repo_path))
         stop_event = threading.Event()
 
         def _run() -> None:

--- a/module_index_db.py
+++ b/module_index_db.py
@@ -127,7 +127,7 @@ class ModuleIndexDB:
     # --------------------------------------------------------------
     def _norm(self, name: str) -> str:
         """Return repository-relative POSIX path for ``name``."""
-        repo_path = Path(os.getenv("SANDBOX_REPO_PATH", ".")).resolve()
+        repo_path = Path(resolve_path(os.getenv("SANDBOX_REPO_PATH", ".")))
         p = Path(name)
         try:
             p = p.resolve()

--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -8614,7 +8614,9 @@ def integrate_new_orphans(
         Repository-relative paths of modules successfully added.
     """
 
-    return discover_and_integrate_orphans(Path(repo_path).resolve(), router=router)
+    return discover_and_integrate_orphans(
+        Path(resolve_path(repo_path)), router=router
+    )
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- resolve repo_path via `resolve_path` before building file paths
- replace `repo / Path(...).with_suffix(".py")` patterns with `Path(resolve_path(...))`
- apply same `resolve_path` handling for `__init__.py` lookups and repository helpers

## Testing
- `pre-commit run --files intent_clusterer.py module_index_db.py sandbox_runner/dependency_utils.py sandbox_runner/environment.py sandbox_runner/orphan_discovery.py self_test_service.py`
- `pytest tests/integration -k orphan` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cf45cabc832ebf515111eff39bcb