### PR TITLE
Track failure reasons in snapshot logging

### DIFF
--- a/self_improvement/prompt_memory.py
+++ b/self_improvement/prompt_memory.py
@@ -167,6 +167,11 @@ def log_prompt_attempt(
         "exec_result": exec_result,
     }
     roi_delta: float | None = None
+    if failure_reason is not None:
+        # Treat the presence of a failure reason as an unsuccessful attempt even
+        # if ``success`` was erroneously marked True by the caller.
+        success = False
+
     if prompt_id:
         entry["prompt_id"] = prompt_id
         if not success:


### PR DESCRIPTION
## Summary
- log ROI, sandbox score, entropy and test regressions with specific failure reasons
- treat failure_reason as a failure in prompt logging and write to the failure log
- add tests covering new failure categories and failure log path

## Testing
- `pytest self_improvement/tests/test_snapshot_delta_logging.py self_improvement/tests/test_log_prompt_failure_reason.py -q`
- `pre-commit run --files self_improvement/engine.py self_improvement/prompt_memory.py self_improvement/tests/test_snapshot_delta_logging.py self_improvement/tests/test_log_prompt_failure_reason.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba16c78e80832ea7de9af6ebcd4e40