### PR TITLE
Capture target regions from harness failures

### DIFF
--- a/self_improvement/target_region.py
+++ b/self_improvement/target_region.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Lightweight representation of a source code region.
+
+This module defines :class:`TargetRegion`, a minimal data container used to
+identify the portion of a file implicated in a failure.  The dataclass is kept
+intentionally small so it can be serialised and passed through various layers
+without incurring heavy dependencies.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class TargetRegion:
+    """Contiguous region in a source file."""
+
+    file: str
+    start_line: int
+    end_line: int
+    function: str
+
+
+__all__ = ["TargetRegion"]


### PR DESCRIPTION
## Summary
- add `self_improvement.TargetRegion` dataclass for referencing failing source regions
- extract failing region from harness output in `SelfCodingManager.run_patch`
- include serialized target region in prompt context for subsequent patch attempts

## Testing
- `pytest tests/test_patch_attempt_tracker.py tests/test_self_coding_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8d75cd2ec832e8f5d0b51b146a904