### PR TITLE
Parameterize snapshot metrics and add snapshot tracker tests

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -2056,6 +2056,18 @@ class SandboxSettings(BaseSettings):
         description="Directories to skip when collecting code metrics.",
     )
 
+    snapshot_metrics: list[str] = Field(
+        default_factory=lambda: [
+            "roi",
+            "sandbox_score",
+            "entropy",
+            "call_graph_complexity",
+            "token_diversity",
+        ],
+        env="SNAPSHOT_METRICS",
+        description="Metrics captured and tracked for each self-improvement snapshot.",
+    )
+
     # self test integration scoring knobs
     integration_score_threshold: float = Field(
         0.0,

--- a/self_improvement/tests/test_delta_regression_flagging.py
+++ b/self_improvement/tests/test_delta_regression_flagging.py
@@ -1,0 +1,70 @@
+import importlib
+import types
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault("dynamic_path_router", types.SimpleNamespace(resolve_path=lambda p: Path(p)))
+sys.modules.setdefault("audit_logger", types.SimpleNamespace(log_event=lambda *a, **k: None))
+sys.modules.setdefault(
+    "snapshot_history_db",
+    types.SimpleNamespace(
+        log_regression=lambda *a, **k: None,
+        record_snapshot=lambda *a, **k: 1,
+        record_delta=lambda *a, **k: None,
+    ),
+)
+sys.modules.setdefault(
+    "module_graph_analyzer",
+    types.SimpleNamespace(
+        build_import_graph=lambda root: types.SimpleNamespace(
+            number_of_nodes=lambda: 0, number_of_edges=lambda: 0
+        )
+    ),
+)
+
+pkg = types.ModuleType("menace_sandbox.self_improvement")
+pkg.__path__ = [str(ROOT / "self_improvement")]
+sys.modules["menace_sandbox.self_improvement"] = pkg
+
+tracker_mod = importlib.import_module("menace_sandbox.self_improvement.snapshot_tracker")
+from menace_sandbox.sandbox_settings import SandboxSettings
+
+
+def test_delta_regression_flagging(monkeypatch, tmp_path):
+    settings = SandboxSettings(
+        sandbox_data_dir=str(tmp_path),
+        snapshot_metrics=["roi", "entropy"],
+    )
+    monkeypatch.setattr(tracker_mod, "SandboxSettings", lambda: settings)
+    tracker = tracker_mod.SnapshotTracker()
+
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        tracker_mod, "log_regression", lambda p, d, delta: calls.append(delta)
+    )
+    monkeypatch.setattr(tracker_mod, "record_delta", lambda *a, **k: None)
+    monkeypatch.setattr(tracker_mod, "audit_log_event", lambda *a, **k: None)
+
+    before = tracker_mod.Snapshot(1.0, 0.0, 0.5, 0.0, 0.1, timestamp=0.0)
+    after = tracker_mod.Snapshot(0.0, 0.0, 0.5, 0.0, 0.1, timestamp=1.0)
+    tracker._snaps["before"] = before
+    tracker._snaps["after"] = after
+    tracker._context["after"] = {}
+
+    delta = tracker.delta()
+    assert delta["regression"]
+    assert calls
+
+    calls.clear()
+    before = tracker_mod.Snapshot(1.0, 0.0, 0.5, 0.0, 0.1, timestamp=0.0)
+    after = tracker_mod.Snapshot(1.0, 0.0, 0.7, 0.0, 0.1, timestamp=1.0)
+    tracker._snaps["before"] = before
+    tracker._snaps["after"] = after
+    delta = tracker.delta()
+    assert delta["regression"]
+    assert calls

--- a/self_improvement/tests/test_snapshot_capture.py
+++ b/self_improvement/tests/test_snapshot_capture.py
@@ -1,0 +1,72 @@
+import importlib
+import types
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault("dynamic_path_router", types.SimpleNamespace(resolve_path=lambda p: Path(p)))
+sys.modules.setdefault("audit_logger", types.SimpleNamespace(log_event=lambda *a, **k: None))
+sys.modules.setdefault(
+    "snapshot_history_db",
+    types.SimpleNamespace(
+        log_regression=lambda *a, **k: None,
+        record_snapshot=lambda *a, **k: 1,
+        record_delta=lambda *a, **k: None,
+    ),
+)
+sys.modules.setdefault(
+    "module_graph_analyzer",
+    types.SimpleNamespace(
+        build_import_graph=lambda root: types.SimpleNamespace(
+            number_of_nodes=lambda: 0, number_of_edges=lambda: 0
+        )
+    ),
+)
+
+pkg = types.ModuleType("menace_sandbox.self_improvement")
+pkg.__path__ = [str(ROOT / "self_improvement")]
+sys.modules["menace_sandbox.self_improvement"] = pkg
+
+baseline_mod = importlib.import_module("menace_sandbox.self_improvement.baseline_tracker")
+tracker_mod = importlib.import_module("menace_sandbox.self_improvement.snapshot_tracker")
+from menace_sandbox.sandbox_settings import SandboxSettings
+
+
+def test_snapshot_capture(monkeypatch, tmp_path):
+    settings = SandboxSettings(
+        sandbox_repo_path=str(tmp_path),
+        sandbox_data_dir=str(tmp_path / "data"),
+        snapshot_metrics=["roi", "entropy"],
+    )
+    monkeypatch.setattr(tracker_mod, "SandboxSettings", lambda: settings)
+    tracker = baseline_mod.BaselineTracker(window=3)
+    monkeypatch.setattr(tracker_mod, "BASELINE_TRACKER", tracker)
+
+    called = {"cg": False}
+
+    monkeypatch.setattr(
+        tracker_mod,
+        "collect_snapshot_metrics",
+        lambda files, settings=None: (0.5, 0.3),
+    )
+
+    def fake_call_graph(repo):  # pragma: no cover
+        called["cg"] = True
+        return 1.0
+
+    monkeypatch.setattr(tracker_mod, "compute_call_graph_complexity", fake_call_graph)
+
+    f = tmp_path / "m.py"
+    f.write_text("print('hi')")
+
+    snap = tracker_mod.capture("pre", [f], roi=1.0, sandbox_score=0.2)
+
+    assert snap.entropy == 0.5
+    assert tracker.current("roi") == 1.0
+    assert tracker.current("entropy") == 0.5
+    assert tracker.current("token_diversity") == 0.0
+    assert called["cg"] is False

--- a/self_improvement/tests/test_strategy_deprioritization.py
+++ b/self_improvement/tests/test_strategy_deprioritization.py
@@ -1,0 +1,88 @@
+import logging
+import importlib
+import types
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault("dynamic_path_router", types.SimpleNamespace(resolve_path=lambda p: p))
+import sandbox_settings
+from menace_sandbox.sandbox_settings import SandboxSettings
+from menace_sandbox.dynamic_path_router import resolve_path
+
+pkg = types.ModuleType("menace_sandbox.self_improvement")
+pkg.__path__ = [str(Path(resolve_path("self_improvement")))]
+sys.modules["menace_sandbox.self_improvement"] = pkg
+boot = types.ModuleType("sandbox_runner.bootstrap")
+boot.initialize_autonomous_sandbox = lambda *a, **k: None
+sys.modules.setdefault("sandbox_runner.bootstrap", boot)
+prompt_memory = importlib.import_module("menace_sandbox.self_improvement.prompt_memory")
+snapshot_tracker = importlib.import_module(
+    "menace_sandbox.self_improvement.snapshot_tracker"
+)
+if "snapshot_history_db" in sys.modules:
+    del sys.modules["snapshot_history_db"]
+snapshot_history_db = importlib.import_module("menace_sandbox.snapshot_history_db")
+
+
+class DummyPrompt:
+    metadata = {"strategy": "s1"}
+
+
+class MiniEngine:
+    def __init__(self):
+        self.deprioritized_strategies = set()
+        self.logger = logging.getLogger("test")
+
+    def _record_snapshot_delta(self, prompt, delta):
+        success = not (delta.get("roi", 0.0) < 0 or delta.get("entropy", 0.0) < 0)
+        if not success:
+            strategy = None
+            metadata = getattr(prompt, "metadata", {})
+            if isinstance(metadata, dict):
+                strategy = metadata.get("strategy") or metadata.get("prompt_id")
+            if strategy:
+                count = snapshot_tracker.record_downgrade(str(strategy))
+                if count >= SandboxSettings().prompt_failure_threshold:
+                    self.deprioritized_strategies.add(str(strategy))
+
+    def _select_prompt_strategy(self, strategies):
+        penalties = prompt_memory.load_prompt_penalties()
+        settings = SandboxSettings()
+        best = None
+        best_weight = -1.0
+        for strat in strategies:
+            if strat in self.deprioritized_strategies:
+                continue
+            count = penalties.get(str(strat), 0)
+            weight = (
+                settings.prompt_penalty_multiplier
+                if count >= settings.prompt_failure_threshold
+                else 1.0
+            )
+            if weight > best_weight:
+                best_weight = weight
+                best = strat
+        return best
+
+
+def test_deprioritized_strategy_skipped(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        snapshot_tracker,
+        "_downgrade_path",
+        Path(resolve_path(str(tmp_path))) / Path("downgrades").with_suffix(".json"),
+    )
+    snapshot_tracker.downgrade_counts.clear()
+    eng = MiniEngine()
+    thr = SandboxSettings().prompt_failure_threshold
+    for _ in range(thr):
+        eng._record_snapshot_delta(DummyPrompt(), {"roi": -1})
+
+    monkeypatch.setattr(prompt_memory, "load_prompt_penalties", lambda: {"s1": thr})
+
+    assert "s1" in eng.deprioritized_strategies
+    choice = eng._select_prompt_strategy(["s1", "s2"])
+    assert choice == "s2"


### PR DESCRIPTION
## Summary
- allow configuring which metrics snapshots track via `SandboxSettings.snapshot_metrics`
- update `SnapshotTracker` to honor configurable metrics and compute deltas accordingly
- add unit tests for snapshot capture, regression flagging, and strategy deprioritization

## Testing
- `pytest self_improvement/tests/test_snapshot_capture.py self_improvement/tests/test_delta_regression_flagging.py self_improvement/tests/test_strategy_deprioritization.py`

------
https://chatgpt.com/codex/tasks/task_e_68b9841e8a5c832e8654fa23374d71b2