### PR TITLE
Track self improvement strategy confidence and checkpoints

### DIFF
--- a/self_improvement/api.py
+++ b/self_improvement/api.py
@@ -42,6 +42,7 @@ from .state_snapshot import (
     delta,
     save_snapshot,
     load_snapshot,
+    save_checkpoint,
 )
 
 __all__ = [
@@ -79,4 +80,5 @@ __all__ = [
     "delta",
     "save_snapshot",
     "load_snapshot",
+    "save_checkpoint",
 ]


### PR DESCRIPTION
## Summary
- add `save_checkpoint` to snapshot utilities to archive updated modules
- record and persist strategy confidence when metrics improve
- snapshot successful patches, logging confidence changes

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*


------
https://chatgpt.com/codex/tasks/task_e_68b955e1d508832e81331a9275b8d8a0