### PR TITLE
Resolve default script path in clipped_master CLI

### DIFF
--- a/clipped/clipped_master.py
+++ b/clipped/clipped_master.py
@@ -1,4 +1,7 @@
-"""Stub coordinator used for tests."""
+"""Stub coordinator used for tests.
+
+Paths are resolved relative to the repository root.
+"""
 
 from __future__ import annotations
 
@@ -62,7 +65,15 @@ def main(argv: Optional[Iterable[str]] = None) -> None:
     """Entry point executing one or more scripts."""
 
     parser = argparse.ArgumentParser(description="Run Menace scripts")
-    parser.add_argument("scripts", nargs="*", default=["menace_master.py"])
+    parser.add_argument(
+        "scripts",
+        nargs="*",
+        default=[str(resolve_path("menace_master.py"))],
+        help=(
+            "Python scripts to run. Paths are resolved relative to the "
+            "repository root (default: menace_master.py)."
+        ),
+    )
     parser.add_argument("--env", action="append", default=[], help="KEY=VALUE")
     parser.add_argument("--parallel", action="store_true", help="Run scripts in parallel")
     args = parser.parse_args(list(argv) if argv is not None else None)

--- a/tests/test_clipped_master.py
+++ b/tests/test_clipped_master.py
@@ -1,5 +1,6 @@
 import subprocess
-from menace.clipped.clipped_master import run_script
+from menace.clipped import clipped_master
+from menace.dynamic_path_router import resolve_path
 
 
 def test_run_script_merges_env(monkeypatch, tmp_path):
@@ -14,6 +15,20 @@ def test_run_script_merges_env(monkeypatch, tmp_path):
     script.write_text("print('hi')")
 
     monkeypatch.setenv("DISPLAY", ":1")
-    run_script(str(script), env={"CUSTOM": "1"}, args=[])
+    clipped_master.run_script(str(script), env={"CUSTOM": "1"}, args=[])
     assert captured["env"]["DISPLAY"] == ":1"
     assert captured["env"]["CUSTOM"] == "1"
+
+
+def test_cli_resolves_default_script_from_other_dir(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_run_scripts(scripts, env=None, parallel=False):
+        captured["scripts"] = scripts
+        return []
+
+    monkeypatch.setattr(clipped_master, "run_scripts", fake_run_scripts)
+    monkeypatch.chdir(tmp_path)
+    clipped_master.main([])
+    expected = str(resolve_path("menace_master.py"))
+    assert captured["scripts"] == [expected]


### PR DESCRIPTION
## Summary
- resolve `menace_master.py` default path at parse time
- clarify help text for CLI and document repo-root path resolution
- test that CLI locates default script when run from another directory

## Testing
- `pytest tests/test_clipped_master.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8e3900604832e94403a2dd6967dcf