### PR TITLE
Use resolved path for failover restarts

### DIFF
--- a/watchdog.py
+++ b/watchdog.py
@@ -336,7 +336,7 @@ class Watchdog:
                     host = self.failover_hosts.pop(0)
                     try:
                         subprocess.Popen(
-                            ["ssh", host, "python", f"{bot}.py"],
+                            ["ssh", host, "python", resolve_path(f"{bot}.py")],
                             stdout=subprocess.DEVNULL,
                             stderr=subprocess.DEVNULL,
                         )


### PR DESCRIPTION
## Summary
- ensure watchdog failover restarts use resolved bot path

## Testing
- `pre-commit run --files watchdog.py`
- `python /tmp/run_watchdog_failover.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8d5c37474832e8bcb6023f74ff426