### PR TITLE
Use dynamic path resolution for governance rules

### DIFF
--- a/governance.py
+++ b/governance.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Dict, Iterable, List, Mapping
 
 import json
 
+from dynamic_path_router import resolve_path
 from .roi_tracker import ROITracker
 
 try:  # pragma: no cover - optional dependency in minimal envs
@@ -53,7 +54,7 @@ def load_rules(config_dir: str | Path | None = None) -> list[Rule]:
     """
 
     if config_dir is None:
-        config_dir = Path(__file__).resolve().parent / "config"
+        config_dir = resolve_path("config")
     cfg = Path(config_dir)
     paths = [cfg / "governance_rules.yaml", cfg / "governance_rules.json"]
     for path in paths:


### PR DESCRIPTION
## Summary
- load governance rules using dynamic_path_router.resolve_path
- import resolve_path for config resolution

## Testing
- `pytest tests/test_governance.py -q` *(fails: ImportError: attempted relative import with no known parent package)*
- `pytest tests/test_central_evaluation_roi.py::test_alignment_veto -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '')*


------
https://chatgpt.com/codex/tasks/task_e_68b9829fc748832ea659e99d88bc7411