### PR TITLE
feat: enhance call graph complexity metric

### DIFF
--- a/self_improvement/system_snapshot.py
+++ b/self_improvement/system_snapshot.py
@@ -15,7 +15,7 @@ from ..sandbox_settings import SandboxSettings
 from .baseline_tracker import BaselineTracker
 from .sandbox_score import get_latest_sandbox_score
 from . import metrics as _si_metrics
-from ..module_graph_analyzer import build_import_graph
+from .metrics import compute_call_graph_complexity
 
 try:  # pragma: no cover - sandbox results logger is optional
     import sandbox_results_logger  # type: ignore
@@ -86,11 +86,7 @@ def capture_snapshot(engine: Any) -> SystemSnapshot:
         token_diversity = 0.0
 
     try:
-        graph = build_import_graph(repo_path)
-        nodes = graph.number_of_nodes()
-        call_complexity = (
-            float(graph.number_of_edges()) / float(nodes) if nodes else 0.0
-        )
+        call_complexity = compute_call_graph_complexity(repo_path)
     except Exception:  # pragma: no cover - best effort
         call_complexity = 0.0
 

--- a/self_improvement/tests/test_collect_snapshot_metrics.py
+++ b/self_improvement/tests/test_collect_snapshot_metrics.py
@@ -42,6 +42,7 @@ metrics_mod = _load(f"{PKG}.self_improvement.metrics", ROOT / "self_improvement"
 SandboxSettings = sandbox_mod.SandboxSettings
 collect_snapshot_metrics = metrics_mod.collect_snapshot_metrics
 _collect_metrics = metrics_mod._collect_metrics
+compute_call_graph_complexity = metrics_mod.compute_call_graph_complexity
 
 
 def test_collect_snapshot_metrics_matches_internal(tmp_path):
@@ -55,3 +56,15 @@ def test_collect_snapshot_metrics_matches_internal(tmp_path):
     entropy, diversity = collect_snapshot_metrics(files, settings=settings)
     assert entropy == pytest.approx(exp_entropy)
     assert diversity == pytest.approx(exp_div)
+
+
+def test_compute_call_graph_complexity(monkeypatch):
+    import networkx as nx
+
+    g = nx.DiGraph()
+    g.add_edge("a", "b")
+    g.add_edge("b", "c")
+    g.add_edge("c", "a")
+
+    monkeypatch.setattr(metrics_mod, "build_import_graph", lambda root: g)
+    assert compute_call_graph_complexity(Path(".")) == pytest.approx(1.0)

--- a/self_improvement/tests/test_snapshot_tracker_flow.py
+++ b/self_improvement/tests/test_snapshot_tracker_flow.py
@@ -37,6 +37,7 @@ def _patch_helpers(monkeypatch, tmp_path, entropies, diversities, complexities):
     monkeypatch.setattr(
         tracker_mod, "compute_call_graph_complexity", lambda repo: next(comp_iter)
     )
+    monkeypatch.setattr(tracker_mod, "relevancy_radar", None)
     monkeypatch.setattr(
         tracker_mod,
         "SandboxSettings",

--- a/self_improvement/tests/test_system_snapshot.py
+++ b/self_improvement/tests/test_system_snapshot.py
@@ -64,15 +64,7 @@ def test_capture_snapshot(monkeypatch, tmp_path):
         return ({}, 0, 0.0, 0, 0.0, 0.6)
 
     monkeypatch.setattr(system_snapshot._si_metrics, "_collect_metrics", fake_collect)
-
-    class FakeGraph:
-        def number_of_edges(self):
-            return 4
-
-        def number_of_nodes(self):
-            return 2
-
-    monkeypatch.setattr(system_snapshot, "build_import_graph", lambda path: FakeGraph())
+    monkeypatch.setattr(system_snapshot, "compute_call_graph_complexity", lambda repo: 2.0)
 
     snap = system_snapshot.capture_snapshot(engine)
     assert snap.roi == 1.5


### PR DESCRIPTION
## Summary
- compute call graph complexity using average out-degree, cyclomatic complexity, and graph diameter
- use richer call graph metric in system snapshot collection
- test call graph metric and snapshot flow

## Testing
- `pytest test_collect_snapshot_metrics.py test_system_snapshot.py test_snapshot_capture.py test_snapshot_tracker_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_68b98c9ce554832e929ac451b0a692b7