### PR TITLE
Resolve news database path using dynamic router

### DIFF
--- a/newsreader_bot.py
+++ b/newsreader_bot.py
@@ -49,8 +49,9 @@ except Exception:  # pragma: no cover - fallback for flat layout
 
 from db_router import GLOBAL_ROUTER, init_db_router
 from scope_utils import Scope, build_scope_clause, apply_scope
+from dynamic_path_router import resolve_path
 
-DB_PATH = Path(__file__).parent / "news.db"
+DB_PATH = resolve_path("news.db")
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- use `resolve_path` to locate `news.db`

## Testing
- `pytest tests/test_newsreader_energy.py tests/test_newsreader_bot_monetise.py tests/test_newsreader_bot.py tests/test_dependency_watchdog_events.py tests/test_menace_master.py tests/test_menace_discovery_engine.py tests/test_synergy_dashboard.py -q` (fails: FileNotFoundError, ImportError)
- `pytest tests/test_newsreader_bot.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba1d644264832e97caf44cd7366473