### PR TITLE
Add escalation tracking for automated debugger

### DIFF
--- a/patch_attempt_tracker.py
+++ b/patch_attempt_tracker.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+from .target_region import TargetRegion
+
+
+@dataclass
+class _Keys:
+    """Internal helper to build dictionary keys."""
+
+    filename: str
+    start_line: int
+    end_line: int
+    function: str
+
+    @property
+    def region(self) -> Tuple[str, int, int]:
+        return (self.filename, self.start_line, self.end_line)
+
+    @property
+    def function_key(self) -> Tuple[str, str]:
+        return (self.filename, self.function)
+
+
+class PatchAttemptTracker:
+    """Track patch attempts and handle escalation logic.
+
+    Escalates from a single-line region to the containing function after two
+    failures and to the entire module after two additional failures at the
+    function level.  Escalation events are logged via the supplied logger which
+    defaults to the :class:`AutoEscalationManager` logger.
+    """
+
+    def __init__(self, logger: logging.Logger | None = None) -> None:
+        self.logger = logger or logging.getLogger("AutoEscalationManager")
+        self._region_failures: Dict[Tuple[str, int, int], int] = {}
+        self._function_failures: Dict[Tuple[str, str], int] = {}
+
+    # ------------------------------------------------------------------
+    def level_for(self, region: TargetRegion, func_region: TargetRegion) -> tuple[str, TargetRegion | None]:
+        """Return the patch level and region to operate on."""
+        k = _Keys(region.filename, region.start_line, region.end_line, region.function)
+        if self._function_failures.get(k.function_key, 0) >= 2:
+            return "module", None
+        if self._region_failures.get(k.region, 0) >= 2:
+            return "function", func_region
+        return "region", region
+
+    # ------------------------------------------------------------------
+    def record_failure(self, level: str, region: TargetRegion, func_region: TargetRegion) -> None:
+        """Record a failed attempt and log escalation events."""
+        k = _Keys(region.filename, region.start_line, region.end_line, region.function)
+        if level == "region":
+            count = self._region_failures.get(k.region, 0) + 1
+            self._region_failures[k.region] = count
+            if count == 2:
+                self.logger.info(
+                    "escalating patch region",
+                    extra={"level": "function", "path": region.filename, "function": region.function},
+                )
+        elif level == "function":
+            count = self._function_failures.get(k.function_key, 0) + 1
+            self._function_failures[k.function_key] = count
+            if count == 2:
+                self.logger.info(
+                    "escalating patch region",
+                    extra={"level": "module", "path": func_region.filename},
+                )
+
+    # ------------------------------------------------------------------
+    def reset(self, region: TargetRegion) -> None:
+        """Reset counters for ``region`` after a successful patch."""
+        k = _Keys(region.filename, region.start_line, region.end_line, region.function)
+        self._region_failures.pop(k.region, None)
+        self._function_failures.pop(k.function_key, None)
+
+
+__all__ = ["PatchAttemptTracker"]


### PR DESCRIPTION
## Summary
- track patch attempts per region with new `PatchAttemptTracker`
- escalate to function or module rewrites after repeated failures and reset counts on success
- log escalation events via `AutoEscalationManager` logger

## Testing
- `pytest tests/test_automated_debugger.py::test_analyse_and_fix -q`
- `pytest tests/test_patch_retry_escalation.py::test_region_escalation -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8d0002990832e948d3922449e3464