### PR TITLE
Implement strategy-aware prompt builder and rotation manager

### DIFF
--- a/prompt_engine.py
+++ b/prompt_engine.py
@@ -756,12 +756,14 @@ class PromptEngine:
         descriptions of file chunks when the full source is too large to
         include.  ``retry_trace`` may contain failure logs or tracebacks from a
         prior attempt.  ``strategy`` selects an optional template from
-        ``prompt_strategy.yaml`` that is inserted near the start of the prompt
-        and recorded in the prompt metadata.  When supplied a "Previous failure"
-        section is appended and the details are de-duplicated so repeated
-        retries do not accumulate duplicate traces.  When retrieval fails or
-        the average confidence of returned patches falls below
-        ``confidence_threshold`` a static fallback template is returned.
+        ``prompt_strategies.yaml`` that is inserted near the start of the prompt
+        and recorded in the prompt metadata.  Recognised values include
+        ``strict_fix``, ``delete_rebuild``, ``comment_refactor`` and
+        ``unit_test_rewrite``.  When supplied a "Previous failure" section is
+        appended and the details are de-duplicated so repeated retries do not
+        accumulate duplicate traces.  When retrieval fails or the average
+        confidence of returned patches falls below ``confidence_threshold`` a
+        static fallback template is returned.
         """
         self._maybe_refresh_optimizer()
         if not self._optimizer_applied:
@@ -1297,8 +1299,10 @@ def build_prompt(
 ) -> Prompt:
     """Convenience wrapper mirroring :meth:`PromptEngine.construct_prompt`.
 
-    The helper instantiates a temporary :class:`PromptEngine` and returns the
-    resulting :class:`Prompt` instance.
+    ``strategy`` accepts the same values as :meth:`PromptEngine.build_prompt`,
+    e.g. ``strict_fix`` or ``delete_rebuild``.  The helper instantiates a
+    temporary :class:`PromptEngine` and returns the resulting :class:`Prompt`
+    instance.
     """
 
     return PromptEngine.construct_prompt(

--- a/self_improvement/strategy_manager.py
+++ b/self_improvement/strategy_manager.py
@@ -1,0 +1,68 @@
+"""Strategy rotation helper for self-improvement tasks.
+
+This lightweight module keeps an ordered list of strategy templates and
+provides :func:`next_strategy` to rotate through them after failures.  Certain
+keywords found in the failure reason trigger specific strategies while unknown
+reasons simply advance to the next entry in the rotation order.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+# Ordered list of available strategies.  The first entry is considered the
+# default starting strategy.
+STRATEGIES: List[str] = [
+    "strict_fix",
+    "delete_rebuild",
+    "comment_refactor",
+    "unit_test_rewrite",
+]
+
+# Mapping of lowercase keywords to strategy names.  When the failure reason
+# contains one of these tokens the associated strategy is selected directly.
+_KEYWORD_MAP: Dict[str, str] = {
+    "test": "unit_test_rewrite",
+    "comment": "comment_refactor",
+    "refactor": "comment_refactor",
+    "delete": "delete_rebuild",
+    "rebuild": "delete_rebuild",
+}
+
+_index = 0
+
+
+def next_strategy(failure_reason: str | None = None) -> str:
+    """Return the next strategy to attempt.
+
+    Parameters
+    ----------
+    failure_reason:
+        Optional text describing why the previous attempt failed.  When the
+        reason contains one of the keywords from ``_KEYWORD_MAP`` the
+        associated strategy becomes the next suggestion.  Unrecognised reasons
+        simply rotate to the next strategy in :data:`STRATEGIES`.
+
+    Returns
+    -------
+    str
+        The name of the strategy that should be attempted next.
+    """
+
+    global _index
+
+    if failure_reason:
+        reason = failure_reason.lower()
+        for key, strategy in _KEYWORD_MAP.items():
+            if key in reason:
+                _index = STRATEGIES.index(strategy)
+                break
+        else:
+            _index = (_index + 1) % len(STRATEGIES)
+    else:
+        _index = (_index + 1) % len(STRATEGIES)
+    return STRATEGIES[_index]
+
+
+__all__ = ["STRATEGIES", "next_strategy"]
+

--- a/templates/prompt_strategies.yaml
+++ b/templates/prompt_strategies.yaml
@@ -1,6 +1,6 @@
 strict_fix: |
   Apply the smallest change necessary to address the issue without altering unrelated code.
-delete_and_rebuild: |
+delete_rebuild: |
   Remove the existing implementation entirely and recreate it from scratch.
 comment_refactor: |
   Restructure or improve comments without modifying the runtime behaviour of the code.


### PR DESCRIPTION
## Summary
- document and support prompt-building strategies like `strict_fix`, `delete_rebuild`, `comment_refactor`, and `unit_test_rewrite`
- add `strategy_manager` helper that rotates strategies based on failure reasons
- rename `delete_and_rebuild` template to `delete_rebuild`

## Testing
- `pytest self_improvement/tests/test_strategy_rotation.py -q`
- `pytest self_improvement/tests/test_strategy_rotation.py tests/test_prompt_engine.py tests/test_prompt_engine_fallback.py tests/test_prompt_engine_chunk_summaries.py tests/test_prompt_engine_llm_client_integration.py tests/test_prompt_engine_optimizer_integration.py tests/test_prompt_engine_vector_service.py -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '')*
- `pytest self_improvement/tests/test_strategy_rotation.py tests/test_prompt_engine.py tests/test_prompt_engine_fallback.py tests/test_prompt_engine_chunk_summaries.py tests/test_prompt_engine_llm_client_integration.py tests/test_prompt_engine_optimizer_integration.py -q` *(fails: assertion errors and missing PromptMemoryTrainer)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1845cfac832ea22b4d44792ca4b5