### PR TITLE
Ensure stripe router usage is enforced

### DIFF
--- a/unit_tests/test_validate_stripe_usage.py
+++ b/unit_tests/test_validate_stripe_usage.py
@@ -1,0 +1,32 @@
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+from codex_output_analyzer import CriticalGenerationFailure, validate_stripe_usage  # noqa: E402
+
+
+def test_router_import_without_usage_raises() -> None:
+    code = """
+import stripe_billing_router
+
+
+def create_invoice():
+    invoice_id = "123"
+    return invoice_id
+"""
+    with pytest.raises(CriticalGenerationFailure):
+        validate_stripe_usage(code)
+
+
+def test_router_import_with_call_passes() -> None:
+    code = """
+import stripe_billing_router
+
+
+def process_payment():
+    return stripe_billing_router.process_payment()
+"""
+    validate_stripe_usage(code)


### PR DESCRIPTION
## Summary
- expand payment keyword detection in stripe usage validator
- require stripe_billing_router to be used when payment keywords appear
- test validator for unused stripe_billing_router imports

## Testing
- `pre-commit run --files codex_output_analyzer.py unit_tests/test_validate_stripe_usage.py`
- `pytest unit_tests/test_validate_stripe_usage.py`


------
https://chatgpt.com/codex/tasks/task_e_68b98bcc5adc832ebd91d1d80ac201f5