### PR TITLE
chore: enforce centralized stripe imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,12 @@ repos:
         language: system
         pass_filenames: true
         files: '\.py$'
+      - id: forbid-stripe-imports
+        name: Prevent direct Stripe imports
+        entry: python scripts/check_stripe_imports.py
+        language: system
+        pass_filenames: true
+        files: '\.py$'
   - repo: https://github.com/pycqa/flake8
     rev: 6.1.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,5 +33,12 @@ wrapped by `resolve_path` or `path_for_prompt` to remain portable across forks
 and clones. The `tools/check_static_paths.py` pre-commit hook scans for these
 violations.
 
+## Stripe integration
+
+To centralize billing logic and API configuration, the `stripe` Python package
+must only be imported by `stripe_billing_router.py`. Other modules should rely
+on the router's helpers rather than interacting with Stripe directly. The
+`check-stripe-imports` pre-commit hook enforces this restriction.
+
 Before submitting a pull request, run `pre-commit run --all-files` to execute
 this and other checks locally.

--- a/scripts/check_stripe_imports.py
+++ b/scripts/check_stripe_imports.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Detect direct Stripe SDK imports outside ``stripe_billing_router.py``."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ALLOWED = {(REPO_ROOT / "stripe_billing_router.py").resolve()}  # path-ignore
+PATTERN = re.compile(r"^\s*(?:import stripe|from stripe\b)")
+
+
+def main() -> int:
+    offenders: list[str] = []
+    for filename in sys.argv[1:]:
+        path = Path(filename)
+        if not path.is_absolute():
+            path = (REPO_ROOT / path).resolve()
+        else:
+            path = path.resolve()
+        if path.suffix != ".py" or path in ALLOWED:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if PATTERN.search(line):
+                try:
+                    rel = path.relative_to(REPO_ROOT)
+                except ValueError:
+                    rel = path
+                offenders.append(f"{rel}:{lineno}:{line.strip()}")
+    if offenders:
+        print("Direct Stripe imports detected (use stripe_billing_router):")
+        for off in offenders:
+            print(off)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add lint script to flag direct stripe imports outside `stripe_billing_router.py`
- wire lint rule into pre-commit hooks
- document centralized stripe integration policy in contributing guide

## Testing
- `pre-commit run --files scripts/check_stripe_imports.py stripe_billing_router.py`


------
https://chatgpt.com/codex/tasks/task_e_68b93e1d128c832e8e98ea647ef0170b