### PR TITLE
feat: analyze repository when no files

### DIFF
--- a/self_improvement/snapshot_tracker.py
+++ b/self_improvement/snapshot_tracker.py
@@ -117,6 +117,11 @@ def capture(
 
     metrics = set(getattr(settings, "snapshot_metrics", []))
 
+    files = list(files)
+    if not files:
+        repo_root = Path(settings.sandbox_repo_path)
+        files = list(repo_root.rglob("*.py"))
+
     entropy = token_diversity = 0.0
     if {"entropy", "token_diversity"} & metrics:
         try:

--- a/tests/test_snapshot_tracker_confidence.py
+++ b/tests/test_snapshot_tracker_confidence.py
@@ -29,6 +29,9 @@ def test_confidence_and_best_checkpoint(tmp_path, monkeypatch):
 
     class Settings:
         sandbox_data_dir = str(tmp_path)
+        snapshot_metrics = {"roi"}
+        roi_drop_threshold = -1.0
+        entropy_regression_threshold = 1e9
 
     sys.modules["sandbox_settings"] = types.SimpleNamespace(
         SandboxSettings=Settings,
@@ -63,3 +66,61 @@ def test_confidence_and_best_checkpoint(tmp_path, monkeypatch):
     assert conf["alpha"] == 1
 
     assert st.get_best_checkpoint(module) == ckpt_file
+
+
+def test_tracker_capture_uses_repo_when_no_files(tmp_path, monkeypatch):
+    sys.modules["audit_logger"] = types.SimpleNamespace(log_event=lambda *a, **k: None)
+    sys.modules["menace_sandbox.audit_logger"] = sys.modules["audit_logger"]
+    sys.modules["snapshot_history_db"] = types.SimpleNamespace(
+        log_regression=lambda *a, **k: None,
+        record_snapshot=lambda *a, **k: 1,
+        record_delta=lambda *a, **k: None,
+    )
+    sys.modules["menace_sandbox.snapshot_history_db"] = sys.modules["snapshot_history_db"]
+    sys.modules["module_index_db"] = types.SimpleNamespace(ModuleIndexDB=None)
+    sys.modules["menace_sandbox.module_index_db"] = sys.modules["module_index_db"]
+    sys.modules["relevancy_radar"] = types.SimpleNamespace(call_graph_complexity=lambda files: 0)
+    sys.modules["menace_sandbox.relevancy_radar"] = sys.modules["relevancy_radar"]
+    sys.modules["dynamic_path_router"] = types.SimpleNamespace(
+        resolve_path=lambda p: p,
+        repo_root=lambda: Path("."),
+    )
+
+    captured: dict[str, list[Path]] = {}
+
+    def fake_collect(files, settings=None):
+        flist = [Path(f) for f in files]
+        captured["files"] = flist
+        return float(len(flist)), float(len(flist))
+
+    metrics_stub = types.SimpleNamespace(
+        collect_snapshot_metrics=fake_collect,
+        compute_call_graph_complexity=lambda *a, **k: 0.0,
+    )
+    sys.modules["menace_sandbox.self_improvement.metrics"] = metrics_stub
+
+    sys.modules.pop("menace_sandbox.self_improvement.snapshot_tracker", None)
+    st = importlib.import_module("menace_sandbox.self_improvement.snapshot_tracker")
+    monkeypatch.setattr(st, "resolve_path", lambda p: p)
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.py").write_text("a = 1\n", encoding="utf-8")
+    (repo / "b.py").write_text("b = 2\n", encoding="utf-8")
+    data_dir = tmp_path / "data"
+
+    class Settings:
+        sandbox_data_dir = str(data_dir)
+        sandbox_repo_path = str(repo)
+        snapshot_metrics = {"entropy", "token_diversity"}
+        roi_drop_threshold = -1.0
+        entropy_regression_threshold = 1e9
+
+    monkeypatch.setattr(st, "SandboxSettings", lambda: Settings())
+
+    tracker = st.SnapshotTracker()
+    snap = tracker.capture("before", {"roi": 0.0, "sandbox_score": 0.0}, repo_path=repo)
+
+    assert snap.entropy == 2.0
+    assert snap.token_diversity == 2.0
+    assert set(captured["files"]) == {repo / "a.py", repo / "b.py"}


### PR DESCRIPTION
## Summary
- enumerate all Python files for snapshot metrics when no file list provided
- test snapshot capture uses entire repo for entropy and token diversity

## Testing
- `pytest tests/test_snapshot_tracker.py tests/test_snapshot_tracker_confidence.py`

------
https://chatgpt.com/codex/tasks/task_e_68b98e42973c832ea67a90dba93bc14c