### PR TITLE
Add snapshot history database and integrate SnapshotTracker logging

### DIFF
--- a/snapshot_history_db.py
+++ b/snapshot_history_db.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-"""Persistent store for snapshot regression records."""
+"""Persistent store for snapshot history and regression records."""
 
-import json
-import time
 from pathlib import Path
 from typing import Any, Dict
+import json
+import time
 
 from sandbox_settings import SandboxSettings
 from self_improvement import prompt_memory
@@ -23,13 +23,50 @@ def _db_path(settings: SandboxSettings | None = None) -> Path:
     return Path(resolve_path(settings.sandbox_data_dir)) / "snapshot_history.db"
 
 
-def log_regression(prompt: str | None, diff: str | None, delta: Dict[str, Any]) -> None:
-    """Persist a regression record to :mod:`snapshot_history.db`."""
+def _get_conn(settings: SandboxSettings | None = None):
+    """Return a connection to the snapshot history database.
 
-    path = _db_path()
+    The required tables are created on demand.
+    """
+
+    path = _db_path(settings)
     path.parent.mkdir(parents=True, exist_ok=True)
     router = DBRouter("snapshot_history", str(path), str(path))
-    conn = router.get_connection("regressions")
+    conn = router.get_connection("history")
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS snapshots(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            cycle INTEGER,
+            stage TEXT,
+            ts REAL,
+            roi REAL,
+            sandbox_score REAL,
+            entropy REAL,
+            call_graph_complexity REAL,
+            token_diversity REAL,
+            prompt TEXT,
+            diff TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS deltas(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            cycle INTEGER,
+            before_id INTEGER,
+            after_id INTEGER,
+            ts REAL,
+            roi_delta REAL,
+            sandbox_score_delta REAL,
+            entropy_delta REAL,
+            call_graph_complexity_delta REAL,
+            token_diversity_delta REAL,
+            regression INTEGER
+        )
+        """
+    )
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS regressions(
@@ -43,6 +80,83 @@ def log_regression(prompt: str | None, diff: str | None, delta: Dict[str, Any]) 
         )
         """
     )
+    return conn
+
+
+def record_snapshot(cycle: int, stage: str, snap: Any) -> int:
+    """Store *snap* for ``cycle`` and return the inserted row id."""
+
+    conn = _get_conn()
+    cur = conn.execute(
+        (
+            "INSERT INTO snapshots(" "cycle, stage, ts, roi, sandbox_score, entropy, "
+            "call_graph_complexity, token_diversity, prompt, diff)"
+            " VALUES(?,?,?,?,?,?,?,?,?,?)"
+        ),
+        (
+            int(cycle),
+            stage,
+            float(getattr(snap, "timestamp", time.time())),
+            float(getattr(snap, "roi", 0.0)),
+            float(getattr(snap, "sandbox_score", 0.0)),
+            float(getattr(snap, "entropy", 0.0)),
+            float(getattr(snap, "call_graph_complexity", 0.0)),
+            float(getattr(snap, "token_diversity", 0.0)),
+            getattr(snap, "prompt", None) or "",
+            getattr(snap, "diff", None) or "",
+        ),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
+
+
+def record_delta(
+    cycle: int,
+    before_id: int,
+    after_id: int,
+    delta: Dict[str, Any],
+    ts: float | None = None,
+) -> int:
+    """Store ``delta`` for ``cycle`` and return the inserted row id."""
+
+    conn = _get_conn()
+    cur = conn.execute(
+        (
+            "INSERT INTO deltas(" "cycle, before_id, after_id, ts, roi_delta, "
+            "sandbox_score_delta, entropy_delta, call_graph_complexity_delta, "
+            "token_diversity_delta, regression) VALUES(" "?,?,?,?,?,?,?,?,?,?)"
+        ),
+        (
+            int(cycle),
+            int(before_id),
+            int(after_id),
+            float(ts if ts is not None else time.time()),
+            float(delta.get("roi", 0.0)),
+            float(delta.get("sandbox_score", 0.0)),
+            float(delta.get("entropy", 0.0)),
+            float(delta.get("call_graph_complexity", 0.0)),
+            float(delta.get("token_diversity", 0.0)),
+            1 if bool(delta.get("regression")) else 0,
+        ),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
+
+
+def last_successful_cycle(settings: SandboxSettings | None = None) -> int | None:
+    """Return the most recent cycle id without a regression."""
+
+    conn = _get_conn(settings)
+    row = conn.execute(
+        "SELECT cycle FROM deltas WHERE regression=0 ORDER BY cycle DESC LIMIT 1"
+    ).fetchone()
+    return int(row[0]) if row else None
+
+
+def log_regression(prompt: str | None, diff: str | None, delta: Dict[str, Any]) -> None:
+    """Persist a regression record to the ``regressions`` table."""
+
+    conn = _get_conn()
     ts = time.time()
     diff_text = diff or ""
     try:
@@ -52,9 +166,8 @@ def log_regression(prompt: str | None, diff: str | None, delta: Dict[str, Any]) 
         diff_text = diff or ""
     conn.execute(
         (
-            "INSERT INTO regressions("
-            "ts, prompt, diff, roi_delta, entropy_delta, delta_json) "
-            "VALUES(?,?,?,?,?,?)"
+            "INSERT INTO regressions(" "ts, prompt, diff, roi_delta, entropy_delta, "
+            "delta_json) VALUES(?,?,?,?,?,?)"
         ),
         (
             ts,
@@ -68,10 +181,16 @@ def log_regression(prompt: str | None, diff: str | None, delta: Dict[str, Any]) 
     conn.commit()
 
     if prompt:
-        try:
+        try:  # pragma: no cover - best effort
             prompt_memory.record_downgrade(str(prompt))
-        except Exception:  # pragma: no cover - best effort
+        except Exception:
             pass
 
 
-__all__ = ["log_regression"]
+__all__ = [
+    "record_snapshot",
+    "record_delta",
+    "last_successful_cycle",
+    "log_regression",
+]
+

--- a/tests/test_snapshot_tracker.py
+++ b/tests/test_snapshot_tracker.py
@@ -14,7 +14,25 @@ package.__path__ = [str(pkg_path)]
 sys.modules["menace_sandbox.self_improvement"] = package
 
 sys.modules["codebase_diff_checker"] = types.ModuleType("codebase_diff_checker")
-sys.modules["logging_utils"] = types.SimpleNamespace(log_record=lambda **k: {})
+
+
+class _Logger:
+    def warning(self, *a, **k):
+        pass
+
+    def info(self, *a, **k):
+        pass
+
+    def debug(self, *a, **k):
+        pass
+
+
+sys.modules["logging_utils"] = types.SimpleNamespace(
+    log_record=lambda **k: {},
+    get_logger=lambda *a, **k: _Logger(),
+    set_correlation_id=lambda *a, **k: None,
+    setup_logging=lambda *a, **k: None,
+)
 stub_pm = types.ModuleType("prompt_memory")
 stub_pm.log_prompt_attempt = lambda *a, **k: None
 stub_pm.reset_penalty = lambda *a, **k: None


### PR DESCRIPTION
## Summary
- persist snapshots and metric deltas to `snapshot_history.db`
- wire `SnapshotTracker` to log snapshots and deltas
- add tests scaffolding for snapshot history queries

## Testing
- `pytest tests/test_snapshot_tracker_confidence.py tests/test_snapshot_regression_logging.py tests/test_snapshot_tracker.py tests/test_snapshot_history_db_storage.py` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68b980ddbdd8832ea91a5f8114c1582a