### PR TITLE
Track failure reasons in prompt attempt logs

### DIFF
--- a/prompt_optimizer.py
+++ b/prompt_optimizer.py
@@ -253,6 +253,7 @@ class PromptOptimizer:
                         entry["prompt"] = entry.get("prompt_text")
                     # If success flag is missing, infer from log type
                     entry.setdefault("success", idx == 0)
+                    entry.setdefault("failure_reason", None)
                     entries.append(entry)
         return entries
 

--- a/self_improvement/prompt_memory.py
+++ b/self_improvement/prompt_memory.py
@@ -89,6 +89,7 @@ def log_prompt_attempt(
     exec_result: Any,
     roi_meta: Dict[str, Any] | None = None,
     prompt_id: str | None = None,
+    failure_reason: str | None = None,
 ) -> None:
     """Record a prompt attempt outcome.
 
@@ -107,6 +108,9 @@ def log_prompt_attempt(
         objects can be stored.
     roi_meta:
         Optional ROI metrics or other contextual information.
+    failure_reason:
+        Optional string describing why the attempt failed. Only stored for
+        unsuccessful attempts.
     """
 
     metadata = getattr(prompt, "metadata", {}) if prompt is not None else {}
@@ -135,6 +139,8 @@ def log_prompt_attempt(
 
     if roi_meta is not None:
         entry["roi_meta"] = roi_meta
+    if failure_reason is not None:
+        entry["failure_reason"] = failure_reason
 
     path = _log_path(success)
     lock = FileLock(str(path) + ".lock")

--- a/self_improvement/tests/test_snapshot_delta_logging.py
+++ b/self_improvement/tests/test_snapshot_delta_logging.py
@@ -17,13 +17,14 @@ def _load_record_snapshot_delta(tmp_path, log_entries, updates):
     assert func_node is not None
     module = ast.Module(body=[func_node], type_ignores=[])
 
-    def _log(prompt, success, exec_result, roi_meta, prompt_id=None):  # pragma: no cover
+    def _log(prompt, success, exec_result, roi_meta, prompt_id=None, failure_reason=None):  # pragma: no cover
         log_entries.append(
             {
                 "prompt": prompt,
                 "success": success,
                 "exec_result": exec_result,
                 "roi_meta": roi_meta,
+                "failure_reason": failure_reason,
             }
         )
 
@@ -53,6 +54,7 @@ def test_record_snapshot_delta_regression(tmp_path):
     assert json.loads(path.read_text().strip()) == delta
     assert logs and not logs[0]["success"]
     assert logs[0]["exec_result"]["diff"] == "d"
+    assert logs[0]["failure_reason"] == "roi_drop"
     assert not updates
 
 
@@ -63,4 +65,5 @@ def test_record_snapshot_delta_success(tmp_path):
     delta = {"roi": 1.0, "entropy": 0.5}
     func(eng, "p", "d", delta)
     assert logs and logs[0]["success"]
+    assert logs[0]["failure_reason"] is None
     assert updates and updates[0] == delta


### PR DESCRIPTION
## Summary
- extend `log_prompt_attempt` to record optional `failure_reason`
- pass specific failure reasons from `SelfImprovementEngine`
- ensure `PromptOptimizer` preserves `failure_reason` when reading logs

## Testing
- `pytest self_improvement/tests/test_snapshot_delta_logging.py tests/test_prompt_logging_and_optimizer.py -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '')*
- `pytest self_improvement/tests/test_snapshot_delta_logging.py -q` *(fails: ModuleNotFoundError: No module named 'sandbox_settings')*
- `pytest tests/test_prompt_optimizer.py -q` *(fails: AssertionError: assert (('m', 'a', 'neutral', 1, 1, True, ...) in {('m', 'a', 'neutral', (), 'none', False, ...): _Stat(...)} )*


------
https://chatgpt.com/codex/tasks/task_e_68ba0249ab88832ebfdeb81456735af1