### PR TITLE
Inject edge case stubs via test harness

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -348,6 +348,7 @@ class SandboxSettings(BaseSettings):
         env="AUTO_INSTALL_DEPENDENCIES",
         description="Automatically install missing Python packages when possible.",
     )
+    inject_edge_cases: bool = Field(True, env="INJECT_EDGE_CASES")
     roi_cycles: int | None = Field(None, env="ROI_CYCLES")
     synergy_cycles: int | None = Field(None, env="SYNERGY_CYCLES")
     baseline_window: int = Field(10, env="BASELINE_WINDOW")


### PR DESCRIPTION
## Summary
- allow `_run_once` to operate on pre-cloned repositories and skip stub writes
- `run_tests` now writes edge case stubs into a temp clone and respects new `inject_edge_cases` flag
- expose `inject_edge_cases` option in `SandboxSettings`

## Testing
- `PYTHONPATH=. pytest sandbox_runner/tests/test_edge_case_stubs_injection.py::test_edge_case_stubs_injected -q`
- `PYTHONPATH=. pytest sandbox_runner/tests/test_edge_case_stubs_injection.py::test_inject_edge_cases_flag -q`

------
https://chatgpt.com/codex/tasks/task_e_68b931b46a34832e9f7ab649ad06ffa1