### PR TITLE
Annotate synthetic paths in run metrics tests

### DIFF
--- a/sandbox_runner/tests/test_run_metrics_persistence.py
+++ b/sandbox_runner/tests/test_run_metrics_persistence.py
@@ -48,7 +48,7 @@ def test_run_records_metrics(tmp_path, monkeypatch):
             "roi": 1.0,
             "coverage": {"file.py": ["func"]},  # path-ignore
             "entropy_delta": 0.1,
-            "executed_functions": ["file.py:func"],
+            "executed_functions": ["file.py:func"],  # path-ignore
         },
     )
 
@@ -89,10 +89,10 @@ def test_run_tests_persists_metrics(tmp_path, monkeypatch):
         path=None,
         stub={},
         preset={},
-        coverage={"file.py": ["func"], "executed_functions": ["file.py:func"]},
+        coverage={"file.py": ["func"], "executed_functions": ["file.py:func"]},  # path-ignore
         edge_cases=None,
         entropy_delta=0.5,
-        executed_functions=["file.py:func"],
+        executed_functions=["file.py:func"],  # path-ignore
     )
     monkeypatch.setattr(th, "_run_once", lambda *a, **k: dummy)
 


### PR DESCRIPTION
## Summary
- mark synthetic `file.py` path references in run metrics tests

## Testing
- `python tools/check_static_paths.py sandbox_runner/tests/test_run_metrics_persistence.py`
- `pytest sandbox_runner/tests/test_run_metrics_persistence.py -q` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*

------
https://chatgpt.com/codex/tasks/task_e_68b955585984832eb2cf518bd84940aa