### PR TITLE
Forward TargetRegion through sandbox cycle

### DIFF
--- a/quick_fix_engine.py
+++ b/quick_fix_engine.py
@@ -182,7 +182,11 @@ def generate_patch(
                     if summary:
                         chunk_desc = f"{base_description}\n\n{summary}"
                     try:
-                        pid, _, _ = engine.apply_patch(
+                        apply = getattr(engine, "apply_patch_with_retry")
+                    except AttributeError:
+                        apply = getattr(engine, "apply_patch")
+                    try:
+                        pid, _, _ = apply(
                             path,
                             chunk_desc,
                             reason="preemptive_fix",
@@ -202,7 +206,11 @@ def generate_patch(
                 patch_id = patch_ids[-1] if patch_ids else None
             else:
                 try:
-                    patch_id, _, _ = engine.apply_patch(
+                    apply = getattr(engine, "apply_patch_with_retry")
+                except AttributeError:
+                    apply = getattr(engine, "apply_patch")
+                try:
+                    patch_id, _, _ = apply(
                         path,
                         base_description,
                         reason="preemptive_fix",

--- a/sandbox_runner/cycle.py
+++ b/sandbox_runner/cycle.py
@@ -836,12 +836,17 @@ def _sandbox_cycle_runner(
             # Include any newly discovered modules after orchestrator modifications
             include_orphan_modules(ctx)
         logger.info("patch engine start", extra=log_record(cycle=idx))
+        region = getattr(ctx, "target_region", None)
         try:
-            result = ctx.improver.run_cycle()
+            if region is not None:
+                result = ctx.improver.run_cycle(target_region=region)
+            else:
+                result = ctx.improver.run_cycle()
         except Exception as exc:
             record_error(exc)
             result = SimpleNamespace(roi=None)
         finally:
+            ctx.target_region = None
             # Include modules introduced during the improvement cycle
             include_orphan_modules(ctx)
         warnings = getattr(result, "warnings", None)
@@ -864,6 +869,7 @@ def _sandbox_cycle_runner(
                 if region:
                     results["target_region"] = region
                     ctx.last_failure_region = region
+                    ctx.target_region = region
         except Exception as exc:
             record_error(exc)
             results = {}

--- a/sandbox_runner/tests/test_target_region_flow.py
+++ b/sandbox_runner/tests/test_target_region_flow.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from error_parser import ErrorParser
+
+
+def _build_trace(file: Path) -> str:
+    return (
+        "Traceback (most recent call last):\n"
+        f"  File \"{file}\", line 2, in divide\n"
+        "    return a/0\n"
+        "ZeroDivisionError: division by zero\n"
+    )
+
+
+class EngineStub:
+    def __init__(self):
+        self.called_with: list | None = []
+
+    def apply_patch_with_retry(self, path: Path, description: str, **kwargs):
+        self.called_with.append(kwargs.get("target_region"))
+        return None, False, 0.0
+
+
+class ImproverStub:
+    def __init__(self):
+        self.self_coding_engine = EngineStub()
+        self.received: list | None = []
+
+    def run_cycle(self, *, target_region=None):
+        self.received.append(target_region)
+        if target_region is not None:
+            self.self_coding_engine.apply_patch_with_retry(
+                Path("buggy.py"), "fix", target_region=target_region
+            )
+        return SimpleNamespace(roi=None)
+
+
+class TesterStub:
+    def __init__(self, traces):
+        self.traces = traces
+        self.results = {}
+        self.idx = 0
+
+    def run_once(self):
+        trace = self.traces[self.idx]
+        self.results = {"stdout": trace, "stderr": ""}
+        self.idx += 1
+
+
+def test_target_region_flows(tmp_path):
+    buggy = tmp_path / "buggy.py"
+    buggy.write_text("def divide(a,b):\n    return a/0\n")
+    trace = _build_trace(buggy)
+
+    ctx = SimpleNamespace(
+        improver=ImproverStub(),
+        tester=TesterStub([trace, ""]),
+        target_region=None,
+    )
+
+    for _ in range(2):
+        ctx.improver.run_cycle(target_region=getattr(ctx, "target_region", None))
+        ctx.tester.run_once()
+        results = getattr(ctx.tester, "results", {}) or {}
+        trace_out = (results.get("stdout", "") + results.get("stderr", "")).strip()
+        if trace_out:
+            parsed = ErrorParser.parse(trace_out)
+            region = parsed.get("target_region") if isinstance(parsed, dict) else None
+            if region:
+                ctx.target_region = region
+
+    improver = ctx.improver
+    assert improver.received == [None, ctx.target_region]
+    assert improver.self_coding_engine.called_with == [ctx.target_region]


### PR DESCRIPTION
## Summary
- persist extracted TargetRegion on sandbox cycle context
- forward stored region into self-improvement engine and patch generation
- route quick fix engine through apply_patch_with_retry
- add regression test for TargetRegion propagation

## Testing
- `pytest sandbox_runner/tests/test_target_region_flow.py tests/self_improvement/test_target_region_patch.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8e4b03f28832e9f3e2381275bdde4