### PR TITLE
Track strategy performance metrics

### DIFF
--- a/self_improvement/tests/test_strategy_deprioritization.py
+++ b/self_improvement/tests/test_strategy_deprioritization.py
@@ -1,4 +1,5 @@
 import logging
+import logging
 import importlib
 import types
 import sys
@@ -36,37 +37,24 @@ class MiniEngine:
     def __init__(self):
         self.deprioritized_strategies = set()
         self.logger = logging.getLogger("test")
+        self.strategy_manager = snapshot_tracker.StrategyManager()
 
     def _record_snapshot_delta(self, prompt, delta):
         success = not (delta.get("roi", 0.0) < 0 or delta.get("entropy", 0.0) < 0)
-        if not success:
-            strategy = None
-            metadata = getattr(prompt, "metadata", {})
-            if isinstance(metadata, dict):
-                strategy = metadata.get("strategy") or metadata.get("prompt_id")
-            if strategy:
+        metadata = getattr(prompt, "metadata", {})
+        strategy = None
+        if isinstance(metadata, dict):
+            strategy = metadata.get("strategy") or metadata.get("prompt_id")
+        if strategy:
+            if not success:
                 count = snapshot_tracker.record_downgrade(str(strategy))
                 if count >= SandboxSettings().prompt_failure_threshold:
                     self.deprioritized_strategies.add(str(strategy))
+            self.strategy_manager.update(str(strategy), delta.get("roi", 0.0), success)
 
-    def _select_prompt_strategy(self, strategies):
-        penalties = prompt_memory.load_prompt_penalties()
-        settings = SandboxSettings()
-        best = None
-        best_weight = -1.0
-        for strat in strategies:
-            if strat in self.deprioritized_strategies:
-                continue
-            count = penalties.get(str(strat), 0)
-            weight = (
-                settings.prompt_penalty_multiplier
-                if count >= settings.prompt_failure_threshold
-                else 1.0
-            )
-            if weight > best_weight:
-                best_weight = weight
-                best = strat
-        return best
+    def next_prompt_strategy(self, strategies):
+        candidates = [s for s in strategies if s not in self.deprioritized_strategies]
+        return self.strategy_manager.best_strategy(candidates)
 
 
 def test_deprioritized_strategy_skipped(tmp_path, monkeypatch):
@@ -84,5 +72,5 @@ def test_deprioritized_strategy_skipped(tmp_path, monkeypatch):
     monkeypatch.setattr(prompt_memory, "load_prompt_penalties", lambda: {"s1": thr})
 
     assert "s1" in eng.deprioritized_strategies
-    choice = eng._select_prompt_strategy(["s1", "s2"])
+    choice = eng.next_prompt_strategy(["s1", "s2"])
     assert choice == "s2"


### PR DESCRIPTION
## Summary
- add a persistent StrategyManager that records attempts, successes, and ROI per strategy
- log strategy performance after each snapshot cycle and pick the best strategy by average ROI

## Testing
- `pre-commit run --files self_improvement/engine.py self_improvement/snapshot_tracker.py self_improvement/tests/test_strategy_deprioritization.py self_improvement/tests/test_strategy_rotation.py tests/test_snapshot_tracker_confidence.py tests/test_strategy_deprioritization.py` *(command failed: pre-commit not found)*
- `pytest tests/test_snapshot_tracker_confidence.py -q`
- `pytest tests/test_strategy_deprioritization.py -q` *(KeyboardInterrupt after tests completed)*
- `pytest self_improvement/tests/test_strategy_deprioritization.py -q` *(ImportError: cannot import name 'repo_root')*
- `pytest self_improvement/tests/test_strategy_rotation.py -q` *(ImportError: cannot import name 'repo_root')*


------
https://chatgpt.com/codex/tasks/task_e_68ba19d7a7fc832e930854e548961fd3