### PR TITLE
Forward run metrics to legacy SQLite logger

### DIFF
--- a/sandbox_results_logger.py
+++ b/sandbox_results_logger.py
@@ -1,38 +1,76 @@
-"""Deprecated sandbox results logger wrapper.
+"""Persist sandbox run metrics to the legacy SQLite backend.
 
-This module previously handled persistence of sandbox run metrics.  It now
-forwards all calls to :mod:`sandbox_runner.scoring` so that legacy imports keep
-working while metrics flow through the unified JSONL/summary pipeline.
+The new :mod:`sandbox_runner.scoring` module aggregates metrics and stores
+them in JSONL/summary form. To maintain backwards compatibility with the
+older SQLite-based logger this module exposes :func:`record_run` which stores
+an identical record in ``sandbox_data/run_metrics.db``.
 """
 
 from __future__ import annotations
 
-from types import SimpleNamespace
+import json
+import sqlite3
+import threading
+from pathlib import Path
 from typing import Any, Dict
 
-from .sandbox_runner.scoring import record_run as _record_run
+try:  # pragma: no cover - optional during tests
+    from .dynamic_path_router import resolve_path  # type: ignore
+except Exception:  # pragma: no cover - fallback for test envs
+    from dynamic_path_router import resolve_path  # type: ignore
+
+
+_LOG_DIR = Path(resolve_path("sandbox_data"))
+_DB_PATH = _LOG_DIR / "run_metrics.db"
+_lock = threading.Lock()
 
 
 def record_run(metrics: Dict[str, Any]) -> None:
-    """Forward *metrics* to :func:`sandbox_runner.scoring.record_run`.
+    """Persist *metrics* to the SQLite ``run_metrics`` table."""
 
-    Parameters
-    ----------
-    metrics:
-        Mapping containing runtime information. Keys such as ``success``,
-        ``runtime`` and ``error`` are translated for the new API. Additional
-        values like ``entropy_delta`` are forwarded unchanged for persistence.
-    """
-
-    _record_run(
-        SimpleNamespace(
-            success=metrics.get("success"),
-            duration=metrics.get("runtime"),
-            failure=metrics.get("error"),
-        ),
-        metrics,
-    )
+    _LOG_DIR.mkdir(parents=True, exist_ok=True)
+    with _lock:
+        conn = sqlite3.connect(_DB_PATH)
+        try:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS runs (
+                    ts TEXT,
+                    success INTEGER,
+                    runtime REAL,
+                    entropy_delta REAL,
+                    roi REAL,
+                    coverage TEXT,
+                    functions_hit INTEGER,
+                    executed_functions TEXT,
+                    error TEXT
+                )
+                """
+            )
+            serialised = {
+                **metrics,
+                "coverage": json.dumps(metrics.get("coverage"))
+                if metrics.get("coverage") is not None
+                else None,
+                "executed_functions": json.dumps(metrics.get("executed_functions"))
+                if metrics.get("executed_functions") is not None
+                else None,
+            }
+            conn.execute(
+                """
+                INSERT INTO runs (
+                    ts, success, runtime, entropy_delta, roi,
+                    coverage, functions_hit, executed_functions, error
+                ) VALUES (
+                    :ts, :success, :runtime, :entropy_delta, :roi,
+                    :coverage, :functions_hit, :executed_functions, :error
+                )
+                """,
+                serialised,
+            )
+            conn.commit()
+        finally:  # pragma: no cover - ensure connection closes
+            conn.close()
 
 
 __all__ = ["record_run"]
-

--- a/sandbox_runner/scoring.py
+++ b/sandbox_runner/scoring.py
@@ -14,6 +14,7 @@ import json
 import threading
 
 from logging_utils import get_logger, log_record
+from sandbox_results_logger import record_run as _legacy_record_run
 
 try:  # pragma: no cover - optional dependency during tests
     from .dynamic_path_router import resolve_path  # type: ignore
@@ -94,6 +95,10 @@ def record_run(result: Any, metrics: Dict[str, Any]) -> None:
         "error": error_trace,
     }
     logger.info("run", extra=log_record(**record))
+    try:  # pragma: no cover - legacy logging best effort
+        _legacy_record_run(record)
+    except Exception:  # pragma: no cover - don't fail caller
+        logger.exception("failed to forward run metrics to legacy logger")
 
     _LOG_DIR.mkdir(parents=True, exist_ok=True)
     with _lock:

--- a/sandbox_runner/tests/test_results_logger_sync.py
+++ b/sandbox_runner/tests/test_results_logger_sync.py
@@ -1,0 +1,33 @@
+import os
+import json
+import sqlite3
+from types import SimpleNamespace
+
+os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
+
+import sandbox_runner.scoring as scoring
+import sandbox_results_logger as legacy
+
+
+def test_jsonl_and_sqlite_backends_receive_same_record(tmp_path, monkeypatch):
+    monkeypatch.setattr(scoring, "_LOG_DIR", tmp_path)
+    monkeypatch.setattr(scoring, "_RUN_LOG", tmp_path / "run_metrics.jsonl")
+    monkeypatch.setattr(scoring, "_SUMMARY_FILE", tmp_path / "run_summary.json")
+
+    monkeypatch.setattr(legacy, "_LOG_DIR", tmp_path)
+    monkeypatch.setattr(legacy, "_DB_PATH", tmp_path / "run_metrics.db")
+
+    scoring.record_run(SimpleNamespace(success=True, duration=1.0, failure=None), {})
+
+    record = json.loads((tmp_path / "run_metrics.jsonl").read_text().splitlines()[0])
+
+    conn = sqlite3.connect(tmp_path / "run_metrics.db")
+    conn.row_factory = sqlite3.Row
+    row = conn.execute("SELECT * FROM runs").fetchone()
+    sqlite_record = dict(row)
+    for key in ("coverage", "executed_functions"):
+        if sqlite_record[key] is not None:
+            sqlite_record[key] = json.loads(sqlite_record[key])
+    conn.close()
+
+    assert sqlite_record == record


### PR DESCRIPTION
## Summary
- ensure `sandbox_runner.scoring.record_run` forwards metrics to the legacy results logger
- implement SQLite persistence in `sandbox_results_logger`
- add regression test validating JSON and SQLite run record parity

## Testing
- `PYTHONPATH=/workspace/menace_sandbox MENACE_LIGHT_IMPORTS=1 pytest menace_sandbox/sandbox_runner/tests/test_results_logger_sync.py menace_sandbox/unit_tests/test_entropy_delta_logging.py menace_sandbox/sandbox_runner/tests/test_coverage_integration.py::test_harness_logs_function_coverage -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9339f0740832e8ea6c5808bfe3006