### PR TITLE
Use dynamic path for container snippets

### DIFF
--- a/tests/test_container_snippet_path.py
+++ b/tests/test_container_snippet_path.py
@@ -7,9 +7,10 @@ import importlib.util
 import atexit
 
 
-sys.modules.setdefault(
-    "dynamic_path_router",
-    types.SimpleNamespace(resolve_path=lambda p: p, repo_root=lambda: "."),
+sys.modules["dynamic_path_router"] = types.SimpleNamespace(
+    resolve_path=lambda p: p,
+    repo_root=lambda: ".",
+    path_for_prompt=lambda name: name,
 )
 sys.modules.setdefault(
     "metrics_exporter",


### PR DESCRIPTION
## Summary
- Resolve container snippet path using `path_for_prompt` and derive directory and filename
- Map snippet files and volumes based on the resolved path for both local and container execution
- Extend snippet path test stubs to include `path_for_prompt`

## Testing
- `pytest tests/test_container_snippet_path.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8e82a7f78832eb7942041346c65d1