### PR TITLE
Resolve sandbox data paths via resolve_path

### DIFF
--- a/menace_visual_agent_2.py
+++ b/menace_visual_agent_2.py
@@ -302,7 +302,7 @@ def _cleanup_stale_files() -> None:
 # Queue management
 
 # Database paths
-DATA_DIR = Path(os.getenv("SANDBOX_DATA_DIR") or resolve_path("sandbox_data"))
+DATA_DIR = Path(resolve_path(os.getenv("SANDBOX_DATA_DIR", "sandbox_data")))
 QUEUE_FILE = DATA_DIR / "visual_agent_queue.jsonl"  # legacy path
 QUEUE_DB = DATA_DIR / "visual_agent_queue.db"
 RECOVERY_METRICS_FILE = DATA_DIR / "visual_agent_recovery.json"

--- a/module_index_db.py
+++ b/module_index_db.py
@@ -23,7 +23,7 @@ class ModuleIndexDB:
         *,
         auto_map: bool | None = None,
     ) -> None:
-        default_dir = Path(os.getenv("SANDBOX_DATA_DIR") or resolve_path("sandbox_data"))
+        default_dir = Path(resolve_path(os.getenv("SANDBOX_DATA_DIR", "sandbox_data")))
         default_path = default_dir / "module_map.json"
         self.path = Path(path) if path is not None else default_path
         if not self.path.exists() and self.path != default_path and default_path.exists():

--- a/relevancy_radar_service.py
+++ b/relevancy_radar_service.py
@@ -108,7 +108,7 @@ class RelevancyRadarService:
             module_names.update(usage_stats.keys())
 
             try:
-                data_dir = Path(os.getenv("SANDBOX_DATA_DIR") or resolve_path("sandbox_data"))
+                data_dir = Path(resolve_path(os.getenv("SANDBOX_DATA_DIR", "sandbox_data")))
                 db = RelevancyMetricsDB(data_dir / "relevancy_metrics.db")
                 roi_deltas = db.get_roi_deltas(module_names)
             except Exception:

--- a/sandbox_recovery_manager.py
+++ b/sandbox_recovery_manager.py
@@ -221,7 +221,7 @@ class SandboxRecoveryManager:
         errors—such as an open circuit or exceeding ``max_retries``—raise
         :class:`SandboxRecoveryError`.
         """
-        data_dir = Path(os.getenv("SANDBOX_DATA_DIR") or resolve_path("sandbox_data"))
+        data_dir = Path(resolve_path(os.getenv("SANDBOX_DATA_DIR", "sandbox_data")))
         attempts = 0
         delay = self.retry_delay
         while True:

--- a/synergy_auto_trainer.py
+++ b/synergy_auto_trainer.py
@@ -104,7 +104,7 @@ class SynergyAutoTrainer:
         self.interval = float(interval)
         self.progress_file = Path(progress_file)
         self._last_id = 0
-        data_dir = Path(os.getenv("SANDBOX_DATA_DIR") or resolve_path("sandbox_data"))
+        data_dir = Path(resolve_path(os.getenv("SANDBOX_DATA_DIR", "sandbox_data")))
 
         if not self.history_file.exists():
             new_path = data_dir / self.history_file.name

--- a/tests/test_data_dir_resolution.py
+++ b/tests/test_data_dir_resolution.py
@@ -1,0 +1,27 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+def _reload(module_name: str):
+    module = sys.modules.get(module_name)
+    if module is not None and not isinstance(module, types.ModuleType):
+        del sys.modules[module_name]
+        return importlib.import_module(module_name)
+    if module is not None:
+        return importlib.reload(module)
+    return importlib.import_module(module_name)
+
+def test_module_index_db_resolves_paths(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    data_dir = repo / "relative"
+    data_dir.mkdir()
+    (data_dir / "module_map.json").write_text("{}")
+    monkeypatch.setenv("SANDBOX_REPO_PATH", str(repo))
+    monkeypatch.setenv("SANDBOX_DATA_DIR", "relative")
+    monkeypatch.setenv("SANDBOX_AUTO_MAP", "0")
+    _reload("dynamic_path_router")
+    mid = _reload("module_index_db")
+    db = mid.ModuleIndexDB(auto_map=False)
+    assert db.path == data_dir / "module_map.json"

--- a/visual_agent_client.py
+++ b/visual_agent_client.py
@@ -133,7 +133,7 @@ class VisualAgentClient:
         self._worker = threading.Thread(target=self._worker_loop, daemon=True)
         self._worker.start()
         self._stop_event = threading.Event()
-        data_dir = Path(os.getenv("SANDBOX_DATA_DIR") or resolve_path("sandbox_data"))
+        data_dir = Path(resolve_path(os.getenv("SANDBOX_DATA_DIR", "sandbox_data")))
         self._local_queue = _LocalQueue(data_dir / "visual_agent_client_queue.jsonl")
         if self.queue_warning_threshold is not None and self.urls and requests:
             self._metrics_thread = threading.Thread(

--- a/visual_agent_manager.py
+++ b/visual_agent_manager.py
@@ -79,7 +79,7 @@ class VisualAgentManager:
         """Start the visual agent using ``token``."""
         env = os.environ.copy()
         env["VISUAL_AGENT_TOKEN"] = token
-        data_dir = Path(env.get("SANDBOX_DATA_DIR") or resolve_path("sandbox_data"))
+        data_dir = Path(resolve_path(env.get("SANDBOX_DATA_DIR", "sandbox_data")))
         queue_db = data_dir / "visual_agent_queue.db"
         queue = VisualAgentQueue(queue_db)
         recovered = False


### PR DESCRIPTION
## Summary
- use `resolve_path` for SANDBOX_DATA_DIR to ensure absolute base path
- adjust modules to build paths from resolved base directory
- add unit test validating data dir resolution with repo relocation

## Testing
- `pytest tests/test_data_dir_resolution.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba08f01588832e91540f871e234fad