### PR TITLE
Add extension support to dynamic path checker

### DIFF
--- a/tests/test_dynamic_paths.py
+++ b/tests/test_dynamic_paths.py
@@ -1,0 +1,51 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKER = ROOT / "tools" / "check_dynamic_paths.py"  # path-ignore
+
+
+@pytest.mark.parametrize("filename", [
+    "config.yaml",
+    "data.json",
+    "records.db",
+])
+def test_extension_triggers(tmp_path, filename) -> None:
+    target = tmp_path / "sample.py"
+    target.write_text(f'PATH = "{filename}"\n', encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(CHECKER), str(target)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "missing resolve_path" in result.stdout
+
+
+def test_sandbox_settings_yaml_trigger(tmp_path) -> None:
+    target = tmp_path / "sample.py"
+    target.write_text('NAME = "sandbox_settings.yaml"\n', encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(CHECKER), str(target)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "missing resolve_path" in result.stdout
+
+
+def test_resolve_path_suppresses_warning(tmp_path) -> None:
+    target = tmp_path / "sample.py"
+    target.write_text(
+        'NAME = "sandbox_settings.yaml"\nresolve_path("sandbox_settings.yaml")\n',
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [sys.executable, str(CHECKER), str(target)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tools/check_dynamic_paths.py
+++ b/tools/check_dynamic_paths.py
@@ -17,12 +17,23 @@ from typing import Iterable
 TRIGGER_SUBSTRINGS = ["sandbox_data"]
 SCRIPT_NAME = Path(__file__).name
 
+# File extensions that should be treated as potential path references. ``.py``
+# continues to require a ``/`` in the string to avoid false positives on module
+# names, while the other extensions are flagged regardless of the presence of a
+# path separator so that bare filenames like ``sandbox_settings.yaml`` are
+# caught.
+_EXTENSIONS_NEED_SLASH = (".py",)
+_EXTENSIONS_ALWAYS = (".yaml", ".yml", ".json", ".db")
+
 
 def _triggers(value: str) -> bool:
-    return (
-        any(sub in value for sub in TRIGGER_SUBSTRINGS)
-        or ("/" in value and value.endswith(".py"))
-    )
+    if any(sub in value for sub in TRIGGER_SUBSTRINGS):
+        return True
+    if any(value.endswith(ext) for ext in _EXTENSIONS_ALWAYS):
+        return True
+    if "/" in value and any(value.endswith(ext) for ext in _EXTENSIONS_NEED_SLASH):
+        return True
+    return False
 
 
 class _Visitor(ast.NodeVisitor):


### PR DESCRIPTION
## Summary
- extend `check_dynamic_paths.py` to flag `.yaml`, `.json`, and `.db` references and detect bare filenames
- add tests validating new extensions and `sandbox_settings.yaml`

## Testing
- `python tools/check_dynamic_paths.py $(git ls-files '*.py')`
- `PYTHONPATH=. pytest tests/test_dynamic_paths.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b949fd94e0832e9a9eaa27eb53a946