### PR TITLE
Add Stripe billing router tests and docs

### DIFF
--- a/docs/stripe_billing_router.md
+++ b/docs/stripe_billing_router.md
@@ -1,0 +1,59 @@
+# Stripe Billing Router
+
+`stripe_billing_router` maps bots to Stripe products, prices and customers.
+It reads API keys from the `STRIPE_SECRET_KEY` and `STRIPE_PUBLIC_KEY`
+environment variables at import time and raises a `RuntimeError` if they are
+missing.
+
+## Usage
+
+Bots are identified by a `"domain:name:category"` string. The router looks up
+routing details for that bot and adds the Stripe keys. For example:
+
+```python
+from stripe_billing_router import charge, get_balance
+
+charge("finance:finance_router_bot:monetization", amount=10.0)
+bal = get_balance("finance:finance_router_bot:monetization")
+```
+
+## Extending to New Bots
+
+New bots can be supported by adding an entry to `BILLING_RULES` at start up:
+
+```python
+from stripe_billing_router import BILLING_RULES
+
+BILLING_RULES[("analytics", "new_bot", "monetization")] = {
+    "product_id": "prod_new_bot",
+    "price_id": "price_new_bot_standard",
+    "customer_id": "cus_new_bot_default",
+}
+```
+
+## Regional Overrides
+
+Per-region adjustments use the `register_override` hook. A qualifier such as a
+region is supplied at call time via `overrides`:
+
+```python
+from stripe_billing_router import charge, register_override
+
+register_override(
+    "finance",
+    "finance_router_bot",
+    "monetization",
+    key="region",
+    value="eu",
+    route={"price_id": "price_finance_eu"},
+)
+
+charge(
+    "finance:finance_router_bot:monetization",
+    amount=10.0,
+    overrides={"region": "eu"},
+)
+```
+
+This updates the price used for European customers while leaving the base rule
+unchanged.

--- a/tests/test_stripe_billing_router.py
+++ b/tests/test_stripe_billing_router.py
@@ -1,0 +1,78 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _import_module(monkeypatch):
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test")
+    monkeypatch.setenv("STRIPE_PUBLIC_KEY", "pk_test")
+    pkg = types.ModuleType("sbrpkg")
+    pkg.__path__ = [str(ROOT)]
+    sys.modules["sbrpkg"] = pkg
+
+    def _load(name: str):
+        spec = importlib.util.spec_from_file_location(
+            f"sbrpkg.{name}", ROOT / f"{name}.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[f"sbrpkg.{name}"] = module
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+
+    _load("stripe_handler")
+    return _load("stripe_billing_router")
+
+
+def test_routing_matches_bot_metadata(monkeypatch):
+    sbr = _import_module(monkeypatch)
+    route = sbr._resolve_route("finance:finance_router_bot:monetization")
+    assert route["product_id"] == "prod_finance_router"
+    assert route["price_id"] == "price_finance_standard"
+    assert route["customer_id"] == "cus_finance_default"
+    assert route["secret_key"] == "sk_test"
+    assert route["public_key"] == "pk_test"
+
+
+def test_unmatched_route_raises(monkeypatch):
+    sbr = _import_module(monkeypatch)
+    with pytest.raises(RuntimeError):
+        sbr._resolve_route("unknown:bot:category")
+
+
+def test_missing_keys_raise(monkeypatch):
+    monkeypatch.delenv("STRIPE_SECRET_KEY", raising=False)
+    monkeypatch.delenv("STRIPE_PUBLIC_KEY", raising=False)
+    pkg = types.ModuleType("sbrpkg")
+    pkg.__path__ = [str(ROOT)]
+    sys.modules["sbrpkg"] = pkg
+    spec = importlib.util.spec_from_file_location(
+        "sbrpkg.stripe_billing_router", ROOT / "stripe_billing_router.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["sbrpkg.stripe_billing_router"] = module
+    assert spec.loader is not None
+    with pytest.raises(RuntimeError):
+        spec.loader.exec_module(module)
+
+
+def test_override_updates_route(monkeypatch):
+    sbr = _import_module(monkeypatch)
+    sbr.register_override(
+        "finance",
+        "finance_router_bot",
+        "monetization",
+        key="region",
+        value="eu",
+        route={"price_id": "price_finance_eu"},
+    )
+    route = sbr._resolve_route(
+        "finance:finance_router_bot:monetization", overrides={"region": "eu"}
+    )
+    assert route["price_id"] == "price_finance_eu"


### PR DESCRIPTION
## Summary
- add documentation on Stripe billing router usage and extending to new bots or regions
- test routing resolution, error handling, and override mechanism in Stripe billing router

## Testing
- `python - <<'PY'
import sys, types, pytest
m = types.ModuleType('dynamic_path_router'); m.resolve_path=lambda p: p; sys.modules['dynamic_path_router']=m
pytest.main(['tests/test_stripe_billing_router.py','-q','--maxfail=1','--confcutdir=tests'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b92ad9c76c832eb46607f0b279b0b4