### PR TITLE
chore: update finance router bot id

### DIFF
--- a/docs/auto_reinvestment.md
+++ b/docs/auto_reinvestment.md
@@ -19,7 +19,7 @@ Menace periodically reinvests a portion of its billing balance into expanding it
 ```python
 from stripe_billing_router import get_balance
 
-balance = get_balance("finance:finance_router_bot:monetization")
+balance = get_balance("finance:finance_router_bot")
 reinvestable = balance * cap_percentage
 predicted = predict_optimal_spend()
 amount_to_spend = min(predicted, reinvestable)

--- a/finance_router_bot.py
+++ b/finance_router_bot.py
@@ -35,7 +35,7 @@ class Transaction:
 class FinanceRouterBot:
     """Route payments and log payouts for Menace."""
 
-    BOT_ID = "finance:finance_router_bot:monetization"
+    BOT_ID = "finance:finance_router_bot"
 
     def __init__(
         self,

--- a/investment_engine.py
+++ b/investment_engine.py
@@ -16,7 +16,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_BOT_ID = "finance:finance_router_bot:monetization"
+DEFAULT_BOT_ID = "finance:finance_router_bot"
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- align finance router bot identifiers with new naming scheme
- fix auto reinvestment doc example

## Testing
- `pytest tests/test_finance_router_bot.py tests/test_investment_engine.py tests/test_finance_router_memory_subscribe.py tests/test_event_integration.py tests/test_stripe_billing_router.py` *(failed: FileNotFoundError: [Errno 2] No such file or directory: '' during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b95f79728c832eb4c7798ac060308c