### PR TITLE
Use resolve_path for helper path

### DIFF
--- a/self_coding_scheduler.py
+++ b/self_coding_scheduler.py
@@ -67,7 +67,7 @@ class SelfCodingScheduler:
             if error_increase is not None
             else self.settings.self_coding_error_increase
         )
-        self.patch_path = patch_path or (resolve_path(".") / "auto_helpers.py")
+        self.patch_path = Path(patch_path) if patch_path else resolve_path("auto_helpers.py")
         self.description = description
         self.last_roi = self.data_bot.roi(self.manager.bot_name)
         self.last_errors = 0.0


### PR DESCRIPTION
## Summary
- Locate default `auto_helpers.py` via `resolve_path` and ensure `SelfCodingScheduler.patch_path` is always a `Path`

## Testing
- `python tools/check_static_paths.py self_coding_scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_68b92db08fd0832ebfe7f6366352e98e