### PR TITLE
Reset path resolver before dependency collection

### DIFF
--- a/sandbox_runner/dependency_utils.py
+++ b/sandbox_runner/dependency_utils.py
@@ -8,7 +8,7 @@ import os
 import logging
 from typing import Callable, Iterable, List, Mapping, Set, Tuple
 
-from dynamic_path_router import resolve_path
+from dynamic_path_router import resolve_path, clear_cache
 
 
 DependencyCallback = Callable[[str, str, List[str]], None]
@@ -63,6 +63,7 @@ def collect_local_dependencies(
         logging and continuing.
     """
 
+    clear_cache()
     repo = Path(resolve_path(os.getenv("SANDBOX_REPO_PATH", ".")))
     queue: List[Tuple[Path, List[str]]] = []
 


### PR DESCRIPTION
## Summary
- reset dynamic path router cache before collecting dependencies
- resolve module paths through `resolve_path` for accurate tracking

## Testing
- `pytest tests/test_dependency_utils_callbacks.py`
- `pytest tests/test_dependency_max_depth.py -q`
- `pytest tests/test_dependency_max_depth.py tests/test_dependency_checks.py tests/test_dependency_watchdog_events.py tests/test_dependency_watchdog.py tests/test_dependency_verifier.py` *(fails: ImportError: attempted relative import beyond top-level package; ModuleNotFoundError: No module named 'menace')*

------
https://chatgpt.com/codex/tasks/task_e_68b8d0a687ec832eb8c602b3c8ba3a2f