### PR TITLE
Expand Stripe keyword detection to handle camelCase and hyphenated identifiers

### DIFF
--- a/codex_output_analyzer.py
+++ b/codex_output_analyzer.py
@@ -174,6 +174,14 @@ def validate_stripe_usage(code: str) -> None:
                         self.has_payment_keyword = True
             self.generic_visit(node)
 
+        def visit_Attribute(self, node: ast.Attribute) -> None:  # pragma: no cover - simple
+            if isinstance(node.ctx, ast.Store):
+                name = node.attr
+                if not name.isupper() and name != "stripe_billing_router":
+                    if contains_payment_keyword(name):
+                        self.has_payment_keyword = True
+            self.generic_visit(node)
+
         def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # pragma: no cover - simple
             if contains_payment_keyword(node.name):
                 self.has_payment_keyword = True

--- a/scripts/check_stripe_imports.py
+++ b/scripts/check_stripe_imports.py
@@ -117,6 +117,14 @@ class StripeAnalyzer(ast.NodeVisitor):
                     self.keyword_lines.add(node.lineno)
         self.generic_visit(node)
 
+    def visit_Attribute(self, node: ast.Attribute) -> None:  # pragma: no cover - simple
+        if isinstance(node.ctx, ast.Store):
+            name = node.attr
+            if not name.isupper() and name != "stripe_billing_router":
+                if contains_payment_keyword(name):
+                    self.keyword_lines.add(node.lineno)
+        self.generic_visit(node)
+
 
 def _root_name(node: ast.AST) -> str | None:
     while isinstance(node, ast.Attribute):

--- a/stripe_detection.py
+++ b/stripe_detection.py
@@ -1,6 +1,7 @@
 """Shared Stripe detection rules and helpers."""
 from __future__ import annotations
 
+import re
 from typing import Iterable
 
 PAYMENT_KEYWORDS = {
@@ -22,5 +23,7 @@ HTTP_LIBRARIES = {"requests", "httpx", "aiohttp", "urllib", "urllib3"}
 
 def contains_payment_keyword(name: str, keywords: Iterable[str] = PAYMENT_KEYWORDS) -> bool:
     """Return ``True`` if ``name`` includes any payment-related keyword."""
-    parts = name.lower().split("_")
-    return any(part in keywords for part in parts)
+    normalized = name.replace("-", "_")
+    normalized = re.sub(r"(?<=[a-z0-9])([A-Z])", r"_\1", normalized)
+    parts = normalized.lower().split("_")
+    return any(part in keywords for part in parts if part)

--- a/unit_tests/test_validate_stripe_usage.py
+++ b/unit_tests/test_validate_stripe_usage.py
@@ -11,6 +11,7 @@ from codex_output_analyzer import (  # noqa: E402
     validate_stripe_usage,
     validate_stripe_usage_generic,
 )
+from stripe_detection import contains_payment_keyword  # noqa: E402
 
 
 def test_router_import_without_usage_raises() -> None:
@@ -64,6 +65,29 @@ def test_js_snippet_keyword_without_router_raises() -> None:
     js = "function sendInvoice() { return true; }"
     with pytest.raises(CriticalGenerationFailure):
         validate_stripe_usage_generic(js)
+
+
+def test_camel_case_identifier_without_router_raises() -> None:
+    code = """
+def processPayment():
+    return True
+"""
+    with pytest.raises(CriticalGenerationFailure):
+        validate_stripe_usage(code)
+
+
+def test_hyphenated_identifier_without_router_raises() -> None:
+    js = "function send-Invoice() { return true; }"
+    with pytest.raises(CriticalGenerationFailure):
+        validate_stripe_usage_generic(js)
+
+
+def test_contains_payment_keyword_camel_case() -> None:
+    assert contains_payment_keyword("processPayment")
+
+
+def test_contains_payment_keyword_hyphen() -> None:
+    assert contains_payment_keyword("send-Invoice")
 
 
 def test_generic_text_with_router_passes() -> None:


### PR DESCRIPTION
## Summary
- Allow payment keyword detection for camelCase and hyphenated names
- Flag payment-related attribute assignments in Stripe import checks and analyzer
- Test detection of processPayment and send-Invoice identifiers

## Testing
- `python -m flake8 stripe_detection.py scripts/check_stripe_imports.py codex_output_analyzer.py unit_tests/test_validate_stripe_usage.py`
- `pytest unit_tests/test_validate_stripe_usage.py tests/test_payment_validator.py tests/test_no_direct_stripe_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba193a2ed4832e99c2171d5829a4ca