### PR TITLE
Log executed functions in coverage metrics

### DIFF
--- a/self_debugger_sandbox.py
+++ b/self_debugger_sandbox.py
@@ -549,6 +549,7 @@ class SelfDebuggerSandbox(AutomatedDebugger):
             xml_tmp.close()
             percent = 0.0
             func_cov: dict[str, dict[str, float]] = {}
+            executed_funcs: list[str] = []
             try:
                 cov.xml_report(
                     outfile=xml_tmp.name,
@@ -574,10 +575,13 @@ class SelfDebuggerSandbox(AutomatedDebugger):
                             )
                             if name and total:
                                 methods[name] = covered / total
+                                if covered > 0 and fname:
+                                    executed_funcs.append(f"{fname}:{name}")
                         if fname and methods:
                             func_cov[fname] = methods
                 except Exception:
                     func_cov = {}
+                    executed_funcs = []
                 self.logger.debug(
                     "coverage report", extra=log_record(output=buf.getvalue())
                 )
@@ -599,6 +603,7 @@ class SelfDebuggerSandbox(AutomatedDebugger):
                     "runtime": runtime,
                     "error": None,
                     "coverage": func_cov,
+                    "executed_functions": executed_funcs,
                 }
             )
             return float(percent or 0.0), func_cov
@@ -677,6 +682,7 @@ class SelfDebuggerSandbox(AutomatedDebugger):
                     "runtime": runtime,
                     "error": failure.trace if failure else output,
                     "coverage": {},
+                    "executed_functions": [],
                 }
             )
         except Exception as exc:
@@ -712,6 +718,7 @@ class SelfDebuggerSandbox(AutomatedDebugger):
                     "runtime": runtime,
                     "error": failure.trace if failure else output,
                     "coverage": {},
+                    "executed_functions": [],
                 }
             )
         else:


### PR DESCRIPTION
## Summary
- Track executed functions when generating coverage in SelfDebuggerSandbox
- Emit executed function list alongside coverage metrics for logging
- Add tests for coverage metrics capturing executed functions

## Testing
- `pytest tests/test_self_debugger_sandbox.py::test_coverage_records_executed_functions -q`
- `pytest tests/test_self_debugger_sandbox.py::test_coverage_xml_report_failure tests/test_self_debugger_sandbox.py::test_coverage_report_failure -q`


------
https://chatgpt.com/codex/tasks/task_e_68b90a4a7a28832ea450ce9f640d8a80