### PR TITLE
Use resolve_path for module map path

### DIFF
--- a/module_index_db.py
+++ b/module_index_db.py
@@ -53,18 +53,17 @@ class ModuleIndexDB:
                 if sem_env is None:
                     sem_env = os.getenv("SANDBOX_MODULE_SEMANTIC")  # legacy
                 use_semantic = sem_env == "1"
-                repo_path = get_project_root()
                 exclude_env = os.getenv("SANDBOX_EXCLUDE_DIRS")
                 exclude = [e for e in exclude_env.split(",") if e] if exclude_env else None
                 mapping = generate_module_map(
                     self.path,
-                    root=repo_path,
+                    root=get_project_root(),
                     algorithm=algo,
                     threshold=threshold,
                     semantic=use_semantic,
                     exclude=exclude,
                 )
-                if self.path != repo_path / "sandbox_data" / "module_map.json":
+                if self.path != resolve_path("sandbox_data/module_map.json"):
                     self.path.parent.mkdir(parents=True, exist_ok=True)
                     with open(self.path, "w", encoding="utf-8") as fh:
                         json.dump(mapping, fh, indent=2)


### PR DESCRIPTION
## Summary
- avoid hardcoded repo path when writing module map
- remove unused variable and rely on resolve_path

## Testing
- `python - <<'PY'
import types, sys, os
from pathlib import Path
stub = types.SimpleNamespace(
    resolve_path=lambda p: Path(p),
    resolve_dir=lambda p: Path(p),
    path_for_prompt=lambda p: Path(p).as_posix(),
    get_project_root=lambda: Path(os.environ.get("SANDBOX_REPO_PATH", Path.cwd()))
)
sys.modules['dynamic_path_router'] = stub
import pytest, sys as _sys
_sys.exit(pytest.main(['tests/test_module_index_db.py','-q']))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b9917dd1c8832eb77ba9a42801a5ea