### PR TITLE
Resolve data_dir in generate_presets_from_history

### DIFF
--- a/environment_generator.py
+++ b/environment_generator.py
@@ -1925,7 +1925,11 @@ def generate_presets_from_history(
     data_dir: str = "sandbox_data", count: int | None = None
 ) -> List[Dict[str, Any]]:
     """Return presets adapted using ROI/security history from ``data_dir``."""
-    history_path = Path(data_dir) / "roi_history.json"
+    try:
+        data_dir = resolve_path(data_dir)
+    except FileNotFoundError:
+        data_dir = Path(data_dir)
+    history_path = data_dir / "roi_history.json"
     try:
         history = str(resolve_path(history_path))
     except FileNotFoundError:


### PR DESCRIPTION
## Summary
- resolve preset history directory with `resolve_path` before reading history
- add regression test to ensure `generate_presets_from_history` works with relocated repo roots

## Testing
- `pre-commit run --files environment_generator.py tests/test_adapt_presets.py`
- `python tests/test_adapt_presets.py::test_generate_presets_from_history_resolves_data_dir (via manual invocation)`
- `pytest tests/test_adapt_presets.py::test_generate_presets_from_history_calls_adapt -q (ImportError: No module named 'dynamic_path_router')`


------
https://chatgpt.com/codex/tasks/task_e_68b9478068e8832ea495a6497ce3e816