### PR TITLE
Track patch escalation metrics

### DIFF
--- a/patch_attempt_tracker.py
+++ b/patch_attempt_tracker.py
@@ -6,6 +6,11 @@ from typing import Dict, Tuple
 
 from .self_improvement.target_region import TargetRegion
 
+try:  # pragma: no cover - optional dependency
+    from . import metrics_exporter as _me
+except Exception:  # pragma: no cover - fallback when executed directly
+    import metrics_exporter as _me  # type: ignore
+
 
 @dataclass
 class _Keys:
@@ -31,13 +36,21 @@ class PatchAttemptTracker:
     Escalates from a single-line region to the containing function after two
     failures and to the entire module after two additional failures at the
     function level.  Escalation events are logged via the supplied logger which
-    defaults to the :class:`AutoEscalationManager` logger.
+    defaults to the :class:`AutoEscalationManager` logger.  If an
+    ``escalation_counter`` gauge is provided, escalation events are also
+    recorded in the ``patch_escalations_total`` metric labelled by escalation
+    level.
     """
 
-    def __init__(self, logger: logging.Logger | None = None) -> None:
+    def __init__(
+        self,
+        logger: logging.Logger | None = None,
+        escalation_counter: _me.Gauge | None = None,
+    ) -> None:
         self.logger = logger or logging.getLogger("AutoEscalationManager")
         self._region_failures: Dict[Tuple[str, int, int], int] = {}
         self._function_failures: Dict[Tuple[str, str], int] = {}
+        self._escalation_counter = escalation_counter
 
     # ------------------------------------------------------------------
     def level_for(self, region: TargetRegion, func_region: TargetRegion) -> tuple[str, TargetRegion | None]:
@@ -57,6 +70,8 @@ class PatchAttemptTracker:
             count = self._region_failures.get(k.region, 0) + 1
             self._region_failures[k.region] = count
             if count == 2:
+                if self._escalation_counter is not None:
+                    self._escalation_counter.labels(level="function").inc()
                 self.logger.info(
                     "escalating patch region",
                     extra={"level": "function", "path": region.filename, "function": region.function},
@@ -65,6 +80,8 @@ class PatchAttemptTracker:
             count = self._function_failures.get(k.function_key, 0) + 1
             self._function_failures[k.function_key] = count
             if count == 2:
+                if self._escalation_counter is not None:
+                    self._escalation_counter.labels(level="module").inc()
                 self.logger.info(
                     "escalating patch region",
                     extra={"level": "module", "path": func_region.filename},

--- a/tests/integration/test_patch_escalation_metrics.py
+++ b/tests/integration/test_patch_escalation_metrics.py
@@ -27,15 +27,22 @@ def test_escalation_metrics(monkeypatch, tmp_path):
     gauge_calls: dict[tuple[tuple[str, str], ...], int] = {}
 
     class DummyGauge:
+        def __init__(self) -> None:
+            self.events: list[tuple[tuple[str, str], ...]] = []
+
         def labels(self, **labels):
             key = tuple(sorted(labels.items()))
-            class Child:
-                def inc(self, amount: float = 1.0):
-                    gauge_calls[key] = gauge_calls.get(key, 0) + amount
-            return Child()
 
-    monkeypatch.setattr(sce, "_PATCH_ATTEMPTS", DummyGauge())
-    monkeypatch.setattr(sce, "_PATCH_ESCALATIONS", DummyGauge())
+            def inc(amount: float = 1.0) -> None:
+                gauge_calls[key] = gauge_calls.get(key, 0) + amount
+                self.events.append(key)
+
+            return types.SimpleNamespace(inc=inc)
+
+    patch_attempts = DummyGauge()
+    patch_escalations = DummyGauge()
+    monkeypatch.setattr(sce, "_PATCH_ATTEMPTS", patch_attempts)
+    monkeypatch.setattr(sce, "_PATCH_ESCALATIONS", patch_escalations)
 
     engine = SelfCodingEngine(code_db=object(), memory_mgr=object())
     engine.audit_trail = types.SimpleNamespace(record=lambda payload: None)
@@ -81,3 +88,7 @@ def test_escalation_metrics(monkeypatch, tmp_path):
     assert gauge_calls[(('scope', 'module'),)] == 1
     assert gauge_calls[(('level', 'function'),)] == 1
     assert gauge_calls[(('level', 'module'),)] == 1
+    assert patch_escalations.events == [
+        (('level', 'function'),),
+        (('level', 'module'),),
+    ]


### PR DESCRIPTION
## Summary
- Track function and module escalations in `PatchAttemptTracker` and expose counts via a metrics gauge
- Register `patch_escalations_total` gauge in `SelfCodingEngine` and supply it to the tracker
- Expand integration tests to assert metric increments at each escalation level

## Testing
- `pytest tests/test_patch_attempt_tracker.py tests/test_patch_retry_escalation.py tests/integration/test_patch_escalation_metrics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8e8ed96b0832e8730eb04c7f3c978