### PR TITLE
Fix orphan parent path resolution

### DIFF
--- a/sandbox_runner/orphan_discovery.py
+++ b/sandbox_runner/orphan_discovery.py
@@ -1009,8 +1009,25 @@ def discover_recursive_orphans(
             redundant_flag = info.get("redundant")
             if redundant_flag is None:
                 redundant_flag = cls in {"legacy", "redundant"}
+            parent_paths: list[str] = []
+            for p in info.get("parents", []):
+                try:
+                    pp = Path(
+                        resolve_path(Path(*p.split(".")).with_suffix(".py"))
+                    )
+                except FileNotFoundError:
+                    try:
+                        pp = Path(
+                            resolve_path(Path(*p.split(".")) / "__init__.py")
+                        )
+                    except FileNotFoundError:
+                        continue
+                try:
+                    parent_paths.append(pp.relative_to(repo).as_posix())
+                except ValueError:
+                    parent_paths.append(pp.as_posix())
             entry = {
-                "parents": info.get("parents", []),
+                "parents": parent_paths,
                 "classification": cls,
                 "redundant": bool(redundant_flag),
             }


### PR DESCRIPTION
## Summary
- resolve repo and module paths with `resolve_path` in orphan inclusion loop
- store orphan parent paths relative to the resolved repo root

## Testing
- `MENACE_LIGHT_IMPORTS=1 pytest tests/test_sandbox_cycle_auto_include_validation.py tests/test_sandbox_cycle_redundant.py tests/test_orphan_rerun_on_change.py -q` *(failed: attempted relative import with no known parent package for adaptive_roi_predictor)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d43dbc88832e87e287d9f3f68974