### PR TITLE
Use resolve_path for dynamic log paths

### DIFF
--- a/central_evaluation_loop.py
+++ b/central_evaluation_loop.py
@@ -72,7 +72,9 @@ ROLLBACK_MANAGER = RollbackManager()
 FORESIGHT_TRACKER = ForesightTracker()
 
 # Paths for input logs and output records
-ACTIONS_FILE = os.getenv("ACTIONS_FILE", "/mnt/shared/menace_logs/actions.jsonl")
+ACTIONS_FILE = resolve_path(
+    os.getenv("ACTIONS_FILE", "menace_logs/actions.jsonl")
+)
 CURSOR_FILE = resolve_path("last_processed.txt")
 AUDIT_DIR = resolve_path("audit_logs")
 

--- a/deployment_governance.py
+++ b/deployment_governance.py
@@ -437,7 +437,9 @@ class DeploymentGovernor:
                 roi_min = float(
                     (policy or {}).get("roi_forecast_min", self.raroi_threshold)
                 )
-                logger_obj = ForecastLogger("forecast_records/decision_log.jsonl")
+                logger_obj = ForecastLogger(
+                    resolve_path("forecast_records/decision_log.jsonl")
+                )
                 forecaster = UpgradeForecaster(foresight_tracker)
                 safe, forecast, reason_codes = is_foresight_safe_to_promote(
                     workflow_id,
@@ -636,7 +638,9 @@ def evaluate_workflow(
             roi_min = float(
                 policy.get("roi_forecast_min", DeploymentGovernor.raroi_threshold)
             )
-            logger_obj = ForecastLogger("forecast_records/decision_log.jsonl")
+            logger_obj = ForecastLogger(
+                resolve_path("forecast_records/decision_log.jsonl")
+            )
             forecaster = UpgradeForecaster(foresight_tracker)
             safe, forecast, reason_codes = is_foresight_safe_to_promote(
                 workflow_id,
@@ -788,7 +792,9 @@ def evaluate(
             logger_obj: ForecastLogger | None = None
             try:
                 graph = WorkflowGraph()
-                logger_obj = ForecastLogger("forecast_records/decision_log.jsonl")
+                logger_obj = ForecastLogger(
+                    resolve_path("forecast_records/decision_log.jsonl")
+                )
                 forecaster = UpgradeForecaster(foresight_tracker)
                 safe, forecast, reason_codes = is_foresight_safe_to_promote(
                     workflow_id,
@@ -1145,7 +1151,9 @@ class RuleEvaluator:
                             logger_obj: ForecastLogger | None = None
                             try:
                                 graph = WorkflowGraph()
-                                logger_obj = ForecastLogger("forecast_records/decision_log.jsonl")
+                                logger_obj = ForecastLogger(
+                                    resolve_path("forecast_records/decision_log.jsonl")
+                                )
                                 forecaster = UpgradeForecaster(foresight_tracker)
                                 safe, forecast, reason_codes = is_foresight_safe_to_promote(
                                     workflow_id,

--- a/weekly_report_generator.py
+++ b/weekly_report_generator.py
@@ -169,8 +169,9 @@ def generate_weekly_report(start_date: str | None = None, end_date: str | None =
 def write_report(report_data: Dict[str, Any], output_path: str) -> None:
     """Write *report_data* to JSON and plaintext in *output_path*."""
 
-    os.makedirs(output_path, exist_ok=True)
-    json_path = os.path.join(output_path, "weekly_report.json")
+    output_dir = resolve_path(output_path)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / "weekly_report.json"
     with open(json_path, "w", encoding="utf-8") as fh:
         json.dump(report_data, fh, indent=2)
 
@@ -196,7 +197,7 @@ def write_report(report_data: Dict[str, Any], output_path: str) -> None:
             f"  - {ev.get('timestamp')} {ev.get('reason')} (severity {ev.get('severity')})"
         )
 
-    text_path = os.path.join(output_path, "weekly_report.txt")
+    text_path = output_dir / "weekly_report.txt"
     with open(text_path, "w", encoding="utf-8") as fh:
         fh.write("\n".join(lines))
 


### PR DESCRIPTION
## Summary
- resolve default action log via `resolve_path` in central evaluation loop
- route decision log file through `resolve_path` in deployment governance
- generate weekly report outputs using repository-relative paths

## Testing
- `python tools/check_dynamic_paths.py central_evaluation_loop.py deployment_governance.py weekly_report_generator.py run_autonomous.py`

------
https://chatgpt.com/codex/tasks/task_e_68b979493da4832ea56ab1c891d5556e