### PR TITLE
Use dynamic path resolution in scripts

### DIFF
--- a/scripts/build_sandbox_image.sh
+++ b/scripts/build_sandbox_image.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 # Build the Docker image for the Menace sandbox
-repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+repo_root=$(python - <<'PY'
+from dynamic_path_router import repo_root
+print(repo_root())
+PY
+)
 image_name="menace_sandbox"
 exec docker build -t "$image_name" "$repo_root"

--- a/scripts/run_sandbox_container.sh
+++ b/scripts/run_sandbox_container.sh
@@ -1,9 +1,18 @@
 #!/bin/sh
 # Run the Menace sandbox Docker image with persistent data
-repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+env_file=$(python - <<'PY'
+from dynamic_path_router import resolve_path
+print(resolve_path('.env'))
+PY
+)
+data_dir=$(python - <<'PY'
+from dynamic_path_router import resolve_path
+print(resolve_path('sandbox_data'))
+PY
+)
 image_name="${IMAGE:-menace_sandbox}"
 
 docker run --rm -it \
-  --env-file "$repo_root/.env" \
-  -v "$repo_root/sandbox_data:/app/sandbox_data" \
+  --env-file "$env_file" \
+  -v "$data_dir:/app/sandbox_data" \
   "$image_name" "$@"

--- a/scripts/setup_personal.sh
+++ b/scripts/setup_personal.sh
@@ -2,7 +2,12 @@
 set -euo pipefail
 
 # Run base Python environment setup
-"$(dirname "$0")/../setup_env.sh"
+setup_env=$(python - <<'PY'
+from dynamic_path_router import resolve_path
+print(resolve_path('setup_env.sh'))
+PY
+)
+"$setup_env"
 
 # Install and verify project dependencies
 python setup_dependencies.py

--- a/scripts/start_autonomous.sh
+++ b/scripts/start_autonomous.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 # Bootstrap PYTHONPATH so the script works from any directory
 # Resolve repository root so imports work regardless of the CWD
-repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+repo_root=$(python - <<'PY'
+from dynamic_path_router import repo_root
+print(repo_root())
+PY
+)
 export PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}"
 export REPO_ROOT="$repo_root"
 

--- a/scripts/start_sandbox.sh
+++ b/scripts/start_sandbox.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 # Ensure dependencies are installed and environment is set up
-"$(dirname "$0")/../setup_env.sh"
+setup_env=$(python - <<'PY'
+from dynamic_path_router import resolve_path
+print(resolve_path('setup_env.sh'))
+PY
+)
+"$setup_env"
 
 # Launch sandbox runner with metrics dashboard
 python $(python -c 'from dynamic_path_router import resolve_path; print(resolve_path("sandbox_runner.py"))') full-autonomous-run --preset-count 3 --dashboard-port 8002 "$@"


### PR DESCRIPTION
## Summary
- Compute `.env` and `sandbox_data` paths via `dynamic_path_router` in sandbox container runner
- Use `dynamic_path_router` to derive repository root and setup script locations in helper scripts

## Testing
- `bash -n scripts/run_sandbox_container.sh scripts/build_sandbox_image.sh scripts/start_autonomous.sh scripts/start_sandbox.sh scripts/setup_personal.sh`
- `PYTHONPATH=. pytest tests/test_dynamic_path_router_env.py::test_resolve_path_with_menace_root -q`


------
https://chatgpt.com/codex/tasks/task_e_68b92ad679c8832e90dc7b24044bbc7f