### PR TITLE
Add edge case generator and pytest plugin

### DIFF
--- a/sandbox_runner/edge_case_generator.py
+++ b/sandbox_runner/edge_case_generator.py
@@ -8,6 +8,10 @@ sentinels, null/empty strings and other invalid formats.
 from __future__ import annotations
 
 from typing import Dict, Any
+import os
+import json
+from pathlib import Path
+import yaml
 
 
 def malformed_json() -> str:
@@ -30,13 +34,53 @@ def invalid_format() -> str:
     return "not a valid format"
 
 
+def _load_extra_payloads() -> Dict[str, Any]:
+    """Load additional payloads from environment or config file."""
+    data: Dict[str, Any] = {}
+
+    raw = os.getenv("SANDBOX_HOSTILE_PAYLOADS")
+    if raw:
+        try:
+            extra = json.loads(raw)
+        except Exception:
+            try:
+                extra = yaml.safe_load(raw)
+            except Exception:
+                extra = {}
+        if isinstance(extra, dict):
+            data.update(extra)
+
+    file_path = os.getenv("SANDBOX_HOSTILE_PAYLOADS_FILE")
+    if file_path:
+        path = Path(file_path)
+        if path.exists():
+            try:
+                content = path.read_text(encoding="utf-8")
+                extra = json.loads(content)
+            except Exception:
+                try:
+                    extra = yaml.safe_load(content)
+                except Exception:
+                    extra = {}
+            if isinstance(extra, dict):
+                data.update(extra)
+
+    return data
+
+
 def generate_edge_cases() -> Dict[str, Any]:
-    """Return a mapping of filenames to edge case payloads."""
+    """Return a mapping of filenames to edge case payloads.
+
+    The set can be extended via ``SANDBOX_HOSTILE_PAYLOADS`` or
+    ``SANDBOX_HOSTILE_PAYLOADS_FILE``.
+    """
     none_value, empty_value = null_or_empty()
-    return {
+    cases = {
         "malformed.json": malformed_json(),
         "timeout": timeout_sentinel(),
         "empty.txt": empty_value,
         "null.txt": none_value,
         "invalid.bin": invalid_format(),
     }
+    cases.update(_load_extra_payloads())
+    return cases

--- a/sandbox_runner/edge_case_plugin.py
+++ b/sandbox_runner/edge_case_plugin.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+import os
+import pytest
+
+from .edge_case_generator import generate_edge_cases
+
+
+def _load_edge_cases() -> dict[str, object]:
+    raw = os.getenv("SANDBOX_EDGE_CASES")
+    if raw:
+        try:
+            data = json.loads(raw)
+            if isinstance(data, dict):
+                return data
+        except Exception:
+            return {}
+    return generate_edge_cases()
+
+
+@pytest.fixture
+def hostile_payloads() -> dict[str, object]:
+    """Return edge case payloads for tests."""
+    return _load_edge_cases()

--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -95,6 +95,13 @@ try:
 except ImportError:  # pragma: no cover - optional dependency
     psutil = None  # type: ignore
 
+
+def generate_edge_cases() -> dict[str, Any]:
+    """Expose edge case payloads for test injection."""
+    from .edge_case_generator import generate_edge_cases as _gen
+
+    return _gen()
+
 _USE_MODULE_SYNERGY = os.getenv("SANDBOX_USE_MODULE_SYNERGY") == "1"
 try:  # pragma: no cover - optional dependency
     from module_synergy_grapher import get_synergy_cluster

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,0 +1,47 @@
+import json
+import os
+import importlib.util
+from pathlib import Path
+
+base = Path(__file__).resolve().parent / ".." / "sandbox_runner"
+base = base.resolve()
+
+spec = importlib.util.spec_from_file_location(
+    "sandbox_runner.edge_case_generator", base / "edge_case_generator.py"
+)
+edge_case_generator = importlib.util.module_from_spec(spec)  # type: ignore
+spec.loader.exec_module(edge_case_generator)  # type: ignore
+generate_edge_cases = edge_case_generator.generate_edge_cases
+
+spec2 = importlib.util.spec_from_file_location(
+    "sandbox_runner.edge_case_plugin", base / "edge_case_plugin.py"
+)
+edge_case_plugin = importlib.util.module_from_spec(spec2)  # type: ignore
+spec2.loader.exec_module(edge_case_plugin)  # type: ignore
+_load_edge_cases = edge_case_plugin._load_edge_cases
+
+
+def test_generate_edge_cases_defaults():
+    cases = generate_edge_cases()
+    assert {
+        "malformed.json",
+        "timeout",
+        "empty.txt",
+        "null.txt",
+        "invalid.bin",
+    }.issubset(cases.keys())
+
+
+def test_generate_edge_cases_env(monkeypatch, tmp_path):
+    extra = {"extra.json": "{}"}
+    monkeypatch.setenv("SANDBOX_HOSTILE_PAYLOADS", json.dumps(extra))
+    cases = generate_edge_cases()
+    assert "extra.json" in cases
+    monkeypatch.delenv("SANDBOX_HOSTILE_PAYLOADS", raising=False)
+
+
+def test_edge_case_plugin_env(monkeypatch):
+    payloads = {"x": "y"}
+    monkeypatch.setenv("SANDBOX_EDGE_CASES", json.dumps(payloads))
+    assert _load_edge_cases() == payloads
+    monkeypatch.delenv("SANDBOX_EDGE_CASES", raising=False)


### PR DESCRIPTION
## Summary
- extend edge case generator with hostile payload overrides via environment or config
- expose helper in environment and use in self debugger sandbox with pytest plugin
- provide pytest plugin and tests for hostile payload injection

## Testing
- `pytest tests/test_edge_cases.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b905f47908832e9b4bc38df9724a9d