### PR TITLE
Persist and rotate prompt strategies across runs

### DIFF
--- a/self_improvement/prompt_strategy_manager.py
+++ b/self_improvement/prompt_strategy_manager.py
@@ -1,0 +1,111 @@
+"""Utilities for rotating prompt strategies with persistent state."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import os
+import tempfile
+from typing import Callable, Sequence
+
+try:  # pragma: no cover - optional helper for dynamic paths
+    from dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback
+    def resolve_path(p: str | Path) -> str | Path:  # type: ignore
+        return p
+
+
+class PromptStrategyManager:
+    """Maintain an ordered list of prompt strategies and rotate on failures.
+
+    The manager keeps track of the currently preferred strategy index and
+    persists it to ``state_path`` so that rotation state survives across runs.
+    When selecting a strategy the provided ``selector`` callable is invoked with
+    the strategies in their current rotation order, allowing the caller to apply
+    custom scoring (for example :meth:`SelfImprovementEngine._select_prompt_strategy`).
+    """
+
+    def __init__(
+        self,
+        strategies: Sequence[str] | None = None,
+        state_path: Path | str | None = None,
+    ) -> None:
+        self.strategies: list[str] = list(strategies or [])
+        if state_path is None:
+            try:  # local import to avoid heavy dependency during import
+                from .init import _data_dir
+
+                state_path = _data_dir() / "prompt_strategy_state.json"
+            except Exception:  # pragma: no cover - fallback when init unavailable
+                state_path = Path(resolve_path("prompt_strategy_state.json"))
+        if not isinstance(state_path, Path):
+            state_path = Path(resolve_path(state_path))
+        self.state_path = state_path
+        self.index: int = 0
+        self._load_state()
+
+    # ------------------------------------------------------------------
+    def _rotated(self) -> list[str]:
+        if not self.strategies:
+            return []
+        return self.strategies[self.index:] + self.strategies[: self.index]
+
+    # ------------------------------------------------------------------
+    def select(self, selector: Callable[[Sequence[str]], str | None]) -> str | None:
+        """Return the next strategy using ``selector`` for scoring."""
+
+        ordered = self._rotated()
+        if not ordered:
+            return None
+        return selector(ordered)
+
+    # ------------------------------------------------------------------
+    def record_failure(self) -> None:
+        """Advance to the next strategy and persist state."""
+
+        if not self.strategies:
+            return
+        self.index = (self.index + 1) % len(self.strategies)
+        self._save_state()
+
+    # ------------------------------------------------------------------
+    def set_strategies(self, strategies: Sequence[str]) -> None:
+        """Replace the managed strategies preserving rotation index."""
+
+        self.strategies = list(strategies)
+        if self.strategies:
+            self.index %= len(self.strategies)
+        else:
+            self.index = 0
+        self._save_state()
+
+    # ------------------------------------------------------------------
+    def _load_state(self) -> None:
+        try:
+            with open(self.state_path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if not self.strategies:
+                self.strategies = list(data.get("strategies", []))
+            self.index = int(data.get("index", 0))
+            if self.strategies:
+                self.index %= len(self.strategies)
+            else:
+                self.index = 0
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    def _save_state(self) -> None:
+        try:
+            self.state_path.parent.mkdir(parents=True, exist_ok=True)
+            with tempfile.NamedTemporaryFile(
+                "w", delete=False, dir=self.state_path.parent, encoding="utf-8"
+            ) as fh:
+                json.dump({"index": self.index, "strategies": self.strategies}, fh)
+                tmp = Path(fh.name)
+            os.replace(tmp, self.state_path)
+        except Exception:  # pragma: no cover - best effort persistence
+            pass
+
+
+__all__ = ["PromptStrategyManager"]

--- a/snapshot_history_db.py
+++ b/snapshot_history_db.py
@@ -8,7 +8,10 @@ import json
 import time
 
 from sandbox_settings import SandboxSettings
-from self_improvement import prompt_memory
+try:  # pragma: no cover - prefer namespaced package when available
+    from menace_sandbox.self_improvement import prompt_memory
+except Exception:  # pragma: no cover - fallback for flat layout
+    from self_improvement import prompt_memory  # type: ignore
 from db_router import DBRouter
 
 try:  # pragma: no cover - optional dependency location
@@ -193,4 +196,3 @@ __all__ = [
     "last_successful_cycle",
     "log_regression",
 ]
-

--- a/tests/test_prompt_strategy_manager.py
+++ b/tests/test_prompt_strategy_manager.py
@@ -1,0 +1,66 @@
+import logging
+import sys
+import types
+import importlib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PARENT = ROOT.parent
+if str(PARENT) not in sys.path:
+    sys.path.insert(0, str(PARENT))
+
+sys.modules.setdefault(
+    "dynamic_path_router", types.SimpleNamespace(resolve_path=lambda p: p)
+)
+from dynamic_path_router import resolve_path  # noqa: E402
+
+pkg_root = types.ModuleType("menace_sandbox")
+pkg_root.__path__ = [str(ROOT)]
+sys.modules["menace_sandbox"] = pkg_root
+
+pkg = types.ModuleType("menace_sandbox.self_improvement")
+pkg.__path__ = [str(ROOT / "self_improvement")]
+sys.modules["menace_sandbox.self_improvement"] = pkg
+
+PromptStrategyManager = importlib.import_module(
+    "menace_sandbox.self_improvement.prompt_strategy_manager"
+).PromptStrategyManager
+
+
+class DummyPrompt:
+    metadata = {"strategy": "s1"}
+
+
+class MiniEngine:
+    def __init__(self, state_path: Path):
+        self.logger = logging.getLogger("test")
+        self.prompt_strategy_manager = PromptStrategyManager(
+            ["s1", "s2"], state_path=state_path
+        )
+
+    def next_strategy(self) -> str | None:
+        return self.prompt_strategy_manager.select(self._select_prompt_strategy)
+
+    def _select_prompt_strategy(self, strategies):
+        return strategies[0] if strategies else None
+
+    def _record_snapshot_delta(self, prompt, delta):
+        success = not (delta.get("roi", 0.0) < 0 or delta.get("entropy", 0.0) < 0)
+        if not success:
+            self.prompt_strategy_manager.record_failure()
+
+
+def test_strategy_rotation_persists(tmp_path):
+    state_file = Path(resolve_path(tmp_path / "state.json"))
+    eng = MiniEngine(state_file)
+    assert eng.next_strategy() == "s1"
+    eng._record_snapshot_delta(DummyPrompt(), {"roi": -1})
+    assert eng.next_strategy() == "s2"
+
+    # Reload to ensure rotation state persisted
+    eng2 = MiniEngine(state_file)
+    assert eng2.next_strategy() == "s2"
+    eng2._record_snapshot_delta(DummyPrompt(), {"roi": -1})
+
+    eng3 = MiniEngine(state_file)
+    assert eng3.next_strategy() == "s1"


### PR DESCRIPTION
## Summary
- add `PromptStrategyManager` to rotate through prompt strategies and persist position
- integrate manager with engine to select next strategy and advance on failures
- ensure snapshot history uses namespaced prompt memory imports

## Testing
- `pre-commit run --files self_improvement/prompt_strategy_manager.py self_improvement/engine.py snapshot_history_db.py tests/test_prompt_strategy_manager.py`
- `pytest tests/test_prompt_strategy_manager.py tests/test_strategy_deprioritization.py self_improvement/tests/test_strategy_deprioritization.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba038db340832e874a39afbf723f78