### PR TITLE
Track snapshot regressions

### DIFF
--- a/snapshot_history_db.py
+++ b/snapshot_history_db.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Persistent store for snapshot regression records."""
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+from sandbox_settings import SandboxSettings
+
+try:  # pragma: no cover - optional dependency location
+    from dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover
+    def resolve_path(p: str) -> str:  # type: ignore
+        return p
+
+
+def _db_path(settings: SandboxSettings | None = None) -> Path:
+    settings = settings or SandboxSettings()
+    return Path(resolve_path(settings.sandbox_data_dir)) / "snapshot_history.db"
+
+
+def log_regression(prompt: str | None, diff: str | None, delta: Dict[str, Any]) -> None:
+    """Persist a regression record to :mod:`snapshot_history.db`."""
+
+    path = _db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS regressions(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts REAL,
+                prompt TEXT,
+                diff TEXT,
+                roi_delta REAL,
+                entropy_delta REAL,
+                delta_json TEXT
+            )
+            """
+        )
+        ts = time.time()
+        diff_text = diff or ""
+        try:
+            if diff and Path(diff).is_file():
+                diff_text = Path(diff).read_text(encoding="utf-8")
+        except Exception:  # pragma: no cover - best effort
+            diff_text = diff or ""
+        conn.execute(
+            "INSERT INTO regressions(ts, prompt, diff, roi_delta, entropy_delta, delta_json) VALUES(?,?,?,?,?,?)",
+            (
+                ts,
+                prompt or "",
+                diff_text,
+                float(delta.get("roi", 0.0)),
+                float(delta.get("entropy", 0.0)),
+                json.dumps(delta),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+__all__ = ["log_regression"]

--- a/tests/test_snapshot_regression_logging.py
+++ b/tests/test_snapshot_regression_logging.py
@@ -1,0 +1,35 @@
+import importlib
+import sqlite3
+from pathlib import Path
+
+def test_delta_logs_regression(tmp_path, monkeypatch):
+    st = importlib.import_module("menace_sandbox.self_improvement.snapshot_tracker")
+    sh = importlib.import_module("menace_sandbox.snapshot_history_db")
+    monkeypatch.setattr(st, "resolve_path", lambda p: p)
+    monkeypatch.setattr(sh, "resolve_path", lambda p: p)
+
+    class Settings:
+        sandbox_data_dir = str(tmp_path)
+
+    monkeypatch.setattr(st, "SandboxSettings", lambda: Settings())
+    monkeypatch.setattr(sh, "SandboxSettings", lambda: Settings())
+
+    events: list[tuple[str, dict]] = []
+    monkeypatch.setattr(st, "audit_log_event", lambda name, payload: events.append((name, payload)))
+
+    tracker = st.SnapshotTracker()
+    before = st.Snapshot(1.0, 0.0, 0.1, 0.0, 0.0)
+    diff_file = tmp_path / "diff.patch"
+    diff_file.write_text("diff-data", encoding="utf-8")
+    after = st.Snapshot(0.5, 0.0, 0.2, 0.0, 0.0, prompt="p", diff=str(diff_file))
+    tracker._snaps["before"] = before
+    tracker._snaps["after"] = after
+    tracker._context["after"] = {"prompt": "p", "diff": str(diff_file)}
+
+    delta = tracker.delta()
+    assert delta["regression"] is True
+
+    conn = sqlite3.connect(tmp_path / "snapshot_history.db")
+    rows = conn.execute("SELECT prompt, diff, roi_delta, entropy_delta FROM regressions").fetchall()
+    assert rows == [("p", "diff-data", -0.5, 0.1)]
+    assert events and events[0][0] == "snapshot_regression"


### PR DESCRIPTION
## Summary
- flag snapshot regressions when ROI drops or entropy rises
- log regression details with prompt and diff to `snapshot_history.db`
- emit audit events for snapshot regressions

## Testing
- `PYTHONPATH=/workspace/menace_sandbox pytest tests/test_checkpoint_creation.py tests/test_strategy_deprioritization.py tests/test_snapshot_tracker.py tests/test_snapshot_regression_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9792193b4832e931a0f98ff32537c