### PR TITLE
Use dynamic path resolution in sandbox runner modules

### DIFF
--- a/sandbox_runner/edge_case_generator.py
+++ b/sandbox_runner/edge_case_generator.py
@@ -13,6 +13,8 @@ import json
 from pathlib import Path
 import yaml
 
+from dynamic_path_router import resolve_path
+
 
 def malformed_json() -> str:
     """Return a JSON string with broken syntax."""
@@ -52,7 +54,10 @@ def _load_extra_payloads() -> Dict[str, Any]:
 
     file_path = os.getenv("SANDBOX_HOSTILE_PAYLOADS_FILE")
     if file_path:
-        path = Path(file_path)
+        try:
+            path = Path(resolve_path(file_path))
+        except FileNotFoundError:
+            path = Path(file_path)
         if path.exists():
             try:
                 content = path.read_text(encoding="utf-8")

--- a/sandbox_runner/input_history_db.py
+++ b/sandbox_runner/input_history_db.py
@@ -7,6 +7,7 @@ from typing import Any, List
 import json
 import threading
 
+from dynamic_path_router import resolve_path
 from db_router import GLOBAL_ROUTER, init_db_router
 
 router = GLOBAL_ROUTER or init_db_router("sandbox_runner_input_history_db")
@@ -22,7 +23,13 @@ class InputHistoryDB:
     """Simple SQLite-backed store for sandbox input stubs."""
 
     def __init__(self, path: Path | str = "input_history.db") -> None:
-        self.path = Path(path)
+        if isinstance(path, Path):
+            self.path = path
+        else:
+            try:
+                self.path = Path(resolve_path(path))
+            except FileNotFoundError:
+                self.path = Path(resolve_path(".")) / path
         self._lock = threading.Lock()
         conn = router.get_connection("history")
         conn.execute(

--- a/sandbox_runner/test_harness.py
+++ b/sandbox_runner/test_harness.py
@@ -20,6 +20,8 @@ import time
 import json
 from typing import Any
 
+from dynamic_path_router import resolve_path
+
 
 from ..error_parser import ErrorParser
 from sandbox_settings import SandboxSettings
@@ -123,6 +125,13 @@ def _run_once(
         tests within it.  ``"docker"`` executes tests inside a temporary Docker
         container.  Defaults to ``"venv"`` for backward compatibility.
     """
+
+    repo_path = Path(resolve_path(str(repo_path)))
+    if changed_path:
+        try:
+            changed_path = Path(resolve_path(str(changed_path)))
+        except FileNotFoundError:
+            changed_path = Path(changed_path)
 
     start = time.time()
     if clone_repo:

--- a/sandbox_runner/tests/test_path_resolution_after_relocation.py
+++ b/sandbox_runner/tests/test_path_resolution_after_relocation.py
@@ -1,0 +1,109 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+sys.modules.pop("dynamic_path_router", None)
+from dynamic_path_router import clear_cache, resolve_path
+from sandbox_runner.edge_case_generator import generate_edge_cases
+from sandbox_runner.metrics_plugins import discover_metrics_plugins
+from sandbox_runner.input_history_db import InputHistoryDB
+from sandbox_runner.workflow_sandbox_runner import WorkflowSandboxRunner
+
+
+def test_edge_case_file_resolves_after_repo_move(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    cfg = repo / "payloads.json"
+    cfg.write_text('{"extra.txt": "data"}', encoding="utf-8")
+    clear_cache()
+    monkeypatch.setenv("SANDBOX_REPO_PATH", str(repo))
+    monkeypatch.setenv("SANDBOX_HOSTILE_PAYLOADS_FILE", "payloads.json")
+    cases = generate_edge_cases()
+    assert "extra.txt" in cases
+
+
+def test_metrics_plugins_config_resolves_after_repo_move(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    plugin_dir = repo / "plugins"
+    plugin_dir.mkdir()
+    (plugin_dir / "p.py").write_text(
+        "def collect_metrics(prev, cur, res):\n    return {'x': 1}\n",
+        encoding="utf-8",
+    )
+    cfg = repo / "metrics.yaml"
+    cfg.write_text("plugin_dirs:\n  - plugins\n", encoding="utf-8")
+    clear_cache()
+    monkeypatch.setenv("SANDBOX_REPO_PATH", str(repo))
+    monkeypatch.setenv("SANDBOX_METRICS_FILE", "metrics.yaml")
+    plugins = discover_metrics_plugins(os.environ)
+    assert plugins and plugins[0](0.0, 0.0, None) == {"x": 1}
+
+
+def test_input_history_db_uses_repo_path(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    clear_cache()
+    monkeypatch.setenv("SANDBOX_REPO_PATH", str(repo))
+
+    class DummyConn:
+        def execute(self, *a, **k):
+            return self
+
+        def fetchall(self):
+            return []
+
+        def commit(self):
+            pass
+
+    class DummyRouter:
+        def get_connection(self, name):
+            return DummyConn()
+
+    monkeypatch.setattr("sandbox_runner.input_history_db.router", DummyRouter())
+    db = InputHistoryDB()
+    assert db.path == repo / "input_history.db"
+
+
+def test_workflow_runner_resolves_coverage_file(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    clear_cache()
+    monkeypatch.setenv("SANDBOX_REPO_PATH", str(repo))
+    monkeypatch.setenv("SANDBOX_CAPTURE_COVERAGE", "1")
+    monkeypatch.setenv("SANDBOX_COVERAGE_FILE", "cov.json")
+
+    called: dict[str, str] = {}
+
+    class DummyData:
+        def measured_files(self):
+            return []
+
+        def lines(self, f):
+            return []
+
+    class DummyCov:
+        def __init__(self, *a, **kw):
+            pass
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def json_report(self, outfile):
+            called["outfile"] = outfile
+
+        def get_data(self):
+            return DummyData()
+
+    monkeypatch.setattr(
+        "sandbox_runner.workflow_sandbox_runner.coverage",
+        types.SimpleNamespace(Coverage=lambda *a, **kw: DummyCov(*a, **kw)),
+    )
+
+    runner = WorkflowSandboxRunner()
+    runner.run(lambda: None, safe_mode=False, use_subprocess=False)
+    assert Path(called["outfile"]) == repo / "cov.json"

--- a/sandbox_runner/workflow_sandbox_runner.py
+++ b/sandbox_runner/workflow_sandbox_runner.py
@@ -58,6 +58,8 @@ from time import perf_counter, process_time
 from typing import Any, Callable, Iterable, Mapping
 from unittest import mock
 
+from dynamic_path_router import resolve_path
+
 try:  # pragma: no cover - resource module may be missing on some platforms
     import resource  # type: ignore
 except Exception:  # pragma: no cover - resource unavailable
@@ -1484,7 +1486,11 @@ class WorkflowSandboxRunner:
                     outfile = os.environ.get("SANDBOX_COVERAGE_FILE")
                     if outfile:
                         try:
-                            cov.json_report(outfile=outfile)
+                            target = resolve_path(outfile)
+                        except FileNotFoundError:
+                            target = resolve_path(".") / outfile
+                        try:
+                            cov.json_report(outfile=str(target))
                         except Exception:
                             logger.exception("coverage json generation failed")
                 except Exception:


### PR DESCRIPTION
## Summary
- Replace literal file references in sandbox runner code with dynamic `resolve_path` calls
- Add tests to ensure path resolution succeeds when the repository root moves

## Testing
- `python tools/check_dynamic_paths.py self_coding_engine.py self_coding_manager.py self_coding_scheduler.py sandbox_runner.py $(find sandbox_runner -maxdepth 1 -name '*.py')`
- `PYTHONPATH=. pytest sandbox_runner/tests/test_path_resolution_after_relocation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b94ae59870832e8d4d63402b2005f7