### PR TITLE
Expand static path pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         entry: python tools/check_static_paths.py
         language: system
         pass_filenames: true
-        files: '(^|/)(self_improvement|sandbox_runner|scripts)/.*\.py$'
+        files: '^((analysis|analytics|annoy|chunk_summary_cache|clipped|compliance|docs|menace|micro_models|migrations|neurosales|plugins|sandbox_runner|scripts|security|self_improvement|tests|tools|unit_tests|vector_service)/.*|[^/]+\.py)$'
       - id: check-dynamic-paths
         name: Ensure dynamic paths use resolve_path
         entry: python tools/check_dynamic_paths.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,3 +25,13 @@ respects environment overrides like `MENACE_ROOT` or `SANDBOX_REPO_PATH`,
 keeping scripts portable. The pre-commit hook
 `tools/check_dynamic_paths.py` enforces this rule by failing if a file contains
 these patterns without a corresponding `resolve_path` call.
+
+## Static path references
+
+Avoid hard coding string literals that end with `.py`. Such paths must be
+wrapped by `resolve_path` or `path_for_prompt` to remain portable across forks
+and clones. The `tools/check_static_paths.py` pre-commit hook scans for these
+violations.
+
+Before submitting a pull request, run `pre-commit run --all-files` to execute
+this and other checks locally.


### PR DESCRIPTION
## Summary
- extend static path checker to cover all python directories
- document static path hook and how to run pre-commit

## Testing
- `pre-commit run --all-files` *(fails: direct sqlite3.connect usage, static path references, dynamic path warnings, flake8 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b93580276c832e8095639ee195f2ec