### PR TITLE
test: add stripe import check

### DIFF
--- a/tests/test_no_direct_stripe_imports.py
+++ b/tests/test_no_direct_stripe_imports.py
@@ -1,0 +1,22 @@
+import subprocess
+import sys
+from pathlib import Path
+
+from dynamic_path_router import resolve_path
+
+
+def test_no_direct_stripe_imports() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    files = subprocess.check_output(
+        ["git", "ls-files", "*.py"],
+        cwd=repo_root,
+        text=True,
+    ).splitlines()
+    script = resolve_path("scripts/check_stripe_imports.py")
+    result = subprocess.run(
+        [sys.executable, str(script), *files],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- add test to ensure no direct stripe imports

## Testing
- `pre-commit run --files tests/test_no_direct_stripe_imports.py`
- `PYTHONPATH=$PWD pytest tests/test_no_direct_stripe_imports.py`

------
https://chatgpt.com/codex/tasks/task_e_68b970bf6550832e864480f97f4f0540