### PR TITLE
Add regression test for static path checker

### DIFF
--- a/tests/test_static_paths.py
+++ b/tests/test_static_paths.py
@@ -1,0 +1,25 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKER = ROOT / "tools" / "check_static_paths.py"  # path-ignore
+FILES = [
+    ROOT / "sandbox_runner" / "orphan_discovery.py",  # path-ignore
+    ROOT / "self_coding_engine.py",  # path-ignore
+    ROOT / "prompt_engine.py",  # path-ignore
+    ROOT / "prompt_optimizer.py",  # path-ignore
+    ROOT / "prompt_memory_trainer.py",  # path-ignore
+]
+
+
+def test_no_static_py_paths() -> None:
+    for file in FILES:
+        result = subprocess.run(
+            [sys.executable, str(CHECKER), str(file)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert result.stdout.strip() == ""
+        assert result.stderr.strip() == ""


### PR DESCRIPTION
## Summary
- add regression test that runs tools/check_static_paths.py against key modules

## Testing
- `python tools/check_static_paths.py sandbox_runner/orphan_discovery.py`
- `python tools/check_static_paths.py self_coding_engine.py`
- `python tools/check_static_paths.py prompt_engine.py`
- `python tools/check_static_paths.py prompt_optimizer.py`
- `python tools/check_static_paths.py prompt_memory_trainer.py`
- `PYTHONPATH=$PWD pytest tests/test_static_paths.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b930553b44832ea73cd0bb418320ae