### PR TITLE
Add call graph complexity metric with tests

### DIFF
--- a/tests/test_call_graph_complexity.py
+++ b/tests/test_call_graph_complexity.py
@@ -1,0 +1,42 @@
+import json
+import importlib.util
+from pathlib import Path
+import types
+import sys
+import pytest
+
+db_router = types.ModuleType("db_router")
+db_router.DBRouter = object
+db_router.GLOBAL_ROUTER = None
+db_router.LOCAL_TABLES = set()
+db_router.init_db_router = lambda *a, **k: None
+sys.modules.setdefault("db_router", db_router)
+
+metrics_exporter = types.ModuleType("metrics_exporter")
+metrics_exporter.update_relevancy_metrics = lambda **k: None
+sys.modules.setdefault("metrics_exporter", metrics_exporter)
+
+relevancy_metrics_db = types.ModuleType("relevancy_metrics_db")
+class _RelevancyMetricsDB:  # pragma: no cover - stub
+    pass
+relevancy_metrics_db.RelevancyMetricsDB = _RelevancyMetricsDB
+sys.modules.setdefault("relevancy_metrics_db", relevancy_metrics_db)
+
+dynamic_path_router = types.ModuleType("dynamic_path_router")
+dynamic_path_router.resolve_path = lambda p: Path(p)
+sys.modules.setdefault("dynamic_path_router", dynamic_path_router)
+
+spec = importlib.util.spec_from_file_location(
+    "relevancy_radar", Path(__file__).resolve().parents[1] / "relevancy_radar.py"
+)
+relevancy_radar = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(relevancy_radar)
+
+
+def test_call_graph_complexity(tmp_path, monkeypatch):
+    data = {"a": ["b", "c"], "b": ["c"]}
+    path = tmp_path / "cg.json"
+    path.write_text(json.dumps(data))
+    monkeypatch.setattr(relevancy_radar, "_RELEVANCY_CALL_GRAPH_FILE", path)
+    assert relevancy_radar.call_graph_complexity() == pytest.approx(1.0)
+


### PR DESCRIPTION
## Summary
- compute call graph complexity from persisted relevancy call graph
- expose helper via module exports
- add test covering complexity calculation

## Testing
- `pytest --noconftest tests/test_call_graph_complexity.py` *(fails: No module named 'sandbox_settings')*


------
https://chatgpt.com/codex/tasks/task_e_68b95fbd974c832eb2b879a0133cf09d