### PR TITLE
Ensure stripe billing router import failures surface

### DIFF
--- a/enhancement_bot.py
+++ b/enhancement_bot.py
@@ -20,10 +20,7 @@ from .chatgpt_enhancement_bot import (
 from .micro_models.diff_summarizer import summarize_diff
 from .micro_models.prefix_injector import inject_prefix
 from billing.prompt_notice import prepend_payment_notice
-try:  # pragma: no cover - optional billing dependency
-    import stripe_billing_router  # noqa: F401
-except Exception:  # pragma: no cover - best effort
-    stripe_billing_router = None  # type: ignore
+import stripe_billing_router  # noqa: F401
 
 try:  # pragma: no cover - optional dependency
     from . import codex_db_helpers as cdh

--- a/prompt_engine.py
+++ b/prompt_engine.py
@@ -27,10 +27,7 @@ from snippet_compressor import compress_snippets
 from chunking import split_into_chunks, summarize_code
 from target_region import TargetRegion, extract_target_region
 from billing.prompt_notice import prepend_payment_notice
-try:  # pragma: no cover - optional billing dependency
-    import stripe_billing_router  # noqa: F401
-except Exception:  # pragma: no cover - best effort
-    stripe_billing_router = None  # type: ignore
+import stripe_billing_router  # noqa: F401
 
 
 SYSTEM_NOTICE = prepend_payment_notice([])[0]["content"]


### PR DESCRIPTION
## Summary
- remove try/except guards around `stripe_billing_router` imports in `prompt_engine` and `enhancement_bot`
- rely on direct import so missing router errors fail fast

## Testing
- `python -m py_compile prompt_engine.py enhancement_bot.py`
- `pytest -q` *(fails: TypeError: unsupported operand type(s) for /: 'str' and 'str')*

------
https://chatgpt.com/codex/tasks/task_e_68ba115f9f48832ea6b14931e88c4035