### PR TITLE
refactor: use resolve_path for path construction

### DIFF
--- a/action_justifier.py
+++ b/action_justifier.py
@@ -12,6 +12,8 @@ from typing import List, Dict, Any
 from string import Template
 from pydantic import BaseModel, ValidationError
 
+from dynamic_path_router import resolve_dir, resolve_path
+
 logger = logging.getLogger(__name__)
 
 try:  # transformers is optional and only used for offline models
@@ -25,16 +27,11 @@ except Exception:  # pragma: no cover - optional dependency
 # Configuration
 _SETTINGS_PATH = os.getenv(
     "JUSTIFIER_SETTINGS_PATH",
-    os.path.join(os.path.dirname(__file__), "config", "justifier_settings.json"),
+    str(resolve_path("config/justifier_settings.json")),
 )
-_LOG_DIR = os.getenv(
-    "JUSTIFIER_LOG_DIR",
-    os.path.join(os.path.dirname(__file__), "logs"),
-)
-_JUSTIFICATION_LOG = os.path.join(
-    _LOG_DIR, os.getenv("JUSTIFICATION_LOG_FILE", "justifications.jsonl")
-)
-_CACHE_DIR = Path(os.getenv("JUSTIFIER_CACHE_DIR", os.path.join(_LOG_DIR, "cache")))
+_LOG_DIR = Path(os.getenv("JUSTIFIER_LOG_DIR") or resolve_dir("logs"))
+_JUSTIFICATION_LOG = _LOG_DIR / os.getenv("JUSTIFICATION_LOG_FILE", "justifications.jsonl")
+_CACHE_DIR = Path(os.getenv("JUSTIFIER_CACHE_DIR") or (_LOG_DIR / "cache"))
 
 
 class ActionLogModel(BaseModel):

--- a/manual_override_handler.py
+++ b/manual_override_handler.py
@@ -13,13 +13,15 @@ from datetime import datetime
 from uuid import uuid4
 from typing import Any, Dict
 
+from dynamic_path_router import resolve_dir, resolve_path
+
 from .override_validator import verify_signature
 
 # ---------------------------------------------------------------------------
 # Paths for violation logs and override records
-LOG_DIR = os.path.join(os.path.dirname(__file__), "logs")
-VIOLATION_LOG = os.path.join(LOG_DIR, "violation_log.jsonl")
-OVERRIDE_LOG = os.path.join(LOG_DIR, "violation_overrides.jsonl")
+LOG_DIR = resolve_dir("logs")
+VIOLATION_LOG = resolve_path("logs/violation_log.jsonl")
+OVERRIDE_LOG = resolve_path("logs/violation_overrides.jsonl")
 
 
 def _ensure_log_dir() -> None:

--- a/reward_dispatcher.py
+++ b/reward_dispatcher.py
@@ -15,11 +15,13 @@ import time
 import hmac
 import hashlib
 
+from dynamic_path_router import resolve_path
+
 from .kpi_reward_core import compute_reward
 
 REWARD_DIR = "/mnt/shared/security_ai"
 REWARD_FILE = os.path.join(REWARD_DIR, "reward.json")
-SECRET_KEY_PATH = os.path.join(os.path.dirname(__file__), "secret.key")
+SECRET_KEY_PATH = resolve_path("secret.key")
 
 
 def _load_secret_key() -> bytes:

--- a/violation_logger.py
+++ b/violation_logger.py
@@ -10,6 +10,8 @@ from datetime import datetime
 from threading import Thread, Lock
 from typing import Any, List, Dict, Optional
 
+from dynamic_path_router import resolve_dir, resolve_path
+
 from .retry_utils import publish_with_retry
 from db_router import GLOBAL_ROUTER
 import sqlite3
@@ -25,9 +27,9 @@ except Exception:  # pragma: no cover - bus optional
     UnifiedEventBus = None  # type: ignore
 
 # Directory and file path for violation logs
-LOG_DIR = os.path.join(os.path.dirname(__file__), "logs")
-LOG_PATH = os.path.join(LOG_DIR, "violation_log.jsonl")
-ALIGNMENT_DB_PATH = os.path.join(LOG_DIR, "alignment_warnings.db")
+LOG_DIR = resolve_dir("logs")
+LOG_PATH = resolve_path("logs/violation_log.jsonl")
+ALIGNMENT_DB_PATH = resolve_path("logs/alignment_warnings.db")
 
 logger = logging.getLogger(__name__)
 _logger_lock = Lock()


### PR DESCRIPTION
## Summary
- use resolve_path/resolve_dir instead of `os.path.join(os.path.dirname(__file__), ...)`
- import path helpers in modules dealing with logs and rewards

## Testing
- `pytest -q`
- `pytest tests/test_workflow_branch_manager.py -q` *(fails: ImportError: attempted relative import with no known parent package)*


------
https://chatgpt.com/codex/tasks/task_e_68b8eaa9764c832e85eccfa77712d535