### PR TITLE
Add prompt downgrade tracking and scheduling safeguards

### DIFF
--- a/self_improvement/prompt_memory.py
+++ b/self_improvement/prompt_memory.py
@@ -23,7 +23,7 @@ _penalty_lock = FileLock(str(_penalty_path) + ".lock")
 
 
 def load_prompt_penalties() -> Dict[str, int]:
-    """Return mapping of prompt identifiers to regression counts."""
+    """Return mapping of prompt identifiers to downgrade counts."""
 
     with _penalty_lock:
         try:
@@ -36,7 +36,7 @@ def load_prompt_penalties() -> Dict[str, int]:
 
 
 def record_regression(prompt_id: str) -> int:
-    """Increment regression count for ``prompt_id`` and persist to disk."""
+    """Increment downgrade count for ``prompt_id`` and persist to disk."""
 
     with _penalty_lock:
         penalties = load_prompt_penalties()
@@ -44,6 +44,20 @@ def record_regression(prompt_id: str) -> int:
         _penalty_path.parent.mkdir(parents=True, exist_ok=True)
         _penalty_path.write_text(json.dumps(penalties), encoding="utf-8")
         return penalties[prompt_id]
+
+
+# Backwards compatible aliases for clarity ---------------------------------
+
+def load_prompt_downgrades() -> Dict[str, int]:
+    """Alias for :func:`load_prompt_penalties`."""
+
+    return load_prompt_penalties()
+
+
+def record_downgrade(prompt_id: str) -> int:
+    """Alias for :func:`record_regression`."""
+
+    return record_regression(prompt_id)
 
 
 def reset_penalty(prompt_id: str) -> None:

--- a/tests/test_snapshot_regression_logging.py
+++ b/tests/test_snapshot_regression_logging.py
@@ -1,8 +1,10 @@
 import importlib
-import sqlite3
 import sys
 import types
 from pathlib import Path
+
+from db_router import DBRouter
+
 
 def test_delta_logs_regression(tmp_path, monkeypatch):
     stub = types.SimpleNamespace(
@@ -14,8 +16,10 @@ def test_delta_logs_regression(tmp_path, monkeypatch):
         resolve_path=lambda p: p,
         resolve_dir=lambda p: Path(p),
     )
+    from dynamic_path_router import resolve_path
     st = importlib.import_module("menace_sandbox.self_improvement.snapshot_tracker")
     sh = importlib.import_module("menace_sandbox.snapshot_history_db")
+    pm = importlib.import_module("menace_sandbox.self_improvement.prompt_memory")
     monkeypatch.setattr(st, "resolve_path", lambda p: p)
     monkeypatch.setattr(sh, "resolve_path", lambda p: p)
 
@@ -24,13 +28,18 @@ def test_delta_logs_regression(tmp_path, monkeypatch):
 
     monkeypatch.setattr(st, "SandboxSettings", lambda: Settings())
     monkeypatch.setattr(sh, "SandboxSettings", lambda: Settings())
+    base = Path(resolve_path(str(tmp_path)))
+    monkeypatch.setattr(pm, "_repo_path", lambda: base)
+    monkeypatch.setattr(pm._settings, "prompt_penalty_path", "penalties.json")
+    monkeypatch.setattr(pm, "_penalty_path", base / "penalties.json")
+    monkeypatch.setattr(pm, "_penalty_lock", pm.FileLock(str(base / "penalties.json") + ".lock"))
 
     events: list[tuple[str, dict]] = []
     monkeypatch.setattr(st, "audit_log_event", lambda name, payload: events.append((name, payload)))
 
     tracker = st.SnapshotTracker()
     before = st.Snapshot(1.0, 0.0, 0.1, 0.0, 0.0)
-    diff_file = tmp_path / "diff.patch"
+    diff_file = Path(resolve_path(str(base / "diff.patch")))
     diff_file.write_text("diff-data", encoding="utf-8")
     after = st.Snapshot(0.5, 0.0, 0.2, 0.0, 0.0, prompt="p", diff=str(diff_file))
     tracker._snaps["before"] = before
@@ -40,7 +49,15 @@ def test_delta_logs_regression(tmp_path, monkeypatch):
     delta = tracker.delta()
     assert delta["regression"] is True
 
-    conn = sqlite3.connect(tmp_path / "snapshot_history.db")
-    rows = conn.execute("SELECT prompt, diff, roi_delta, entropy_delta FROM regressions").fetchall()
+    router = DBRouter(
+        "snapshot_history",
+        str(base / "snapshot_history.db"),
+        str(base / "snapshot_history.db"),
+    )
+    conn = router.get_connection("regressions")
+    rows = conn.execute(
+        "SELECT prompt, diff, roi_delta, entropy_delta FROM regressions"
+    ).fetchall()
     assert rows == [("p", "diff-data", -0.5, 0.1)]
     assert events and events[0][0] == "snapshot_regression"
+    assert pm.load_prompt_penalties()["p"] == 1


### PR DESCRIPTION
## Summary
- track per-prompt downgrades with helper aliases in `prompt_memory`
- record downgrades when snapshot regressions are logged and route DB writes through `DBRouter`
- deprioritise strategies with excessive regressions during selection
- add regression penalty tests for snapshot logging and strategy choice

## Testing
- `pre-commit run --files self_improvement/prompt_memory.py snapshot_history_db.py self_improvement/engine.py tests/test_snapshot_regression_logging.py tests/test_strategy_deprioritization.py`
- `python - <<'PY'
import types, sys, pytest
sys.modules['dynamic_path_router'] = types.SimpleNamespace(resolve_path=lambda p: p, resolve_dir=lambda p: p)
res = pytest.main(['tests/test_snapshot_regression_logging.py','tests/test_strategy_deprioritization.py','self_improvement/tests/test_prompt_penalties.py'])
print('exit', res)
PY` *(fails: AttributeError: 'str' object has no attribute 'parent')*

------
https://chatgpt.com/codex/tasks/task_e_68b97c923e9c832ebbf96c80276684f4