### PR TITLE
refactor: use resolve_path for target region loading

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -143,9 +143,10 @@ except Exception:  # pragma: no cover - fallback for direct execution
     import importlib.util
     import sys
 
+    target_region_path = resolve_path("self_improvement/target_region.py")
     spec = importlib.util.spec_from_file_location(
         "_target_region_fallback",
-        resolve_path("self_improvement/target_region.py"),
+        target_region_path,
     )
     module = importlib.util.module_from_spec(spec)
     sys.modules["_target_region_fallback"] = module


### PR DESCRIPTION
## Summary
- refactor `self_coding_engine` to compute target region path via `resolve_path`
- ensure fallback import passes an absolute `Path` to `importlib`

## Testing
- `pytest tests/test_target_region_resolution.py::test_self_coding_engine_fallback_imports_target_region -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8e5681df0832e8ea3dcab10a1d7de