### PR TITLE
Normalize path handling in prompt and coding engines

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -1238,6 +1238,7 @@ class SelfCodingEngine:
         context are presented to the model and the generated code is spliced back
         into the original file at the specified range.
         """
+        path = Path(resolve_path(path))
         try:
             code = self.generate_helper(
                 description,


### PR DESCRIPTION
## Summary
- resolve template and weight file defaults via `resolve_path`
- normalize target-region file access using `resolve_path`
- ensure `patch_file` resolves its path input before modification

## Testing
- `python tools/check_static_paths.py prompt_engine.py self_coding_engine.py quick_fix_engine.py`
- `PYTHONPATH=. pytest tests/test_quick_fix_engine.py::test_generate_patch_no_module tests/test_self_coding_engine.py::test_patch_file_appends_code -q` *(fails: ImportError: cannot import name 'PatchLogger')*


------
https://chatgpt.com/codex/tasks/task_e_68b93397aa4c832eaed7a5bb4908e8d3