### PR TITLE
Use dynamic paths in workflow graph CLI

### DIFF
--- a/tools/workflow_graph_cli.py
+++ b/tools/workflow_graph_cli.py
@@ -14,8 +14,10 @@ import json
 import os
 from typing import Dict, List, Set, Tuple
 
+from dynamic_path_router import resolve_path
 
-DEFAULT_PATH = os.path.join("sandbox_data", "workflow_graph.json")
+
+DEFAULT_PATH = str(resolve_path("sandbox_data/workflow_graph.json"))
 
 
 def _load_graph(path: str) -> Dict[str, List[str]]:
@@ -89,13 +91,15 @@ def _latest_snapshots(base_path: str) -> List[str]:
 
 
 def cmd_chain(args: argparse.Namespace) -> None:
-    graph = _load_graph(args.path)
+    path = str(resolve_path(args.path))
+    graph = _load_graph(path)
     chains = _dependency_chains(graph, str(args.workflow_id))
     print(json.dumps(chains))
 
 
 def cmd_diff(args: argparse.Namespace) -> None:
-    snaps = _latest_snapshots(args.path)
+    path = str(resolve_path(args.path))
+    snaps = _latest_snapshots(path)
     if len(snaps) < 2:
         print(json.dumps({"error": "not enough snapshots"}))
         return


### PR DESCRIPTION
## Summary
- Resolve workflow graph paths using `resolve_path`
- Default workflow graph path now derived via `resolve_path`
- Resolve user-supplied paths before loading graph data

## Testing
- `python tools/check_dynamic_paths.py tools/workflow_graph_cli.py`
- `pytest tools -q`

------
https://chatgpt.com/codex/tasks/task_e_68b91711ab44832ea71eba678a2df811