### PR TITLE
Log sandbox run metrics

### DIFF
--- a/sandbox_runner/test_harness.py
+++ b/sandbox_runner/test_harness.py
@@ -445,6 +445,16 @@ def _run_once(
             entropy_delta=entropy_delta,
             executed_functions=executed_functions,
         )
+        record_run(
+            result=res,
+            metrics={
+                "runtime": duration,
+                "entropy_delta": entropy_delta,
+                "coverage": coverage_map,
+                "executed_functions": executed_functions,
+                "failure": failure,
+            },
+        )
         return res
     finally:
         if old_edge_env is None:
@@ -565,6 +575,7 @@ def run_tests(
                         "executed_functions": res.executed_functions,
                         "entropy_delta": res.entropy_delta,
                         "runtime": res.duration,
+                        "failure": res.failure,
                     },
                 )
                 results.append(res)


### PR DESCRIPTION
## Summary
- forward per-run metrics from `_run_once` to `record_run`
- propagate run details including failures from `run_tests` to scoring

## Testing
- `PYTHONPATH=. pytest -q sandbox_runner/tests/test_run_metrics_persistence.py sandbox_runner/tests/test_results_logger_sync.py unit_tests/test_entropy_delta_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9442f16d4832ebc954181d8a0c6fd