### PR TITLE
Consolidate sandbox run logging

### DIFF
--- a/sandbox_runner/test_harness.py
+++ b/sandbox_runner/test_harness.py
@@ -444,21 +444,6 @@ def _run_once(
             entropy_delta=entropy_delta,
             executed_functions=executed_functions,
         )
-        try:
-            from .scoring import record_run as _score_record_run
-            _score_record_run(
-                res,
-                {
-                    "roi": (
-                        coverage_pct if coverage_pct is not None else (1.0 if res.success else 0.0)
-                    ),
-                    "coverage": coverage_map or {},
-                    "entropy_delta": entropy_delta,
-                    "executed_functions": executed_functions or [],
-                },
-            )
-        except Exception:  # pragma: no cover - best effort
-            logger.exception("failed to record test run")
         return res
     finally:
         if old_edge_env is None:

--- a/sandbox_runner/tests/test_run_metrics_persistence.py
+++ b/sandbox_runner/tests/test_run_metrics_persistence.py
@@ -1,0 +1,36 @@
+import json
+import sqlite3
+from types import SimpleNamespace
+
+import sandbox_runner.scoring as scoring
+import sandbox_results_logger as legacy
+
+
+def test_run_records_metrics(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    monkeypatch.setattr(scoring, "_LOG_DIR", log_dir)
+    monkeypatch.setattr(scoring, "_RUN_LOG", log_dir / "run_metrics.jsonl")
+    monkeypatch.setattr(scoring, "_SUMMARY_FILE", log_dir / "run_summary.json")
+    monkeypatch.setattr(legacy, "_LOG_DIR", log_dir)
+    monkeypatch.setattr(legacy, "_DB_PATH", log_dir / "run_metrics.db")
+
+    result = SimpleNamespace(success=True, duration=1.0, failure=None)
+    scoring.record_run(
+        result,
+        {
+            "roi": 1.0,
+            "coverage": {"file.py": ["func"]},
+            "entropy_delta": 0.1,
+            "executed_functions": ["file.py:func"],
+        },
+    )
+
+    assert scoring._RUN_LOG.read_text().count("\n") == 1
+    summary = json.loads(scoring._SUMMARY_FILE.read_text())
+    assert summary["runs"] == 1
+
+    conn = sqlite3.connect(log_dir / "run_metrics.db")
+    count = conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0]
+    conn.close()
+    assert count == 1
+


### PR DESCRIPTION
## Summary
- centralize run metric persistence and forward records to SQLite via `sandbox_results_logger`
- drop redundant run recording from the test harness
- add regression test to ensure run metrics hit JSONL, summary, and SQLite outputs

## Testing
- `PYTHONPATH=. MENACE_LIGHT_IMPORTS=1 pytest sandbox_runner/tests/test_results_logger_sync.py sandbox_runner/tests/test_run_metrics_persistence.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b93ceb3268832eb1feaa1f6420dcaa