### PR TITLE
Record executed functions in coverage results

### DIFF
--- a/sandbox_runner/scoring.py
+++ b/sandbox_runner/scoring.py
@@ -61,12 +61,19 @@ def record_run(result: Any, metrics: Dict[str, Any]) -> None:
     roi = metrics.get("roi")
     coverage = metrics.get("coverage")
     executed_functions = metrics.get("executed_functions")
-    if executed_functions is None and isinstance(coverage, dict):
-        executed_functions = [
-            f"{path}:{fn}"
-            for path, funcs in coverage.items()
-            for fn in funcs
-        ]
+    if executed_functions is None:
+        if isinstance(coverage, dict) and "executed_functions" in coverage:
+            executed_functions = coverage.get("executed_functions")
+        elif isinstance(coverage, dict):
+            executed_functions = [
+                f"{path}:{fn}"
+                for path, funcs in coverage.items()
+                for fn in funcs
+            ]
+        else:
+            cov_attr = getattr(result, "coverage", None)
+            if isinstance(cov_attr, dict):
+                executed_functions = cov_attr.get("executed_functions")
     functions_hit = len(executed_functions) if executed_functions is not None else None
 
     failure = getattr(result, "failure", None)

--- a/sandbox_runner/test_harness.py
+++ b/sandbox_runner/test_harness.py
@@ -398,6 +398,7 @@ def _run_once(
                 except Exception:
                     executed_functions = []
                     coverage_map = {}
+                cov_data["executed_functions"] = executed_functions
         entropy_delta = None
         if cov_data is not None:
             try:

--- a/sandbox_runner/tests/test_coverage_integration.py
+++ b/sandbox_runner/tests/test_coverage_integration.py
@@ -54,7 +54,7 @@ def test_harness_logs_function_coverage(tmp_path, monkeypatch):
 
     res = _run_once(repo)
     assert res.coverage is not None
-    assert isinstance(res.executed_functions, list)
+    assert isinstance(res.coverage.get("executed_functions"), list)
     data = json.loads(scoring._RUN_LOG.read_text().splitlines()[-1])
     assert data["functions_hit"] is not None
     assert isinstance(data["executed_functions"], list)


### PR DESCRIPTION
## Summary
- attach executed function names to coverage data in sandbox test harness
- ensure scoring logs executed function lists for downstream analysis
- adjust coverage integration test for new coverage structure

## Testing
- `pytest sandbox_runner/tests/test_results_logger_sync.py -q`
- ⚠️ `pytest sandbox_runner/tests/test_coverage_integration.py -q` *(missing dependency: environment module requirements)*


------
https://chatgpt.com/codex/tasks/task_e_68b93b2e1488832ebff5a0a625a8e15f