### PR TITLE
test: cover stripe billing router and finance flows

### DIFF
--- a/tests/test_finance_router_bot.py
+++ b/tests/test_finance_router_bot.py
@@ -1,10 +1,61 @@
-import pytest
-pytest.skip("optional dependencies not installed", allow_module_level=True)
-import json  # noqa: E402
-import menace.finance_router_bot as frb  # noqa: E402
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _import_finance_router(monkeypatch):
+    pkg = types.ModuleType("frbpkg")
+    pkg.__path__ = [str(ROOT)]
+    sys.modules["frbpkg"] = pkg
+
+    def _load(name: str):
+        spec = importlib.util.spec_from_file_location(
+            f"frbpkg.{name}", ROOT / f"{name}.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[f"frbpkg.{name}"] = module
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+
+    sys.modules["frbpkg.capital_management_bot"] = types.SimpleNamespace(
+        CapitalManagementBot=type(
+            "CM", (), {"log_inflow": lambda self, amount, model_id: None}
+        )
+    )
+    sys.modules["frbpkg.unified_event_bus"] = types.SimpleNamespace(
+        UnifiedEventBus=type(
+            "UEB", (), {"subscribe": lambda *a, **k: None, "publish": lambda *a, **k: None}
+        )
+    )
+    sys.modules["frbpkg.menace_memory_manager"] = types.SimpleNamespace(
+        MenaceMemoryManager=type("MMM", (), {"subscribe": lambda *a, **k: None}),
+        MemoryEntry=object,
+    )
+
+    vsp = _load("vault_secret_provider")
+    monkeypatch.setattr(
+        vsp.VaultSecretProvider,
+        "get",
+        lambda self, name: {
+            "stripe_secret_key": "sk_test",
+            "stripe_public_key": "pk_test",
+        }.get(name, ""),
+    )
+    _load("stripe_handler")
+    sbr = _load("stripe_billing_router")
+    sys.modules["frbpkg.stripe_billing_router"] = sbr
+
+    return _load("finance_router_bot")
 
 
 def test_route_and_summary(tmp_path, monkeypatch):
+    frb = _import_finance_router(monkeypatch)
     log = tmp_path / "payout.json"
     calls = {}
 
@@ -22,3 +73,21 @@ def test_route_and_summary(tmp_path, monkeypatch):
     assert data and data[0]["model_id"] == "model1"
     summary = bot.report_earnings_summary()
     assert summary["model1"] == 10.0
+
+
+def test_router_error_propagates(tmp_path, monkeypatch):
+    frb = _import_finance_router(monkeypatch)
+    log = tmp_path / "payout.json"
+    calls = {}
+
+    def bad_charge(bot_id, amount, description=None, *, overrides=None):
+        calls["bot_id"] = bot_id
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(frb.stripe_billing_router, "init_charge", bad_charge)
+    bot = frb.FinanceRouterBot(payout_log_path=log)
+    res = bot.route_payment(5.0, "model2")
+    assert res.startswith("error:")
+    assert calls["bot_id"] == "model2"
+    data = json.loads(log.read_text())
+    assert data and data[0]["result"].startswith("error:")

--- a/tests/test_investment_engine.py
+++ b/tests/test_investment_engine.py
@@ -1,9 +1,47 @@
-import pytest
-pytest.skip("optional dependencies not installed", allow_module_level=True)
-import menace.investment_engine as ie  # noqa: E402
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _import_investment_engine(monkeypatch):
+    pkg = types.ModuleType("iepkg")
+    pkg.__path__ = [str(ROOT)]
+    sys.modules["iepkg"] = pkg
+
+    def _load(name: str):
+        spec = importlib.util.spec_from_file_location(
+            f"iepkg.{name}", ROOT / f"{name}.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[f"iepkg.{name}"] = module
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+
+    vsp = _load("vault_secret_provider")
+    monkeypatch.setattr(
+        vsp.VaultSecretProvider,
+        "get",
+        lambda self, name: {
+            "stripe_secret_key": "sk_test",
+            "stripe_public_key": "pk_test",
+        }.get(name, ""),
+    )
+    _load("stripe_handler")
+    sbr = _load("stripe_billing_router")
+    sys.modules["iepkg.stripe_billing_router"] = sbr
+    dbm = _load("db_router")
+    dbm.GLOBAL_ROUTER = None
+    sys.modules["db_router"] = dbm
+    return _load("investment_engine")
 
 
 def test_reinvest_cap(monkeypatch, tmp_path):
+    ie = _import_investment_engine(monkeypatch)
     db = ie.InvestmentDB(tmp_path / "i.db")
     engine = ie.PredictiveSpendEngine(db)
     bot = ie.AutoReinvestmentBot(
@@ -25,3 +63,26 @@ def test_reinvest_cap(monkeypatch, tmp_path):
     assert spent == 100.0  # capped at 50% of 200
     rows = db.fetch()
     assert rows and rows[0][0] == 100.0
+
+
+def test_reinvest_error_propagates(monkeypatch, tmp_path):
+    ie = _import_investment_engine(monkeypatch)
+    db = ie.InvestmentDB(tmp_path / "i.db")
+    engine = ie.PredictiveSpendEngine(db)
+    bot = ie.AutoReinvestmentBot(predictor=engine, db=db)
+    monkeypatch.setattr(
+        ie.stripe_billing_router, "get_balance", lambda *a, **k: 200.0
+    )
+    calls = {}
+
+    def bad_charge(bot_id, amount, description=None, *, overrides=None):
+        calls["bot_id"] = bot_id
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(ie.stripe_billing_router, "init_charge", bad_charge)
+    monkeypatch.setattr(engine, "predict", lambda balance, cap: (50.0, 0.2))
+
+    spent = bot.reinvest()
+    assert spent == 0.0
+    assert calls["bot_id"] == bot.bot_id
+    assert db.fetch() == []


### PR DESCRIPTION
## Summary
- add comprehensive tests for stripe billing router including charge and customer flows
- ensure finance router bot delegates to billing router and propagates errors
- verify investment engine reinvestment logic and error delegation

## Testing
- `pre-commit run --files tests/test_stripe_billing_router.py tests/test_finance_router_bot.py tests/test_investment_engine.py`
- `PYTHONPATH=$PWD pytest tests/test_stripe_billing_router.py tests/test_finance_router_bot.py tests/test_investment_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_68b934f59314832eb9e6854c57c69b13