### PR TITLE
Support per-route currency in Stripe billing router

### DIFF
--- a/config/stripe_billing_router.yaml
+++ b/config/stripe_billing_router.yaml
@@ -5,3 +5,11 @@ stripe:
         product_id: prod_finance_router
         price_id: price_finance_standard
         customer_id: cus_finance_default
+        currency: usd
+  eu:
+    finance:
+      finance_router_bot:
+        product_id: prod_finance_router_eu
+        price_id: price_finance_eu
+        customer_id: cus_finance_eu
+        currency: eur

--- a/docs/billing_router.md
+++ b/docs/billing_router.md
@@ -2,8 +2,8 @@
 
 `stripe_billing_router` centralises **all** Stripe usage and is the sole payment
 interface for bots.  The module owns the Stripe API keys, resolves the correct
-product, price and customer identifiers for a bot via `_resolve_route` and
-exposes helpers such as `charge` and `create_customer`.  Routes may **not**
+product, price, customer and currency identifiers for a bot via `_resolve_route`
+and exposes helpers such as `charge` and `create_customer`.  Routes may **not**
 include `secret_key` or `public_key` fields—the router injects centrally
 managed keys and prevents per‑route overrides.  Keys must not be duplicated or
 reimplemented in other modules.
@@ -25,10 +25,27 @@ adjustments via `register_override`.  More complex policies can subclass
 ```python
 from stripe_billing_router import register_route
 
+# Default USD billing
 register_route(
     "finance",
     "finance_router_bot",
-    {"product_id": "prod_finance_router", "price_id": "price_finance_standard"},
+    {
+        "product_id": "prod_finance_router",
+        "price_id": "price_finance_standard",
+        "currency": "usd",
+    },
+)
+
+# EU region uses EUR for the same bot
+register_route(
+    "finance",
+    "finance_router_bot",
+    {
+        "product_id": "prod_finance_router_eu",
+        "price_id": "price_finance_eu",
+        "currency": "eur",
+    },
+    region="eu",
 )
 ```
 

--- a/stripe_billing_router.py
+++ b/stripe_billing_router.py
@@ -274,8 +274,10 @@ def _resolve_route(
     _validate_no_api_keys(route)
     route.setdefault("secret_key", STRIPE_SECRET_KEY)
     route.setdefault("public_key", STRIPE_PUBLIC_KEY)
+    route.setdefault("currency", "usd")
     for strategy in _STRATEGIES:
         route = strategy.apply(bot_id, dict(route))
+    route.setdefault("currency", "usd")
     secret = route.get("secret_key", "")
     public = route.get("public_key", "")
     if not secret or not public:
@@ -313,6 +315,7 @@ def charge(
     price = price_id or route.get("price_id")
     customer = route.get("customer_id")
     description = description or route.get("product_id", "")
+    currency = route.get("currency", "usd")
 
     amt: float | None = None
     if amount is not None:
@@ -365,7 +368,7 @@ def charge(
     idempotency_key = f"{bot_id}-{amt}-{timestamp_ms}"
     params = {
         "amount": int(amt * 100),
-        "currency": "usd",
+        "currency": currency,
         "description": description,
         "idempotency_key": idempotency_key,
     }


### PR DESCRIPTION
## Summary
- allow Stripe billing routes to include a `currency` field defaulting to `usd`
- use resolved currency when creating PaymentIntents
- document currency configuration with regional examples

## Testing
- `pre-commit run --files config/stripe_billing_router.yaml docs/billing_router.md stripe_billing_router.py tests/test_stripe_billing_router.py`
- `PYTHONPATH=/workspace/menace_sandbox/tests:/workspace/menace_sandbox pytest --noconftest test_stripe_billing_router.py`

------
https://chatgpt.com/codex/tasks/task_e_68b95ae5befc832e81c95b30ed944bdf