### PR TITLE
Extend Stripe detection to additional file formats

### DIFF
--- a/scripts/check_raw_stripe_usage.py
+++ b/scripts/check_raw_stripe_usage.py
@@ -25,7 +25,19 @@ PATTERN = re.compile(r"api\.stripe\.com|['\"](?:sk_|pk_)[^'\"]*['\"]")
 
 def _tracked_files() -> list[Path]:
     result = subprocess.run(
-        ["git", "ls-files", "*.py", "*.js", "*.ts", "*.md", "*.yaml"],
+        [
+            "git",
+            "ls-files",
+            "*.py",
+            "*.js",
+            "*.ts",
+            "*.md",
+            "*.yaml",
+            "*.html",
+            "*.json",
+            "*.jsx",
+            "*.tsx",
+        ],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,

--- a/tests/test_raw_stripe_usage_non_python.py
+++ b/tests/test_raw_stripe_usage_non_python.py
@@ -10,6 +10,10 @@ import pytest
         (".ts", "const key = 'sk_test_123';"),
         (".md", "See https://api.stripe.com/v1/customers"),
         (".yaml", "stripe_key: \"sk_test_123\""),
+        (".html", '<a href="https://api.stripe.com/v1/payments">'),
+        (".json", '{"key": "sk_live_123"}'),
+        (".jsx", 'const k = "pk_live_123";'),
+        (".tsx", "fetch('https://api.stripe.com/v1/refunds')"),
     ],
 )
 


### PR DESCRIPTION
## Summary
- scan `.html`, `.json`, `.jsx`, and `.tsx` files for raw Stripe keys or endpoints
- test Stripe detection against the new extensions

## Testing
- `python -m pytest tests/test_raw_stripe_usage_non_python.py -q`
- `python -m pytest tests/test_no_raw_stripe_usage.py tests/test_no_direct_stripe_imports.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba06b757ac832eab7f8470fe80e333