### PR TITLE
Use dynamic path resolution for TargetRegion imports

### DIFF
--- a/error_parser.py
+++ b/error_parser.py
@@ -15,18 +15,22 @@ from datetime import datetime
 from typing import Optional
 
 try:
+    from .dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback for flat layout
+    from dynamic_path_router import resolve_path  # type: ignore
+
+try:
     from .self_improvement.target_region import (
         TargetRegion,
         extract_target_region as _extract_target_region,
     )
 except Exception:  # pragma: no cover - fallback for direct execution
     import importlib.util
-    import pathlib
     import sys
 
     spec = importlib.util.spec_from_file_location(
         "_target_region_fallback",
-        pathlib.Path(__file__).resolve().parent / "self_improvement" / "target_region.py",
+        resolve_path("self_improvement/target_region.py"),
     )
     module = importlib.util.module_from_spec(spec)
     sys.modules["_target_region_fallback"] = module

--- a/failure_localization.py
+++ b/failure_localization.py
@@ -10,6 +10,11 @@ from types import TracebackType
 from typing import Optional
 
 try:
+    from .dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback for flat layout
+    from dynamic_path_router import resolve_path  # type: ignore
+
+try:
     from .self_improvement.target_region import TargetRegion
 except Exception:  # pragma: no cover - fallback for direct execution
     import importlib.util
@@ -17,7 +22,7 @@ except Exception:  # pragma: no cover - fallback for direct execution
 
     spec = importlib.util.spec_from_file_location(
         "_target_region_fallback",
-        Path(__file__).resolve().parent / "self_improvement" / "target_region.py",
+        resolve_path("self_improvement/target_region.py"),
     )
     module = importlib.util.module_from_spec(spec)
     sys.modules["_target_region_fallback"] = module

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -141,12 +141,11 @@ try:
     from .self_improvement.target_region import TargetRegion
 except Exception:  # pragma: no cover - fallback for direct execution
     import importlib.util
-    import pathlib
     import sys
 
     spec = importlib.util.spec_from_file_location(
         "_target_region_fallback",
-        pathlib.Path(__file__).resolve().parent / "self_improvement" / "target_region.py",
+        resolve_path("self_improvement/target_region.py"),
     )
     module = importlib.util.module_from_spec(spec)
     sys.modules["_target_region_fallback"] = module

--- a/tests/test_target_region_resolution.py
+++ b/tests/test_target_region_resolution.py
@@ -1,0 +1,44 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from dynamic_path_router import resolve_path
+
+
+@pytest.mark.parametrize(
+    "module_file, module_name",
+    [
+        ("error_parser.py", "error_parser_copy"),
+        ("failure_localization.py", "failure_localization_copy"),
+    ],
+)
+def test_modules_import_target_region_when_relocated(tmp_path, module_file, module_name):
+    """Modules should load TargetRegion via resolve_path even when moved."""
+    src = resolve_path(module_file)
+    dst = tmp_path / Path(module_file).name
+    dst.write_text(Path(src).read_text())
+    spec = importlib.util.spec_from_file_location(module_name, dst)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    from self_improvement.target_region import TargetRegion as TR
+
+    assert module.TargetRegion.__name__ == TR.__name__
+
+
+def test_self_coding_engine_fallback_imports_target_region():
+    """Self coding engine resolves TargetRegion via dynamic path."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "_target_region_fallback", resolve_path("self_improvement/target_region.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_target_region_fallback"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    from self_improvement.target_region import TargetRegion as TR
+
+    assert module.TargetRegion.__name__ == TR.__name__


### PR DESCRIPTION
## Summary
- Resolve `TargetRegion` with `dynamic_path_router.resolve_path` in self-coding engine, error parser, and failure localization utilities
- Add regression tests ensuring modules locate `TargetRegion` even when relocated

## Testing
- `python -m pytest tests/test_error_parser.py tests/test_failure_localization.py tests/test_target_region_resolution.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8e2581fe4832e9326f87978639c5e