### PR TITLE
Use AST for Stripe usage validation and checks

### DIFF
--- a/stripe_detection.py
+++ b/stripe_detection.py
@@ -1,0 +1,23 @@
+"""Shared Stripe detection rules and helpers."""
+from __future__ import annotations
+
+from typing import Iterable
+
+PAYMENT_KEYWORDS = {
+    "payment",
+    "checkout",
+    "billing",
+    "stripe",
+    "invoice",
+    "subscription",
+    "payout",
+    "charge",
+}
+
+HTTP_LIBRARIES = {"requests", "httpx"}
+
+
+def contains_payment_keyword(name: str, keywords: Iterable[str] = PAYMENT_KEYWORDS) -> bool:
+    """Return ``True`` if ``name`` includes any payment-related keyword."""
+    parts = name.lower().split("_")
+    return any(part in keywords for part in parts)


### PR DESCRIPTION
## Summary
- centralize payment keywords and HTTP libraries in `stripe_detection`
- refactor `validate_stripe_usage` to parse AST and flag Stripe imports, raw API calls, and payment identifiers
- update `check_stripe_imports.py` to use AST and shared rules

## Testing
- `pytest tests/test_payment_validator.py unit_tests/test_validate_stripe_usage.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9940079ec832e99e889c35414357d