### PR TITLE
Use resolve_path for sandbox data in tests

### DIFF
--- a/tests/test_adapt_presets.py
+++ b/tests/test_adapt_presets.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import sys
 import types
 
+from dynamic_path_router import resolve_path
+
 import menace_sandbox.dynamic_path_router as dpr
 import menace_sandbox.environment_generator as eg
 
@@ -25,7 +27,7 @@ def test_policy_persists(monkeypatch, tmp_path):
 
     tracker = _tracker()
     eg.adapt_presets(tracker, [{"CPU_LIMIT": "1"}])
-    policy_file = Path("sandbox_data") / "preset_policy.json"
+    policy_file = resolve_path("sandbox_data") / "preset_policy.json"
     assert policy_file.exists()
 
     with open(policy_file, "wb") as fh:

--- a/tests/test_full_autonomous_run.py
+++ b/tests/test_full_autonomous_run.py
@@ -4,6 +4,8 @@ import sys
 import types
 from pathlib import Path
 
+from dynamic_path_router import resolve_path
+
 os.environ["MENACE_LIGHT_IMPORTS"] = "1"
 
 scipy_stub = types.ModuleType("scipy")
@@ -68,7 +70,7 @@ def test_full_autonomous_run_with_recovery(monkeypatch, tmp_path):
 
     monkeypatch.chdir(tmp_path)
     args = argparse.Namespace(
-        sandbox_data_dir=str(Path("sandbox_data")),
+        sandbox_data_dir=str(resolve_path("sandbox_data")),
         preset_count=1,
         max_iterations=1,
         dashboard_port=None,
@@ -78,6 +80,6 @@ def test_full_autonomous_run_with_recovery(monkeypatch, tmp_path):
 
     cli.full_autonomous_run(args)
 
-    roi_file = Path("sandbox_data") / "roi_history.json"
+    roi_file = resolve_path("sandbox_data") / "roi_history.json"
     assert roi_file.exists()
     assert calls == ["call", "call"]

--- a/tests/test_run_scenarios.py
+++ b/tests/test_run_scenarios.py
@@ -4,6 +4,8 @@ from tests.test_scenario_roi_deltas import _setup_tracker
 from pathlib import Path
 import json
 
+from dynamic_path_router import resolve_path
+
 
 def test_run_scenarios_records_all_deltas(monkeypatch):
     _setup_mm_stubs(monkeypatch)
@@ -27,7 +29,7 @@ def test_run_scenarios_records_all_deltas(monkeypatch):
 
     monkeypatch.setattr(env, "_section_worker", fake_worker)
 
-    out = Path("sandbox_data/scenario_deltas.json")
+    out = resolve_path("sandbox_data") / "scenario_deltas.json"
     out.unlink(missing_ok=True)
     tracker_obj, cards, summary = env.run_scenarios(
         ["simple_functions:print_ten"], tracker=rt.ROITracker(filter_outliers=False)

--- a/tests/test_scenario_roi_deltas.py
+++ b/tests/test_scenario_roi_deltas.py
@@ -2,6 +2,7 @@ import types, sys, importlib.util
 from pathlib import Path
 import json
 import pytest
+from dynamic_path_router import resolve_path
 from tests.test_menace_master import _setup_mm_stubs
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -173,7 +174,7 @@ def test_generate_scorecard(monkeypatch):
     )
 
     wf_id = card["workflow_id"]
-    out_path = Path("sandbox_data") / f"scorecard_{wf_id}.json"
+    out_path = resolve_path("sandbox_data") / f"scorecard_{wf_id}.json"
     assert out_path.exists()
     persisted = json.loads(out_path.read_text())
     assert persisted == card

--- a/tests/test_workflow_synthesizer.py
+++ b/tests/test_workflow_synthesizer.py
@@ -4,6 +4,8 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+from dynamic_path_router import resolve_path
+
 import networkx as nx
 import pytest
 
@@ -185,7 +187,7 @@ def test_generate_workflows_persist_and_rank(tmp_path, monkeypatch):
     # The second best workflow follows the next step in the synergy chain
     assert [step.module for step in workflows[1]] == ["mod_a", "mod_b", "mod_c"]
 
-    out_dir = Path("sandbox_data/generated_workflows")
+    out_dir = resolve_path("sandbox_data") / "generated_workflows"
     saved = sorted(out_dir.glob("*.workflow.json"))
     assert len(saved) >= 2 and saved[0].name.startswith("mod_a_0")
 
@@ -217,7 +219,9 @@ def test_generate_workflows_auto_evaluate(tmp_path, monkeypatch):
     assert synth.workflow_score_details[0]["success"] is True
     assert synth.workflow_score_details[1]["success"] is False
 
-    saved = sorted(Path("sandbox_data/generated_workflows").glob("*.workflow.json"))
+    saved = sorted(
+        (resolve_path("sandbox_data") / "generated_workflows").glob("*.workflow.json")
+    )
     data = json.loads(saved[0].read_text())
     assert data.get("success") is True
 


### PR DESCRIPTION
## Summary
- import `resolve_path` in workflow, scenario, full autonomy, adapt presets, and run scenarios tests
- resolve all `sandbox_data` file references via `resolve_path("sandbox_data")`

## Testing
- `PYTHONPATH=/workspace/menace_sandbox pytest tests/test_run_scenarios.py -q` *(fails: ModuleNotFoundError: No module named 'menace.workflow_run_summary')*

------
https://chatgpt.com/codex/tasks/task_e_68b95cc79840832eb72503edb8685fb0