### PR TITLE
Capture and log per-run function coverage metrics

### DIFF
--- a/sandbox_runner/scoring.py
+++ b/sandbox_runner/scoring.py
@@ -57,6 +57,8 @@ def record_run(result: Any, metrics: Dict[str, Any]) -> None:
     entropy_delta = metrics.get("entropy_delta")
     roi = metrics.get("roi")
     coverage = metrics.get("coverage")
+    executed_functions = metrics.get("executed_functions")
+    functions_hit = len(executed_functions) if executed_functions is not None else None
 
     failure = getattr(result, "failure", None)
     error_trace: str | None = None
@@ -77,6 +79,10 @@ def record_run(result: Any, metrics: Dict[str, Any]) -> None:
         "entropy_delta": entropy_delta,
         "roi": roi,
         "coverage": _serialise(coverage) if coverage is not None else None,
+        "functions_hit": functions_hit,
+        "executed_functions": _serialise(executed_functions)
+        if executed_functions is not None
+        else None,
         "error": error_trace,
     }
     logger.info("run", extra=log_record(**record))
@@ -98,6 +104,10 @@ def record_run(result: Any, metrics: Dict[str, Any]) -> None:
             summary["runtime_total"] = summary.get("runtime_total", 0.0) + runtime
             if entropy_delta is not None:
                 summary["entropy_total"] = summary.get("entropy_total", 0.0) + float(entropy_delta)
+            if functions_hit is not None:
+                summary["functions_hit_total"] = summary.get(
+                    "functions_hit_total", 0
+                ) + int(functions_hit)
             _SUMMARY_FILE.write_text(json.dumps(summary))
         except Exception:  # pragma: no cover - logging is best effort
             logger.exception("failed to persist run metrics")

--- a/sandbox_runner/tests/test_coverage_integration.py
+++ b/sandbox_runner/tests/test_coverage_integration.py
@@ -1,7 +1,13 @@
 import os
+import json
+import subprocess
 
 os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
-from sandbox_runner.workflow_sandbox_runner import WorkflowSandboxRunner
+from menace_sandbox.sandbox_runner.workflow_sandbox_runner import (  # noqa: E402
+    WorkflowSandboxRunner,
+)
+from menace_sandbox.sandbox_runner.test_harness import _run_once  # noqa: E402
+import menace_sandbox.sandbox_runner.scoring as scoring  # noqa: E402
 
 
 def _sample_module():
@@ -10,10 +16,44 @@ def _sample_module():
     return inner()
 
 
-def test_module_coverage_reporting():
+def test_module_coverage_reporting(monkeypatch):
+    monkeypatch.setenv("SANDBOX_CAPTURE_COVERAGE", "1")
     runner = WorkflowSandboxRunner()
     metrics = runner.run(_sample_module, use_subprocess=False)
     mod = metrics.modules[0]
     assert isinstance(mod.coverage_files, list)
     assert isinstance(mod.coverage_functions, list)
 
+
+def test_harness_logs_function_coverage(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mod_name = "mod" + ".py"
+    test_name = "test_mod" + ".py"
+    (repo / mod_name).write_text("def foo():\n    return 1\n", encoding="utf-8")
+    (repo / test_name).write_text(
+        "from mod import foo\n\n\ndef test_foo():\n    assert foo() == 1\n",
+        encoding="utf-8",
+    )
+    (repo / "requirements.txt").write_text("pytest\n", encoding="utf-8")
+    subprocess.run(["git", "init"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    env = {
+        "GIT_AUTHOR_NAME": "a",
+        "GIT_AUTHOR_EMAIL": "a@b.c",
+        "GIT_COMMITTER_NAME": "a",
+        "GIT_COMMITTER_EMAIL": "a@b.c",
+    }
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, env=env)
+
+    log_dir = tmp_path / "logs"
+    monkeypatch.setattr(scoring, "_LOG_DIR", log_dir)
+    monkeypatch.setattr(scoring, "_RUN_LOG", log_dir / "run_metrics.jsonl")
+    monkeypatch.setattr(scoring, "_SUMMARY_FILE", log_dir / "run_summary.json")
+    monkeypatch.delenv("SANDBOX_CAPTURE_COVERAGE", raising=False)
+
+    res = _run_once(repo)
+    assert res.coverage is not None
+    data = json.loads(scoring._RUN_LOG.read_text().splitlines()[-1])
+    assert data["functions_hit"] is not None
+    assert isinstance(data["executed_functions"], list)


### PR DESCRIPTION
## Summary
- enable coverage collection by default in test harness, installing coverage package as needed
- aggregate executed functions from coverage reports and log per-run coverage counts
- exercise coverage logging in new integration tests

## Testing
- `pre-commit run --files sandbox_runner/test_harness.py sandbox_runner/environment.py sandbox_runner/scoring.py sandbox_runner/tests/test_coverage_integration.py`
- `PYTHONPATH=/workspace/menace_sandbox MENACE_LIGHT_IMPORTS=1 pytest sandbox_runner/tests/test_coverage_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68b92b8b7bb4832eae6985d8b6e62efd