### PR TITLE
Resolve default DB paths in orchestrator and clusterer

### DIFF
--- a/intent_clusterer.py
+++ b/intent_clusterer.py
@@ -545,8 +545,20 @@ class IntentClusterer:
                 self.router = _ur_router
             except Exception:  # pragma: no cover - fallback
                 mid = menace_id or "intent"
-                local = str(local_db_path or f"./{mid}.db")
-                shared = str(shared_db_path or local)
+                if local_db_path is None:
+                    local = str(resolve_path(f"{mid}.db"))
+                else:
+                    try:
+                        local = str(resolve_path(local_db_path))
+                    except FileNotFoundError:
+                        local = str(local_db_path)
+                if shared_db_path is None:
+                    shared = local
+                else:
+                    try:
+                        shared = str(resolve_path(shared_db_path))
+                    except FileNotFoundError:
+                        shared = str(shared_db_path)
                 self.router = init_db_router(mid, local, shared)
         self.conn = self.router.get_connection("intent_embeddings")
         self._ensure_table()

--- a/menace_orchestrator.py
+++ b/menace_orchestrator.py
@@ -11,6 +11,7 @@ import time
 import threading
 import asyncio
 import uuid
+from dynamic_path_router import resolve_path
 from .knowledge_graph import KnowledgeGraph
 
 from .advanced_error_management import AutomatedRollbackManager
@@ -219,8 +220,8 @@ class MenaceOrchestrator:
         if router is None:
             router = DBRouter(
                 menace_id,
-                f"./menace_{menace_id}_local.db",
-                "./shared/global.db",
+                str(resolve_path(f"menace_{menace_id}_local.db")),
+                str(resolve_path("shared/global.db")),
             )
         db_router.GLOBAL_ROUTER = router
         self.router = router


### PR DESCRIPTION
## Summary
- use `resolve_path` for MenaceOrchestrator's default local and shared DB files
- resolve local and shared database paths in IntentClusterer with fallbacks for provided paths

## Testing
- `pre-commit run --files menace_orchestrator.py intent_clusterer.py` *(command not found)*
- `python - <<'PY'
import sys, types
from pathlib import Path
sys.modules['dynamic_path_router'] = types.SimpleNamespace(resolve_path=lambda p: Path.cwd() / p, resolve_dir=lambda p: Path.cwd() / p)
import pytest
raise SystemExit(pytest.main(['tests/test_menace_orchestrator.py', '-q']))
PY`
- `python - <<'PY'
import sys
from pathlib import Path
import dynamic_path_router as dpr
setattr(dpr, 'resolve_path', lambda p: Path.cwd() / p)
setattr(dpr, 'resolve_dir', lambda p: Path.cwd() / p)
import pytest
raise SystemExit(pytest.main(['tests/test_intent_clusterer.py', 'tests/test_intent_clusterer_synergy.py', 'tests/test_menace_orchestrator.py', '-q']))
PY` *(missing AutoModel in transformers)*

------
https://chatgpt.com/codex/tasks/task_e_68b95138e850832eb2256eddbb8a015f