### PR TITLE
feat: add strategy templates

### DIFF
--- a/prompt_strategy.yaml
+++ b/prompt_strategy.yaml
@@ -4,3 +4,12 @@ heuristics:
   ask_type_hints: 0.2
 max_tokens: 256
 default_model: gpt-3.5-turbo
+templates:
+  strict_fix: |
+    Apply the smallest change necessary to address the issue without altering unrelated code.
+  delete_and_rebuild: |
+    Remove the existing implementation entirely and recreate it from scratch.
+  comment_refactor: |
+    Restructure or improve comments without modifying the runtime behaviour of the code.
+  unit_test_rewrite: |
+    Rewrite or expand unit tests to clarify intent while avoiding changes to production code.

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -1050,6 +1050,13 @@ class SelfCodingEngine:
             str(metadata.get("retrieval_context", "")) if metadata else ""
         )
         retry_trace = self._fetch_retry_trace(metadata)
+        strategy = None
+        if metadata:
+            strategy = (
+                metadata.get("strategy")
+                or metadata.get("prompt_id")
+                or metadata.get("prompt_strategy")
+            )
         try:
             prompt_obj = self.prompt_engine.build_prompt(
                 description,
@@ -1059,6 +1066,7 @@ class SelfCodingEngine:
                 tone=self.prompt_tone,
                 summaries=summaries,
                 target_region=target_region,
+                strategy=strategy,
             )
         except TypeError:
             if target_region is not None:
@@ -1080,6 +1088,7 @@ class SelfCodingEngine:
                 retrieval_context=retrieval_context,
                 retry_trace=retry_trace,
                 summaries=summaries,
+                strategy=strategy,
             )
         except Exception as exc:
             self._last_retry_trace = str(exc)


### PR DESCRIPTION
## Summary
- extend prompt strategy config with common templates
- support strategy-specific prompts in `PromptEngine.build_prompt`
- forward selected strategy from `SelfCodingEngine`

## Testing
- `pytest tests/test_prompt_engine.py tests/test_build_prompt_summaries.py tests/test_self_coding_engine_logging.py tests/test_build_visual_agent_prompt.py unit_tests/test_prompt_engine.py -q` *(fails: ImportError attempted relative import with no known parent package; FileNotFoundError for rollback_manager paths)*

------
https://chatgpt.com/codex/tasks/task_e_68ba07467038832eb15880114e5567c5