### PR TITLE
Resolve PatchSafety paths via dynamic router

### DIFF
--- a/tests/integration/test_patch_risk_penalties.py
+++ b/tests/integration/test_patch_risk_penalties.py
@@ -25,7 +25,7 @@ class DummyBus:
 
 
 def test_failing_patch_increases_risk_and_penalises_ranker(tmp_path):
-    ps = PatchSafety(threshold=1.1, max_alerts=1, storage_path=str(tmp_path / "failures.jsonl"))
+    ps = PatchSafety(threshold=1.1, max_alerts=1, storage_path=str(tmp_path / "failures.jsonl"), failure_db_path=None)
     vm = VectorMetricsDB(tmp_path / "vec.db")
     bus = DummyBus()
     pl = PatchLogger(patch_safety=ps, vector_metrics=vm, max_alerts=1, event_bus=bus)
@@ -64,7 +64,7 @@ def test_failing_patch_increases_risk_and_penalises_ranker(tmp_path):
 
 
 def test_patch_logger_respects_severity_threshold(tmp_path):
-    ps = PatchSafety(max_alert_severity=0.5)
+    ps = PatchSafety(max_alert_severity=0.5, failure_db_path=None)
     pl = PatchLogger(patch_safety=ps, max_alert_severity=0.5)
     start = _VIOLATIONS.labels("severity")._value.get()
     res = pl.track_contributors(

--- a/tests/test_cognition_layer.py
+++ b/tests/test_cognition_layer.py
@@ -205,7 +205,7 @@ def _make_layer_with_patch_safety(results):
     tracker = DummyROITracker()
     metrics = VectorMetricsDB(":memory:")
     builder = DummyContextBuilder(retriever, ranking_model=ranker)
-    ps = PatchSafety()
+    ps = PatchSafety(failure_db_path=None)
     logger = PatchLogger(vector_metrics=metrics, roi_tracker=tracker, patch_safety=ps)
     layer = CognitionLayer(
         context_builder=builder,

--- a/tests/test_patch_examples_retrieval.py
+++ b/tests/test_patch_examples_retrieval.py
@@ -6,6 +6,7 @@ from vector_service.retriever import PatchRetriever, Retriever
 from vector_service.vector_store import AnnoyVectorStore
 from vector_service.context_builder import ContextBuilder
 from vector_service.cognition_layer import CognitionLayer
+from patch_safety import PatchSafety
 
 
 def test_nl_query_returns_patch_diff(monkeypatch, tmp_path):
@@ -31,7 +32,12 @@ def test_nl_query_returns_patch_diff(monkeypatch, tmp_path):
     retr = Retriever()
     monkeypatch.setattr(retr, "search", lambda *a, **k: [])
 
-    cb = ContextBuilder(retriever=retr, patch_retriever=patch_ret, max_tokens=1000)
+    cb = ContextBuilder(
+        retriever=retr,
+        patch_retriever=patch_ret,
+        max_tokens=1000,
+        patch_safety=PatchSafety(failure_db_path=None),
+    )
     monkeypatch.setattr(cb, "refresh_db_weights", lambda *a, **k: None)
     monkeypatch.setattr(cb.patch_safety, "load_failures", lambda *a, **k: None)
 

--- a/tests/test_patch_logger_failure_record.py
+++ b/tests/test_patch_logger_failure_record.py
@@ -4,11 +4,11 @@ from vector_service.patch_logger import PatchLogger
 
 def test_track_contributors_records_failure(tmp_path):
     store = tmp_path / "failures.jsonl"
-    ps = PatchSafety(storage_path=str(store))
+    ps = PatchSafety(storage_path=str(store), failure_db_path=None)
     pl = PatchLogger(patch_safety=ps)
     meta = {"error:1": {"category": "fail", "module": "m"}}
     pl.track_contributors(["error:1"], False, retrieval_metadata=meta)
-    ps2 = PatchSafety(storage_path=str(store))
+    ps2 = PatchSafety(storage_path=str(store), failure_db_path=None)
     ok, score, _ = ps2.evaluate({}, {"category": "fail", "module": "m"})
     assert not ok
     assert score >= ps.threshold

--- a/tests/test_patch_logger_origin_penalty.py
+++ b/tests/test_patch_logger_origin_penalty.py
@@ -3,7 +3,7 @@ from vector_service.patch_logger import PatchLogger
 
 
 def test_patch_logger_origin_penalty():
-    ps = PatchSafety(threshold=10.0)
+    ps = PatchSafety(threshold=10.0, failure_db_path=None)
     pl = PatchLogger(patch_safety=ps)
     failure_meta = {"error:1": {"category": "fail", "module": "m"}}
     pl.track_contributors(["error:1"], False, retrieval_metadata=failure_meta)

--- a/tests/test_patch_provenance_semantic.py
+++ b/tests/test_patch_provenance_semantic.py
@@ -11,7 +11,7 @@ from patch_safety import PatchSafety
 
 def test_rejects_semantic_risk(tmp_path):
     db = PatchHistoryDB(tmp_path / "p.db")
-    app = create_app(db, PatchSuggestionDB(tmp_path / "s.db"), PatchSafety())
+    app = create_app(db, PatchSuggestionDB(tmp_path / "s.db"), PatchSafety(failure_db_path=None))
     client = app.test_client()
     res = client.post(
         "/patches",

--- a/tests/test_patch_safety_origin_penalty.py
+++ b/tests/test_patch_safety_origin_penalty.py
@@ -2,7 +2,7 @@ from patch_safety import PatchSafety
 
 
 def test_origin_specific_similarity_penalty():
-    ps = PatchSafety()
+    ps = PatchSafety(failure_db_path=None)
     err = {"category": "fail", "module": "m"}
     ps.record_failure(err, origin="error")
     ok_same, score_same, _ = ps.evaluate({}, err, origin="error")

--- a/tests/test_patch_safety_persistence.py
+++ b/tests/test_patch_safety_persistence.py
@@ -3,11 +3,11 @@ from patch_safety import PatchSafety
 
 def test_persistence_roundtrip(tmp_path):
     store = tmp_path / "failures.jsonl"
-    ps = PatchSafety(storage_path=str(store))
+    ps = PatchSafety(storage_path=str(store), failure_db_path=None)
     failure = {"category": "fail", "module": "m.py"}
     ps.record_failure(failure)
     assert store.exists()
-    ps2 = PatchSafety(storage_path=str(store))
+    ps2 = PatchSafety(storage_path=str(store), failure_db_path=None)
     ok, score, _ = ps2.evaluate({}, failure)
     assert not ok
     assert score >= ps.threshold

--- a/tests/test_patch_safety_unified.py
+++ b/tests/test_patch_safety_unified.py
@@ -2,7 +2,7 @@ from patch_safety import PatchSafety
 
 
 def test_metadata_rejection(tmp_path):
-    ps = PatchSafety(max_alerts=1, max_alert_severity=0.5, storage_path=str(tmp_path / "f.jsonl"))
+    ps = PatchSafety(max_alerts=1, max_alert_severity=0.5, storage_path=str(tmp_path / "f.jsonl"), failure_db_path=None)
     ok, score, _ = ps.evaluate({"license": "GPL-3.0"})
     assert not ok and score == 0.0
     ok, _, _ = ps.evaluate({"semantic_alerts": ["a", "b"]})
@@ -12,7 +12,7 @@ def test_metadata_rejection(tmp_path):
 
 
 def test_similarity_scoring(tmp_path):
-    ps = PatchSafety(threshold=0.5, storage_path=str(tmp_path / "f.jsonl"))
+    ps = PatchSafety(threshold=0.5, storage_path=str(tmp_path / "f.jsonl"), failure_db_path=None)
     failure = {"error": "boom"}
     ps.record_failure(failure)
     ok, score, _ = ps.evaluate({}, failure)

--- a/tests/test_patch_suggestion_db_semantic.py
+++ b/tests/test_patch_suggestion_db_semantic.py
@@ -40,7 +40,7 @@ def test_add_unsafe_suggestion(tmp_path):
 
 
 def test_failure_similarity_rejected(tmp_path):
-    safety = PatchSafety()
+    safety = PatchSafety(failure_db_path=None)
     safety.record_failure({"category": "fail", "module": "m.py"})
     db = PatchSuggestionDB(tmp_path / "s.db", safety=safety)
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- resolve relative PatchSafety paths against repo root using dynamic_path_router.resolve_path
- adjust tests to specify failure_db_path for isolation

## Testing
- `pytest tests/test_patch_logger_failure_record.py tests/test_patch_safety_unified.py tests/integration/test_patch_risk_penalties.py tests/test_patch_logger_origin_penalty.py tests/test_patch_safety_persistence.py tests/test_patch_safety_origin_penalty.py tests/test_patch_examples_retrieval.py tests/test_patch_suggestion_db_semantic.py -q`
- `pytest tests/test_patch_logger_failure_record.py tests/test_patch_safety_unified.py tests/integration/test_patch_risk_penalties.py tests/test_patch_logger_origin_penalty.py tests/test_patch_safety_persistence.py tests/test_patch_safety_origin_penalty.py tests/test_patch_examples_retrieval.py tests/test_patch_suggestion_db_semantic.py tests/test_patch_provenance_semantic.py tests/test_cognition_layer.py -q` *(fails: ImportError: cannot import name 'PatchRecord'; multiple errors in test_cognition_layer.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fc23f10c832e863cc37605903851