### PR TITLE
Propagate Stripe balance retrieval errors

### DIFF
--- a/stripe_billing_router.py
+++ b/stripe_billing_router.py
@@ -400,7 +400,7 @@ def get_balance(
         return float(amount)
     except Exception as exc:  # pragma: no cover - network/API issues
         logger.exception("Stripe balance retrieval failed: %s", exc)
-        return 0.0
+        raise RuntimeError("Stripe balance retrieval failed") from exc
 
 
 def create_customer(

--- a/tests/test_stripe_billing_router.py
+++ b/tests/test_stripe_billing_router.py
@@ -199,6 +199,19 @@ def test_charge_amount_validation(monkeypatch, tmp_path):
     assert calls == []
 
 
+def test_get_balance_error(monkeypatch, tmp_path):
+    sbr = _import_module(monkeypatch, tmp_path)
+    monkeypatch.setattr(sbr, "_client", lambda api_key: None)
+
+    def bad_retrieve(*args, **kwargs):
+        raise ValueError("boom")
+
+    fake_stripe = types.SimpleNamespace(Balance=types.SimpleNamespace(retrieve=bad_retrieve))
+    monkeypatch.setattr(sbr, "stripe", fake_stripe)
+    with pytest.raises(RuntimeError):
+        sbr.get_balance("finance:finance_router_bot")
+
+
 def test_missing_keys_or_rule(monkeypatch, tmp_path):
     sbr = _import_module(monkeypatch, tmp_path)
 


### PR DESCRIPTION
## Summary
- raise `RuntimeError` when Stripe balance retrieval fails instead of returning zero
- ensure `AutoReinvestmentBot.reinvest` logs and propagates balance errors
- add tests for error propagation and failure handling

## Testing
- `pre-commit run --files investment_engine.py stripe_billing_router.py tests/test_investment_engine.py tests/test_stripe_billing_router.py`
- `PYTHONPATH=$PWD pytest tests/test_investment_engine.py tests/test_stripe_billing_router.py`


------
https://chatgpt.com/codex/tasks/task_e_68b95c3b1bd0832eb124ad0842f96253