### PR TITLE
Wrap static .py paths in unit tests

### DIFF
--- a/unit_tests/test_chunking.py
+++ b/unit_tests/test_chunking.py
@@ -16,7 +16,7 @@ def test_token_counting_respects_limit(tmp_path):
         '    y = 2\n'
         '    return y\n'
     )
-    path = tmp_path / 'sample.py'
+    path = tmp_path / 'sample.py'  # path-ignore
     path.write_text(code)
     enc = tiktoken.get_encoding('cl100k_base')
     limit = 20
@@ -35,7 +35,7 @@ def test_ast_boundary_accuracy(tmp_path):
         '    y = 2\n'
         '    return y\n'
     )
-    path = tmp_path / 'code.py'
+    path = tmp_path / 'code.py'  # path-ignore
     path.write_text(code)
     chunks = chunk_file(path, 20)
     assert (chunks[0].start_line, chunks[0].end_line) == (1, 3)

--- a/unit_tests/test_environment_security_features.py
+++ b/unit_tests/test_environment_security_features.py
@@ -5,10 +5,11 @@ import socket
 import sys
 
 import pytest
+from dynamic_path_router import resolve_path
 
 spec = importlib.util.spec_from_file_location(
     "sandbox_runner.environment",
-    pathlib.Path(__file__).resolve().parents[1] / "sandbox_runner" / "environment.py",
+    resolve_path("sandbox_runner/environment.py"),
 )
 env = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
@@ -17,7 +18,7 @@ spec.loader.exec_module(env)
 
 
 def test_patched_import_records_relative_path(tmp_path, monkeypatch):
-    module_path = tmp_path / "foo.py"
+    module_path = tmp_path / "foo.py"  # path-ignore
     module_path.write_text("x = 1\n")
     recorded: list[str] = []
     monkeypatch.setattr(env, "record_module_usage", recorded.append, raising=False)
@@ -26,7 +27,7 @@ def test_patched_import_records_relative_path(tmp_path, monkeypatch):
     try:
         with env._patched_imports():
             importlib.import_module("foo")
-        assert recorded == ["foo.py"]
+        assert recorded == ["foo.py"]  # path-ignore
     finally:
         sys.path.remove(str(tmp_path))
         sys.modules.pop("foo", None)

--- a/unit_tests/test_prompt_path_resolution.py
+++ b/unit_tests/test_prompt_path_resolution.py
@@ -1,13 +1,8 @@
-import importlib.util
+import sys
 from pathlib import Path
 
-spec = importlib.util.spec_from_file_location(
-    "dynamic_path_router", Path(__file__).resolve().parent.parent / "dynamic_path_router.py"
-)
-dr = importlib.util.module_from_spec(spec)
-assert spec.loader
-spec.loader.exec_module(dr)
-resolve_path = dr.resolve_path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from dynamic_path_router import resolve_path, path_for_prompt
 
 
 def _visual_agent_prompt(path: str) -> str:
@@ -21,10 +16,10 @@ def _error_logger_prompt(module: str, hint: str) -> str:
 
 
 def test_visual_agent_prompt_resolves_paths():
-    body = _visual_agent_prompt("error_logger.py")
+    body = _visual_agent_prompt(path_for_prompt("error_logger.py"))
     assert str(resolve_path("error_logger.py")) in body
 
 
 def test_error_logger_prompt_resolves_paths():
-    prompt = _error_logger_prompt("enhancement_bot.py", "hint")
+    prompt = _error_logger_prompt(path_for_prompt("enhancement_bot.py"), "hint")
     assert str(resolve_path("enhancement_bot.py")) in prompt

--- a/unit_tests/test_self_improvement_boundaries.py
+++ b/unit_tests/test_self_improvement_boundaries.py
@@ -2,6 +2,7 @@ import importlib.util
 import sys
 import types
 from pathlib import Path
+from dynamic_path_router import path_for_prompt
 
 PKG_DIR = Path(__file__).resolve().parents[1] / "self_improvement"
 
@@ -45,7 +46,7 @@ def test_update_alignment_baseline_delegates():
     metrics_stub._update_alignment_baseline = fake_update
     module = load_module(
         "self_improvement.roi_tracking",
-        "roi_tracking.py",
+        path_for_prompt("self_improvement/roi_tracking.py"),
         {"self_improvement.metrics": metrics_stub},
     )
     assert module.update_alignment_baseline('cfg') == 'ok'
@@ -75,7 +76,7 @@ def test_generate_patch_delegates():
 
     module = load_module(
         "menace_sandbox.self_improvement.patch_application",
-        "patch_application.py",
+        path_for_prompt("self_improvement/patch_application.py"),
         {
             "menace_sandbox.self_improvement.patch_generation": patch_stub,
             "menace_sandbox.self_improvement.utils": utils_stub,
@@ -106,7 +107,7 @@ def test_orphan_handlers_delegate():
 
     module = load_module(
         "self_improvement.orphan_handling",
-        "orphan_handling.py",
+        path_for_prompt("self_improvement/orphan_handling.py"),
         {
             "self_improvement.utils": utils_stub,
             "sandbox_settings": ss_stub,

--- a/unit_tests/test_workflow_chain_suggester.py
+++ b/unit_tests/test_workflow_chain_suggester.py
@@ -2,6 +2,7 @@ import sys
 import types
 import importlib.util
 from pathlib import Path
+from dynamic_path_router import resolve_path
 
 
 def _load_wcs(monkeypatch):
@@ -44,7 +45,7 @@ def _load_wcs(monkeypatch):
 
     spec = importlib.util.spec_from_file_location(
         "workflow_chain_suggester",
-        Path(__file__).resolve().parent.parent / "workflow_chain_suggester.py",
+        resolve_path("workflow_chain_suggester.py"),
     )
     module = importlib.util.module_from_spec(spec)
     sys.modules["workflow_chain_suggester"] = module


### PR DESCRIPTION
## Summary
- Wrap hard-coded `.py` strings in unit tests with `resolve_path`/`path_for_prompt`
- Annotate temporary test paths with `# path-ignore`
- Import dynamic path helpers in tests to satisfy static path checks

## Testing
- `python tools/check_static_paths.py unit_tests/test_chunking.py unit_tests/test_collect_local_dependencies.py unit_tests/test_environment_security_features.py unit_tests/test_prompt_path_resolution.py unit_tests/test_self_improvement_boundaries.py unit_tests/test_workflow_chain_suggester.py`

------
https://chatgpt.com/codex/tasks/task_e_68b9572b2f28832eb2625c68599c87b5