### PR TITLE
Use stripe billing router with explicit bot identifiers

### DIFF
--- a/finance_router_bot.py
+++ b/finance_router_bot.py
@@ -11,8 +11,6 @@ from typing import Dict, List, Optional
 import asyncio
 import logging
 
-from dotenv import load_dotenv
-
 from dynamic_path_router import resolve_path
 
 from . import stripe_billing_router
@@ -37,6 +35,8 @@ class Transaction:
 class FinanceRouterBot:
     """Route payments and log payouts for Menace."""
 
+    BOT_ID = "finance:finance_router_bot:monetization"
+
     def __init__(
         self,
         payout_log_path: Path | str | None = None,
@@ -45,7 +45,6 @@ class FinanceRouterBot:
         event_bus: Optional[UnifiedEventBus] = None,
         memory_mgr: MenaceMemoryManager | None = None,
     ) -> None:
-        load_dotenv()
         self.capital_manager = capital_manager
         raw_log_path = str(
             payout_log_path
@@ -118,8 +117,8 @@ class FinanceRouterBot:
     def route_payment(self, amount: float, model_id: str) -> str:
         """Charge via Stripe and log the result."""
         try:
-            resp = stripe_billing_router.init_charge(
-                model_id,
+            resp = stripe_billing_router.charge(
+                self.BOT_ID,
                 amount,
                 description=model_id,
             )

--- a/investment_engine.py
+++ b/investment_engine.py
@@ -15,6 +15,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_BOT_ID = "finance:finance_router_bot:monetization"
+
 
 @dataclass
 class InvestmentRecord:
@@ -146,7 +148,7 @@ class AutoReinvestmentBot:
         minimum_threshold: float = 10.0,
         predictor: PredictiveSpendEngine | None = None,
         db: InvestmentDB | None = None,
-        bot_id: str = "finance:finance_router_bot:monetization",
+        bot_id: str = DEFAULT_BOT_ID,
     ) -> None:
         self.cap_percentage = cap_percentage
         self.safety_reserve = safety_reserve
@@ -162,7 +164,7 @@ class AutoReinvestmentBot:
 
     def _execute_spending(self, amount: float) -> str:
         try:
-            resp = stripe_billing_router.init_charge(
+            resp = stripe_billing_router.charge(
                 self.bot_id, amount, description="reinvestment"
             )
             status = resp.get("status")

--- a/tests/test_finance_router_bot.py
+++ b/tests/test_finance_router_bot.py
@@ -66,11 +66,11 @@ def test_route_and_summary(tmp_path, monkeypatch):
         calls["amount"] = amount
         return {"status": "succeeded"}
 
-    monkeypatch.setattr(frb.stripe_billing_router, "init_charge", fake_charge)
+    monkeypatch.setattr(frb.stripe_billing_router, "charge", fake_charge)
     bot = frb.FinanceRouterBot(payout_log_path=log)
     res = bot.route_payment(10.0, "model1")
     assert res
-    assert calls == {"bot_id": "model1", "amount": 10.0}
+    assert calls == {"bot_id": frb.FinanceRouterBot.BOT_ID, "amount": 10.0}
     data = json.loads(log.read_text())
     assert data and data[0]["model_id"] == "model1"
     summary = bot.report_earnings_summary()
@@ -86,10 +86,10 @@ def test_router_error_propagates(tmp_path, monkeypatch):
         calls["bot_id"] = bot_id
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(frb.stripe_billing_router, "init_charge", bad_charge)
+    monkeypatch.setattr(frb.stripe_billing_router, "charge", bad_charge)
     bot = frb.FinanceRouterBot(payout_log_path=log)
     res = bot.route_payment(5.0, "model2")
     assert res.startswith("error:")
-    assert calls["bot_id"] == "model2"
+    assert calls["bot_id"] == frb.FinanceRouterBot.BOT_ID
     data = json.loads(log.read_text())
     assert data and data[0]["result"].startswith("error:")


### PR DESCRIPTION
## Summary
- FinanceRouterBot now charges via stripe_billing_router with a fixed bot identifier
- AutoReinvestmentBot delegates spending through stripe_billing_router.charge
- Tests assert bots supply their domain:name:category when invoking the billing router

## Testing
- `python scripts/check_stripe_imports.py`
- `PYTHONPATH=$PWD pytest tests/test_finance_router_bot.py tests/test_investment_engine.py tests/test_stripe_billing_router.py tests/test_startup_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_68b940339578832e8d7542dfd17fe04d