### PR TITLE
refactor literal .py paths to use resolve_path

### DIFF
--- a/clipped/clipped_master.py
+++ b/clipped/clipped_master.py
@@ -7,6 +7,11 @@ import os
 import subprocess
 from typing import Iterable, List, Optional, Sequence
 
+try:  # pragma: no cover - support package and flat layouts
+    from ..dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback when executed directly
+    from dynamic_path_router import resolve_path  # type: ignore
+
 
 def run_script(
     script: str, env: Optional[dict] = None, args: Optional[List[str]] = None
@@ -61,12 +66,13 @@ def main(argv: Optional[Iterable[str]] = None) -> None:
     parser.add_argument("--env", action="append", default=[], help="KEY=VALUE")
     parser.add_argument("--parallel", action="store_true", help="Run scripts in parallel")
     args = parser.parse_args(list(argv) if argv is not None else None)
+    scripts = [str(resolve_path(s)) for s in args.scripts]
 
     env = dict(item.split("=", 1) for item in args.env)
     if args.parallel:
-        run_scripts(args.scripts, env=env, parallel=True)
+        run_scripts(scripts, env=env, parallel=True)
     else:
-        run_scripts(args.scripts, env=env)
+        run_scripts(scripts, env=env)
 
 
 __all__ = ["run_script", "run_scripts", "main"]

--- a/diagnostic_manager.py
+++ b/diagnostic_manager.py
@@ -11,6 +11,11 @@ from typing import List, Tuple
 
 from db_router import GLOBAL_ROUTER, LOCAL_TABLES, init_db_router
 
+try:  # pragma: no cover - support package and flat layouts
+    from .dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback when executed directly
+    from dynamic_path_router import resolve_path  # type: ignore
+
 try:
     import pandas as pd  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
@@ -108,7 +113,11 @@ class DiagnosticManager:
         try:
             import subprocess
             subprocess.run(["pkill", "-f", bot], check=False)
-            subprocess.Popen(["python", f"{bot}.py"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.Popen(
+                ["python", str(resolve_path(f"{bot}.py"))],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
             return True
         except Exception as exc:  # pragma: no cover - runtime restart errors
             self.logger.error("Bot restart failed: %s", exc)

--- a/dynamic_module_mapper.py
+++ b/dynamic_module_mapper.py
@@ -35,7 +35,7 @@ def discover_module_groups(
             try:
                 path = Path(resolve_path(root / mod / "__init__.py"))
             except FileNotFoundError:
-                path = root / f"{mod}.py"
+                path = Path(resolve_path(root / f"{mod}.py"))
         if "/" in mod:
             groups.setdefault(cid, []).append(mod)
             continue
@@ -79,7 +79,7 @@ def build_module_map(
                 try:
                     path = Path(resolve_path(root / mod / "__init__.py"))
                 except FileNotFoundError:
-                    path = root / f"{mod}.py"
+                    path = Path(resolve_path(root / f"{mod}.py"))
             if "/" in mod:
                 filtered[mod] = grp
                 continue

--- a/environment_generator.py
+++ b/environment_generator.py
@@ -18,6 +18,11 @@ import logging
 from logging_utils import log_record
 import yaml
 
+try:  # pragma: no cover - support package and flat layouts
+    from .dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback when executed directly
+    from dynamic_path_router import resolve_path  # type: ignore
+
 logger = logging.getLogger(__name__)
 debug = os.getenv("PRESET_DEBUG") == "1"
 
@@ -357,10 +362,12 @@ def suggest_profiles_for_module(module_name: str) -> List[str]:
             mod_path = os.path.join(mod_path, "__init__.py")
         else:
             mod_path = f"{mod_path}.py"
-        if os.path.isfile(mod_path):
-            path = mod_path
-        else:
+        try:
+            path = str(resolve_path(mod_path))
+        except FileNotFoundError:
             path = ""
+    else:
+        path = str(resolve_path(path))
 
     if path:
         profiles.extend(infer_profiles_from_ast(path))

--- a/intent_clusterer.py
+++ b/intent_clusterer.py
@@ -563,7 +563,7 @@ class IntentClusterer:
             try:
                 mapping = json.loads(map_file.read_text())
                 for mod, gid in mapping.items():
-                    path = root / f"{mod}.py"
+                    path = Path(resolve_path(root / f"{mod}.py"))
                     groups.setdefault(str(gid), []).append(str(path))
                 return groups
             except Exception as exc:

--- a/intent_db.py
+++ b/intent_db.py
@@ -15,6 +15,11 @@ try:  # pragma: no cover - import available when running inside package
 except Exception:  # pragma: no cover - top level import fallback
     from db_router import DBRouter, GLOBAL_ROUTER, init_db_router  # type: ignore
 
+try:  # pragma: no cover - support package and flat layouts
+    from .dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback when executed directly
+    from dynamic_path_router import resolve_path  # type: ignore
+
 from intent_vectorizer import IntentVectorizer
 
 
@@ -146,7 +151,7 @@ class IntentDB(EmbeddableDBMixin):
         vectors: List[List[float]] = []
         members: List[str] = []
         for mod in cluster:
-            path = root / f"{mod}.py"
+            path = Path(resolve_path(root / f"{mod}.py"))
             try:
                 text = self._vectorizer.bundle(path)
             except Exception:

--- a/menace_cli.py
+++ b/menace_cli.py
@@ -415,17 +415,26 @@ def main(argv: list[str] | None = None) -> int:
         return _run(["pytest"] + (args.pytest_args or []))
 
     if args.cmd == "improve":
-        return _run(["python", "run_autonomous.py", "--runs", "1"] + (args.extra_args or []))
+        return _run(
+            ["python", str(resolve_path("run_autonomous.py")), "--runs", "1"]
+            + (args.extra_args or [])
+        )
 
     if args.cmd == "benchmark":
-        return _run(["python", "workflow_benchmark.py"])
+        return _run(["python", str(resolve_path("workflow_benchmark.py"))])
 
     if args.cmd == "deploy":
-        return _run(["python", "service_installer.py"] + (args.extra_args or []))
+        return _run(
+            ["python", str(resolve_path("service_installer.py"))]
+            + (args.extra_args or [])
+        )
 
     if args.cmd == "sandbox":
         if args.sandbox_cmd == "run":
-            return _run(["python", "run_autonomous.py"] + (args.extra_args or []))
+            return _run(
+                ["python", str(resolve_path("run_autonomous.py"))]
+                + (args.extra_args or [])
+            )
 
     if args.cmd == "patches":
         db = PatchHistoryDB()

--- a/menace_orchestrator.py
+++ b/menace_orchestrator.py
@@ -519,7 +519,10 @@ class MenaceOrchestrator:
                                     shared_db_path=data_dir / "intent.db",
                                 )
                                 self.intent_clusterer = clusterer
-                            paths = {repo / f"{m}.py" for m in added_modules}
+                            paths = {
+                                Path(resolve_path(repo / f"{m}.py"))
+                                for m in added_modules
+                            }
                             clusterer.index_modules(paths)
                         except Exception:
                             self.logger.exception("failed to index intent modules")

--- a/module_synergy_grapher.py
+++ b/module_synergy_grapher.py
@@ -461,7 +461,7 @@ class ModuleSynergyGrapher:
         updated = False
 
         def _worker(mod: str) -> tuple[str, dict[str, object] | None, dict[str, object] | None, bool]:
-            file = root / f"{mod}.py"
+            file = Path(resolve_path(root / f"{mod}.py"))
             if not file.exists():
                 return mod, None, None, False
             mtime = file.stat().st_mtime

--- a/workflow_synthesizer.py
+++ b/workflow_synthesizer.py
@@ -326,7 +326,7 @@ class ModuleIOAnalyzer:
 def inspect_module(module_name: str) -> "ModuleSignature":
     """Return :class:`ModuleSignature` information for ``module_name``."""
 
-    path = Path(module_name.replace(".", "/")).with_suffix(".py")
+    path = resolve_path(Path(module_name.replace(".", "/")).with_suffix(".py"))
     if ModuleSignature is None or get_io_signature is None:
         return ModuleSignature(name=path.stem)
     analyzer = ModuleIOAnalyzer()
@@ -586,7 +586,7 @@ class WorkflowSynthesizer:
         for mod in modules:
             req: Set[str] = set()
             opt: Set[str] = set()
-            path = Path(mod.name.replace(".", "/")).with_suffix(".py")
+            path = resolve_path(Path(mod.name.replace(".", "/")).with_suffix(".py"))
             try:
                 source = path.read_text(encoding="utf-8")
                 tree = ast.parse(source, filename=str(path))
@@ -861,7 +861,7 @@ class WorkflowSynthesizer:
         analyzer = ModuleIOAnalyzer()
         signatures: List[ModuleSignature] = []
         for mod in sorted(modules):
-            path = Path(mod.replace(".", "/")).with_suffix(".py")
+            path = resolve_path(Path(mod.replace(".", "/")).with_suffix(".py"))
             sig = analyzer.analyze(path)
             sig.name = mod
             if overrides and mod in overrides:
@@ -902,7 +902,7 @@ class WorkflowSynthesizer:
             start_module = start.get("module") or start.get("start")
             problem = start.get("problem")
         else:
-            module_path = Path(start.replace(".", "/")).with_suffix(".py")
+            module_path = resolve_path(Path(start.replace(".", "/")).with_suffix(".py"))
             if module_path.exists():
                 start_module, problem = start, None
             else:
@@ -974,7 +974,7 @@ class WorkflowSynthesizer:
         analyzer = ModuleIOAnalyzer()
         signatures: List[ModuleSignature] = []
         for mod in sorted(modules):
-            path = Path(mod.replace(".", "/")).with_suffix(".py")
+            path = resolve_path(Path(mod.replace(".", "/")).with_suffix(".py"))
             sig = analyzer.analyze(path)
             sig.name = mod
             signatures.append(sig)


### PR DESCRIPTION
## Summary
- wrap bot restart subprocess path with `resolve_path`
- resolve script paths in CLI and helper utilities
- route module path lookups through `resolve_path`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError, AttributeError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d9039fa4832e88dd2c52d11799aa