### PR TITLE
Use resolved telemetry DB path

### DIFF
--- a/roi_tracker.py
+++ b/roi_tracker.py
@@ -293,7 +293,9 @@ class ROITracker:
         self.confidence_threshold = float(confidence_threshold)
         self.raroi_borderline_threshold = float(raroi_borderline_threshold)
         self.borderline_bucket = borderline_bucket or BorderlineBucket()
-        self.telemetry = telemetry_backend or TelemetryBackend("./telemetry.db")
+        self.telemetry = telemetry_backend or TelemetryBackend(
+            str(resolve_path("telemetry.db"))
+        )
         self.results_db = results_db
         self.current_workflow_id: str | None = None
         self.current_run_id: str | None = None


### PR DESCRIPTION
## Summary
- ensure ROITracker resolves telemetry database path via dynamic path router

## Testing
- `pytest tests/test_roi_tracker.py::test_scorecard_cli -q` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*

------
https://chatgpt.com/codex/tasks/task_e_68b9530071ac832e919447ef5e40903b