### PR TITLE
feat: detect payment keywords in generic text

### DIFF
--- a/codex_output_analyzer.py
+++ b/codex_output_analyzer.py
@@ -18,7 +18,11 @@ import sys
 import tokenize
 import io
 from pathlib import Path
-from stripe_detection import HTTP_LIBRARIES, contains_payment_keyword
+from stripe_detection import (
+    PAYMENT_KEYWORDS,
+    HTTP_LIBRARIES,
+    contains_payment_keyword,
+)
 
 from dynamic_path_router import resolve_path
 
@@ -67,12 +71,18 @@ _RAW_STRIPE_PATTERN = re.compile(
 
 
 def validate_stripe_usage_generic(text: str) -> None:
-    """Raise if *text* contains raw Stripe endpoints or keys without router."""
+    """Raise if *text* contains Stripe endpoints, keys or keywords without router."""
 
+    lowered = text.lower()
     if _RAW_STRIPE_PATTERN.search(text):
-        if "stripe_billing_router" not in text:
+        if "stripe_billing_router" not in lowered:
             raise CriticalGenerationFailure(
-                "critical generation failure: raw Stripe usage detected"
+                "critical generation failure: raw Stripe usage detected",
+            )
+    if any(keyword in lowered for keyword in PAYMENT_KEYWORDS):
+        if "stripe_billing_router" not in lowered:
+            raise CriticalGenerationFailure(
+                "critical generation failure: payment keywords without stripe_billing_router",
             )
 
 

--- a/unit_tests/test_validate_stripe_usage.py
+++ b/unit_tests/test_validate_stripe_usage.py
@@ -5,7 +5,11 @@ import pytest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 
-from codex_output_analyzer import CriticalGenerationFailure, validate_stripe_usage  # noqa: E402
+from codex_output_analyzer import (  # noqa: E402
+    CriticalGenerationFailure,
+    validate_stripe_usage,
+    validate_stripe_usage_generic,
+)
 
 
 def test_router_import_without_usage_raises() -> None:
@@ -41,3 +45,26 @@ def test_js_snippet_without_router_raises() -> None:
 def test_js_snippet_with_router_import_passes() -> None:
     code = "import stripe_billing_router\nfetch('https://api.stripe.com/v1/charges')"
     validate_stripe_usage(code)
+
+
+def test_plain_text_keyword_without_router_raises() -> None:
+    text = "This page handles billing for users"
+    with pytest.raises(CriticalGenerationFailure):
+        validate_stripe_usage_generic(text)
+
+
+def test_html_snippet_keyword_without_router_raises() -> None:
+    html = "<div>Start checkout now</div>"
+    with pytest.raises(CriticalGenerationFailure):
+        validate_stripe_usage_generic(html)
+
+
+def test_js_snippet_keyword_without_router_raises() -> None:
+    js = "function sendInvoice() { return true; }"
+    with pytest.raises(CriticalGenerationFailure):
+        validate_stripe_usage_generic(js)
+
+
+def test_generic_text_with_router_passes() -> None:
+    text = "Payments are processed via stripe_billing_router"
+    validate_stripe_usage_generic(text)


### PR DESCRIPTION
## Summary
- flag Stripe payment keywords in arbitrary text when `stripe_billing_router` absent
- test generic validator against plain text, HTML, and JS samples

## Testing
- `pre-commit run --files codex_output_analyzer.py unit_tests/test_validate_stripe_usage.py`
- `pytest unit_tests/test_validate_stripe_usage.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba0e7c2718832eb38d5f7a7146cd31