### PR TITLE
feat: track coverage per sandbox module

### DIFF
--- a/sandbox_runner/tests/test_coverage_integration.py
+++ b/sandbox_runner/tests/test_coverage_integration.py
@@ -1,0 +1,19 @@
+import os
+
+os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
+from sandbox_runner.workflow_sandbox_runner import WorkflowSandboxRunner
+
+
+def _sample_module():
+    def inner():
+        return 42
+    return inner()
+
+
+def test_module_coverage_reporting():
+    runner = WorkflowSandboxRunner()
+    metrics = runner.run(_sample_module, use_subprocess=False)
+    mod = metrics.modules[0]
+    assert isinstance(mod.coverage_files, list)
+    assert isinstance(mod.coverage_functions, list)
+


### PR DESCRIPTION
## Summary
- start coverage for each module in workflow sandbox runner and capture executed files/functions
- run pytest under coverage in test harness when SANDBOX_CAPTURE_COVERAGE is set
- expose per-module coverage info via environment helpers and add regression test

## Testing
- `python -m pytest sandbox_runner/tests/test_coverage_integration.py -q`
- `python -m pytest sandbox_runner/tests -q` *(fails: ModuleNotFoundError: No module named 'self_improvement.baseline_tracker'; AttributeError: '_StubSettings' object has no attribute 'stub_save_timeout')*


------
https://chatgpt.com/codex/tasks/task_e_68b8fccd5bf4832ead6db50bb6d781ff