### PR TITLE
Use resolve_path for preset policy and history paths

### DIFF
--- a/environment_generator.py
+++ b/environment_generator.py
@@ -1077,7 +1077,7 @@ def adapt_presets(
     agent = None
     rl_path = os.getenv("SANDBOX_PRESET_RL_PATH")
     if not rl_path:
-        rl_path = resolve_path("sandbox_data/preset_policy.json")
+        rl_path = str(resolve_path("sandbox_data/preset_policy.json"))
     rl_strategy = os.getenv("SANDBOX_PRESET_RL_STRATEGY")
     if rl_path:
         os.makedirs(os.path.dirname(rl_path), exist_ok=True)
@@ -1924,14 +1924,18 @@ def generate_presets_from_history(
     data_dir: str = "sandbox_data", count: int | None = None
 ) -> List[Dict[str, Any]]:
     """Return presets adapted using ROI/security history from ``data_dir``."""
-    history = Path(resolve_path(data_dir)) / "roi_history.json"
+    history_path = Path(data_dir) / "roi_history.json"
+    try:
+        history = str(resolve_path(history_path))
+    except FileNotFoundError:
+        history = history_path.as_posix()
     tracker = None
-    if history.exists():
+    if Path(history).exists():
         try:
             from .roi_tracker import ROITracker
 
             tracker = ROITracker()
-            tracker.load_history(str(history))
+            tracker.load_history(history)
         except Exception:
             tracker = None
     presets = generate_presets(count)


### PR DESCRIPTION
## Summary
- use `resolve_path` to set RL policy file location and keep the path as a string
- resolve ROI history path via `resolve_path` with graceful fallback to missing files

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_adapt_presets.py::test_generate_presets_from_history_calls_adapt tests/test_adapt_presets.py::test_generate_presets_from_history_missing -q`


------
https://chatgpt.com/codex/tasks/task_e_68b91d04b83c832e8ac0550a0611066b