### PR TITLE
Use resolve_path for prompt penalty file

### DIFF
--- a/self_improvement/prompt_memory.py
+++ b/self_improvement/prompt_memory.py
@@ -14,11 +14,12 @@ from typing import Any, Dict
 from filelock import FileLock
 
 from sandbox_settings import SandboxSettings
+from dynamic_path_router import resolve_path
 from .init import _repo_path
 
 _settings = SandboxSettings()
 
-_penalty_path = _repo_path() / _settings.prompt_penalty_path
+_penalty_path = Path(resolve_path(_settings.prompt_penalty_path))
 _penalty_lock = FileLock(str(_penalty_path) + ".lock")
 
 


### PR DESCRIPTION
## Summary
- load prompt penalty file using dynamic `resolve_path` instead of `_repo_path`
- update penalty tests to patch `resolve_path` and stub sandbox settings

## Testing
- `pytest self_improvement/tests/test_prompt_penalties.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b99423ff5c832e8700ba654ef45083