### PR TITLE
Use resolve_path for keyword DB in passive discovery bot

### DIFF
--- a/passive_discovery_bot.py
+++ b/passive_discovery_bot.py
@@ -11,6 +11,8 @@ import os
 import logging
 import time
 
+from dynamic_path_router import resolve_path
+
 from .resilience import (
     CircuitBreaker,
     CircuitOpenError,
@@ -40,7 +42,7 @@ from .prediction_manager_bot import PredictionManager
 
 from . import database_manager
 
-KEYWORD_DB = Path(__file__).parent / "keyword_bank.json"
+KEYWORD_DB = resolve_path("keyword_bank.json")
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Resolve keyword_bank.json path via `resolve_path` helper
- Import `resolve_path` in `passive_discovery_bot`

## Testing
- `pytest passive_discovery_bot.py` *(fails: ModuleNotFoundError: No module named 'db_router')*
- `PYTHONPATH=. pytest passive_discovery_bot.py` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '')*


------
https://chatgpt.com/codex/tasks/task_e_68b989699c20832e85fb2b5934d7c712