### PR TITLE
Refactor snapshot tracking to unified tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1518,7 +1518,7 @@ mutations.
 #### State snapshots
 
 The sandbox records ROI, entropy and call graph metrics for every cycle via
-[`self_improvement/state_snapshot.py`](self_improvement/state_snapshot.py).
+[`self_improvement/snapshot_tracker.py`](self_improvement/snapshot_tracker.py).
 Snapshots and diffs are written to `SNAPSHOT_DIR` / `SNAPSHOT_DIFF_DIR` and
 successful changes are checkpointed under `CHECKPOINT_DIR`.  Tune retention and
 penalty behaviour with `CHECKPOINT_RETENTION`, `ROI_PENALTY_THRESHOLD` and

--- a/self_improvement/api.py
+++ b/self_improvement/api.py
@@ -36,12 +36,10 @@ from .dashboards import (
 )
 from .registry import ImprovementEngineRegistry, auto_x
 from .orchestration_utils import benchmark_workflow_variants
-from .state_snapshot import (
+from .snapshot_tracker import (
     Snapshot,
-    capture_snapshot,
-    delta,
-    save_snapshot,
-    load_snapshot,
+    capture as capture_snapshot,
+    compute_delta as delta,
     save_checkpoint,
 )
 
@@ -78,7 +76,5 @@ __all__ = [
     "Snapshot",
     "capture_snapshot",
     "delta",
-    "save_snapshot",
-    "load_snapshot",
     "save_checkpoint",
 ]

--- a/self_improvement/state_snapshot.py
+++ b/self_improvement/state_snapshot.py
@@ -1,260 +1,48 @@
 from __future__ import annotations
 
-"""Capture and compare self-improvement state metrics."""
+"""Deprecated snapshot helpers.
 
-from dataclasses import asdict, dataclass
-from pathlib import Path
-from typing import Any, Dict
+The functionality previously implemented in this module now lives in
+:smod:`snapshot_tracker`.  The old entry points are retained as thin wrappers
+for backwards compatibility but will be removed in a future release.
+"""
 
-import json
-import logging
-import shutil
-import time
+from warnings import warn
 
-import codebase_diff_checker
-import logging_utils
-from . import prompt_memory
-try:  # pragma: no cover - optional dependency location
-    from ..dynamic_path_router import resolve_path
-except Exception:  # pragma: no cover
-    from dynamic_path_router import resolve_path  # type: ignore
-from .baseline_tracker import BaselineTracker
-from ..sandbox_settings import SandboxSettings
-from .sandbox_score import get_latest_sandbox_score
-from . import metrics
-from ..module_graph_analyzer import build_import_graph
+from .snapshot_tracker import (
+    Snapshot,
+    SnapshotTracker,
+    capture,
+    compute_delta,
+    save_checkpoint,
+    get_best_checkpoint,
+    downgrade_counts,
+    record_downgrade,
+)
 
+warn(
+    "state_snapshot is deprecated; use snapshot_tracker instead",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-@dataclass
-class StateSnapshot:
-    """Snapshot of repository metrics at a point in time."""
+# Compatibility aliases -----------------------------------------------------
 
-    roi: float
-    sandbox_score: float
-    entropy: float
-    call_graph_edge_count: int
-    token_diversity: float
+capture_snapshot = capture
 
-
-# ---------------------------------------------------------------------------
-
-def capture_state(repo_path: Path, tracker: BaselineTracker) -> StateSnapshot:
-    """Collect current repository metrics into a :class:`StateSnapshot`."""
-
-    settings = SandboxSettings()
-    roi = float(tracker.current("roi"))
-    sandbox_score = float(get_latest_sandbox_score(settings.sandbox_score_db))
-
-    files = list(repo_path.rglob("*.py"))
-    entropy = float(metrics.compute_code_entropy(files, settings=settings))
-
-    try:
-        _, _, _, _, _, diversity = metrics._collect_metrics(
-            files, repo_path, settings
-        )
-    except Exception:  # pragma: no cover - best effort
-        diversity = 0.0
-
-    try:
-        graph = build_import_graph(repo_path)
-        edge_count = int(graph.number_of_edges())
-    except Exception:  # pragma: no cover - best effort
-        edge_count = 0
-
-    return StateSnapshot(
-        roi=roi,
-        sandbox_score=sandbox_score,
-        entropy=entropy,
-        call_graph_edge_count=edge_count,
-        token_diversity=float(diversity),
-    )
-
-
-# ---------------------------------------------------------------------------
-
-def compare_snapshots(
-    before: StateSnapshot, after: StateSnapshot
-) -> Dict[str, float]:
-    """Return per-metric differences between two snapshots ``after - before``."""
-
-    return {
-        "roi": after.roi - before.roi,
-        "sandbox_score": after.sandbox_score - before.sandbox_score,
-        "entropy": after.entropy - before.entropy,
-        "call_graph_edge_count": after.call_graph_edge_count
-        - before.call_graph_edge_count,
-        "token_diversity": after.token_diversity - before.token_diversity,
-    }
-
-
-# ---------------------------------------------------------------------------
-
-
-class SnapshotTracker:
-    """Track state snapshots across self-improvement iterations."""
-
-    def __init__(self, repo_path: Path, tracker: BaselineTracker) -> None:
-        self.repo_path = Path(repo_path)
-        self.tracker = tracker
-        self.logger = logging.getLogger(__name__)
-        base = Path(resolve_path(SandboxSettings().sandbox_data_dir)) / "snapshots"
-        self._persist_path = base / "last_snapshot.json"
-        try:
-            data = json.loads(self._persist_path.read_text(encoding="utf-8"))
-            self.last_snapshot = StateSnapshot(**data)
-        except Exception:
-            self.last_snapshot = None
-
-    # --------------------------------------------------------------
-    def _persist_last_snapshot(self) -> None:
-        if self.last_snapshot is None:
-            return
-        try:
-            self._persist_path.parent.mkdir(parents=True, exist_ok=True)
-            self._persist_path.write_text(
-                json.dumps(asdict(self.last_snapshot)), encoding="utf-8"
-            )
-        except Exception:  # pragma: no cover - best effort
-            self.logger.debug("failed to persist snapshot", exc_info=True)
-
-    def store(self, snap: StateSnapshot) -> None:
-        self.last_snapshot = snap
-        self._persist_last_snapshot()
-
-    def capture(self) -> StateSnapshot:
-        """Capture and store the current repository snapshot."""
-
-        snap = capture_state(self.repo_path, self.tracker)
-        self.store(snap)
-        return snap
-
-    def evaluate_change(
-        self, after: StateSnapshot, prompt: Any, diff_path: str | Path
-    ) -> Dict[str, float]:
-        """Evaluate ``after`` against the previous snapshot.
-
-        If ROI decreased or entropy increased a warning is logged, the prompt
-        attempt recorded and a diff snapshot stored under
-        ``sandbox_data/diffs/``.
-
-        When all metric deltas are positive the changed modules referenced by
-        ``diff_path`` are copied to ``sandbox_data/checkpoints/<ts>/`` and the
-        confidence score for the associated strategy is incremented.
-        """
-
-        before = self.last_snapshot
-        self.store(after)
-        if before is None:
-            return {}
-
-        delta = compare_snapshots(before, after)
-
-        if all(v > 0 for v in delta.values()):
-            try:
-                settings = SandboxSettings()
-                base = Path(resolve_path(settings.sandbox_data_dir))
-                ckpt_dir = base / "checkpoints" / str(int(time.time()))
-
-                files: list[Path] = []
-                try:
-                    diff_text = Path(diff_path).read_text(encoding="utf-8")
-                    for line in diff_text.splitlines():
-                        if line.startswith("+++ b/"):
-                            name = line[6:]
-                            if name != "/dev/null":
-                                files.append(Path(name))
-                except Exception:
-                    files = []
-
-                for rel in files:
-                    src = self.repo_path / rel
-                    dest = ckpt_dir / rel
-                    dest.parent.mkdir(parents=True, exist_ok=True)
-                    try:
-                        shutil.copy2(src, dest)
-                    except Exception:
-                        try:
-                            dest.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
-                        except Exception:
-                            pass
-
-                strategy: str | None = None
-                if isinstance(prompt, dict):
-                    strategy = (
-                        prompt.get("strategy") or prompt.get("strategy_name")
-                    )
-                elif hasattr(prompt, "strategy"):
-                    strategy = getattr(prompt, "strategy")
-                elif isinstance(prompt, str):
-                    strategy = prompt
-
-                if strategy:
-                    try:
-                        prompt_memory.reset_penalty(str(strategy))
-                    except Exception:
-                        pass
-                    conf_path = base / "strategy_confidence.json"
-                    try:
-                        conf = json.loads(conf_path.read_text(encoding="utf-8"))
-                        if not isinstance(conf, dict):
-                            conf = {}
-                    except Exception:
-                        conf = {}
-                    conf[str(strategy)] = int(conf.get(str(strategy), 0)) + 1
-                    conf_path.parent.mkdir(parents=True, exist_ok=True)
-                    conf_path.write_text(json.dumps(conf), encoding="utf-8")
-            except Exception:  # pragma: no cover - best effort
-                pass
-
-        elif delta.get("roi", 0) < 0 or delta.get("entropy", 0) > 0:
-            try:  # pragma: no cover - best effort logging
-                prompt_memory.log_prompt_attempt(
-                    prompt, success=False, exec_result=None, roi_meta=delta
-                )
-            except Exception:
-                pass
-
-            try:  # pragma: no cover - diff storage best effort
-                settings = SandboxSettings()
-                diff_dir = Path(resolve_path(settings.sandbox_data_dir)) / "diffs"
-                diff_dir.mkdir(parents=True, exist_ok=True)
-                output = diff_dir / Path(diff_path)
-                codebase_diff_checker.compare_snapshots(before, after, output)
-            except Exception:
-                pass
-
-            self.logger.warning(
-                "negative roi or increased entropy",
-                extra=logging_utils.log_record(delta=delta),
-            )
-
-        return delta
-
-
-# ---------------------------------------------------------------------------
-# Backwards compatibility aliases
-
-Snapshot = StateSnapshot
-
-
-def capture_snapshot(tracker: BaselineTracker, settings: SandboxSettings) -> StateSnapshot:
-    """Compatibility wrapper forwarding to :func:`capture_state`."""
-
-    return capture_state(Path(resolve_path(settings.sandbox_repo_path)), tracker)
-
-
-def delta(a: StateSnapshot, b: StateSnapshot) -> Dict[str, float]:
-    """Compatibility wrapper for :func:`compare_snapshots`."""
-
-    return compare_snapshots(a, b)
-
+def delta(a: Snapshot, b: Snapshot):
+    """Backward compatible alias for :func:`compute_delta`."""
+    return compute_delta(a, b)
 
 __all__ = [
-    "StateSnapshot",
-    "capture_state",
-    "compare_snapshots",
-    "SnapshotTracker",
     "Snapshot",
+    "SnapshotTracker",
+    "capture",
+    "compute_delta",
     "capture_snapshot",
     "delta",
+    "save_checkpoint",
+    "get_best_checkpoint",
+    "downgrade_counts",
+    "record_downgrade",
 ]


### PR DESCRIPTION
## Summary
- Deprecate `state_snapshot` in favor of `snapshot_tracker` and re-export APIs
- Update meta planning, engine, and API modules to use `snapshot_tracker`
- Refresh tests to reference the consolidated tracker

## Testing
- `python -m pytest self_improvement/tests/test_snapshot_capture.py -q`
- `python -m pytest self_improvement/tests/test_delta_regression_flagging.py -q`
- `python -m pytest self_improvement/tests/test_snapshot_tracker_flow.py -q`
- `python -m pytest tests/test_snapshot_tracker.py -q`
- `python -m pytest tests/test_snapshot_history_db_storage.py -q`
- `python -m pytest tests/test_snapshot_regression_logging.py -q` *(fails: attempted relative import with no known parent package)*
- `python -m pytest tests/test_snapshot_tracker_confidence.py -q` *(fails: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68b98a3beda4832e9fd6670532f4ab23