### PR TITLE
Refine Stripe billing router API

### DIFF
--- a/stripe_billing_router.py
+++ b/stripe_billing_router.py
@@ -123,7 +123,7 @@ def _resolve_route(
     return route
 
 
-def init_charge(
+def initiate_charge(
     bot_id: str,
     amount: float,
     description: str | None = None,
@@ -144,7 +144,8 @@ def init_charge(
 
 
 # Backward compatibility
-charge = init_charge
+init_charge = initiate_charge
+charge = initiate_charge
 
 
 def get_balance(
@@ -175,6 +176,7 @@ def create_customer(
 
 
 __all__ = [
+    "initiate_charge",
     "init_charge",
     "charge",
     "get_balance",


### PR DESCRIPTION
## Summary
- rename `init_charge` to `initiate_charge` and expose aliases
- keep exporting Stripe billing helpers and override features

## Testing
- `pre-commit run --files stripe_billing_router.py`

------
https://chatgpt.com/codex/tasks/task_e_68b936e04f00832eb46acad8e2d47f7f