### PR TITLE
Use resolve_path for telemetry module lookup

### DIFF
--- a/telemetry_feedback.py
+++ b/telemetry_feedback.py
@@ -2,15 +2,11 @@ from __future__ import annotations
 
 """Automatic patching feedback loop using telemetry."""
 
-from pathlib import Path
 import threading
 import time
 from typing import Optional, List, Tuple
 
-try:  # pragma: no cover - prefer package import
-    from .dynamic_path_router import resolve_path  # type: ignore
-except Exception:  # pragma: no cover - allow running as script
-    from dynamic_path_router import resolve_path  # type: ignore
+from .dynamic_path_router import resolve_path
 
 from .db_router import (
     DBRouter,


### PR DESCRIPTION
## Summary
- switch telemetry feedback to use dynamic `resolve_path` for module resolution
- simplify imports and handle missing modules via `FileNotFoundError`
- adjust telemetry feedback tests for new path resolution

## Testing
- `pytest tests/test_telemetry_feedback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8dae8ba28832ead63dda071ccb080