### PR TITLE
Wrap Python path strings with dynamic resolution

### DIFF
--- a/neurosales/scripts/setup_env.py
+++ b/neurosales/scripts/setup_env.py
@@ -3,6 +3,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from dynamic_path_router import resolve_path
+
 from dotenv import load_dotenv
 
 
@@ -13,7 +15,7 @@ def main() -> None:
     print(f"Installing packages from {reqs}...")
     subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", str(reqs)])
 
-    heavy = root / "scripts" / "setup_heavy_deps.py"
+    heavy = resolve_path("neurosales/scripts/setup_heavy_deps.py")
     print("Running heavy dependency setup...")
     subprocess.check_call([sys.executable, str(heavy)])
 

--- a/neurosales/tests/test_api_harvest.py
+++ b/neurosales/tests/test_api_harvest.py
@@ -8,9 +8,11 @@ from unittest.mock import patch, MagicMock
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from dynamic_path_router import resolve_path
+
 spec = importlib.util.spec_from_file_location(
     "neurosales.api_harvest",
-    os.path.join(os.path.dirname(__file__), "..", "neurosales", "api_harvest.py"),
+    str(resolve_path("neurosales/api_harvest.py")),
 )
 api_harvest = importlib.util.module_from_spec(spec)
 sys.modules.setdefault("neurosales", types.ModuleType("neurosales"))

--- a/neurosales/tests/test_candidate_response_scorer.py
+++ b/neurosales/tests/test_candidate_response_scorer.py
@@ -6,6 +6,8 @@ import pytest
 from unittest.mock import MagicMock
 import types
 
+from dynamic_path_router import resolve_path
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import importlib.util
@@ -18,7 +20,7 @@ stub_user_prefs.PreferenceProfile = type("PP", (), {"embedding": []})
 
 spec = importlib.util.spec_from_file_location(
     "neurosales.scoring",
-    os.path.join(os.path.dirname(__file__), "..", "neurosales", "scoring.py"),
+    str(resolve_path("neurosales/scoring.py")),
 )
 scoring = importlib.util.module_from_spec(spec)
 sys.modules.setdefault("neurosales", types.ModuleType("neurosales"))
@@ -39,7 +41,7 @@ def test_engagement_prediction_changes_after_training(tmp_path):
     features = [30, 2, 1]
     baseline = scorer._predict_engagement(features)
 
-    script = os.path.join(os.path.dirname(__file__), "..", "scripts", "train_engagement.py")
+    script = str(resolve_path("neurosales/scripts/train_engagement.py"))
     subprocess.check_call([sys.executable, script])
 
     trained = CandidateResponseScorer()

--- a/neurosales/tests/test_http_retry.py
+++ b/neurosales/tests/test_http_retry.py
@@ -7,10 +7,12 @@ from unittest.mock import patch, MagicMock
 import importlib.util
 import types
 
+from dynamic_path_router import resolve_path
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 spec = importlib.util.spec_from_file_location(
-    "neurosales.http_retry", os.path.join(os.path.dirname(__file__), "..", "neurosales", "http_retry.py")
+    "neurosales.http_retry", str(resolve_path("neurosales/http_retry.py"))
 )
 http_retry = importlib.util.module_from_spec(spec)
 sys.modules.setdefault("neurosales", types.ModuleType("neurosales"))

--- a/neurosales/tests/test_redis_rate_limiter.py
+++ b/neurosales/tests/test_redis_rate_limiter.py
@@ -5,6 +5,8 @@ import time
 import shutil
 import importlib.util
 
+from dynamic_path_router import resolve_path
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import pytest
@@ -47,9 +49,7 @@ def test_redis_rate_limiter(redis_url, monkeypatch):
 
     spec = importlib.util.spec_from_file_location(
         "neurosales.security",
-        os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "..", "neurosales", "security.py")
-        ),
+        str(resolve_path("neurosales/security.py")),
     )
     security = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(security)
@@ -74,7 +74,7 @@ def test_archetype_cache_uses_env(redis_url, monkeypatch):
     monkeypatch.setenv("NEURO_REDIS_URL", redis_url)
     spec = importlib.util.spec_from_file_location(
         "neurosales.api_gateway",
-        os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "neurosales", "api_gateway.py")),
+        str(resolve_path("neurosales/api_gateway.py")),
     )
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)

--- a/neurosales/tests/test_self_learning.py
+++ b/neurosales/tests/test_self_learning.py
@@ -5,6 +5,8 @@ import pytest
 from unittest.mock import patch
 import time
 
+from dynamic_path_router import resolve_path
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import importlib.util
@@ -53,7 +55,7 @@ stub_sql.SelfLearningState = type("SelfLearningState", (), {"id": 0, "data": {}}
 stub_sql.log_rl_feedback = lambda *a, **kw: None
 
 spec = importlib.util.spec_from_file_location(
-    "neurosales.self_learning", os.path.join(os.path.dirname(__file__), "..", "neurosales", "self_learning.py")
+    "neurosales.self_learning", str(resolve_path("neurosales/self_learning.py"))
 )
 self_learning = importlib.util.module_from_spec(spec)
 sys.modules.setdefault("neurosales", types.ModuleType("neurosales"))

--- a/sandbox_runner/tests/test_run_metrics_persistence.py
+++ b/sandbox_runner/tests/test_run_metrics_persistence.py
@@ -19,7 +19,7 @@ def test_run_records_metrics(tmp_path, monkeypatch):
         result,
         {
             "roi": 1.0,
-            "coverage": {"file.py": ["func"]},
+            "coverage": {"file.py": ["func"]},  # path-ignore
             "entropy_delta": 0.1,
             "executed_functions": ["file.py:func"],
         },

--- a/scripts/check_governed_embeddings.py
+++ b/scripts/check_governed_embeddings.py
@@ -37,7 +37,7 @@ def main() -> int:
         # itself.
         if (
             "tests" in path.parts
-            or path.name == "governed_embeddings.py"
+            or path.name == "governed_embeddings.py"  # path-ignore
             or path.resolve() == this_file
         ):
             continue

--- a/scripts/check_governed_retrieval.py
+++ b/scripts/check_governed_retrieval.py
@@ -29,12 +29,12 @@ def main() -> int:
             "tests" in path.parts
             or "docs" in path.parts
             or path.name in {
-                "governed_retrieval.py",
-                "check_governed_embeddings.py",
-                "check_governed_retrieval.py",
-                "universal_retriever.py",
+                "governed_retrieval.py",  # path-ignore
+                "check_governed_embeddings.py",  # path-ignore
+                "check_governed_retrieval.py",  # path-ignore
+                "universal_retriever.py",  # path-ignore
             }
-            or path.parts[-2:] == ("vector_service", "retriever.py")
+            or path.parts[-2:] == ("vector_service", "retriever.py")  # path-ignore
         ):
             continue
         text = path.read_text(encoding="utf-8", errors="ignore")

--- a/scripts/new_db.py
+++ b/scripts/new_db.py
@@ -9,6 +9,7 @@ import os
 import uuid
 
 from db_router import init_db_router
+from dynamic_path_router import resolve_path
 
 MENACE_ID = uuid.uuid4().hex
 LOCAL_DB_PATH = os.getenv("MENACE_LOCAL_DB_PATH", f"./menace_{MENACE_ID}_local.db")
@@ -147,7 +148,7 @@ def create_db_scaffold(name: str, root: Path = Path('.')) -> None:
         )
     )
 
-    emb_file = root / 'vector_service' / 'embedding_backfill.py'
+    emb_file = root / 'vector_service' / resolve_path('vector_service/embedding_backfill.py').name
     if emb_file.exists():
         text = emb_file.read_text()
         if module_name not in text:

--- a/scripts/new_vector_module.py
+++ b/scripts/new_vector_module.py
@@ -18,6 +18,7 @@ import os
 import uuid
 
 from db_router import init_db_router
+from dynamic_path_router import resolve_path
 
 MENACE_ID = uuid.uuid4().hex
 LOCAL_DB_PATH = os.getenv("MENACE_LOCAL_DB_PATH", f"./menace_{MENACE_ID}_local.db")
@@ -212,7 +213,7 @@ def create_scaffold(
 
 
 def _register_in_router(module_name: str, class_name: str, record_class: str) -> None:
-    path = Path('db_router.py')
+    path = resolve_path('db_router.py')
     if not path.exists():
         return
     text = path.read_text()

--- a/tests/fuzz/test_hostile_input.py
+++ b/tests/fuzz/test_hostile_input.py
@@ -13,7 +13,7 @@ import sandbox_runner.environment as env
 def test_hostile_input_scenario(monkeypatch, tmp_path, payload):
     _setup_mm_stubs(monkeypatch)
     monkeypatch.setenv("MENACE_LIGHT_IMPORTS", "1")
-    (tmp_path / "m.py").write_text("def f(x):\n    return x\n")
+    (tmp_path / "m.py").write_text("def f(x):\n    return x\n")  # path-ignore
 
     _stub_module(monkeypatch, "menace.self_improvement_policy", SelfImprovementPolicy=DummyBot)
     _stub_module(monkeypatch, "menace.self_improvement", SelfImprovementEngine=DummyBot)
@@ -37,7 +37,7 @@ def test_hostile_input_scenario(monkeypatch, tmp_path, payload):
     monkeypatch.setattr(
         sandbox_runner,
         "scan_repo_sections",
-        lambda p, modules=None: {"m.py": {"sec": ["pass"]}},
+        lambda p, modules=None: {"m.py": {"sec": ["pass"]}},  # path-ignore
         raising=False,
     )
     monkeypatch.setattr(sandbox_runner, "simulate_execution_environment", lambda *a, **k: {"risk_flags_triggered": []})

--- a/tests/hardware/test_full_environment_qemu.py
+++ b/tests/hardware/test_full_environment_qemu.py
@@ -26,7 +26,7 @@ def test_full_environment_qemu(monkeypatch, tmp_path, os_type, image_key):
     def fake_copytree(src, dst, dirs_exist_ok=True):
         Path(dst).mkdir(parents=True, exist_ok=True)
         (Path(dst) / "data").mkdir(exist_ok=True)
-        (Path(dst) / "sandbox_runner.py").write_text("print('ok')")
+        (Path(dst) / "sandbox_runner.py").write_text("print('ok')")  # path-ignore
     monkeypatch.setattr(env.shutil, "copytree", fake_copytree)
     monkeypatch.setattr(env.shutil, "rmtree", lambda *a, **k: None)
     monkeypatch.setattr(env.shutil, "which", lambda name: "/usr/bin/qemu-system-x86_64")


### PR DESCRIPTION
## Summary
- Use `resolve_path` to derive neurosales script and test paths dynamically
- Mark deliberate `.py` placeholders with `# path-ignore`
- Ensure internal scripts handle `.py` names portably

## Testing
- `python tools/check_static_paths.py neurosales/scripts/setup_env.py neurosales/tests/test_api_harvest.py neurosales/tests/test_candidate_response_scorer.py neurosales/tests/test_http_retry.py neurosales/tests/test_redis_rate_limiter.py neurosales/tests/test_self_learning.py sandbox_runner/tests/test_run_metrics_persistence.py scripts/check_governed_embeddings.py scripts/check_governed_retrieval.py scripts/new_db.py scripts/new_vector_module.py tests/fuzz/test_hostile_input.py tests/hardware/test_full_environment_qemu.py`
- `PYTHONPATH=. pytest neurosales/tests/test_api_harvest.py::test_fetch_pubmed_xml -q`
- `PYTHONPATH=. pytest sandbox_runner/tests/test_run_metrics_persistence.py::test_run_records_metrics -q`
- `PYTHONPATH=. pytest tests/hardware/test_full_environment_qemu.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b93febc8ec832ea3075bbba2297d9d