### PR TITLE
Simplify embedding backfill path resolution

### DIFF
--- a/scripts/new_db.py
+++ b/scripts/new_db.py
@@ -151,7 +151,7 @@ def create_db_scaffold(name: str, root: Path = Path('.')) -> None:
         )
     )
 
-    emb_file = root / 'vector_service' / resolve_path('vector_service/embedding_backfill.py').name
+    emb_file = resolve_path("vector_service/embedding_backfill.py")
     if emb_file.exists():
         text = emb_file.read_text()
         if module_name not in text:


### PR DESCRIPTION
## Summary
- Refactor new_db scaffold to resolve embedding_backfill path directly

## Testing
- `pytest tests/test_menace_cli_new_db.py -q` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*
- `PYTHONPATH=. pytest tests/test_menace_cli_new_db.py -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '')*

------
https://chatgpt.com/codex/tasks/task_e_68b962463388832eb1b945d46f201c58