### PR TITLE
feat: enforce stripe router presence

### DIFF
--- a/docs/billing_router.md
+++ b/docs/billing_router.md
@@ -69,3 +69,8 @@ stored outside this module.  Bypassing the router skips key management and audit
 checks and risks charging the wrong customer.  Always call the router helpers
 and let them obtain a configured Stripe client.
 
+The repository includes `scripts/check_raw_stripe_usage.py` which scans all
+tracked text files for raw Stripe keys or payment related keywords such as
+"payment", "checkout" or "billing".  Any file mentioning these keywords must
+also reference ``stripe_billing_router`` or the check fails.
+

--- a/tests/test_raw_stripe_usage_non_python.py
+++ b/tests/test_raw_stripe_usage_non_python.py
@@ -16,7 +16,6 @@ import pytest
         (".tsx", "fetch('https://api.stripe.com/v1/refunds')"),
     ],
 )
-
 def test_detects_stripe_in_non_python_files(tmp_path, monkeypatch, capsys, extension, content):
     path = tmp_path / f"bad{extension}"
     path.write_text(content)
@@ -26,3 +25,25 @@ def test_detects_stripe_in_non_python_files(tmp_path, monkeypatch, capsys, exten
     assert check.main() == 1
     captured = capsys.readouterr()
     assert path.name in captured.out
+
+
+def test_payment_keywords_require_router(tmp_path, monkeypatch, capsys):
+    path = tmp_path / "payment.txt"
+    path.write_text("checkout flow here")
+
+    monkeypatch.setattr(check, "_tracked_files", lambda: [path])
+
+    assert check.main() == 1
+    captured = capsys.readouterr()
+    assert path.name in captured.out
+
+
+def test_payment_keywords_with_router_ok(tmp_path, monkeypatch, capsys):
+    path = tmp_path / "ok.txt"
+    path.write_text("billing via stripe_billing_router")
+
+    monkeypatch.setattr(check, "_tracked_files", lambda: [path])
+
+    assert check.main() == 0
+    captured = capsys.readouterr()
+    assert path.name not in captured.out


### PR DESCRIPTION
## Summary
- scan all tracked text files for raw Stripe keywords and require stripe_billing_router mention
- test payment keyword detection and allowed router usage
- document repository check for payment keywords

## Testing
- `pre-commit run --files scripts/check_raw_stripe_usage.py tests/test_raw_stripe_usage_non_python.py docs/billing_router.md`
- `pytest tests/test_raw_stripe_usage_non_python.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba1b0a7934832e85fbc2468c26aab3