### PR TITLE
Expand Stripe HTTP client detection

### DIFF
--- a/stripe_detection.py
+++ b/stripe_detection.py
@@ -14,7 +14,10 @@ PAYMENT_KEYWORDS = {
     "charge",
 }
 
-HTTP_LIBRARIES = {"requests", "httpx"}
+# Common HTTP client libraries that can issue requests to Stripe's API.
+# Detected usages of these libraries contacting the Stripe service must go
+# through ``stripe_billing_router``.
+HTTP_LIBRARIES = {"requests", "httpx", "aiohttp", "urllib", "urllib3"}
 
 
 def contains_payment_keyword(name: str, keywords: Iterable[str] = PAYMENT_KEYWORDS) -> bool:

--- a/tests/test_payment_validator.py
+++ b/tests/test_payment_validator.py
@@ -11,8 +11,17 @@ def test_detect_import_stripe():
         validate_stripe_usage(code)
 
 
-def test_detect_direct_api_call():
-    code = "import requests\nrequests.get('https://api.stripe.com/v1')\n"
+@pytest.mark.parametrize(
+    "code",
+    [
+        "import requests\nrequests.get('https://api.stripe.com/v1')\n",
+        "import httpx\nhttpx.get('https://api.stripe.com/v1')\n",
+        "import aiohttp\naiohttp.request('GET', 'https://api.stripe.com/v1')\n",
+        "import urllib\nurllib.request.urlopen('https://api.stripe.com/v1')\n",
+        "import urllib3\nurllib3.request('GET', 'https://api.stripe.com/v1')\n",
+    ],
+)
+def test_detect_direct_api_call(code):
     with pytest.raises(CriticalGenerationFailure):
         validate_stripe_usage(code)
 


### PR DESCRIPTION
## Summary
- include aiohttp, urllib, and urllib3 in Stripe HTTP library set
- document and propagate new libraries in validator and import check script
- add regression tests to ensure each client is routed through stripe_billing_router

## Testing
- `pre-commit run --files stripe_detection.py codex_output_analyzer.py scripts/check_stripe_imports.py tests/test_payment_validator.py`
- `pytest tests/test_payment_validator.py -q`
- `pytest unit_tests/test_validate_stripe_usage.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba015e6ad4832e92f773c8ad394308