### PR TITLE
test: add stripe billing router coverage

### DIFF
--- a/tests/test_finance_router_bot.py
+++ b/tests/test_finance_router_bot.py
@@ -22,6 +22,7 @@ def _import_finance_router(monkeypatch):
         )
         module = importlib.util.module_from_spec(spec)
         sys.modules[f"frbpkg.{name}"] = module
+        sys.modules[name] = module
         assert spec.loader is not None
         spec.loader.exec_module(module)
         return module
@@ -52,6 +53,7 @@ def _import_finance_router(monkeypatch):
     )
     sbr = _load("stripe_billing_router")
     sys.modules["frbpkg.stripe_billing_router"] = sbr
+    sys.modules["stripe_billing_router"] = sbr
 
     return _load("finance_router_bot")
 

--- a/tests/test_investment_engine.py
+++ b/tests/test_investment_engine.py
@@ -1,9 +1,10 @@
 import importlib.util
-import importlib.util
 import sys
 import types
 from pathlib import Path
 
+# Tests previously mocked a deprecated ``stripe_handler``.  These tests ensure
+# ``stripe_billing_router`` is patched instead.
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -19,6 +20,7 @@ def _import_investment_engine(monkeypatch):
         )
         module = importlib.util.module_from_spec(spec)
         sys.modules[f"iepkg.{name}"] = module
+        sys.modules[name] = module
         assert spec.loader is not None
         spec.loader.exec_module(module)
         return module
@@ -34,6 +36,7 @@ def _import_investment_engine(monkeypatch):
     )
     sbr = _load("stripe_billing_router")
     sys.modules["iepkg.stripe_billing_router"] = sbr
+    sys.modules["stripe_billing_router"] = sbr
     dbm = _load("db_router")
     dbm.GLOBAL_ROUTER = None
     sys.modules["db_router"] = dbm


### PR DESCRIPTION
## Summary
- add focused tests for `stripe_billing_router` covering routing, error cases, and overrides
- ensure finance router and investment engine tests patch `stripe_billing_router` directly

## Testing
- `python - <<'PY'
import sys, types, pathlib, pytest
ROOT = pathlib.Path('.').resolve(); pkg = types.ModuleType('menace_sandbox'); pkg.__path__=[str(ROOT)]; sys.modules['menace_sandbox']=pkg; sys.modules['menace']=pkg
sys.modules['dynamic_path_router'] = types.SimpleNamespace(resolve_path=lambda p: p, resolve_dir=lambda p: pathlib.Path(p))
sys.modules['sandbox_settings'] = types.SimpleNamespace(SandboxSettings=lambda: None, load_sandbox_settings=lambda: None)
pytest.main(['tests/test_stripe_billing_router.py','tests/test_finance_router_bot.py','tests/test_investment_engine.py','--noconftest','--import-mode=importlib'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b947616cec832ea0b65c2861138652