### PR TITLE
Centralize payment notice helper and enforce usage

### DIFF
--- a/billing/prompt_notice.py
+++ b/billing/prompt_notice.py
@@ -1,6 +1,37 @@
-"""Centralized payment router notice for LLM prompts."""
+"""Utilities for injecting the payment router notice into prompts.
+
+This module centralises usage of :data:`PAYMENT_ROUTER_NOTICE` and exposes a
+small helper to prepend the notice to OpenAI style message lists.  The helper
+ensures that all outbound prompts remind the model that billing is routed
+through the approved payment router.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
 
 from stripe_policy import PAYMENT_ROUTER_NOTICE
-import stripe_billing_router  # noqa: F401
+try:  # pragma: no cover - optional runtime dependency
+    import stripe_billing_router  # noqa: F401
+except Exception:  # pragma: no cover - best effort
+    stripe_billing_router = None  # type: ignore
 
-__all__ = ["PAYMENT_ROUTER_NOTICE"]
+
+def prepend_payment_notice(messages: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Return ``messages`` with :data:`PAYMENT_ROUTER_NOTICE` prepended.
+
+    If a system message already exists it is updated to include the notice at
+    the beginning of its content.  Otherwise a new system message containing the
+    notice is inserted at the start of the list.
+    """
+
+    msgs = list(messages)
+    if msgs and msgs[0].get("role") == "system":
+        content = msgs[0].get("content", "")
+        msgs[0]["content"] = PAYMENT_ROUTER_NOTICE + "\n" + content
+    else:
+        msgs = [{"role": "system", "content": PAYMENT_ROUTER_NOTICE}, *msgs]
+    return msgs
+
+
+__all__ = ["PAYMENT_ROUTER_NOTICE", "prepend_payment_notice"]

--- a/tests/test_payment_notice.py
+++ b/tests/test_payment_notice.py
@@ -1,0 +1,147 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from billing.prompt_notice import PAYMENT_ROUTER_NOTICE, prepend_payment_notice
+from prompt_engine import PromptEngine
+
+# Stub heavy dependencies so chatgpt_idea_bot can be imported without side effects
+package = types.ModuleType("menace_sandbox")
+package.RAISE_ERRORS = False
+sys.modules.setdefault("menace_sandbox", package)
+
+dm = types.ModuleType("menace_sandbox.database_manager")
+dm.DB_PATH = "db"
+dm.search_models = lambda *a, **k: []
+sys.modules["menace_sandbox.database_manager"] = dm
+
+dmb = types.ModuleType("menace_sandbox.database_management_bot")
+class _DBot: ...
+dmb.DatabaseManagementBot = _DBot
+sys.modules["menace_sandbox.database_management_bot"] = dmb
+
+log_tags = types.SimpleNamespace(
+    FEEDBACK="fb", IMPROVEMENT_PATH="ip", ERROR_FIX="ef", INSIGHT="ins"
+)
+sys.modules["menace_sandbox.log_tags"] = log_tags
+
+shared_mem = types.SimpleNamespace(GPT_MEMORY_MANAGER=None)
+sys.modules["menace_sandbox.shared_gpt_memory"] = shared_mem
+
+memory_logging = types.SimpleNamespace(log_with_tags=lambda *a, **k: None)
+sys.modules["menace_sandbox.memory_logging"] = memory_logging
+
+memory_client = types.SimpleNamespace(ask_with_memory=lambda *a, **k: {})
+sys.modules["menace_sandbox.memory_aware_gpt_client"] = memory_client
+
+class _LKM:
+    def __init__(self, *a, **k):
+        pass
+local_mod = types.SimpleNamespace(LocalKnowledgeModule=_LKM)
+sys.modules["menace_sandbox.local_knowledge_module"] = local_mod
+
+retriever_stub = types.SimpleNamespace(
+    get_feedback=lambda *a, **k: [],
+    get_improvement_paths=lambda *a, **k: [],
+    get_error_fixes=lambda *a, **k: [],
+)
+sys.modules["menace_sandbox.knowledge_retriever"] = retriever_stub
+
+sys.modules["menace_sandbox.run_autonomous"] = types.SimpleNamespace(
+    LOCAL_KNOWLEDGE_MODULE=None
+)
+sys.modules["menace_sandbox.sandbox_runner"] = types.SimpleNamespace(
+    LOCAL_KNOWLEDGE_MODULE=None
+)
+
+vector_service = types.SimpleNamespace(Retriever=None, FallbackResult=list)
+sys.modules.setdefault("vector_service", vector_service)
+
+governed = types.SimpleNamespace(govern_retrieval=lambda *a, **k: None, redact=lambda x: x)
+sys.modules.setdefault("governed_retrieval", governed)
+
+# Stubs for enhancement_bot dependencies
+code_db = types.SimpleNamespace(CodeDB=type("CodeDB", (), {}))
+sys.modules.setdefault("code_database", code_db)
+sys.modules.setdefault("menace_sandbox.code_database", code_db)
+
+chatgpt_enh = types.SimpleNamespace(
+    EnhancementDB=type("EnhancementDB", (), {}),
+    EnhancementHistory=type("EnhancementHistory", (), {}),
+    Enhancement=type("Enhancement", (), {}),
+)
+sys.modules.setdefault("chatgpt_enhancement_bot", chatgpt_enh)
+sys.modules.setdefault("menace_sandbox.chatgpt_enhancement_bot", chatgpt_enh)
+
+diff_summarizer = types.SimpleNamespace(summarize_diff=lambda a, b: "")
+prefix_injector = types.SimpleNamespace(
+    inject_prefix=lambda msgs, prefix, conf, role="system": msgs
+)
+micro_models_pkg = types.ModuleType("menace_sandbox.micro_models")
+sys.modules.setdefault("menace_sandbox.micro_models", micro_models_pkg)
+sys.modules.setdefault(
+    "menace_sandbox.micro_models.diff_summarizer", diff_summarizer
+)
+sys.modules.setdefault(
+    "menace_sandbox.micro_models.prefix_injector", prefix_injector
+)
+
+from menace_sandbox.enhancement_bot import EnhancementBot
+from menace_sandbox.chatgpt_idea_bot import ChatGPTClient
+
+
+def test_prepend_payment_notice_helper():
+    msgs = [{"role": "user", "content": "hello"}]
+    new_msgs = prepend_payment_notice(msgs)
+    assert new_msgs[0]["role"] == "system"
+    assert new_msgs[0]["content"].startswith(PAYMENT_ROUTER_NOTICE)
+    assert new_msgs[1]["content"] == "hello"
+
+
+def test_chatgpt_client_injects_notice(monkeypatch):
+    captured = {}
+
+    class DummyResponse:
+        status_code = 200
+
+        def json(self):
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+        def raise_for_status(self):
+            return None
+
+    class DummySession:
+        def post(self, url, headers=None, json=None, timeout=None):
+            captured["messages"] = json["messages"]
+            return DummyResponse()
+
+    client = ChatGPTClient(session=DummySession(), gpt_memory=None)
+    client.ask([{"role": "user", "content": "hi"}], use_memory=False, tags=[])
+    assert captured["messages"][0]["content"].startswith(PAYMENT_ROUTER_NOTICE)
+
+
+def test_enhancement_bot_injects_notice(monkeypatch):
+    captured = {}
+    fake_openai = types.SimpleNamespace()
+
+    def fake_create(*args, **kwargs):
+        captured["messages"] = kwargs.get("messages")
+        return {"choices": [{"message": {"content": ""}}]}
+
+    fake_openai.ChatCompletion = types.SimpleNamespace(create=fake_create)
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    bot = EnhancementBot()
+    bot._codex_summarize("a", "b")
+    assert captured["messages"][0]["content"].startswith(PAYMENT_ROUTER_NOTICE)
+
+
+def test_prompt_engine_build_prompt_contains_notice():
+    engine = PromptEngine(retriever=None)
+    prompt = engine.build_prompt("task")
+    assert prompt.system.startswith(PAYMENT_ROUTER_NOTICE)


### PR DESCRIPTION
## Summary
- add `prepend_payment_notice` helper to centralize payment router notice
- refactor prompt-related modules to use helper
- test that ChatGPT, enhancement, and prompt engine messages include payment notice

## Testing
- `pytest tests/test_payment_notice.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba0bcab84c832eabb1db7a1a9f428d