### PR TITLE
test: cover nested repository path resolution

### DIFF
--- a/tests/test_resolve_path_nested_repo.py
+++ b/tests/test_resolve_path_nested_repo.py
@@ -3,6 +3,8 @@ import os
 import shutil
 from pathlib import Path
 
+import pytest
+
 
 def test_resolve_path_in_nested_clone(monkeypatch, tmp_path):
     project_root = Path(__file__).resolve().parents[1]
@@ -45,3 +47,89 @@ def test_resolve_path_in_nested_clone(monkeypatch, tmp_path):
     ).resolve()
 
     assert calls
+
+
+def test_get_project_root_and_resolve_path_with_nested_repos(monkeypatch, tmp_path):
+    project_root = Path(__file__).resolve().parents[1]
+
+    outer = tmp_path / "outer_repo"
+    inner = outer / "inner_repo"
+    (outer / ".git").mkdir(parents=True)
+    (inner / ".git").mkdir(parents=True)
+    (inner / "nested" / "deep").mkdir(parents=True)
+
+    monkeypatch.delenv("SANDBOX_REPO_PATH", raising=False)
+    monkeypatch.delenv("MENACE_ROOT", raising=False)
+
+    shutil.copy(project_root / "dynamic_path_router.py", outer / "dynamic_path_router.py")
+    shutil.copy(project_root / "dynamic_path_router.py", inner / "dynamic_path_router.py")
+
+    (outer / "outer_file.py").write_text("outer")
+    (inner / "inner_file.py").write_text("inner")
+
+    spec_outer = importlib.util.spec_from_file_location(
+        "dynamic_path_router_outer", outer / "dynamic_path_router.py"
+    )
+    dr_outer = importlib.util.module_from_spec(spec_outer)
+    assert spec_outer.loader
+    spec_outer.loader.exec_module(dr_outer)
+
+    spec_inner = importlib.util.spec_from_file_location(
+        "dynamic_path_router_inner", inner / "dynamic_path_router.py"
+    )
+    dr_inner = importlib.util.module_from_spec(spec_inner)
+    assert spec_inner.loader
+    spec_inner.loader.exec_module(dr_inner)
+
+    monkeypatch.chdir(inner / "nested" / "deep")
+
+    dr_outer.clear_cache()
+    assert dr_outer.get_project_root() == outer.resolve()
+    assert dr_outer.resolve_path("outer_file.py") == (outer / "outer_file.py").resolve()
+
+    dr_inner.clear_cache()
+    assert dr_inner.get_project_root() == inner.resolve()
+    assert dr_inner.resolve_path("inner_file.py") == (inner / "inner_file.py").resolve()
+
+
+def test_multiple_repos_shared_parent(monkeypatch, tmp_path):
+    project_root = Path(__file__).resolve().parents[1]
+
+    parent = tmp_path / "parent"
+    repo_a = parent / "repo_a"
+    repo_b = parent / "repo_b"
+    for repo in (repo_a, repo_b):
+        (repo / ".git").mkdir(parents=True)
+        shutil.copy(project_root / "dynamic_path_router.py", repo / "dynamic_path_router.py")
+        (repo / "target.py").write_text(repo.name)
+
+    monkeypatch.delenv("SANDBOX_REPO_PATH", raising=False)
+    monkeypatch.delenv("MENACE_ROOT", raising=False)
+
+    spec_a = importlib.util.spec_from_file_location(
+        "dynamic_path_router_a", repo_a / "dynamic_path_router.py"
+    )
+    dr_a = importlib.util.module_from_spec(spec_a)
+    assert spec_a.loader
+    spec_a.loader.exec_module(dr_a)
+
+    spec_b = importlib.util.spec_from_file_location(
+        "dynamic_path_router_b", repo_b / "dynamic_path_router.py"
+    )
+    dr_b = importlib.util.module_from_spec(spec_b)
+    assert spec_b.loader
+    spec_b.loader.exec_module(dr_b)
+
+    monkeypatch.chdir(repo_a)
+    dr_a.clear_cache()
+    assert dr_a.get_project_root() == repo_a.resolve()
+    assert dr_a.resolve_path("target.py") == (repo_a / "target.py").resolve()
+    with pytest.raises(FileNotFoundError):
+        dr_a.resolve_path("missing.py")
+
+    monkeypatch.chdir(repo_b)
+    dr_b.clear_cache()
+    assert dr_b.get_project_root() == repo_b.resolve()
+    assert dr_b.resolve_path("target.py") == (repo_b / "target.py").resolve()
+    with pytest.raises(FileNotFoundError):
+        dr_b.resolve_path("missing.py")


### PR DESCRIPTION
## Summary
- add test verifying get_project_root and resolve_path in nested repositories
- add test verifying path resolution with multiple sibling repos

## Testing
- `PYTHONPATH=. pytest tests/test_resolve_path_nested_repo.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b944389c2c832e83b3618ac9bc9f13