### PR TITLE
Add snapshot configuration and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1515,6 +1515,15 @@ Self-improvement compares ROI gains against this moving baseline and escalates
 an internal urgency tier when momentum stalls, encouraging more aggressive
 mutations.
 
+#### State snapshots
+
+The sandbox records ROI, entropy and call graph metrics for every cycle via
+[`self_improvement/state_snapshot.py`](self_improvement/state_snapshot.py).
+Snapshots and diffs are written to `SNAPSHOT_DIR` / `SNAPSHOT_DIFF_DIR` and
+successful changes are checkpointed under `CHECKPOINT_DIR`.  Tune retention and
+penalty behaviour with `CHECKPOINT_RETENTION`, `ROI_PENALTY_THRESHOLD` and
+`ENTROPY_PENALTY_THRESHOLD` in `SandboxSettings`.
+
 #### Example workflow
 
 ```bash

--- a/docs/self_improvement_engine.md
+++ b/docs/self_improvement_engine.md
@@ -23,6 +23,22 @@ Persisting cycle data across runs is possible by providing `state_path` when cre
 
 Each engine may use its own databases, event bus and automation pipeline allowing multiple bots to improve in parallel.
 
+## Snapshot Tracking
+
+`SnapshotTracker` records key metrics before and after each cycle so
+regressions can be detected and improvements checkpointed.  Set
+`ENABLE_SNAPSHOT_TRACKER=0` to disable the feature or adjust the
+locations and thresholds via `SandboxSettings`:
+
+* `SNAPSHOT_DIR` and `SNAPSHOT_DIFF_DIR` – where snapshots and diff
+  artefacts are written (default `sandbox_data/snapshots` and
+  `sandbox_data/diffs`).
+* `CHECKPOINT_DIR` – base directory for saved checkpoints.
+* `CHECKPOINT_RETENTION` – number of checkpoint directories to keep.
+* `ROI_PENALTY_THRESHOLD` / `ENTROPY_PENALTY_THRESHOLD` – ROI drops or
+  entropy gains beyond these values penalise the responsible prompt until
+  a positive cycle resets the count.
+
 ## Optional Dependencies
 
 Some features of the engine depend on optional packages. Missing modules now

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -1389,6 +1389,7 @@ class SandboxSettings(BaseSettings):
         "adaptive_roi_retrain_interval",
         "adaptive_roi_train_interval",
         "backup_rotation_count",
+        "checkpoint_retention",
     )
     def _validate_positive_training(cls, v: int, info: Any) -> int:
         if v <= 0:
@@ -1774,9 +1775,39 @@ class SandboxSettings(BaseSettings):
         env="ENTROPY_REGRESSION_THRESHOLD",
         description="Entropy delta at or below this value flags a regression.",
     )
+    roi_penalty_threshold: float = Field(
+        0.0,
+        env="ROI_PENALTY_THRESHOLD",
+        description="ROI delta at or below this value applies prompt penalties.",
+    )
+    entropy_penalty_threshold: float = Field(
+        0.0,
+        env="ENTROPY_PENALTY_THRESHOLD",
+        description="Entropy delta at or above this value applies prompt penalties.",
+    )
     sandbox_score_db: str = Field(
         (resolve_path(".") / "score_history.db").as_posix(),
         env="SANDBOX_SCORE_DB",
+    )
+    snapshot_dir: str = Field(
+        (resolve_path("sandbox_data") / "snapshots").as_posix(),
+        env="SNAPSHOT_DIR",
+        description="Directory where state snapshots are stored.",
+    )
+    snapshot_diff_dir: str = Field(
+        (resolve_path("sandbox_data") / "diffs").as_posix(),
+        env="SNAPSHOT_DIFF_DIR",
+        description="Directory where snapshot diffs are written.",
+    )
+    checkpoint_dir: str = Field(
+        (resolve_path("sandbox_data") / "checkpoints").as_posix(),
+        env="CHECKPOINT_DIR",
+        description="Directory where state checkpoints are saved.",
+    )
+    checkpoint_retention: int = Field(
+        5,
+        env="CHECKPOINT_RETENTION",
+        description="Number of checkpoint directories to retain.",
     )
     synergy_weights_lr: float = Field(
         0.1,


### PR DESCRIPTION
## Summary
- expose snapshot, diff, and checkpoint directories in `SandboxSettings`
- add ROI/entropy penalty thresholds and checkpoint retention option
- document snapshot tracking in Self-Improvement Engine and README

## Testing
- `PYTHONPATH=. pytest tests/test_checkpoint_creation.py self_improvement/tests/test_prompt_penalties.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b974111c68832e9b4a43c96f6bbcf1