### PR TITLE
Harden Stripe billing router

### DIFF
--- a/docs/stripe_billing_router.md
+++ b/docs/stripe_billing_router.md
@@ -2,7 +2,9 @@
 
 `stripe_billing_router` maps bots to Stripe products, prices and customers.
 API keys are pulled from a secure vault provider or fall back to baked‑in
-production values. A `RuntimeError` is raised if the keys are missing or empty.
+production values. A `RuntimeError` is raised if the keys are missing, empty or
+test mode keys. Routing attempts for unsupported domains or missing rules also
+raise `RuntimeError`.
 
 ## Bot Invocation and Routing Rules
 

--- a/tests/test_event_integration.py
+++ b/tests/test_event_integration.py
@@ -3,8 +3,8 @@ pytest.importorskip("jinja2")
 pytest.importorskip("git")
 import os  # noqa: E402
 
-os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
-os.environ.setdefault("STRIPE_PUBLIC_KEY", "pk_test")
+os.environ.setdefault("STRIPE_SECRET_KEY", "sk_live_dummy")
+os.environ.setdefault("STRIPE_PUBLIC_KEY", "pk_live_dummy")
 
 import menace.data_bot as db  # noqa: E402
 from menace.unified_event_bus import UnifiedEventBus  # noqa: E402

--- a/tests/test_finance_router_bot.py
+++ b/tests/test_finance_router_bot.py
@@ -43,8 +43,8 @@ def _import_finance_router(monkeypatch):
         vsp.VaultSecretProvider,
         "get",
         lambda self, name: {
-            "stripe_secret_key": "sk_test",
-            "stripe_public_key": "pk_test",
+            "stripe_secret_key": "sk_live_dummy",
+            "stripe_public_key": "pk_live_dummy",
         }.get(name, ""),
     )
     sbr = _load("stripe_billing_router")

--- a/tests/test_investment_engine.py
+++ b/tests/test_investment_engine.py
@@ -27,8 +27,8 @@ def _import_investment_engine(monkeypatch):
         vsp.VaultSecretProvider,
         "get",
         lambda self, name: {
-            "stripe_secret_key": "sk_test",
-            "stripe_public_key": "pk_test",
+            "stripe_secret_key": "sk_live_dummy",
+            "stripe_public_key": "pk_live_dummy",
         }.get(name, ""),
     )
     sbr = _load("stripe_billing_router")

--- a/tests/test_stripe_billing_router.py
+++ b/tests/test_stripe_billing_router.py
@@ -29,8 +29,8 @@ def _import_module(monkeypatch):
         vsp.VaultSecretProvider,
         "get",
         lambda self, name: {
-            "stripe_secret_key": "sk_test",
-            "stripe_public_key": "pk_test",
+            "stripe_secret_key": "sk_live_dummy",
+            "stripe_public_key": "pk_live_dummy",
         }.get(name, ""),
     )
 
@@ -43,14 +43,20 @@ def test_routing_matches_bot_metadata(monkeypatch):
     assert route["product_id"] == "prod_finance_router"
     assert route["price_id"] == "price_finance_standard"
     assert route["customer_id"] == "cus_finance_default"
-    assert route["secret_key"] == "sk_test"
-    assert route["public_key"] == "pk_test"
+    assert route["secret_key"] == "sk_live_dummy"
+    assert route["public_key"] == "pk_live_dummy"
+
+
+def test_unsupported_domain_raises(monkeypatch):
+    sbr = _import_module(monkeypatch)
+    with pytest.raises(RuntimeError, match="Unsupported billing domain"):
+        sbr._resolve_route("unknown:bot:category")
 
 
 def test_unmatched_route_raises(monkeypatch):
     sbr = _import_module(monkeypatch)
-    with pytest.raises(RuntimeError):
-        sbr._resolve_route("unknown:bot:category")
+    with pytest.raises(RuntimeError, match="No billing route"):
+        sbr._resolve_route("finance:unknown_bot:monetization")
 
 
 def test_missing_keys_raise(monkeypatch):


### PR DESCRIPTION
## Summary
- Validate Stripe API keys at load, reject test-mode keys, and log any configuration failures
- Raise detailed `RuntimeError`s for unsupported domains or missing routes with logging across failure paths
- Update tests and documentation to use live key placeholders and cover new error scenarios

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*
- `python -m py_compile stripe_billing_router.py tests/test_stripe_billing_router.py tests/test_finance_router_bot.py tests/test_investment_engine.py tests/test_event_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68b939370584832ea289e5f50264b156