### PR TITLE
Enforce stripe billing router in prompt templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1091,7 +1091,7 @@ The deployment helpers use the following variables:
 - `AUTOSCALER_PROVIDER` – scaling backend: `local`, `kubernetes` or `swarm`.
 - `K8S_DEPLOYMENT` – target deployment when using the Kubernetes provider.
 - `SWARM_SERVICE` – target service when using the Docker Swarm provider.
-- `PROMPT_TEMPLATES_PATH` – path to `prompt_templates.v1.json` when running
+- `PROMPT_TEMPLATES_PATH` – path to `prompt_templates.v2.json` when running
 
   outside the repository.
 - `METRICS_PORT` – start the internal metrics exporter on this port (same as `--metrics-port`).

--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -136,7 +136,7 @@ class RetryStrategy:
         raise RuntimeError("retry strategy exhausted")
 
 
-DEFAULT_TEMPLATE = Path(__file__).resolve().parent / "config" / "prompt_templates.v1.json"
+DEFAULT_TEMPLATE = Path(__file__).resolve().parent / "config" / "prompt_templates.v2.json"
 PROMPT_TEMPLATES_PATH = Path(os.getenv("PROMPT_TEMPLATES_PATH", DEFAULT_TEMPLATE))
 
 TEMPLATE_SECTION_KEY = "templates"

--- a/config/prompt_templates.v2.json
+++ b/config/prompt_templates.v2.json
@@ -1,10 +1,11 @@
 {
-  "version": 1,
+  "version": 2,
   "templates": {
     "coding_standards": [
       "- Follow PEP8 style guidelines with 4 space indents and lines under 79 characters.",
       "- Provide Google style docstrings for modules, classes and functions.",
-      "- Include inline comments explaining complex logic."
+      "- Include inline comments explaining complex logic.",
+      "- All payment logic must import and use stripe_billing_router; failing to do so is a critical generation error. Raw Stripe keys, API calls, or checkout flows outside this router are forbidden."
     ],
     "repository_layout": [
       "- Place source code in {name}.py at the repository root.",
@@ -23,8 +24,7 @@
       "- Include at least one test per function and output coverage with 'pytest --cov'."
     ],
     "billing": [
-      "- All payment logic must import and use stripe_billing_router.",
-      "- Direct Stripe SDK calls or raw Stripe keys are forbidden."
+      "- All payment logic must import and use stripe_billing_router; failing to do so is a critical generation error. Raw Stripe keys, API calls, or checkout flows outside this router are forbidden."
     ]
   }
 }

--- a/prompt_engine.py
+++ b/prompt_engine.py
@@ -216,7 +216,7 @@ class PromptEngine:
     template_path: Path = Path(
         os.getenv(
             "PROMPT_TEMPLATES_PATH",
-            str(resolve_path("config/prompt_templates.v1.json")),
+            str(resolve_path("config/prompt_templates.v2.json")),
         )
     )
     template_sections: List[str] = field(


### PR DESCRIPTION
## Summary
- require payment logic to use `stripe_billing_router` in prompt templates with critical error notice
- bump prompt template config to v2 and update references

## Testing
- `bash scripts/setup_tests.sh`
- `pytest` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*


------
https://chatgpt.com/codex/tasks/task_e_68b97dff7f60832ebe9b13f18c6b00ca