### PR TITLE
Use resolve_path for target region imports

### DIFF
--- a/error_parser.py
+++ b/error_parser.py
@@ -15,9 +15,9 @@ from datetime import datetime
 from typing import Optional
 
 try:
-    from .dynamic_path_router import resolve_path
-except Exception:  # pragma: no cover - fallback for flat layout
-    from dynamic_path_router import resolve_path  # type: ignore
+    from dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback for package layout
+    from .dynamic_path_router import resolve_path  # type: ignore
 
 try:
     from .self_improvement.target_region import (


### PR DESCRIPTION
## Summary
- import `resolve_path` from `dynamic_path_router` with fallback to package layout
- load `self_improvement/target_region.py` via `resolve_path`

## Testing
- `pytest tests/test_error_parser.py tests/test_target_region.py tests/test_target_region_resolution.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8e707e164832ea3e167b7f7bfa4d4