### PR TITLE
Normalize paths in bot creation prompts

### DIFF
--- a/bot_creation_bot.py
+++ b/bot_creation_bot.py
@@ -37,6 +37,10 @@ from .database_manager import DB_PATH, update_model
 from vector_service.cognition_layer import CognitionLayer
 from .roi_tracker import ROITracker
 try:  # pragma: no cover - allow flat imports
+    from .dynamic_path_router import path_for_prompt
+except Exception:  # pragma: no cover - fallback for flat layout
+    from dynamic_path_router import path_for_prompt  # type: ignore
+try:  # pragma: no cover - allow flat imports
     from .intent_clusterer import IntentClusterer
     from .universal_retriever import UniversalRetriever
 except Exception:  # pragma: no cover - fallback for flat layout
@@ -435,8 +439,9 @@ class BotCreationBot(AdminBotBase):
             raise
         if self.self_coding_engine:
             try:
+                prompt_module = path_for_prompt(str(file_path))
                 _ctx, session_id = self.cognition_layer.query(
-                    f"self coding patch for {file_path}"
+                    f"self coding patch for {prompt_module}"
                 )
                 self.self_coding_engine.patch_file(file_path, "helper")
                 self.cognition_layer.record_patch_outcome(session_id, True, contribution=1.0)


### PR DESCRIPTION
## Summary
- normalize module paths inserted into bot creation prompts using `path_for_prompt`

## Testing
- `python tools/check_static_paths.py bot_creation_bot.py prompt_engine.py quick_fix_engine.py`
- `PYTHONPATH=. pytest tests/test_bot_creation_bot.py tests/test_prompt_engine.py tests/test_quick_fix_engine.py tests/test_self_coding_engine.py -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'Gauge')*


------
https://chatgpt.com/codex/tasks/task_e_68b93c3a7364832eb33e74a47407f5a7