### PR TITLE
refactor path handling in self coding modules

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -283,7 +283,7 @@ class SelfCodingEngine:
         )
         self.baseline_tracker = delta_tracker or METRIC_BASELINES
         data_dir = getattr(_settings, "sandbox_data_dir", ".")
-        state_candidate = Path(data_dir) / "self_coding_engine_state.json"
+        state_candidate = resolve_path(data_dir) / "self_coding_engine_state.json"
         try:
             self._state_path = resolve_path(state_candidate)
         except FileNotFoundError:
@@ -1238,7 +1238,7 @@ class SelfCodingEngine:
         context are presented to the model and the generated code is spliced back
         into the original file at the specified range.
         """
-        path = Path(resolve_path(path))
+        path = resolve_path(path)
         try:
             code = self.generate_helper(
                 description,
@@ -1261,7 +1261,7 @@ class SelfCodingEngine:
         if self.formal_verifier:
             with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as fh:
                 fh.write(code)
-                tmp_path = Path(fh.name)
+                tmp_path = resolve_path(fh.name)
             try:
                 verified = self.formal_verifier.verify(tmp_path)
             finally:
@@ -1363,7 +1363,7 @@ class SelfCodingEngine:
 
         def workflow() -> bool:
             ok = True
-            target = Path(file_name) if file_name else resolve_path(".")
+            target = resolve_path(file_name) if file_name else resolve_path(".")
             if self.formal_verifier and path is not None:
                 try:
                     if not self.formal_verifier.verify(target):
@@ -1462,7 +1462,7 @@ class SelfCodingEngine:
             if self.formal_verifier:
                 with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as fh:
                     fh.write(snippet)
-                    tmp_path = Path(fh.name)
+                    tmp_path = resolve_path(fh.name)
                 try:
                     return self.formal_verifier.verify(tmp_path)
                 finally:
@@ -1858,7 +1858,7 @@ class SelfCodingEngine:
             if target_region is not None:
                 with tempfile.NamedTemporaryFile("w", suffix=path.suffix, delete=False) as fh:
                     fh.write(generated_code)
-                    tmp_path = Path(fh.name)
+                    tmp_path = resolve_path(fh.name)
                 try:
                     verified = self.formal_verifier.verify(tmp_path)
                 finally:
@@ -2372,7 +2372,9 @@ class SelfCodingEngine:
         ):
             try:
                 self.patch_suggestion_db.add(
-                    SuggestionRecord(module=Path(path).name, description=description)
+                    SuggestionRecord(
+                        module=resolve_path(path).name, description=description
+                    )
                 )
             except Exception:
                 self.logger.exception("failed storing suggestion")

--- a/self_coding_manager.py
+++ b/self_coding_manager.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 """Manage self-coding patches and deployment cycles."""
 
 from pathlib import Path
+try:  # pragma: no cover - allow flat imports
+    from .dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback for flat layout
+    from dynamic_path_router import resolve_path  # type: ignore
 import logging
 import subprocess
 import tempfile
@@ -220,7 +224,7 @@ class SelfCodingManager:
         roi_delta = 0.0
         with tempfile.TemporaryDirectory() as tmp:
             subprocess.run(["git", "clone", str(repo_root), tmp], check=True)
-            clone_root = Path(tmp)
+            clone_root = resolve_path(tmp)
             cloned_path = clone_root / path.resolve().relative_to(repo_root)
             attempt = 0
             patch_id: int | None = None
@@ -746,7 +750,7 @@ class SelfCodingManager:
             self.logger.exception("failed to fetch suggestions")
             return
         for sid, module, description in rows:
-            path = Path(module)
+            path = resolve_path(module)
             try:
                 if getattr(self.engine, "audit_trail", None):
                     try:


### PR DESCRIPTION
## Summary
- use `resolve_path` for engine state file lookup
- resolve temporary and suggestion paths via `resolve_path`
- update manager to resolve module and clone paths dynamically

## Testing
- `pytest self_coding_engine.py self_coding_manager.py -q` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*


------
https://chatgpt.com/codex/tasks/task_e_68b938748d58832ea1423d60cfe50bf8