### PR TITLE
Track executed functions and coverage map in sandbox runs

### DIFF
--- a/sandbox_runner/scoring.py
+++ b/sandbox_runner/scoring.py
@@ -48,8 +48,10 @@ def record_run(result: Any, metrics: Dict[str, Any]) -> None:
         Object describing the run outcome. It may be a boolean or an object
         exposing ``success``/``duration``/``failure`` attributes.
     metrics:
-        Mapping containing optional ``roi``, ``coverage``, ``entropy_delta`` or
-        ``runtime`` overrides.
+        Mapping containing optional ``roi``, ``coverage`` (mapping of files to
+        executed function names), ``executed_functions`` (flattened
+        ``"file:function"`` entries), ``entropy_delta`` or ``runtime``
+        overrides.
     """
 
     success = bool(getattr(result, "success", result))
@@ -58,6 +60,12 @@ def record_run(result: Any, metrics: Dict[str, Any]) -> None:
     roi = metrics.get("roi")
     coverage = metrics.get("coverage")
     executed_functions = metrics.get("executed_functions")
+    if executed_functions is None and isinstance(coverage, dict):
+        executed_functions = [
+            f"{path}:{fn}"
+            for path, funcs in coverage.items()
+            for fn in funcs
+        ]
     functions_hit = len(executed_functions) if executed_functions is not None else None
 
     failure = getattr(result, "failure", None)

--- a/sandbox_runner/tests/test_coverage_integration.py
+++ b/sandbox_runner/tests/test_coverage_integration.py
@@ -54,6 +54,7 @@ def test_harness_logs_function_coverage(tmp_path, monkeypatch):
 
     res = _run_once(repo)
     assert res.coverage is not None
+    assert isinstance(res.executed_functions, list)
     data = json.loads(scoring._RUN_LOG.read_text().splitlines()[-1])
     assert data["functions_hit"] is not None
     assert isinstance(data["executed_functions"], list)

--- a/tests/test_self_debugger_sandbox.py
+++ b/tests/test_self_debugger_sandbox.py
@@ -713,7 +713,11 @@ def test_coverage_records_executed_functions(monkeypatch, tmp_path):
 
     monkeypatch.setattr(sds, "Coverage", Cov)
     captured = {}
-    monkeypatch.setattr(sds, "record_run", lambda m: captured.update(m))
+    monkeypatch.setattr(
+        sds,
+        "record_run",
+        lambda *a, **k: captured.update(a[1] if len(a) > 1 else a[0]),
+    )
 
     percent, _ = asyncio.run(dbg._coverage_percent([Path("dummy.py")]))
     assert percent == 100.0


### PR DESCRIPTION
## Summary
- Default coverage collection in `_run_once` and persist executed function list
- Record per-file function coverage map instead of percentage
- Store executed functions on `TestHarnessResult`

## Testing
- `PYTHONPATH=/workspace/menace_sandbox MENACE_LIGHT_IMPORTS=1 pytest sandbox_runner/tests/test_coverage_integration.py unit_tests/test_entropy_delta_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b92fff33a8832e84cec74c8e972bb7