### PR TITLE
Add Stripe billing router

### DIFF
--- a/stripe_billing_router.py
+++ b/stripe_billing_router.py
@@ -1,0 +1,161 @@
+"""Stripe billing router for mapping bots to Stripe products and customers.
+
+This module selects Stripe API keys and product/customer identifiers based on
+bot metadata. A fatal exception is raised if API keys are missing or no routing
+rule matches the supplied bot.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Mapping, Optional
+
+from .stripe_handler import is_enabled
+
+try:  # optional dependency
+    import stripe  # type: ignore
+except Exception as exc:  # pragma: no cover - optional dependency
+    stripe = None  # type: ignore
+    logging.getLogger(__name__).warning("stripe library unavailable: %s", exc)
+
+logger = logging.getLogger(__name__)
+
+STRIPE_SECRET_KEY = os.getenv("STRIPE_SECRET_KEY")
+STRIPE_PUBLIC_KEY = os.getenv("STRIPE_PUBLIC_KEY")
+
+if not STRIPE_SECRET_KEY or not STRIPE_PUBLIC_KEY:
+    raise RuntimeError("Stripe API keys must be set in STRIPE_SECRET_KEY and STRIPE_PUBLIC_KEY")
+
+# Base routing rules: (domain, name, category) -> identifiers
+BILLING_RULES: dict[tuple[str, str, str], dict[str, str]] = {
+    (
+        "finance",
+        "finance_router_bot",
+        "monetization",
+    ): {
+        "product_id": "prod_finance_router",
+        "price_id": "price_finance_standard",
+        "customer_id": "cus_finance_default",
+    }
+}
+
+# Overrides: (domain, name, category, key, value) -> route updates
+OVERRIDES: dict[tuple[str, str, str, str, str], dict[str, str]] = {}
+
+
+def register_override(
+    domain: str,
+    name: str,
+    category: str,
+    *,
+    key: str,
+    value: str,
+    route: Mapping[str, str],
+) -> None:
+    """Register a routing override for a specific bot and qualifier."""
+    OVERRIDES[(domain, name, category, key, value)] = dict(route)
+
+
+def _use_mock() -> bool:
+    return os.getenv("MENACE_MODE", "test").lower() != "production"
+
+
+class _MockCharge:
+    @staticmethod
+    def create(**kwargs: Any) -> dict[str, Any]:
+        logger.info("Mock Stripe charge: %s", kwargs)
+        return {"id": "mock_charge", "status": "succeeded"}
+
+
+class _MockCustomer:
+    @staticmethod
+    def create(**kwargs: Any) -> dict[str, Any]:
+        logger.info("Mock Stripe customer: %s", kwargs)
+        return {"id": "mock_customer"}
+
+
+class _MockStripe:
+    api_key: str = ""
+    Charge = _MockCharge
+    Customer = _MockCustomer
+
+
+def _client(api_key: str):
+    if not is_enabled() or not api_key:
+        return None
+    if stripe is None or _use_mock():
+        return _MockStripe()
+    stripe.api_key = api_key
+    return stripe
+
+
+def _parse_bot_id(bot_id: str) -> tuple[str, str, str]:
+    try:
+        domain, name, category = bot_id.split(":", 2)
+    except ValueError as exc:  # pragma: no cover - input validation
+        raise ValueError("bot_id must be in 'domain:name:category' format") from exc
+    return domain, name, category
+
+
+def _resolve_route(
+    bot_id: str, overrides: Optional[Mapping[str, str]] = None
+) -> dict[str, str]:
+    domain, name, category = _parse_bot_id(bot_id)
+    route = BILLING_RULES.get((domain, name, category))
+    if overrides:
+        for key, value in overrides.items():
+            update = OVERRIDES.get((domain, name, category, key, value))
+            if update:
+                if route:
+                    route = {**route, **update}
+                else:
+                    route = dict(update)
+    if not route:
+        raise RuntimeError(f"No billing route for bot '{bot_id}'")
+    route.setdefault("secret_key", STRIPE_SECRET_KEY)
+    route.setdefault("public_key", STRIPE_PUBLIC_KEY)
+    if not route.get("secret_key") or not route.get("public_key"):
+        raise RuntimeError("Stripe keys are not configured for the resolved route")
+    return route
+
+
+def charge(
+    bot_id: str,
+    amount: float,
+    description: str | None = None,
+    *,
+    overrides: Optional[Mapping[str, str]] = None,
+) -> dict[str, Any]:
+    """Charge a customer for the given bot."""
+    route = _resolve_route(bot_id, overrides)
+    client = _client(route["secret_key"])
+    if client is None:
+        raise RuntimeError("Stripe client unavailable or disabled")
+    params = {
+        "amount": int(amount * 100),
+        "currency": "usd",
+        "description": description or route.get("product_id", ""),
+    }
+    if customer := route.get("customer_id"):
+        params["customer"] = customer
+    if _use_mock():
+        params["source"] = "tok_visa"
+    return client.Charge.create(**params)
+
+
+def create_customer(
+    bot_id: str,
+    customer_info: Mapping[str, Any],
+    *,
+    overrides: Optional[Mapping[str, str]] = None,
+) -> dict[str, Any]:
+    """Create a new Stripe customer for the given bot."""
+    route = _resolve_route(bot_id, overrides)
+    client = _client(route["secret_key"])
+    if client is None:
+        raise RuntimeError("Stripe client unavailable or disabled")
+    return client.Customer.create(**customer_info)
+
+
+__all__ = ["charge", "create_customer", "register_override"]


### PR DESCRIPTION
## Summary
- add Stripe billing router module to map bots to Stripe products, plans and customers
- provide override registry and routing logic that raises if keys missing or no rule matches
- expose `charge` and `create_customer` helpers using selected keys

## Testing
- `pre-commit run --files stripe_billing_router.py`
- `pytest stripe_billing_router.py` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*

------
https://chatgpt.com/codex/tasks/task_e_68b924e00304832ebd52ca97352e48d6