### PR TITLE
Add system snapshot utilities

### DIFF
--- a/self_improvement/system_snapshot.py
+++ b/self_improvement/system_snapshot.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+"""System level snapshot utilities.
+
+This module captures high level system metrics such as ROI, sandbox score and
+code statistics so that self-improvement cycles can be evaluated over time.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+import time
+
+from ..sandbox_settings import SandboxSettings
+from .baseline_tracker import BaselineTracker
+from .sandbox_score import get_latest_sandbox_score
+from . import metrics as _si_metrics
+from ..module_graph_analyzer import build_import_graph
+
+try:  # pragma: no cover - sandbox results logger is optional
+    import sandbox_results_logger  # type: ignore
+except Exception:  # pragma: no cover
+    sandbox_results_logger = None  # type: ignore
+
+
+@dataclass
+class SystemSnapshot:
+    """Snapshot of system metrics at a point in time."""
+
+    roi: float
+    sandbox_score: float
+    entropy: float
+    call_graph_complexity: float
+    token_diversity: float
+    timestamp: float
+    metadata: Dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+
+def _get_sandbox_score(settings: SandboxSettings) -> float:
+    """Return the latest sandbox score.
+
+    Preference is given to the :mod:`sandbox_results_logger` summary when
+    available, otherwise the configured SQLite database is consulted.
+    """
+
+    score = 0.0
+    if sandbox_results_logger is not None:
+        load_summary = getattr(sandbox_results_logger, "load_summary", None)
+        if callable(load_summary):
+            try:
+                summary = load_summary()  # type: ignore[misc]
+                score = float(
+                    summary.get("sandbox_score")
+                    or summary.get("score")
+                    or 0.0
+                )
+            except Exception:  # pragma: no cover - best effort
+                score = 0.0
+    if score == 0.0:
+        try:
+            score = float(get_latest_sandbox_score(settings.sandbox_score_db))
+        except Exception:  # pragma: no cover - best effort
+            score = 0.0
+    return score
+
+
+def capture_snapshot(engine: Any) -> SystemSnapshot:
+    """Collect current metrics from *engine* into a :class:`SystemSnapshot`."""
+
+    settings = SandboxSettings()
+    repo_path = Path(settings.sandbox_repo_path)
+
+    tracker: BaselineTracker = getattr(engine, "roi_tracker")
+    roi = float(tracker.current("roi"))
+    entropy = float(tracker.current("entropy"))
+    sandbox_score = _get_sandbox_score(settings)
+
+    files = list(repo_path.rglob("*.py"))
+    try:
+        _, _, _, _, _, token_diversity = _si_metrics._collect_metrics(
+            files, repo_path, settings
+        )
+    except Exception:  # pragma: no cover - best effort
+        token_diversity = 0.0
+
+    try:
+        graph = build_import_graph(repo_path)
+        nodes = graph.number_of_nodes()
+        call_complexity = (
+            float(graph.number_of_edges()) / float(nodes) if nodes else 0.0
+        )
+    except Exception:  # pragma: no cover - best effort
+        call_complexity = 0.0
+
+    metadata = {
+        "prompt": getattr(engine, "last_prompt", None)
+        or getattr(getattr(engine, "self_coding_engine", None), "_last_prompt", None),
+        "module_paths": getattr(engine, "module_paths", None)
+        or getattr(engine, "last_module_paths", None),
+    }
+
+    return SystemSnapshot(
+        roi=roi,
+        sandbox_score=sandbox_score,
+        entropy=entropy,
+        call_graph_complexity=call_complexity,
+        token_diversity=float(token_diversity),
+        timestamp=float(time.time()),
+        metadata=metadata,
+    )
+
+
+# ---------------------------------------------------------------------------
+
+def compare_snapshots(before: SystemSnapshot, after: SystemSnapshot) -> Dict[str, float]:
+    """Return per-metric differences between two snapshots ``after - before``."""
+
+    return {
+        "roi": after.roi - before.roi,
+        "sandbox_score": after.sandbox_score - before.sandbox_score,
+        "entropy": after.entropy - before.entropy,
+        "call_graph_complexity": after.call_graph_complexity
+        - before.call_graph_complexity,
+        "token_diversity": after.token_diversity - before.token_diversity,
+    }
+
+
+__all__ = ["SystemSnapshot", "capture_snapshot", "compare_snapshots"]

--- a/self_improvement/tests/test_system_snapshot.py
+++ b/self_improvement/tests/test_system_snapshot.py
@@ -1,0 +1,113 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Prepare fake package hierarchy to satisfy relative imports
+ROOT_DIR = Path(__file__).resolve().parents[2]
+PACKAGE_DIR = ROOT_DIR / "self_improvement"
+root_name = "menace_sandbox"
+if root_name not in sys.modules:
+    root_pkg = types.ModuleType(root_name)
+    root_pkg.__path__ = [str(ROOT_DIR)]  # type: ignore[attr-defined]
+    sys.modules[root_name] = root_pkg
+
+package_name = f"{root_name}.self_improvement"
+if package_name not in sys.modules:
+    pkg = types.ModuleType(package_name)
+    pkg.__path__ = [str(PACKAGE_DIR)]  # type: ignore[attr-defined]
+    sys.modules[package_name] = pkg
+
+# Load BaselineTracker without executing package __init__
+spec = importlib.util.spec_from_file_location(
+    f"{package_name}.baseline_tracker", PACKAGE_DIR / "baseline_tracker.py"
+)
+baseline_tracker = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = baseline_tracker
+spec.loader.exec_module(baseline_tracker)  # type: ignore[assignment]
+BaselineTracker = baseline_tracker.BaselineTracker
+
+# Load system_snapshot module
+spec = importlib.util.spec_from_file_location(
+    f"{package_name}.system_snapshot", PACKAGE_DIR / "system_snapshot.py"
+)
+system_snapshot = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = system_snapshot
+spec.loader.exec_module(system_snapshot)  # type: ignore[assignment]
+
+
+class DummyEngine:
+    def __init__(self, tracker):
+        self.roi_tracker = tracker
+        self.last_prompt = "test prompt"
+        self.module_paths = ["a.py", "b.py"]
+
+
+def test_capture_snapshot(monkeypatch, tmp_path):
+    tracker = BaselineTracker()
+    tracker.update(roi=1.5, entropy=0.25)
+    engine = DummyEngine(tracker)
+
+    # stub sandbox_results_logger.load_summary
+    fake_logger = types.SimpleNamespace(load_summary=lambda: {"sandbox_score": 0.8})
+    monkeypatch.setitem(sys.modules, "sandbox_results_logger", fake_logger)
+    monkeypatch.setattr(system_snapshot, "sandbox_results_logger", fake_logger)
+
+    # stub SandboxSettings to point at temporary repo
+    settings = system_snapshot.SandboxSettings(sandbox_repo_path=str(tmp_path))
+    monkeypatch.setattr(system_snapshot, "SandboxSettings", lambda: settings)
+
+    # stub metrics._collect_metrics to control token_diversity
+    def fake_collect(files, repo, settings=None):
+        return ({}, 0, 0.0, 0, 0.0, 0.6)
+
+    monkeypatch.setattr(system_snapshot._si_metrics, "_collect_metrics", fake_collect)
+
+    class FakeGraph:
+        def number_of_edges(self):
+            return 4
+
+        def number_of_nodes(self):
+            return 2
+
+    monkeypatch.setattr(system_snapshot, "build_import_graph", lambda path: FakeGraph())
+
+    snap = system_snapshot.capture_snapshot(engine)
+    assert snap.roi == 1.5
+    assert snap.sandbox_score == 0.8
+    assert snap.entropy == 0.25
+    assert snap.call_graph_complexity == 2.0
+    assert snap.token_diversity == 0.6
+    assert snap.metadata["prompt"] == "test prompt"
+    assert snap.metadata["module_paths"] == ["a.py", "b.py"]
+
+
+def test_compare_snapshots():
+    before = system_snapshot.SystemSnapshot(
+        roi=1.0,
+        sandbox_score=0.5,
+        entropy=0.1,
+        call_graph_complexity=1.0,
+        token_diversity=0.2,
+        timestamp=0.0,
+        metadata={},
+    )
+    after = system_snapshot.SystemSnapshot(
+        roi=2.0,
+        sandbox_score=0.7,
+        entropy=0.3,
+        call_graph_complexity=1.5,
+        token_diversity=0.25,
+        timestamp=1.0,
+        metadata={},
+    )
+    delta = system_snapshot.compare_snapshots(before, after)
+    assert delta == {
+        "roi": pytest.approx(1.0),
+        "sandbox_score": pytest.approx(0.2),
+        "entropy": pytest.approx(0.2),
+        "call_graph_complexity": pytest.approx(0.5),
+        "token_diversity": pytest.approx(0.05),
+    }


### PR DESCRIPTION
## Summary
- add SystemSnapshot dataclass and helpers to capture ROI, sandbox score, entropy and code metrics
- implement snapshot comparison utilities
- cover new functionality with targeted unit tests

## Testing
- `PYTHONPATH=$PWD pytest self_improvement/tests/test_system_snapshot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b97560a8d4832eb863e36d63dc0fd5