### PR TITLE
Use dynamic path resolution for prompt memory trainer CLI

### DIFF
--- a/prompt_memory_trainer_cli.py
+++ b/prompt_memory_trainer_cli.py
@@ -9,18 +9,19 @@ import sys
 from pathlib import Path
 from typing import Iterable
 
+from dynamic_path_router import resolve_path
 from prompt_memory_trainer import PromptMemoryTrainer
 
 DEFAULT_STATE_PATH = Path(
     os.getenv(
         "PROMPT_MEMORY_WEIGHTS_PATH",
-        Path(__file__).resolve().parent / "config" / "prompt_memory_weights.json",
+        resolve_path("config/prompt_memory_weights.json"),
     )
 )
 DEFAULT_DB_PATH = Path(
     os.getenv(
         "PROMPT_STYLE_DB_PATH",
-        Path(__file__).resolve().parent / "prompt_styles.db",
+        resolve_path("prompt_styles.db"),
     )
 )
 


### PR DESCRIPTION
## Summary
- Import `resolve_path` utility
- Dynamically resolve default weight and database paths in `prompt_memory_trainer_cli`

## Testing
- `pre-commit run --files prompt_memory_trainer_cli.py`
- `PYTHONPATH=. pytest -k prompt_memory_trainer -q` *(fails: ImportError, ModuleNotFoundError and other collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b966216f48832ea9afdd7ecb8f0b83