### PR TITLE
Add static .py path pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,12 @@ repos:
         language: system
         pass_filenames: true
         files: '\.py$'
+      - id: check-static-paths
+        name: Prevent static .py path references
+        entry: python tools/check_static_paths.py
+        language: system
+        pass_filenames: true
+        files: '\.py$'
   - repo: https://github.com/pycqa/flake8
     rev: 6.1.0
     hooks:

--- a/docs/dynamic_path_router.md
+++ b/docs/dynamic_path_router.md
@@ -41,3 +41,10 @@ cache mapping for debugging purposes.
   `resolve_path` and clear the cache in tests if paths change.
 - External tools can override the repository root by setting `MENACE_ROOT` or
   `SANDBOX_REPO_PATH`.
+
+## Static path enforcement
+
+A `pre-commit` hook named `check-static-paths` scans modified Python files for
+string literals that end with `.py`. These paths **must** be wrapped with
+`resolve_path` or `path_for_prompt` to remain portable across forks and
+clones. The hook fails if an unwrapped `.py` path is found.

--- a/tools/check_static_paths.py
+++ b/tools/check_static_paths.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Pre-commit check for hard coded `.py` paths.
+
+The hook scans Python source files for string literals ending with `.py`. Any
+such literal must be wrapped by :func:`resolve_path` or
+:func:`path_for_prompt` to ensure paths remain portable across forks and
+clones.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from typing import Iterable, List, Set
+
+ALLOWED_FUNCS = {"resolve_path", "path_for_prompt"}
+PY_EXT = ".py"
+
+
+def _is_py_string(node: ast.Constant) -> bool:
+    return (
+        isinstance(node.value, str)
+        and node.value.endswith(PY_EXT)
+        and len(node.value) > len(PY_EXT)
+    )
+
+
+class _Collector(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.all_nodes: List[ast.Constant] = []
+        self.allowed_nodes: Set[ast.Constant] = set()
+
+    def visit_Constant(self, node: ast.Constant) -> None:  # type: ignore[override]
+        if _is_py_string(node):
+            self.all_nodes.append(node)
+
+    def visit_Call(self, node: ast.Call) -> None:  # type: ignore[override]
+        func_name = None
+        if isinstance(node.func, ast.Name):
+            func_name = node.func.id
+        elif isinstance(node.func, ast.Attribute):
+            func_name = node.func.attr
+        if func_name in ALLOWED_FUNCS:
+            for sub_node in ast.walk(node):
+                if isinstance(sub_node, ast.Constant) and _is_py_string(sub_node):
+                    self.allowed_nodes.add(sub_node)
+        self.generic_visit(node)
+
+
+def check_file(path: str) -> List[ast.Constant]:
+    with open(path, "r", encoding="utf-8") as handle:
+        try:
+            tree = ast.parse(handle.read(), filename=path)
+        except SyntaxError:
+            return []
+    collector = _Collector()
+    collector.visit(tree)
+    return [n for n in collector.all_nodes if n not in collector.allowed_nodes]
+
+
+def main(argv: Iterable[str]) -> int:
+    has_error = False
+    for file_path in argv:
+        for node in check_file(file_path):
+            print(
+                f"{file_path}:{node.lineno}: static path '{node.value}' not wrapped "
+                "with resolve_path or path_for_prompt",
+            )
+            has_error = True
+    return 1 if has_error else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add `tools/check_static_paths.py` to detect unwrapped `.py` paths
- run the check via a new `check-static-paths` pre-commit hook
- document the requirement in `docs/dynamic_path_router.md`

## Testing
- `pre-commit run --files docs/dynamic_path_router.md tools/check_static_paths.py .pre-commit-config.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68b8e45a0a00832e8c718a0effe38e54