### PR TITLE
ci: add static path check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,18 @@ on:
         default: 'false'
 
 jobs:
+  static-paths:
+    runs-on: ubuntu-latest
+    env:
+      MENACE_SAFE: "1"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Check for static path references
+        run: "python tools/check_static_paths.py $(git ls-files '*.py')"
+
   tests:
     runs-on: ubuntu-latest
     env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,8 @@ Avoid hard coding string literals that end with `.py`. Such paths must be
 wrapped by `resolve_path` or `path_for_prompt` to remain portable across forks
 and clones. The `tools/check_static_paths.py` pre-commit hook scans for these
 violations.
+CI enforces this rule by running `python tools/check_static_paths.py $(git ls-files '*.py')`,
+and the workflow fails if any static path is detected.
 
 ## Stripe integration
 


### PR DESCRIPTION
## Summary
- run static path scan across all Python files in CI
- document static path enforcement in contributor guide

## Testing
- `pre-commit run --files .github/workflows/tests.yml CONTRIBUTING.md`
- `python tools/check_static_paths.py $(git ls-files '*.py')` *(fails: static path 'orphan2.py' not wrapped with resolve_path or path_for_prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b941b6857c832ebad91dfaa0e50b70