### PR TITLE
Use billing router init_charge directly and update tests

### DIFF
--- a/finance_router_bot.py
+++ b/finance_router_bot.py
@@ -118,8 +118,8 @@ class FinanceRouterBot:
     def route_payment(self, amount: float, model_id: str) -> str:
         """Charge via Stripe and log the result."""
         try:
-            resp = stripe_billing_router.charge(
-                "finance:finance_router_bot:monetization",
+            resp = stripe_billing_router.init_charge(
+                model_id,
                 amount,
                 description=model_id,
             )

--- a/investment_engine.py
+++ b/investment_engine.py
@@ -165,7 +165,7 @@ class AutoReinvestmentBot:
 
     def _execute_spending(self, amount: float) -> str:
         try:
-            resp = stripe_billing_router.charge(
+            resp = stripe_billing_router.init_charge(
                 self.bot_id, amount, description="reinvestment"
             )
             status = resp.get("status")

--- a/tests/test_finance_router_bot.py
+++ b/tests/test_finance_router_bot.py
@@ -6,14 +6,18 @@ import menace.finance_router_bot as frb  # noqa: E402
 
 def test_route_and_summary(tmp_path, monkeypatch):
     log = tmp_path / "payout.json"
-    monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test")
-    monkeypatch.setenv("STRIPE_PUBLIC_KEY", "pk_test")
-    monkeypatch.setattr(
-        frb.stripe_billing_router, "charge", lambda *a, **k: {"status": "succeeded"}
-    )
+    calls = {}
+
+    def fake_charge(bot_id, amount, description=None, *, overrides=None):
+        calls["bot_id"] = bot_id
+        calls["amount"] = amount
+        return {"status": "succeeded"}
+
+    monkeypatch.setattr(frb.stripe_billing_router, "init_charge", fake_charge)
     bot = frb.FinanceRouterBot(payout_log_path=log)
     res = bot.route_payment(10.0, "model1")
     assert res
+    assert calls == {"bot_id": "model1", "amount": 10.0}
     data = json.loads(log.read_text())
     assert data and data[0]["model_id"] == "model1"
     summary = bot.report_earnings_summary()

--- a/tests/test_finance_router_memory_subscribe.py
+++ b/tests/test_finance_router_memory_subscribe.py
@@ -4,8 +4,6 @@ import sys
 import types
 
 os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
-os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
-os.environ.setdefault("STRIPE_PUBLIC_KEY", "pk_test")
 sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda *a, **k: None))
 jinja_mod = types.ModuleType("jinja2")
 jinja_mod.Template = lambda *a, **k: None


### PR DESCRIPTION
## Summary
- route payments through `stripe_billing_router.init_charge` using provided bot identity
- remove test-time Stripe key env dependencies and mock router calls
- update reinvestment spending to use new billing router API

## Testing
- `PYTHONPATH=. MENACE_LIGHT_IMPORTS=1 pytest tests/test_finance_router_bot.py -q`
- `PYTHONPATH=. MENACE_LIGHT_IMPORTS=1 pytest tests/test_stripe_billing_router.py -q`
- `PYTHONPATH=. MENACE_LIGHT_IMPORTS=1 pytest tests/test_finance_router_memory_subscribe.py -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'Gauge')*

------
https://chatgpt.com/codex/tasks/task_e_68b92f2553e4832ebb90e07d65398afd