### PR TITLE
chore: flag jsonl and log paths

### DIFF
--- a/tools/check_dynamic_paths.py
+++ b/tools/check_dynamic_paths.py
@@ -14,7 +14,7 @@ import sys
 from pathlib import Path
 from typing import Iterable
 
-TRIGGER_SUBSTRINGS = ["sandbox_data"]
+TRIGGER_SUBSTRINGS = ["sandbox_data", "logs"]
 SCRIPT_NAME = Path(__file__).name
 
 # File extensions that should be treated as potential path references. ``.py``
@@ -23,7 +23,7 @@ SCRIPT_NAME = Path(__file__).name
 # path separator so that bare filenames like ``sandbox_settings.yaml`` are
 # caught.
 _EXTENSIONS_NEED_SLASH = (".py",)
-_EXTENSIONS_ALWAYS = (".yaml", ".yml", ".json", ".db")
+_EXTENSIONS_ALWAYS = (".yaml", ".yml", ".json", ".jsonl", ".db", ".log")
 
 
 def _triggers(value: str) -> bool:


### PR DESCRIPTION
## Summary
- broaden dynamic path checker to look for common log directories
- flag .jsonl and .log references as dynamic paths

## Testing
- `python tools/check_dynamic_paths.py review_queue.py`

------
https://chatgpt.com/codex/tasks/task_e_68b97a8920c4832e8f59a1a4037f9564