### PR TITLE
feat: add prompt regression penalty tracking

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -754,6 +754,21 @@ class SandboxSettings(BaseSettings):
         env="PROMPT_FAILURE_LOG_PATH",
         description="Path for recording failed prompt executions.",
     )
+    prompt_penalty_path: str = Field(
+        "sandbox_data/prompt_penalties.json",
+        env="PROMPT_PENALTY_PATH",
+        description="File storing per-prompt regression counts.",
+    )
+    prompt_failure_threshold: int = Field(
+        3,
+        env="PROMPT_FAILURE_THRESHOLD",
+        description="Failure count after which prompt selection is penalised.",
+    )
+    prompt_penalty_multiplier: float = Field(
+        0.1,
+        env="PROMPT_PENALTY_MULTIPLIER",
+        description="Multiplier applied to value estimates of penalised prompts.",
+    )
     failure_fingerprint_path: str = Field(
         "failure_fingerprints.jsonl",
         env="FAILURE_FINGERPRINT_PATH",

--- a/self_improvement/tests/test_prompt_penalties.py
+++ b/self_improvement/tests/test_prompt_penalties.py
@@ -1,0 +1,36 @@
+import json
+import sys
+from types import SimpleNamespace, ModuleType
+
+sys.modules.setdefault("dynamic_path_router", ModuleType("dynamic_path_router"))
+
+from self_improvement import prompt_memory
+from self_improvement.prompt_memory import record_regression
+from self_improvement_policy import SelfImprovementPolicy, PolicyConfig
+
+
+def test_record_regression(monkeypatch, tmp_path):
+    monkeypatch.setattr(prompt_memory, "_repo_path", lambda: tmp_path)
+    monkeypatch.setattr(prompt_memory._settings, "prompt_penalty_path", "penalties.json")
+    assert record_regression("p1") == 1
+    assert record_regression("p1") == 2
+    data = json.loads((tmp_path / "penalties.json").read_text())
+    assert data["p1"] == 2
+
+
+def test_policy_respects_penalties(monkeypatch):
+    monkeypatch.setattr(
+        prompt_memory, "load_prompt_penalties", lambda: {"1": 5}
+    )
+
+    class DummySettings(SimpleNamespace):
+        prompt_failure_threshold = 3
+        prompt_penalty_multiplier = 0.1
+
+    monkeypatch.setattr("self_improvement_policy.SandboxSettings", lambda: DummySettings())
+
+    policy = SelfImprovementPolicy(config=PolicyConfig(epsilon=0.0))
+    state = (0,)
+    policy.values[state] = {0: 2.0, 1: 10.0}
+    action = policy.select_action(state)
+    assert action == 0


### PR DESCRIPTION
## Summary
- track per-prompt regression counts and logging in prompt memory
- configure prompt penalty thresholds in sandbox settings
- bias self-improvement policy away from prompts with repeated failures

## Testing
- `python -m py_compile self_improvement/prompt_memory.py self_improvement_policy.py sandbox_settings.py self_improvement/tests/test_prompt_penalties.py`
- `pytest self_improvement/tests/test_prompt_penalties.py -q` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*


------
https://chatgpt.com/codex/tasks/task_e_68b9576573e0832eb968ce99821965b5