### PR TITLE
Add generic Stripe usage validator for arbitrary text

### DIFF
--- a/unit_tests/test_validate_stripe_usage.py
+++ b/unit_tests/test_validate_stripe_usage.py
@@ -30,3 +30,14 @@ def process_payment():
     return stripe_billing_router.process_payment()
 """
     validate_stripe_usage(code)
+
+
+def test_js_snippet_without_router_raises() -> None:
+    code = "fetch('https://api.stripe.com/v1/charges')"
+    with pytest.raises(CriticalGenerationFailure):
+        validate_stripe_usage(code)
+
+
+def test_js_snippet_with_router_import_passes() -> None:
+    code = "import stripe_billing_router\nfetch('https://api.stripe.com/v1/charges')"
+    validate_stripe_usage(code)


### PR DESCRIPTION
## Summary
- add `validate_stripe_usage_generic` to scan any text for Stripe endpoints or keys
- run generic Stripe checks from `validate_stripe_usage` to cover non-Python snippets
- test JS snippets requiring `stripe_billing_router` import

## Testing
- `pytest unit_tests/test_validate_stripe_usage.py tests/test_payment_validator.py tests/test_raw_stripe_usage_non_python.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba07cc6258832e86891348cac38c38