### PR TITLE
Add raw Stripe usage enforcement script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,12 @@ repos:
         language: system
         pass_filenames: true
         types: [text]
+      - id: forbid-raw-stripe-usage
+        name: Prevent raw Stripe keys or endpoints
+        entry: python scripts/check_raw_stripe_usage.py
+        language: system
+        pass_filenames: false
+        files: '\.py$'
   - repo: https://github.com/pycqa/flake8
     rev: 6.1.0
     hooks:

--- a/scripts/check_raw_stripe_usage.py
+++ b/scripts/check_raw_stripe_usage.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Detect raw Stripe key or endpoint usage in tracked files."""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from dynamic_path_router import resolve_path  # noqa: E402
+
+REPO_ROOT = resolve_path(".")
+# Exclude specific paths (resolved absolute)
+EXCLUDED = {
+    resolve_path("stripe_billing_router.py").resolve(),
+    resolve_path("scripts/check_stripe_imports.py").resolve(),
+    resolve_path("scripts/check_raw_stripe_usage.py").resolve(),
+}
+# Files under any of these directory names are ignored
+EXCLUDED_DIRS = {"tests", "unit_tests", "fixtures", "finance_logs"}
+
+PATTERN = re.compile(r"api\.stripe\.com|['\"](?:sk_|pk_)[^'\"]*['\"]")
+
+
+def _tracked_python_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "*.py"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    paths: list[Path] = []
+    for line in result.stdout.splitlines():
+        p = (REPO_ROOT / line).resolve()
+        if p in EXCLUDED:
+            continue
+        if any(part in EXCLUDED_DIRS for part in p.parts):
+            continue
+        if p.is_file():
+            paths.append(p)
+    return paths
+
+
+def main() -> int:
+    offenders: list[str] = []
+    for path in _tracked_python_files():
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if PATTERN.search(line):
+                try:
+                    rel = path.relative_to(REPO_ROOT)
+                except ValueError:
+                    rel = path
+                offenders.append(f"{rel}:{lineno}:{line.strip()}")
+    if offenders:
+        print("Raw Stripe keys or endpoints detected:")
+        for off in offenders:
+            print(off)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_no_raw_stripe_usage.py
+++ b/tests/test_no_raw_stripe_usage.py
@@ -1,0 +1,17 @@
+import subprocess
+import sys
+from pathlib import Path
+
+from dynamic_path_router import resolve_path
+
+
+def test_no_raw_stripe_usage() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    script = resolve_path("scripts/check_raw_stripe_usage.py")
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- add script to scan tracked Python files for raw Stripe keys or endpoints
- hook raw Stripe usage check into pre-commit
- test that repository passes the new raw Stripe scanner

## Testing
- `pre-commit run --files scripts/check_raw_stripe_usage.py tests/test_no_raw_stripe_usage.py .pre-commit-config.yaml`
- `PYTHONPATH=. pytest tests/test_no_raw_stripe_usage.py tests/test_no_direct_stripe_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9733b87c0832ea659a2854a211922