### PR TITLE
Use dynamic path resolution for workflow chain data

### DIFF
--- a/workflow_chain_suggester.py
+++ b/workflow_chain_suggester.py
@@ -7,7 +7,9 @@ from typing import List, Sequence, Dict, Any, Tuple, Iterable, Set
 import random
 import json
 from pathlib import Path
+import sys
 
+from dynamic_path_router import resolve_path
 from vector_utils import cosine_similarity
 from roi_results_db import ROIResultsDB
 from workflow_stability_db import WorkflowStabilityDB
@@ -38,9 +40,17 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - used in tests without the real DB
     logger.warning("code_database import failed; context tag support disabled")
     CodeDB = None  # type: ignore
+    sys.modules.pop("code_database", None)
+
+try:  # pragma: no cover - compute default embedding path
+    _CHAIN_EMBEDDINGS_PATH = resolve_path("sandbox_data/embeddings.jsonl")
+except FileNotFoundError:  # pragma: no cover - file may not exist yet
+    _CHAIN_EMBEDDINGS_PATH = resolve_path("sandbox_data") / "embeddings.jsonl"
 
 
-def _load_chain_embeddings(path: Path = Path("embeddings.jsonl")) -> List[Dict[str, Any]]:
+def _load_chain_embeddings(
+    path: Path = _CHAIN_EMBEDDINGS_PATH,
+) -> List[Dict[str, Any]]:
     """Return stored workflow chain embeddings with metadata."""
 
     records: List[Dict[str, Any]] = []

--- a/workflow_stability_db.py
+++ b/workflow_stability_db.py
@@ -25,7 +25,10 @@ class WorkflowStabilityDB:
     """
 
     def __init__(self, path: str | Path = _DEFAULT_PATH) -> None:
-        self.path = Path(path)
+        try:
+            self.path = Path(resolve_path(str(path)))
+        except FileNotFoundError:
+            self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._load()
 


### PR DESCRIPTION
## Summary
- route workflow chain embeddings via dynamic_path_router
- resolve ROI, stability, and CodeDB file paths using resolve_path
- default CodeDB to repository-relative locations and handle missing vector_service

## Testing
- `pytest tests/test_workflow_chain_suggester.py tests/test_find_synergy_chain.py tests/test_roi_results_db.py tests/test_codedb_fts.py` *(fails: module 'code_database' has no attribute 'CodeDB')*

------
https://chatgpt.com/codex/tasks/task_e_68b90c8c0fd8832ea8573bb7484d935a