### PR TITLE
Use resolve_path for ROI profile fallback

### DIFF
--- a/composite_workflow_scorer.py
+++ b/composite_workflow_scorer.py
@@ -73,7 +73,7 @@ class ROIScorer(BaseROIScorer):
         except Exception as exc:  # pragma: no cover - configuration errors
             logging.critical("Failed to initialise ROICalculator: %s", exc)
             try:
-                with Path("configs/roi_profiles.yaml").open(
+                with resolve_path("configs/roi_profiles.yaml").open(
                     "r", encoding="utf-8"
                 ) as fh:
                     profiles: Dict[str, Dict[str, Any]] = yaml.safe_load(fh) or {}


### PR DESCRIPTION
## Summary
- use `resolve_path` to locate default ROI profiles in composite workflow scorer

## Testing
- `pre-commit run --files composite_workflow_scorer.py`

------
https://chatgpt.com/codex/tasks/task_e_68b97478a4a8832ea638e83ea140713c