### PR TITLE
Use resolve_path for code template paths

### DIFF
--- a/deployment_bot.py
+++ b/deployment_bot.py
@@ -442,7 +442,7 @@ class DeploymentBot:
         existing = self.code_db.fetch_all(scope="all")
 
         for bot_name, bot_id in bot_map.items():
-            path = Path(resolve_path(f"{bot_name}.py"))
+            path = resolve_path(f"{bot_name}.py")
             if not path.exists():
                 continue
             text = path.read_text()


### PR DESCRIPTION
## Summary
- Use `resolve_path` to locate bot source files when recording code templates
- Ensure `resolve_path` is imported to support path resolution

## Testing
- `python -m pytest tests/test_deployment_bot.py -q`
- `python -m pytest tests/test_deployment_db_scope.py -q` *(fails: ImportError: cannot import name 'AutoModel' from 'transformers')*


------
https://chatgpt.com/codex/tasks/task_e_68b8dc76e7b8832ea79d32df93284022