### PR TITLE
Log sandbox metrics on failed prompt attempts

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -2746,6 +2746,8 @@ class SelfCodingEngine:
                             False,
                             {"error": str(exc), "trace": trace},
                             {"roi": roi_val, "roi_delta": 0.0},
+                            failure_reason=str(exc),
+                            sandbox_metrics={"roi": roi_val},
                         )
                     except Exception:
                         self.logger.exception("log_prompt_attempt failed")
@@ -2788,6 +2790,8 @@ class SelfCodingEngine:
                             not reverted,
                             exec_res,
                             roi_meta,
+                            failure_reason="reverted" if reverted else None,
+                            sandbox_metrics=roi_meta if reverted else None,
                         )
                     except Exception:
                         self.logger.exception("log_prompt_attempt failed")
@@ -2876,6 +2880,8 @@ class SelfCodingEngine:
                     False,
                     exec_res,
                     {"roi": roi_val, "roi_delta": 0.0},
+                    failure_reason=None,
+                    sandbox_metrics={"roi": roi_val},
                 )
             except Exception:
                 self.logger.exception("log_prompt_attempt failed")

--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -1579,6 +1579,7 @@ class SelfImprovementEngine:
                                 False,
                                 {"delta": delta_vals, "patch_diff": patch_diff},
                                 failure_reason=reason,
+                                sandbox_metrics=delta_vals,
                             )
                         except Exception:
                             self.logger.exception("log_prompt_attempt failed")
@@ -1676,6 +1677,7 @@ class SelfImprovementEngine:
                 exec_res,
                 roi_meta,
                 failure_reason=failure_reason if not success else None,
+                sandbox_metrics=roi_meta if not success else None,
             )
         except Exception:
             self.logger.exception("log_prompt_attempt failed")
@@ -6506,6 +6508,7 @@ class SelfImprovementEngine:
             exec_result={"diff": diff},
             roi_meta=delta,
             failure_reason=failure_reason,
+            sandbox_metrics=delta if not success else None,
         )
         if success:
             for f in files or []:

--- a/self_improvement/prompt_memory.py
+++ b/self_improvement/prompt_memory.py
@@ -124,6 +124,7 @@ def log_prompt_attempt(
     roi_meta: Dict[str, Any] | None = None,
     prompt_id: str | None = None,
     failure_reason: str | None = None,
+    sandbox_metrics: Dict[str, Any] | None = None,
 ) -> None:
     """Record a prompt attempt outcome.
 
@@ -143,8 +144,9 @@ def log_prompt_attempt(
     roi_meta:
         Optional ROI metrics or other contextual information.
     failure_reason:
-        Optional string describing why the attempt failed. Only stored for
-        unsuccessful attempts and omitted from success logs.
+        Optional string describing why the attempt failed.
+    sandbox_metrics:
+        Optional dictionary containing sandbox execution metrics.
     """
 
     metadata = getattr(prompt, "metadata", {}) if prompt is not None else {}
@@ -183,8 +185,9 @@ def log_prompt_attempt(
             roi_delta = roi_meta.get("roi_delta") if isinstance(roi_meta, dict) else None
         if roi_delta is None and isinstance(roi_meta, dict):
             roi_delta = roi_meta.get("roi")
-    if not success and failure_reason is not None:
+    if not success:
         entry["failure_reason"] = failure_reason
+        entry["sandbox_metrics"] = sandbox_metrics
 
     if prompt_id and roi_delta is not None:
         try:

--- a/self_improvement/tests/test_log_prompt_failure_reason.py
+++ b/self_improvement/tests/test_log_prompt_failure_reason.py
@@ -38,11 +38,13 @@ def test_log_prompt_attempt_records_failure_reason(tmp_path, monkeypatch):
         success=True,
         exec_result={"detail": "x"},
         failure_reason="bad_result",
+        sandbox_metrics={"m": 1},
     )
 
     failure_log = tmp_path / "failure.jsonl"
     assert failure_log.exists()
     entry = json.loads(failure_log.read_text().strip())
     assert entry["failure_reason"] == "bad_result"
+    assert entry["sandbox_metrics"] == {"m": 1}
     # No success log should be written
     assert not (tmp_path / "success.jsonl").exists()

--- a/self_improvement/tests/test_snapshot_delta_logging.py
+++ b/self_improvement/tests/test_snapshot_delta_logging.py
@@ -25,6 +25,7 @@ def _load_record_snapshot_delta(tmp_path, log_entries, updates):
         roi_meta,
         prompt_id=None,
         failure_reason=None,
+        sandbox_metrics=None,
     ):  # pragma: no cover
         log_entries.append(
             {
@@ -33,6 +34,7 @@ def _load_record_snapshot_delta(tmp_path, log_entries, updates):
                 "exec_result": exec_result,
                 "roi_meta": roi_meta,
                 "failure_reason": failure_reason,
+                "sandbox_metrics": sandbox_metrics,
             }
         )
 
@@ -75,6 +77,7 @@ def test_record_snapshot_delta_failures(tmp_path, delta, reason):
     assert json.loads(path.read_text().strip()) == delta
     assert logs and not logs[0]["success"]
     assert logs[0]["failure_reason"] == reason
+    assert logs[0]["sandbox_metrics"] == delta
     assert not updates
 
 
@@ -86,4 +89,5 @@ def test_record_snapshot_delta_success(tmp_path):
     func(eng, "p", "d", delta)
     assert logs and logs[0]["success"]
     assert logs[0]["failure_reason"] is None
+    assert logs[0]["sandbox_metrics"] is None
     assert updates and updates[0] == delta

--- a/tests/self_improvement/test_prompt_strategy_behavior.py
+++ b/tests/self_improvement/test_prompt_strategy_behavior.py
@@ -68,11 +68,13 @@ def test_failure_reason_logged(tmp_path, monkeypatch, dummy_prompt):
         success=False,
         exec_result={"error": "boom"},
         failure_reason="api_error",
+        sandbox_metrics={"s": 2},
     )
 
     log_path = tmp_path / "fail.json"
     entry = json.loads(log_path.read_text().splitlines()[0])
     assert entry["failure_reason"] == "api_error"
+    assert entry["sandbox_metrics"] == {"s": 2}
     assert entry["prompt_id"] == dummy_prompt.metadata["prompt_id"]
 
 


### PR DESCRIPTION
## Summary
- capture optional `failure_reason` and `sandbox_metrics` in `log_prompt_attempt`
- forward these fields from self-improvement engine and self-coding engine
- add tests for recording failure reason and sandbox metrics

## Testing
- `pytest self_improvement/tests/test_log_prompt_failure_reason.py self_improvement/tests/test_snapshot_delta_logging.py tests/self_improvement/test_prompt_strategy_behavior.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba1c8c96b4832ea15b6069e6e5c0eb