### PR TITLE
Use resolve_path for chunk summary cache fallback

### DIFF
--- a/prompt_engine.py
+++ b/prompt_engine.py
@@ -60,7 +60,6 @@ except Exception:  # pragma: no cover - logging only when available
 
 
 logger = logging.getLogger(__name__)
-ROOT_DIR = resolve_path(".")
 
 try:  # pragma: no cover - optional precise tokenizer
     import tiktoken
@@ -199,7 +198,7 @@ class PromptEngine:
     chunk_summary_cache_dir: Path = field(
         default_factory=lambda: resolve_path(_SETTINGS.chunk_summary_cache_dir)
         if _SETTINGS
-        else ROOT_DIR / "chunk_summary_cache"
+        else resolve_path("chunk_summary_cache")
     )
     llm: LLMClient | None = None
     roi_weight: float = 1.0


### PR DESCRIPTION
## Summary
- Use `resolve_path("chunk_summary_cache")` as PromptEngine's default cache directory when settings are missing, removing the unused root constant.
- Confirm other file paths in PromptEngine continue to use `resolve_path` or `path_for_prompt` as appropriate.

## Testing
- `pre-commit run --files prompt_engine.py`
- `pytest tests/test_prompt_engine.py` *(fails: ImportError: cannot import name 'path_for_prompt')*


------
https://chatgpt.com/codex/tasks/task_e_68b976c7eca4832e9fa733f5ce70bfa7