### PR TITLE
Redact partially masked Stripe keys

### DIFF
--- a/finance_router_bot.py
+++ b/finance_router_bot.py
@@ -22,7 +22,10 @@ from .menace_memory_manager import MenaceMemoryManager, MemoryEntry
 
 logger = logging.getLogger(__name__)
 
-_STRIPE_KEY_RE = re.compile(r"(?:sk|pk)_(?:live|test)?_[A-Za-z0-9]+")
+# Match Stripe keys that may be partially masked with ``*`` characters.
+# This ensures that even keys like ``sk_live_1234****5678`` are fully
+# redacted rather than leaking their visible prefix.
+_STRIPE_KEY_RE = re.compile(r"(?:sk|pk)_(?:live|test)?_[A-Za-z0-9*]+")
 
 
 def _sanitize_stripe_keys(text: str) -> str:

--- a/scripts/check_stripe_imports.py
+++ b/scripts/check_stripe_imports.py
@@ -49,8 +49,9 @@ ALLOWED = {
     (REPO_ROOT / "codex_output_analyzer.py").resolve(),  # path-ignore
     (REPO_ROOT / "stripe_detection.py").resolve(),  # path-ignore
 }
+# Detect exposures of Stripe keys, including partially redacted ones with ``*``.
 KEY_PATTERN = re.compile(
-    r"sk_live|pk_live|STRIPE_SECRET_KEY|STRIPE_PUBLIC_KEY"
+    r"(?:sk|pk)_(?:live|test)?_[A-Za-z0-9]*\*+[A-Za-z0-9*]*|sk_live|pk_live|STRIPE_SECRET_KEY|STRIPE_PUBLIC_KEY"
 )
 
 

--- a/tests/test_stripe_import_lint.py
+++ b/tests/test_stripe_import_lint.py
@@ -38,3 +38,11 @@ def test_clean_file_passes(tmp_path: Path) -> None:
     result = _run([str(good)])
     assert result.returncode == 0, result.stdout + result.stderr
 
+
+def test_flags_partially_redacted_key(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.log"
+    bad.write_text("oops sk_live_1234****5678\n")
+    result = _run(["--keys", str(bad)])
+    assert result.returncode == 1
+    assert "Potential Stripe live keys" in result.stdout
+


### PR DESCRIPTION
## Summary
- broaden Stripe key regex to scrub partially masked keys
- flag partially redacted keys in `check_stripe_imports`
- test sanitization and detection of masked Stripe keys

## Testing
- `pytest tests/test_finance_router_bot.py tests/test_stripe_import_lint.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba09e09254832e832fb61ad47a90a7