### PR TITLE
Use dynamic path resolver and normalize scan paths

### DIFF
--- a/self_improvement/prompt_strategy_manager.py
+++ b/self_improvement/prompt_strategy_manager.py
@@ -8,11 +8,7 @@ import os
 import tempfile
 from typing import Callable, Sequence
 
-try:  # pragma: no cover - optional helper for dynamic paths
-    from dynamic_path_router import resolve_path
-except Exception:  # pragma: no cover - fallback
-    def resolve_path(p: str | Path) -> str | Path:  # type: ignore
-        return p
+from dynamic_path_router import resolve_path
 
 
 class PromptStrategyManager:
@@ -37,9 +33,9 @@ class PromptStrategyManager:
 
                 state_path = _data_dir() / "prompt_strategy_state.json"
             except Exception:  # pragma: no cover - fallback when init unavailable
-                state_path = Path(resolve_path("prompt_strategy_state.json"))
+                state_path = resolve_path("prompt_strategy_state.json")
         if not isinstance(state_path, Path):
-            state_path = Path(resolve_path(state_path))
+            state_path = resolve_path(state_path)
         self.state_path = state_path
         self.index: int = 0
         self._load_state()

--- a/snapshot_history_db.py
+++ b/snapshot_history_db.py
@@ -14,16 +14,12 @@ except Exception:  # pragma: no cover - fallback for flat layout
     from self_improvement import prompt_memory  # type: ignore
 from db_router import DBRouter
 
-try:  # pragma: no cover - optional dependency location
-    from dynamic_path_router import resolve_path
-except Exception:  # pragma: no cover
-    def resolve_path(p: str) -> str:  # type: ignore
-        return p
+from dynamic_path_router import resolve_path
 
 
 def _db_path(settings: SandboxSettings | None = None) -> Path:
     settings = settings or SandboxSettings()
-    return Path(resolve_path(settings.sandbox_data_dir)) / "snapshot_history.db"
+    return resolve_path(settings.sandbox_data_dir) / "snapshot_history.db"
 
 
 def _get_conn(settings: SandboxSettings | None = None):


### PR DESCRIPTION
## Summary
- use `dynamic_path_router.resolve_path` instead of local stubs
- normalize Stripe scan paths via `resolve_path`
- simplify prompt strategy state path handling

## Testing
- `pytest tests/test_prompt_strategy_manager.py tests/self_improvement/test_prompt_strategy_behavior.py`
- `pytest tests/test_no_direct_stripe_imports.py tests/test_stripe_import_lint.py`
- `pytest tests/test_snapshot_history_db_storage.py` *(fails: ImportError: attempted relative import with no known parent package)*
- `pytest tests/test_snapshot_regression_logging.py` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68ba140bd5bc832e8e699c97777e53af