### PR TITLE
Integrate strategy rotator for prompt template failures

### DIFF
--- a/self_improvement/strategy_rotator.py
+++ b/self_improvement/strategy_rotator.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Utility for rotating prompt strategies after repeated failures."""
+
+from typing import Dict, List
+
+# Ordered list of available prompt templates.
+TEMPLATES: List[str] = [
+    "strict_fix",
+    "delete_rebuild",
+    "comment_refactor",
+    "unit_test_rewrite",
+]
+
+# Track consecutive failures for each strategy.
+failure_counts: Dict[str, int] = {name: 0 for name in TEMPLATES}
+# Consecutive failures allowed for each strategy before rotating. The default
+# is a single attempt but the mapping allows per-strategy customisation.
+failure_limits: Dict[str, int] = {name: 1 for name in TEMPLATES}
+
+
+def next_strategy(current: str, reason: str) -> str:
+    """Record a failure for ``current`` and return the next strategy.
+
+    Parameters
+    ----------
+    current:
+        The strategy that has just failed.
+    reason:
+        Free form text describing the failure; stored for diagnostic
+        purposes but otherwise unused.
+
+    Returns
+    -------
+    str
+        The strategy to attempt next in the ordered template list.
+    """
+
+    failure_counts[current] = failure_counts.get(current, 0) + 1
+    limit = failure_limits.get(current, 1)
+    if failure_counts[current] < limit:
+        return current
+    try:
+        idx = TEMPLATES.index(current)
+    except ValueError:
+        idx = -1
+    return TEMPLATES[(idx + 1) % len(TEMPLATES)]
+
+
+__all__ = ["TEMPLATES", "failure_counts", "next_strategy"]

--- a/self_improvement/tests/test_strategy_rotation.py
+++ b/self_improvement/tests/test_strategy_rotation.py
@@ -1,0 +1,59 @@
+import importlib
+import logging
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault("dynamic_path_router", types.SimpleNamespace(resolve_path=lambda p: p))
+pkg = types.ModuleType("menace_sandbox.self_improvement")
+pkg.__path__ = [str(ROOT / "self_improvement")]
+sys.modules["menace_sandbox.self_improvement"] = pkg
+strategy_rotator = importlib.import_module(
+    "menace_sandbox.self_improvement.strategy_rotator"
+)
+
+
+class DummyPrompt:
+    def __init__(self, strategy: str):
+        self.metadata = {"strategy": strategy}
+
+
+class MiniEngine:
+    def __init__(self):
+        self.logger = logging.getLogger("test")
+        self.prompt_strategy_manager = types.SimpleNamespace(record_failure=lambda: None)
+        self.pending_strategy = None
+
+    def _record_snapshot_delta(self, prompt, delta):
+        success = not (delta.get("roi", 0.0) < 0 or delta.get("entropy", 0.0) < 0)
+        if success:
+            return
+        strategy = getattr(prompt, "metadata", {}).get("strategy")
+        if strategy:
+            self.pending_strategy = strategy_rotator.next_strategy(strategy, "regression")
+
+    def _select_prompt_strategy(self, strategies):
+        pending = self.pending_strategy
+        if pending and pending in strategies:
+            self.pending_strategy = None
+            return pending
+        return strategies[0] if strategies else None
+
+
+def test_rotation_and_pending_strategy():
+    for key in strategy_rotator.failure_counts:
+        strategy_rotator.failure_counts[key] = 0
+
+    eng = MiniEngine()
+    prompt = DummyPrompt("strict_fix")
+    eng._record_snapshot_delta(prompt, {"roi": -1})
+    assert strategy_rotator.failure_counts["strict_fix"] == 1
+    assert eng.pending_strategy == "delete_rebuild"
+
+    choice = eng._select_prompt_strategy(strategy_rotator.TEMPLATES)
+    assert choice == "delete_rebuild"
+    assert eng.pending_strategy is None


### PR DESCRIPTION
## Summary
- add strategy_rotator module tracking consecutive failures and rotating among strict_fix, delete_rebuild, comment_refactor, and unit_test_rewrite templates
- wire SelfImprovementEngine to consult rotator on regression and honour pending strategy during prompt selection
- add regression test for strategy rotation and pending strategy logic

## Testing
- `pre-commit run --files self_improvement/strategy_rotator.py self_improvement/engine.py self_improvement/tests/test_strategy_rotation.py`
- `pytest self_improvement/tests/test_strategy_rotation.py self_improvement/tests/test_strategy_deprioritization.py tests/test_prompt_strategy_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba0e71c57c832e8e01d96ff1340186