### PR TITLE
Scan generated files for Stripe imports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,8 @@ jobs:
         run: pre-commit run forbid-sqlite3-connect --all-files
       - name: Prevent direct Stripe imports
         run: pre-commit run forbid-stripe-imports --all-files
+      - name: Prevent Stripe live keys or endpoints
+        run: pre-commit run forbid-stripe-keys --all-files
       - name: Run flake8
         run: pre-commit run flake8 --all-files
       - name: Enforce DB router usage


### PR DESCRIPTION
## Summary
- Run `scripts/check_stripe_imports.py` during bot generation and fail when direct Stripe imports are detected.
- Extend CI to invoke the Stripe key check as part of pre-commit validation.

## Testing
- `pre-commit run --files bot_development_bot.py .github/workflows/tests.yml`
- `PYTHONPATH=. pytest tests/test_db_router_enforcement.py -q` *(fails: Disallowed sqlite3.connect usage)*

------
https://chatgpt.com/codex/tasks/task_e_68b977fb0bd0832e832e6a7355ba5ac3