### PR TITLE
Extend edge case generator with network anomalies

### DIFF
--- a/sandbox_runner/edge_case_generator.py
+++ b/sandbox_runner/edge_case_generator.py
@@ -1,8 +1,10 @@
 """Utilities for generating edge case test inputs.
 
 This module emits a set of payloads covering common edge cases used during
-sandbox testing. The payloads intentionally contain malformed JSON, timeout
-sentinels, null/empty strings and other invalid formats.
+sandbox testing.  The payloads intentionally contain malformed JSON, timeout
+sentinels, null/empty strings and other invalid formats.  Network/API
+anomalies are also provided via mock URLs allowing callers to stub out
+HTTP responses without performing real network requests.
 """
 
 from __future__ import annotations
@@ -32,6 +34,48 @@ def null_or_empty() -> list[str | None]:
 def invalid_format() -> str:
     """Return data in an unexpected format."""
     return "not a valid format"
+
+
+def malformed_json_response() -> str:
+    """Return a network response containing malformed JSON."""
+    return malformed_json()
+
+
+def http_timeout_marker() -> str:
+    """Return a marker representing an HTTP timeout."""
+    return timeout_sentinel()
+
+
+def empty_payload() -> str:
+    """Return an empty network payload."""
+    return ""
+
+
+def null_payload() -> None:
+    """Return a null network payload."""
+    none, _ = null_or_empty()
+    return none
+
+
+def invalid_payload_format() -> str:
+    """Return network data in an unexpected format."""
+    return invalid_format()
+
+
+def network_anomalies() -> Dict[str, Any]:
+    """Return mapping of URLs to anomalous network responses.
+
+    Keys are mock URLs consumed by network interceptors in tests.  Each value
+    mirrors the corresponding local edge case variant.
+    """
+    none_val, empty_val = null_or_empty()
+    return {
+        "http://edge-case.test/malformed": malformed_json_response(),
+        "http://edge-case.test/timeout": http_timeout_marker(),
+        "http://edge-case.test/empty": empty_val,
+        "http://edge-case.test/null": none_val,
+        "http://edge-case.test/invalid": invalid_payload_format(),
+    }
 
 
 def _load_extra_payloads() -> Dict[str, Any]:
@@ -69,10 +113,23 @@ def _load_extra_payloads() -> Dict[str, Any]:
 
 
 def generate_edge_cases() -> Dict[str, Any]:
-    """Return a mapping of filenames to edge case payloads.
+    """Return a mapping of filenames and URLs to edge case payloads.
 
     The set can be extended via ``SANDBOX_HOSTILE_PAYLOADS`` or
     ``SANDBOX_HOSTILE_PAYLOADS_FILE``.
+
+    Network mock keys:
+
+    ``http://edge-case.test/malformed``
+        Malformed JSON response.
+    ``http://edge-case.test/timeout``
+        Timeout sentinel payload.
+    ``http://edge-case.test/empty``
+        Empty string payload.
+    ``http://edge-case.test/null``
+        ``None`` payload.
+    ``http://edge-case.test/invalid``
+        Unexpected format payload.
     """
     none_value, empty_value = null_or_empty()
     cases = {
@@ -82,5 +139,6 @@ def generate_edge_cases() -> Dict[str, Any]:
         "null.txt": none_value,
         "invalid.bin": invalid_format(),
     }
+    cases.update(network_anomalies())
     cases.update(_load_extra_payloads())
     return cases

--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -146,15 +146,23 @@ def get_edge_case_profiles() -> list[dict[str, Any]]:
     none_val, empty_val = _ec_null_or_empty()
     profiles: list[dict[str, Any]] = []
     if _edge_case_enabled("malformed_json"):
-        profiles.append({"malformed.json": _ec_malformed_json()})
+        val = _ec_malformed_json()
+        profiles.append({"malformed.json": val})
+        profiles.append({"http://edge-case.test/malformed": val})
     if _edge_case_enabled("timeouts"):
-        profiles.append({"timeout": _ec_timeout()})
+        val = _ec_timeout()
+        profiles.append({"timeout": val})
+        profiles.append({"http://edge-case.test/timeout": val})
     if _edge_case_enabled("nulls"):
         profiles.append({"null.txt": none_val})
+        profiles.append({"http://edge-case.test/null": none_val})
     if _edge_case_enabled("empty_strings"):
         profiles.append({"empty.txt": empty_val})
+        profiles.append({"http://edge-case.test/empty": empty_val})
     if _edge_case_enabled("invalid_formats"):
-        profiles.append({"invalid.bin": _ec_invalid_format()})
+        val = _ec_invalid_format()
+        profiles.append({"invalid.bin": val})
+        profiles.append({"http://edge-case.test/invalid": val})
     return profiles
 
 

--- a/sandbox_runner/test_harness.py
+++ b/sandbox_runner/test_harness.py
@@ -18,6 +18,7 @@ import sys
 import tempfile
 import time
 import json
+import urllib.parse
 from typing import Any
 
 
@@ -168,6 +169,9 @@ def _run_once(
             if edge_data:
                 for name, payload in edge_data.items():
                     try:
+                        scheme = urllib.parse.urlparse(name).scheme
+                        if scheme in {"http", "https"}:
+                            continue
                         dest = tmpdir / name
                         dest.parent.mkdir(parents=True, exist_ok=True)
                         content = (
@@ -522,6 +526,9 @@ def run_tests(
                 if edge_cases:
                     for name, payload in edge_cases.items():
                         try:
+                            scheme = urllib.parse.urlparse(name).scheme
+                            if scheme in {"http", "https"}:
+                                continue
                             dest = repo_tmp / name
                             dest.parent.mkdir(parents=True, exist_ok=True)
                             content = (

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -29,6 +29,11 @@ def test_generate_edge_cases_defaults():
         "empty.txt",
         "null.txt",
         "invalid.bin",
+        "http://edge-case.test/malformed",
+        "http://edge-case.test/timeout",
+        "http://edge-case.test/empty",
+        "http://edge-case.test/null",
+        "http://edge-case.test/invalid",
     }.issubset(cases.keys())
 
 


### PR DESCRIPTION
## Summary
- add network/API anomaly generators and URL-based payloads
- expand environment profile and harness support for network edge cases
- cover network payloads in tests

## Testing
- `PYTHONPATH=. pytest tests/test_edge_cases.py sandbox_runner/tests/test_edge_case_profiles.py`
- `PYTHONPATH=. pytest tests/test_edge_cases.py sandbox_runner/tests/test_edge_case_stubs_injection.py sandbox_runner/tests/test_edge_case_profiles.py` *(fails: ImportError: cannot import name 'resolve_dir')*

------
https://chatgpt.com/codex/tasks/task_e_68b9450ca970832ea9861f040f9d3799