### PR TITLE
refactor: use resolve_path in self-improvement tests

### DIFF
--- a/sandbox_runner/tests/test_minimal_cycle.py
+++ b/sandbox_runner/tests/test_minimal_cycle.py
@@ -23,7 +23,7 @@ def _setup_base_packages():
     menace_pkg.__path__ = []
     sys.modules["menace"] = menace_pkg
     si_pkg = types.ModuleType("menace.self_improvement")
-    si_pkg.__path__ = [str(Path("self_improvement"))]
+    si_pkg.__path__ = [str(resolve_path("self_improvement"))]
     sys.modules["menace.self_improvement"] = si_pkg
     logger = types.SimpleNamespace(
         info=lambda *a, **k: None,

--- a/sandbox_runner/tests/test_self_improvement_flow.py
+++ b/sandbox_runner/tests/test_self_improvement_flow.py
@@ -24,7 +24,7 @@ def _setup_base_packages():
     menace_pkg.__path__ = []
     sys.modules["menace"] = menace_pkg
     si_pkg = types.ModuleType("menace.self_improvement")
-    si_pkg.__path__ = [str(Path("self_improvement"))]
+    si_pkg.__path__ = [str(resolve_path("self_improvement"))]
     sys.modules["menace.self_improvement"] = si_pkg
     # minimal logging utils
     logger = types.SimpleNamespace(

--- a/tests/self_improvement/test_cycle.py
+++ b/tests/self_improvement/test_cycle.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Mapping, Sequence
 import pytest
 from sandbox_settings import SandboxSettings
 import self_improvement.baseline_tracker as baseline_tracker
+from dynamic_path_router import resolve_path
 
 
 def _load_module(name: str, path: Path):
@@ -45,7 +46,7 @@ def test_self_improvement_cycle_runs(tmp_path, monkeypatch, in_memory_dbs):
     menace_pkg.__path__ = []
     sys.modules["menace"] = menace_pkg
     si_pkg = types.ModuleType("menace.self_improvement")
-    si_pkg.__path__ = [str(Path("self_improvement"))]
+    si_pkg.__path__ = [str(resolve_path("self_improvement"))]
     sys.modules["menace.self_improvement"] = si_pkg
 
     bootstrap = types.ModuleType("sandbox_runner.bootstrap")
@@ -107,9 +108,12 @@ def test_self_improvement_cycle_runs(tmp_path, monkeypatch, in_memory_dbs):
 
     sys.modules["menace.sandbox_settings"] = sandbox_settings_module
 
-    init_module = _load_module("menace.self_improvement.init", Path("self_improvement/init.py"))
+    init_module = _load_module(
+        "menace.self_improvement.init", resolve_path("self_improvement/init.py")
+    )
     meta_planning = _load_module(
-        "menace.self_improvement.meta_planning", Path("self_improvement/meta_planning.py")
+        "menace.self_improvement.meta_planning",
+        resolve_path("self_improvement/meta_planning.py"),
     )
 
     monkeypatch.setattr(baseline_tracker.TRACKER, "get", track)
@@ -163,7 +167,7 @@ def test_self_improvement_cycle_handles_db_errors(tmp_path, monkeypatch, in_memo
     menace_pkg.__path__ = []
     sys.modules["menace"] = menace_pkg
     si_pkg = types.ModuleType("menace.self_improvement")
-    si_pkg.__path__ = [str(Path("self_improvement"))]
+    si_pkg.__path__ = [str(resolve_path("self_improvement"))]
     sys.modules["menace.self_improvement"] = si_pkg
 
     bootstrap = types.ModuleType("sandbox_runner.bootstrap")
@@ -215,9 +219,12 @@ def test_self_improvement_cycle_handles_db_errors(tmp_path, monkeypatch, in_memo
 
     sys.modules["menace.sandbox_settings"] = sandbox_settings_module
 
-    init_module = _load_module("menace.self_improvement.init", Path("self_improvement/init.py"))
+    init_module = _load_module(
+        "menace.self_improvement.init", resolve_path("self_improvement/init.py")
+    )
     meta_planning = _load_module(
-        "menace.self_improvement.meta_planning", Path("self_improvement/meta_planning.py")
+        "menace.self_improvement.meta_planning",
+        resolve_path("self_improvement/meta_planning.py"),
     )
 
     monkeypatch.setattr(init_module, "verify_dependencies", lambda auto_install=False: None)
@@ -262,7 +269,7 @@ def test_start_self_improvement_cycle_dependency_failure(tmp_path, monkeypatch, 
     menace_pkg.__path__ = []
     sys.modules["menace"] = menace_pkg
     si_pkg = types.ModuleType("menace.self_improvement")
-    si_pkg.__path__ = [str(Path("self_improvement"))]
+    si_pkg.__path__ = [str(resolve_path("self_improvement"))]
     sys.modules["menace.self_improvement"] = si_pkg
 
     logger = types.SimpleNamespace(
@@ -301,9 +308,12 @@ def test_start_self_improvement_cycle_dependency_failure(tmp_path, monkeypatch, 
     import sandbox_settings as sandbox_settings_module
     sys.modules["menace.sandbox_settings"] = sandbox_settings_module
 
-    init_module = _load_module("menace.self_improvement.init", Path("self_improvement/init.py"))
+    init_module = _load_module(
+        "menace.self_improvement.init", resolve_path("self_improvement/init.py")
+    )
     meta_planning = _load_module(
-        "menace.self_improvement.meta_planning", Path("self_improvement/meta_planning.py")
+        "menace.self_improvement.meta_planning",
+        resolve_path("self_improvement/meta_planning.py"),
     )
     monkeypatch.setattr(init_module, "load_sandbox_settings", lambda: SandboxSettings())
     monkeypatch.setattr(init_module, "verify_dependencies", lambda auto_install=False: None)
@@ -320,7 +330,7 @@ def test_start_self_improvement_cycle_dependency_failure(tmp_path, monkeypatch, 
 
 
 def _load_cycle_funcs():
-    src = Path("self_improvement/meta_planning.py").read_text()
+    src = resolve_path("self_improvement/meta_planning.py").read_text()
     tree = ast.parse(src)
     wanted = {
         "self_improvement_cycle",

--- a/tests/self_improvement/test_init.py
+++ b/tests/self_improvement/test_init.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 from sandbox_settings import SandboxSettings
+from dynamic_path_router import resolve_path
 
 
 def _load_module(name: str, path: Path):
@@ -37,7 +38,7 @@ def test_get_default_synergy_weights_reflects_settings(monkeypatch):
     menace_pkg.__path__ = []
     sys.modules["menace"] = menace_pkg
     si_pkg = types.ModuleType("menace.self_improvement")
-    si_pkg.__path__ = [str(Path("self_improvement"))]
+    si_pkg.__path__ = [str(resolve_path("self_improvement"))]
     sys.modules["menace.self_improvement"] = si_pkg
 
     monkeypatch.setenv(
@@ -54,7 +55,9 @@ def test_get_default_synergy_weights_reflects_settings(monkeypatch):
             }
         ),
     )
-    init_module = _load_module("menace.self_improvement.init", Path("self_improvement/init.py"))
+    init_module = _load_module(
+        "menace.self_improvement.init", resolve_path("self_improvement/init.py")
+    )
     first = init_module.get_default_synergy_weights()
 
     monkeypatch.setenv(
@@ -82,7 +85,7 @@ def test_init_creates_synergy_weights(tmp_path, monkeypatch):
     menace_pkg.__path__ = []
     sys.modules["menace"] = menace_pkg
     si_pkg = types.ModuleType("menace.self_improvement")
-    si_pkg.__path__ = [str(Path("self_improvement"))]
+    si_pkg.__path__ = [str(resolve_path("self_improvement"))]
     sys.modules["menace.self_improvement"] = si_pkg
 
     bootstrap = types.ModuleType("sandbox_runner.bootstrap")
@@ -98,7 +101,9 @@ def test_init_creates_synergy_weights(tmp_path, monkeypatch):
     meta_stub.reload_settings = lambda cfg: None
     sys.modules["menace.self_improvement.meta_planning"] = meta_stub
 
-    init_module = _load_module("menace.self_improvement.init", Path("self_improvement/init.py"))
+    init_module = _load_module(
+        "menace.self_improvement.init", resolve_path("self_improvement/init.py")
+    )
 
     monkeypatch.setattr(
         importlib.metadata,
@@ -136,7 +141,7 @@ def test_init_meta_planning_failure(tmp_path, monkeypatch, caplog):
     menace_pkg.__path__ = []
     sys.modules["menace"] = menace_pkg
     si_pkg = types.ModuleType("menace.self_improvement")
-    si_pkg.__path__ = [str(Path("self_improvement"))]
+    si_pkg.__path__ = [str(resolve_path("self_improvement"))]
     sys.modules["menace.self_improvement"] = si_pkg
 
     bootstrap = types.ModuleType("sandbox_runner.bootstrap")
@@ -151,7 +156,9 @@ def test_init_meta_planning_failure(tmp_path, monkeypatch, caplog):
     meta_stub.reload_settings = fail
     sys.modules["menace.self_improvement.meta_planning"] = meta_stub
 
-    init_module = _load_module("menace.self_improvement.init", Path("self_improvement/init.py"))
+    init_module = _load_module(
+        "menace.self_improvement.init", resolve_path("self_improvement/init.py")
+    )
 
     monkeypatch.setattr(
         importlib.metadata,
@@ -184,14 +191,16 @@ def test_init_enables_auto_install_when_unattended(tmp_path, monkeypatch):
     menace_pkg.__path__ = []
     sys.modules["menace"] = menace_pkg
     si_pkg = types.ModuleType("menace.self_improvement")
-    si_pkg.__path__ = [str(Path("self_improvement"))]
+    si_pkg.__path__ = [str(resolve_path("self_improvement"))]
     sys.modules["menace.self_improvement"] = si_pkg
 
     meta_stub = types.ModuleType("menace.self_improvement.meta_planning")
     meta_stub.reload_settings = lambda cfg: None
     sys.modules["menace.self_improvement.meta_planning"] = meta_stub
 
-    init_module = _load_module("menace.self_improvement.init", Path("self_improvement/init.py"))
+    init_module = _load_module(
+        "menace.self_improvement.init", resolve_path("self_improvement/init.py")
+    )
 
     settings = SandboxSettings()
     settings.sandbox_data_dir = str(tmp_path)

--- a/tests/self_improvement/test_meta_planning_logging.py
+++ b/tests/self_improvement/test_meta_planning_logging.py
@@ -6,13 +6,15 @@ from pathlib import Path
 import importlib.util
 import types
 
+from dynamic_path_router import resolve_path
+
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 menace_pkg = types.ModuleType("menace")
 menace_pkg.__path__ = []
 sys.modules["menace"] = menace_pkg
 si_pkg = types.ModuleType("menace.self_improvement")
-si_pkg.__path__ = [str(Path("self_improvement"))]
+si_pkg.__path__ = [str(resolve_path("self_improvement"))]
 sys.modules["menace.self_improvement"] = si_pkg
 # Stub out dependencies required by meta_planning during import
 logging_utils = types.ModuleType("menace.logging_utils")
@@ -99,7 +101,8 @@ init_mod = types.ModuleType("menace.self_improvement.init")
 init_mod.settings = _SandboxSettings()
 sys.modules["menace.self_improvement.init"] = init_mod
 spec = importlib.util.spec_from_file_location(
-    "menace.self_improvement.meta_planning", Path("self_improvement/meta_planning.py")
+    "menace.self_improvement.meta_planning",
+    resolve_path("self_improvement/meta_planning.py"),
 )
 mp = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mp)

--- a/tests/self_improvement/test_verify_dependencies.py
+++ b/tests/self_improvement/test_verify_dependencies.py
@@ -13,6 +13,7 @@ import types
 from pathlib import Path
 
 import pytest
+from dynamic_path_router import resolve_path
 
 
 def _load_module(name: str, path: Path):
@@ -51,14 +52,14 @@ def _prepare_modules(*, missing: tuple[str, ...] = ()):  # pragma: no cover - he
     menace_pkg.__path__ = []
     sys.modules["menace"] = menace_pkg
     si_pkg = types.ModuleType("menace.self_improvement")
-    si_pkg.__path__ = [str(Path("self_improvement"))]
+    si_pkg.__path__ = [str(resolve_path("self_improvement"))]
     sys.modules["menace.self_improvement"] = si_pkg
 
 
 def test_verify_dependencies_does_not_attempt_install(monkeypatch):
     _prepare_modules(missing=("quick_fix_engine",))
     init_mod = _load_module(
-        "menace.self_improvement.init", Path("self_improvement/init.py")
+        "menace.self_improvement.init", resolve_path("self_improvement/init.py")
     )
 
     def fail_run(*args, **kwargs):
@@ -86,7 +87,7 @@ def test_verify_dependencies_does_not_attempt_install(monkeypatch):
 def test_verify_dependencies_attempts_install_when_enabled(monkeypatch):
     _prepare_modules(missing=("quick_fix_engine",))
     init_mod = _load_module(
-        "menace.self_improvement.init", Path("self_improvement/init.py")
+        "menace.self_improvement.init", resolve_path("self_improvement/init.py")
     )
 
     cmds: list[list[str]] = []
@@ -126,7 +127,7 @@ def test_verify_dependencies_attempts_install_when_enabled(monkeypatch):
 def test_verify_dependencies_install_failure_raises(monkeypatch):
     _prepare_modules(missing=("quick_fix_engine",))
     init_mod = _load_module(
-        "menace.self_improvement.init", Path("self_improvement/init.py")
+        "menace.self_improvement.init", resolve_path("self_improvement/init.py")
     )
 
     def failing_run(cmd, check):
@@ -148,7 +149,7 @@ def test_verify_dependencies_install_failure_raises(monkeypatch):
 def test_verify_dependencies_reports_version_mismatch(monkeypatch):
     _prepare_modules()
     init_mod = _load_module(
-        "menace.self_improvement.init", Path("self_improvement/init.py")
+        "menace.self_improvement.init", resolve_path("self_improvement/init.py")
     )
 
     def fake_version(name):
@@ -168,7 +169,7 @@ def test_logs_when_neurosales_metadata_missing(monkeypatch, caplog):
     _prepare_modules()
     sys.modules["neurosales"] = types.ModuleType("neurosales")
     init_mod = _load_module(
-        "menace.self_improvement.init", Path("self_improvement/init.py")
+        "menace.self_improvement.init", resolve_path("self_improvement/init.py")
     )
 
     def fake_version(name: str) -> str:

--- a/tests/test_dependency_checks.py
+++ b/tests/test_dependency_checks.py
@@ -8,9 +8,9 @@ import importlib
 import importlib.util
 import sys
 import types
-from pathlib import Path
 
 import pytest
+from dynamic_path_router import resolve_path
 
 
 def _stub_modules(exclude: set[str] | None = None) -> None:
@@ -55,7 +55,7 @@ def _stub_modules(exclude: set[str] | None = None) -> None:
 
 def _load_init():
     spec = importlib.util.spec_from_file_location(
-        "self_improvement.init", Path("self_improvement/init.py")
+        "self_improvement.init", resolve_path("self_improvement/init.py")
     )
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)

--- a/tests/test_relevancy_thresholds.py
+++ b/tests/test_relevancy_thresholds.py
@@ -3,10 +3,12 @@ import types
 import importlib.util
 from pathlib import Path
 
+from dynamic_path_router import resolve_path
+
 
 def _load_baseline_tracker():
     spec = importlib.util.spec_from_file_location(
-        "baseline", Path("self_improvement") / "baseline_tracker.py"
+        "baseline", resolve_path("self_improvement/baseline_tracker.py")
     )
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
@@ -14,7 +16,7 @@ def _load_baseline_tracker():
 
 
 def _load_eval_method():
-    src = Path("self_improvement/engine.py").read_text()
+    src = resolve_path("self_improvement/engine.py").read_text()
     tree = ast.parse(src)
     func = None
     for node in tree.body:

--- a/tests/test_self_improvement_confidence.py
+++ b/tests/test_self_improvement_confidence.py
@@ -4,9 +4,10 @@ from pathlib import Path
 from typing import Iterable
 
 import pytest
+from dynamic_path_router import resolve_path
 
 
-source = Path("self_improvement.py").read_text()
+source = resolve_path("self_improvement/engine.py").read_text()
 module_ast = ast.parse(source)
 cls = next(
     n for n in module_ast.body if isinstance(n, ast.ClassDef) and n.name == "SelfImprovementEngine"

--- a/tests/test_workflow_variant_scenarios.py
+++ b/tests/test_workflow_variant_scenarios.py
@@ -11,6 +11,7 @@ from workflow_synthesizer import (
     WorkflowSynthesizer,
     generate_variants,
 )
+from dynamic_path_router import resolve_path
 
 
 FIXTURES = Path(__file__).with_name("fixtures")
@@ -69,7 +70,7 @@ def test_benchmark_workflow_variants_calculates_roi_delta():
         def record_mutation_outcome(*a, **k):
             pass
 
-    src = Path("self_improvement/orchestration_utils.py").read_text()
+    src = resolve_path("self_improvement/orchestration_utils.py").read_text()
     tree = ast.parse(src)
     func_node = next(
         n


### PR DESCRIPTION
## Summary
- import resolve_path and replace direct Path lookups for self_improvement files across tests
- adjust test helpers to work with resolve_path Path objects

## Testing
- `PYTHONPATH=$PWD pytest tests/test_dependency_checks.py tests/test_self_improvement_confidence.py tests/test_workflow_variant_scenarios.py tests/test_relevancy_thresholds.py tests/self_improvement/test_init.py tests/self_improvement/test_meta_planning_logging.py tests/self_improvement/test_verify_dependencies.py tests/self_improvement/test_cycle.py sandbox_runner/tests/test_minimal_cycle.py sandbox_runner/tests/test_self_improvement_flow.py` *(fails: ImportError, AttributeError, TypeError, RuntimeError)*

------
https://chatgpt.com/codex/tasks/task_e_68b928ddd750832eab3aa31c9cf46f14