### PR TITLE
Handle line-range prompts in helper generation

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -1063,6 +1063,19 @@ class SelfCodingEngine:
                 target_region=target_region,
             )
         except TypeError:
+            if target_region is not None:
+                path_hint = path_for_prompt(path) if path else None
+                instr = (
+                    f"Modify only lines {target_region.start_line}-{target_region.end_line}"
+                )
+                if path_hint:
+                    instr += f" in {path_hint}"
+                instr += " unless dependent code requires changes."
+                context_block = (
+                    "\n".join([instr, context_block])
+                    if context_block
+                    else instr
+                )
             prompt_obj = self.prompt_engine.build_prompt(
                 description,
                 context=context_block,


### PR DESCRIPTION
## Summary
- ensure generate_helper injects explicit instructions when prompt engine lacks target_region support
- add regression test for line-range prompts in generate_helper

## Testing
- `pytest tests/test_self_coding_engine_chunking.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8d8f33700832eb1cb89888480ecb7