### PR TITLE
chore: remove stripe env vars and document billing router

### DIFF
--- a/docs/auto_reinvestment.md
+++ b/docs/auto_reinvestment.md
@@ -1,9 +1,9 @@
 # Menace Auto-Reinvestment Logic
 
-Menace periodically reinvests a portion of its Stripe balance into expanding its own capabilities. This process is fully automated and adjusts spending based on predicted ROI.
+Menace periodically reinvests a portion of its billing balance into expanding its own capabilities. This process is fully automated and adjusts spending based on predicted ROI.
 
-## 1. Stripe Account Integration
-- **Read Balance**: Menace reads the current available balance from Stripe.
+## 1. Billing Integration
+- **Read Balance**: Menace reads the current available balance via `stripe_billing_router`.
 - **Available for Reinvestment**: `reinvestable_amount = balance * cap_percentage`.
 - **Execute Spend**: Funds can be used to buy services (compute, data, proxies) or hire freelancers.
 
@@ -17,7 +17,9 @@ Menace periodically reinvests a portion of its Stripe balance into expanding its
 
 ## 4. Reinvestment Execution
 ```python
-balance = stripe.get_balance()
+from stripe_billing_router import get_balance
+
+balance = get_balance("finance:finance_router_bot:monetization")
 reinvestable = balance * cap_percentage
 predicted = predict_optimal_spend()
 amount_to_spend = min(predicted, reinvestable)
@@ -37,4 +39,4 @@ if amount_to_spend >= minimum_threshold:
 
 Example: With a $100,000 balance and a 50% cap, if predicted ROI plateaus after $14,000, only $14,000 is spent and $86,000 stays in reserve.
 
-Implementation lives in `investment_engine.AutoReinvestmentBot` which reads the Stripe balance, predicts optimal spend and logs each transaction via `InvestmentDB`.
+Implementation lives in `investment_engine.AutoReinvestmentBot` which reads the balance through `stripe_billing_router`, predicts optimal spend and logs each transaction via `InvestmentDB`.

--- a/docs/sandbox_environment.md
+++ b/docs/sandbox_environment.md
@@ -46,7 +46,7 @@ functionality but do not prevent basic operation.
 
 - **System tools**: `ffmpeg`, `tesseract`, `qemu-system-x86_64`
 - **Python packages**: `matplotlib`, `statsmodels`, `uvicorn`, `fastapi`,
-  `sklearn`, `stripe`, `httpx`
+  `sklearn`, `httpx`
 
 ## Directory layout
 

--- a/docs/stripe_billing_router.md
+++ b/docs/stripe_billing_router.md
@@ -4,6 +4,17 @@
 API keys are pulled from a secure vault provider or fall back to baked‑in
 production values. A `RuntimeError` is raised if the keys are missing or empty.
 
+## Bot Invocation and Routing Rules
+
+Bots either import `stripe_billing_router` directly or use the compatibility
+wrapper `stripe_handler`. Each bot supplies a `"domain:name:category"` string
+which the router uses to look up billing information and attach the appropriate
+Stripe keys.
+
+Routing rules live in the global `BILLING_RULES` mapping inside
+`stripe_billing_router.py`. Edit this mapping at start‑up or use
+`register_override` for dynamic adjustments.
+
 ## Usage
 
 Bots are identified by a `"domain:name:category"` string. The router looks up

--- a/docs/upgrade_notes.md
+++ b/docs/upgrade_notes.md
@@ -1,5 +1,14 @@
 # Upgrade Notes
 
+## Stripe per-bot keys removed
+
+Legacy per-bot Stripe secret and public keys have been retired. Bots now route
+charges and balance lookups through `stripe_billing_router`, which loads a
+single set of API keys and maps bots to products and prices via the
+`BILLING_RULES` mapping. Remove any `STRIPE_*` entries from existing `.env`
+files or vault records and configure routes in `stripe_billing_router.py`
+instead.
+
 ## vector_service API
 
 The `vector_service` package provides retrieval helpers and HTTP endpoints

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -634,7 +634,6 @@ class SandboxSettings(BaseSettings):
             "uvicorn",
             "fastapi",
             "sklearn",
-            "stripe",
             "httpx",
         ],
         env="SANDBOX_OPTIONAL_PYTHON_PKGS",

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -3,5 +3,5 @@ set -e
 python -m pip install --upgrade pip
 pip install -e .
 pip install pytest
-pip install stripe python-dotenv scikit-learn
+pip install python-dotenv scikit-learn
 pip install hypothesis


### PR DESCRIPTION
## Summary
- drop Stripe install from setup_env.sh and optional sandbox packages
- document stripe_billing_router usage and routing configuration
- note migration away from per-bot Stripe keys

## Testing
- `pre-commit run --files setup_env.sh sandbox_settings.py docs/auto_reinvestment.md docs/sandbox_environment.md docs/stripe_billing_router.md docs/upgrade_notes.md`
- `PYTHONPATH=. pytest tests/test_stripe_billing_router.py tests/test_investment_engine.py`
- `PYTHONPATH=. pytest tests/test_stripe_billing_router.py tests/test_startup_checks.py tests/test_investment_engine.py` (failed: RuntimeError not raised in test_verify_stripe_router_checks)


------
https://chatgpt.com/codex/tasks/task_e_68b933a84198832e90411d89f76f3bd1