### PR TITLE
docs: document dynamic path resolution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,8 @@ explanation for the exemption.
 
 Hard coding repository-relative paths (e.g., strings containing `sandbox_data`
 or path fragments like `foo/bar.py`) can break when the project moves. Use
-`resolve_path` to build such paths dynamically. The pre-commit hook
+`dynamic_path_router.resolve_path` to build such paths dynamically. The resolver
+respects environment overrides like `MENACE_ROOT` or `SANDBOX_REPO_PATH`,
+keeping scripts portable. The pre-commit hook
 `tools/check_dynamic_paths.py` enforces this rule by failing if a file contains
 these patterns without a corresponding `resolve_path` call.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 See [docs/sandbox_environment.md](docs/sandbox_environment.md) for required environment variables, optional dependencies and directory layout.
 
-## Dynamic Path Router
+## Dynamic path routing
 
 Scripts and data files are located with `dynamic_path_router.resolve_path` so
 shell commands remain portable across forked layouts or nested repositories.
@@ -289,7 +289,13 @@ environment variables and recovery steps.
 A background daemon flushes the queue into the shared database:
 
 ```bash
-python sync_shared_db.py --db-url sqlite:///menace.db --queue-dir sandbox_data/queues
+python sync_shared_db.py --db-url sqlite:///menace.db \
+  --queue-dir "$(python - <<'PY'
+from dynamic_path_router import resolve_path
+import os
+print(resolve_path(f"{os.getenv('SANDBOX_DATA_DIR', 'sandbox_data')}/queues"))
+PY
+)"
 ```
 
 Successful rows are committed and removed, retries happen up to three times and
@@ -454,7 +460,12 @@ bucket is configured or run as a limited pilot.
       --auto-include-isolated --clean-orphans
 
   # 3. Inspect the generated module map and workflows
-  cat sandbox_data/module_map.json
+  python - <<'PY'
+  from dynamic_path_router import resolve_path
+  import os
+  path = resolve_path(f"{os.getenv('SANDBOX_DATA_DIR', 'sandbox_data')}/module_map.json")
+  print(open(path).read())
+  PY
   ```
 
   `sandbox_runner.discover_recursive_orphans` traces the `candidate -> util`

--- a/docs/sandbox_environment.md
+++ b/docs/sandbox_environment.md
@@ -14,19 +14,18 @@ The sandbox expects a few variables to be set before launch:
 Run `auto_env_setup.ensure_env()` to generate a `.env` file with these variables when
 missing. Values may also be supplied via the shell environment.
 
+## Dynamic path routing
+
 Use `dynamic_path_router.resolve_path` for all repository file lookups so paths
-remain portable. Combine it with `SANDBOX_DATA_DIR` when accessing runtime
-artifacts:
+remain portable. The resolver infers the project root from Git metadata and can
+be overridden by setting `MENACE_ROOT` or `SANDBOX_REPO_PATH`. Combine it with
+`SANDBOX_DATA_DIR` when accessing runtime artifacts:
 
 ```python
 import os
 from dynamic_path_router import resolve_path
 data_dir = resolve_path(os.getenv("SANDBOX_DATA_DIR", "sandbox_data"))
 ```
-
-Setting `MENACE_ROOT` or `SANDBOX_REPO_PATH` changes the repository root used by
-`resolve_path`, allowing alternate checkouts to be targeted without modifying
-code.
 
 ## Prompt logging variables
 
@@ -69,11 +68,13 @@ version control:
 ```python
 from secrets_manager import SecretsManager
 from sandbox_settings import SandboxSettings
+from dynamic_path_router import resolve_path
+import os
 
 secrets = SecretsManager()
 settings = SandboxSettings(
-    sandbox_repo_path="/path/to/menace_sandbox",
-    sandbox_data_dir="/path/to/data",
+    sandbox_repo_path=resolve_path("."),
+    sandbox_data_dir=resolve_path(os.getenv("SANDBOX_DATA_DIR", "sandbox_data")),
     visual_agent_token=secrets.get("visual_agent_token"),
 )
 ```


### PR DESCRIPTION
## Summary
- note dynamic path routing capabilities and environment overrides
- switch example paths to `resolve_path`
- remind contributors to resolve repo paths dynamically

## Testing
- `pre-commit run --files README.md docs/sandbox_environment.md CONTRIBUTING.md`

------
https://chatgpt.com/codex/tasks/task_e_68b926bd4084832e8bf0852d3e508a6e