### PR TITLE
test: cover path resolution cache behavior

### DIFF
--- a/tests/test_path_resolution_cache.py
+++ b/tests/test_path_resolution_cache.py
@@ -1,0 +1,72 @@
+import importlib
+from pathlib import Path
+
+
+def test_resolve_path_updates_after_repo_move(monkeypatch, tmp_path):
+    repo_a = tmp_path / "repo_a"
+    (repo_a / ".git").mkdir(parents=True)
+    file_a = repo_a / "sandbox_runner.py"
+    file_a.write_text("a\n")
+
+    repo_b = tmp_path / "repo_b"
+    (repo_b / ".git").mkdir(parents=True)
+    file_b = repo_b / "nested" / "sandbox_runner.py"
+    file_b.parent.mkdir(parents=True)
+    file_b.write_text("b\n")
+
+    monkeypatch.setenv("MENACE_ROOT", str(repo_a))
+    import menace.dynamic_path_router as dpr
+    dpr.clear_cache()
+    assert dpr.resolve_path("sandbox_runner.py") == file_a.resolve()
+
+    monkeypatch.setenv("MENACE_ROOT", str(repo_b))
+    # Cache still points to repo_a
+    assert dpr.resolve_path("sandbox_runner.py") == file_a.resolve()
+
+    dpr.clear_cache()
+    resolved = dpr.resolve_path("sandbox_runner.py")
+    assert resolved == file_b.resolve()
+    assert dpr.path_for_prompt("sandbox_runner.py") == resolved.as_posix()
+
+
+def test_error_logger_path_for_prompt_cache(monkeypatch, tmp_path):
+    repo_a = tmp_path / "a"
+    (repo_a / ".git").mkdir(parents=True)
+    file_a = repo_a / "pkg" / "mod.py"
+    file_a.parent.mkdir(parents=True)
+    file_a.write_text("a\n")
+
+    repo_b = tmp_path / "b"
+    (repo_b / ".git").mkdir(parents=True)
+    file_b = repo_b / "pkg" / "mod.py"
+    file_b.parent.mkdir(parents=True)
+    file_b.write_text("b\n")
+
+    monkeypatch.setenv("MENACE_ROOT", str(repo_a))
+    import menace.dynamic_path_router as dpr
+    dpr.clear_cache()
+
+    el = importlib.reload(importlib.import_module("menace.error_logger"))
+    monkeypatch.setattr(el, "cdh", None)
+    monkeypatch.setattr(el, "propose_fix", lambda metrics, profile: [("pkg/mod.py", "hint")])
+
+    class DummyDB:
+        def __init__(self):
+            self.events = []
+
+        def add_telemetry(self, event):
+            self.events.append(event)
+
+    logger = el.ErrorLogger(db=DummyDB())
+    events1 = logger.log_fix_suggestions({}, {})
+    assert events1 and events1[0].module == file_a.resolve().as_posix()
+
+    monkeypatch.setenv("MENACE_ROOT", str(repo_b))
+    events2 = logger.log_fix_suggestions({}, {})
+    assert events2 and events2[0].module == file_a.resolve().as_posix()
+
+    dpr.clear_cache()
+    events3 = logger.log_fix_suggestions({}, {})
+    expected = file_b.resolve().as_posix()
+    assert events3 and events3[0].module == expected
+    assert dpr.path_for_prompt("pkg/mod.py") == expected


### PR DESCRIPTION
## Summary
- add regression tests for relocate repo path resolution
- verify ErrorLogger honors path_for_prompt after cache clear

## Testing
- `pytest tests/test_path_resolution_cache.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8efcab374832e9cbb55be3ca3c902