### PR TITLE
Use dynamic path for autonomous setup marker

### DIFF
--- a/run_autonomous.py
+++ b/run_autonomous.py
@@ -509,7 +509,10 @@ def validate_synergy_history(hist: list[dict]) -> list[dict[str, float]]:
     return validated
 
 
-_SETUP_MARKER = Path(".autonomous_setup_complete")
+# Resolve the setup marker path via the dynamic router to avoid
+# reliance on relative paths when the module is imported from different
+# working directories.
+_SETUP_MARKER = resolve_path(".autonomous_setup_complete")
 
 
 def _check_dependencies(settings: SandboxSettings) -> bool:

--- a/tests/test_run_autonomous_setup_marker.py
+++ b/tests/test_run_autonomous_setup_marker.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import re
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_run_autonomous_uses_dynamic_setup_marker():
+    src = (REPO_ROOT / "run_autonomous.py").read_text()
+    assert 'resolve_path(".autonomous_setup_complete")' in src
+    assert 'Path(".autonomous_setup_complete")' not in src
+
+
+def test_self_coding_modules_have_no_hardcoded_paths():
+    pattern = re.compile(r'Path\(\"|\"[^"\n]+/[^"\n]+\.py\"')
+    for name in ["self_coding_manager.py", "quick_fix_engine.py"]:
+        text = (REPO_ROOT / name).read_text()
+        matches = pattern.findall(text)
+        assert not matches, f"{name} contains hard-coded paths: {matches}"


### PR DESCRIPTION
## Summary
- resolve `_SETUP_MARKER` via `resolve_path` in `run_autonomous`
- add test ensuring self-coding modules avoid hard-coded paths

## Testing
- `python -m pytest tests/test_run_autonomous_setup_marker.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b978070278832e87d17773e941a565