### PR TITLE
refactor tests to use dynamic path router

### DIFF
--- a/sandbox_runner/tests/test_edge_case_profiles.py
+++ b/sandbox_runner/tests/test_edge_case_profiles.py
@@ -2,9 +2,10 @@ import os
 import sys
 import urllib.request
 from pathlib import Path
+from dynamic_path_router import resolve_path
 
 os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(resolve_path("")))
 
 from sandbox_runner.workflow_sandbox_runner import WorkflowSandboxRunner
 

--- a/sandbox_runner/tests/test_edge_case_stubs_injection.py
+++ b/sandbox_runner/tests/test_edge_case_stubs_injection.py
@@ -3,20 +3,14 @@ import subprocess
 import sys
 from pathlib import Path
 import types
+from dynamic_path_router import get_project_root
 
 os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
-root = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(get_project_root()))
+root = get_project_root()
 data_dir = root / "sandbox_data"
 data_dir.mkdir(exist_ok=True)
 (data_dir / "cleanup.log").write_text("", encoding="utf-8")
-
-sys.modules["dynamic_path_router"] = types.SimpleNamespace(
-    resolve_path=lambda p: Path(p),
-    repo_root=lambda: root,
-    path_for_prompt=lambda p: p,
-    get_project_root=lambda: root,
-)
 
 
 class _DummyLogger:

--- a/sandbox_runner/tests/test_generative_stub_backends.py
+++ b/sandbox_runner/tests/test_generative_stub_backends.py
@@ -2,13 +2,14 @@ import os
 import sys
 import types
 from pathlib import Path
+from dynamic_path_router import resolve_path
 
 sys.modules.setdefault(
     "db_router",
     types.SimpleNamespace(GLOBAL_ROUTER=None, init_db_router=lambda *a, **k: None),
 )
 
-sys.path.append(str(Path(__file__).resolve().parents[2]))
+sys.path.append(str(resolve_path("")))
 
 from sandbox_runner import generative_stub_provider as gsp  # noqa: E402
 import pytest

--- a/sandbox_runner/tests/test_generative_stub_provider_config.py
+++ b/sandbox_runner/tests/test_generative_stub_provider_config.py
@@ -2,12 +2,13 @@ import json
 import sys
 import types
 from pathlib import Path
+from dynamic_path_router import resolve_path
 
 sys.modules.setdefault(
     "db_router", types.SimpleNamespace(GLOBAL_ROUTER=None, init_db_router=lambda *a, **k: None)
 )
 
-sys.path.append(str(Path(__file__).resolve().parents[2]))
+sys.path.append(str(resolve_path("")))
 
 from sandbox_runner import generative_stub_provider as gsp  # noqa: E402
 

--- a/sandbox_runner/tests/test_minimal_cycle.py
+++ b/sandbox_runner/tests/test_minimal_cycle.py
@@ -3,10 +3,10 @@ import sys
 import time
 import types
 from pathlib import Path
+from dynamic_path_router import resolve_path
 
-sys.path.append(str(Path(__file__).resolve().parents[2]))
+sys.path.append(str(resolve_path("")))
 
-from dynamic_path_router import resolve_path  # noqa: E402
 from sandbox_settings import SandboxSettings  # noqa: E402
 
 

--- a/sandbox_runner/tests/test_self_improvement_flow.py
+++ b/sandbox_runner/tests/test_self_improvement_flow.py
@@ -4,10 +4,10 @@ import json
 import sys
 import types
 from pathlib import Path
+from dynamic_path_router import resolve_path
 
-sys.path.append(str(Path(__file__).resolve().parents[2]))
+sys.path.append(str(resolve_path("")))
 
-from dynamic_path_router import resolve_path  # noqa: E402
 from sandbox_settings import SandboxSettings  # noqa: E402
 
 

--- a/sandbox_runner/tests/test_shutdown_cleanup.py
+++ b/sandbox_runner/tests/test_shutdown_cleanup.py
@@ -2,8 +2,9 @@ import sys
 import threading
 import types
 from pathlib import Path
+from dynamic_path_router import resolve_path
 
-sys.path.append(str(Path(__file__).resolve().parents[2]))
+sys.path.append(str(resolve_path("")))
 
 from sandbox_settings import SandboxSettings  # noqa: E402
 

--- a/sandbox_runner/tests/test_start_autonomous_failure.py
+++ b/sandbox_runner/tests/test_start_autonomous_failure.py
@@ -2,10 +2,11 @@ import sys
 import types
 import logging
 from pathlib import Path
+from dynamic_path_router import resolve_path
 
 import pytest
 
-sys.path.append(str(Path(__file__).resolve().parents[2]))
+sys.path.append(str(resolve_path("")))
 
 
 def _setup_base_packages():

--- a/sandbox_runner/tests/test_start_autonomous_health.py
+++ b/sandbox_runner/tests/test_start_autonomous_health.py
@@ -4,8 +4,9 @@ import sys
 import threading
 import types
 from pathlib import Path
+from dynamic_path_router import resolve_path
 
-sys.path.append(str(Path(__file__).resolve().parents[2]))
+sys.path.append(str(resolve_path("")))
 
 
 # Minimal stubs for external modules used during sandbox bootstrap

--- a/sandbox_runner/tests/test_start_autonomous_launch.py
+++ b/sandbox_runner/tests/test_start_autonomous_launch.py
@@ -3,10 +3,11 @@ import sys
 import threading
 import types
 from pathlib import Path
+from dynamic_path_router import resolve_path
 
 import pytest
 
-sys.path.append(str(Path(__file__).resolve().parents[2]))
+sys.path.append(str(resolve_path("")))
 
 from sandbox_settings import SandboxSettings  # noqa: E402
 

--- a/sandbox_runner/tests/test_start_autonomous_noninteractive.py
+++ b/sandbox_runner/tests/test_start_autonomous_noninteractive.py
@@ -2,12 +2,13 @@ import sys
 import threading
 import types
 from pathlib import Path
+from dynamic_path_router import resolve_path
 
 import logging
 import pytest
 
 # ensure repository root on path
-sys.path.append(str(Path(__file__).resolve().parents[2]))
+sys.path.append(str(resolve_path("")))
 
 from sandbox_settings import SandboxSettings  # noqa: E402
 

--- a/sandbox_runner/tests/test_stub_provider_metrics.py
+++ b/sandbox_runner/tests/test_stub_provider_metrics.py
@@ -3,9 +3,10 @@ from pathlib import Path
 import sys
 import types
 import pytest
+from dynamic_path_router import resolve_path
 
-MODULE_DIR = Path(__file__).resolve().parents[1]
-ROOT_DIR = Path(__file__).resolve().parents[2]
+MODULE_DIR = resolve_path("sandbox_runner")
+ROOT_DIR = resolve_path("")
 sys.path.append(str(ROOT_DIR))
 
 

--- a/tests/integration/test_service_layer_isolation.py
+++ b/tests/integration/test_service_layer_isolation.py
@@ -1,5 +1,6 @@
 import ast
 from pathlib import Path
+from dynamic_path_router import path_for_prompt
 
 
 def _imports(path: str) -> set[str]:
@@ -15,8 +16,8 @@ def _imports(path: str) -> set[str]:
 
 
 def test_no_direct_imports_between_cycle_and_bot_creation():
-    cycle_imports = _imports("sandbox_runner/cycle.py")  # path-ignore
-    bot_imports = _imports("bot_creation_bot.py")  # path-ignore
+    cycle_imports = _imports(path_for_prompt("sandbox_runner/cycle.py"))  # path-ignore
+    bot_imports = _imports(path_for_prompt("bot_creation_bot.py"))  # path-ignore
     assert "bot_creation_bot" not in cycle_imports
     assert all(not name.startswith("bot_creation_bot") for name in cycle_imports)
     assert "sandbox_runner" not in bot_imports

--- a/tests/test_adaptive_synergy_thresholds.py
+++ b/tests/test_adaptive_synergy_thresholds.py
@@ -4,6 +4,7 @@ import sys
 import types
 import shutil
 from pathlib import Path
+from dynamic_path_router import resolve_path
 
 import pytest
 
@@ -84,7 +85,7 @@ def _load_run_autonomous(monkeypatch):
     monkeypatch.setitem(sys.modules, "sandbox_runner.environment", env_stub)
 
     cli_spec = importlib.util.spec_from_file_location(
-        "sandbox_runner.cli", str(Path("sandbox_runner/cli.py"))
+        "sandbox_runner.cli", str(resolve_path("sandbox_runner/cli.py"))
     )
     cli_mod = importlib.util.module_from_spec(cli_spec)
     sys.modules["sandbox_runner.cli"] = cli_mod

--- a/tests/test_sandbox_runner_backends.py
+++ b/tests/test_sandbox_runner_backends.py
@@ -4,6 +4,7 @@ import shutil
 import subprocess
 import sys
 import types
+from dynamic_path_router import resolve_path
 
 
 def _prepare_repo(tmp_path: Path) -> Path:
@@ -21,7 +22,7 @@ def _prepare_repo(tmp_path: Path) -> Path:
 
 def test_run_tests_supports_backends(monkeypatch, tmp_path):
     repo = _prepare_repo(tmp_path)
-    path = Path(__file__).resolve().parents[1] / "sandbox_runner/test_harness.py"
+    path = resolve_path("sandbox_runner/test_harness.py")
     pkg = types.ModuleType("menace.sandbox_runner")
     pkg.__path__ = []  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "menace.sandbox_runner", pkg)

--- a/tests/test_sandbox_runner_failures.py
+++ b/tests/test_sandbox_runner_failures.py
@@ -4,10 +4,11 @@ import shutil
 import subprocess
 import sys
 import pytest
+from dynamic_path_router import resolve_path
 
 
 def _load_test_harness(monkeypatch):
-    path = Path(__file__).resolve().parents[1] / "sandbox_runner/test_harness.py"
+    path = resolve_path("sandbox_runner/test_harness.py")
     spec = importlib.util.spec_from_file_location("menace.sandbox_runner.test_harness", path)
     th = importlib.util.module_from_spec(spec)
     assert spec.loader is not None

--- a/tests/test_synergy_ranking.py
+++ b/tests/test_synergy_ranking.py
@@ -1,8 +1,9 @@
 import importlib.util
 import roi_tracker as rt
+from dynamic_path_router import resolve_path
 
 spec = importlib.util.spec_from_file_location(
-    "env", "sandbox_runner/environment.py"
+    "env", str(resolve_path("sandbox_runner/environment.py"))
 )
 env = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(env)


### PR DESCRIPTION
## Summary
- replace `Path(__file__)` usage in tests with `resolve_path`/`path_for_prompt`
- import dynamic path router utilities for sandbox runner and integration tests

## Testing
- `pytest sandbox_runner/tests -q` *(fails: ModuleNotFoundError, FileNotFoundError)*
- `pytest tests/test_sandbox_runner_backends.py tests/test_sandbox_runner_failures.py tests/test_synergy_ranking.py tests/test_adaptive_synergy_thresholds.py tests/integration/test_service_layer_isolation.py -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_68b98ca3f190832eb0ef3e4bc1d34954