### PR TITLE
Use canonical paths in prompt construction

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -1056,7 +1056,8 @@ class SelfCodingEngine:
                     metadata = None
         repo_layout = self._get_repo_layout(VA_REPO_LAYOUT_LINES)
         context_block = "\n".join([p for p in (context, repo_layout) if p])
-        self._apply_prompt_style(description, module=str(path) if path else "generate_helper")
+        module_name = path_for_prompt(path) if path else "generate_helper"
+        self._apply_prompt_style(description, module=module_name)
         retrieval_context = (
             str(metadata.get("retrieval_context", "")) if metadata else ""
         )

--- a/tests/test_self_coding_engine_logging.py
+++ b/tests/test_self_coding_engine_logging.py
@@ -84,6 +84,10 @@ roi_mod.ROITracker = lambda: object()
 sys.modules.setdefault("roi_tracker", roi_mod)
 
 # Import the SelfCodingEngine after stubs
+import importlib
+menace_pkg = importlib.import_module("menace")
+sys.modules["code_database"] = code_db_mod
+sys.modules["menace.code_database"] = code_db_mod
 import menace.self_coding_engine as sce
 SelfCodingEngine = sce.SelfCodingEngine
 
@@ -147,7 +151,8 @@ def test_knowledge_service_logging(monkeypatch, caplog):
     )
     caplog.set_level(logging.WARNING)
     caplog.clear()
-    engine.generate_helper("desc", path=dynamic_path_router.resolve_path(".") / "a.py")
+    target = dynamic_path_router.resolve_path("tests/fixtures/semantic/a.py")
+    engine.generate_helper("desc", path=target)
     messages = [record.message for record in caplog.records]
     assert any("recent_feedback" in m for m in messages)
     assert any("recent_improvement_path" in m for m in messages)


### PR DESCRIPTION
## Summary
- Normalize helper generation metadata with `path_for_prompt`
- Update visual-agent prompt tests to resolve and assert canonical file paths
- Ensure self-coding engine logging tests reference repository paths

## Testing
- `pytest tests/test_build_visual_agent_prompt.py tests/test_self_coding_engine_logging.py` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'chunk_summary_cache_dir')*

------
https://chatgpt.com/codex/tasks/task_e_68b8ec25a134832e883a32610cb65a6b