### PR TITLE
Ensure sandbox override paths resolve via dynamic router

### DIFF
--- a/environment_generator.py
+++ b/environment_generator.py
@@ -236,7 +236,8 @@ def _load_keyword_overrides() -> Dict[str, List[str]]:
 
     path = os.getenv("SANDBOX_SETTINGS_YAML", "sandbox_settings.yaml")
     try:
-        with open(path, "r", encoding="utf-8") as fh:
+        resolved = resolve_path(path)
+        with resolved.open("r", encoding="utf-8") as fh:
             data = yaml.safe_load(fh) or {}
     except FileNotFoundError:
         return {}

--- a/unit_tests/test_environment_generator_keyword_overrides.py
+++ b/unit_tests/test_environment_generator_keyword_overrides.py
@@ -1,0 +1,33 @@
+import importlib
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+
+def test_load_keyword_overrides_repo_moved(tmp_path, monkeypatch):
+    config = "keyword_profiles:\n  sample: [alpha, beta]\n"
+    moved_root = tmp_path / "moved_repo"
+    moved_root.mkdir()
+    (moved_root / "sandbox_settings.yaml").write_text(config, encoding="utf-8")
+
+    monkeypatch.setenv("SANDBOX_REPO_PATH", str(moved_root))
+    monkeypatch.setenv("SANDBOX_SETTINGS_YAML", "sandbox_settings.yaml")
+
+    sys.modules.pop("dynamic_path_router", None)
+    spec = importlib.util.spec_from_file_location(
+        "dynamic_path_router",
+        pathlib.Path(__file__).resolve().parents[1] / "dynamic_path_router.py",
+    )
+    dynamic_path_router = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(dynamic_path_router)
+    dynamic_path_router._PROJECT_ROOT = None  # type: ignore[attr-defined]
+    dynamic_path_router._PATH_CACHE.clear()  # type: ignore[attr-defined]
+
+    sys.modules.pop("environment_generator", None)
+    env_gen = importlib.import_module("environment_generator")
+
+    overrides = env_gen._load_keyword_overrides()
+    assert overrides == {"sample": ["alpha", "beta"]}


### PR DESCRIPTION
## Summary
- resolve sandbox override path using `resolve_path`
- test keyword overrides loading when repository root changes

## Testing
- `PYTHONPATH=. pytest unit_tests/test_environment_generator_keyword_overrides.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b94642c11c832e9122e5f99fb28007