### PR TITLE
Use resolve_path for retrieval stats path

### DIFF
--- a/metrics_plugins.py
+++ b/metrics_plugins.py
@@ -5,6 +5,11 @@ from pathlib import Path
 from statistics import mean
 from typing import Callable, Dict, List, Optional
 
+try:  # pragma: no cover - allow running as script
+    from .dynamic_path_router import resolve_path  # type: ignore
+except Exception:  # pragma: no cover - fallback when executed directly
+    from dynamic_path_router import resolve_path  # type: ignore
+
 logger = logging.getLogger(__name__)
 
 MetricsFunc = Callable[[float, float, Optional[Dict[str, float]]], Dict[str, float]]
@@ -77,11 +82,7 @@ def fetch_retrieval_stats(path: str | Path | None = None) -> Dict[str, float]:
     """
 
     if path is None:
-        path = (
-            Path(__file__).resolve().parent
-            / "analytics"
-            / "retrieval_outcomes.jsonl"
-        )
+        path = resolve_path("analytics/retrieval_outcomes.jsonl")
     else:
         path = Path(path)
     if not path.exists():


### PR DESCRIPTION
## Summary
- import `resolve_path` in `metrics_plugins`
- use `resolve_path` to locate default retrieval outcomes file

## Testing
- ⚠️ `pytest tests/test_metrics_aggregator_stats.py::test_compute_retriever_stats -q` (missing dependencies)
- ✅ `PYTHONPATH=. pytest tests/test_dynamic_path_router_nested.py::test_resolve_path_in_nested_clone -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9733dfb64832eb4a52569d0d7df84