### PR TITLE
Wrap OpenAI ChatCompletion with payment notice

### DIFF
--- a/billing/openai_wrapper.py
+++ b/billing/openai_wrapper.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Lightweight OpenAI wrapper that injects the payment notice.
+
+This module exposes :func:`chat_completion_create` which mirrors
+``openai.ChatCompletion.create`` but automatically prepends
+:data:`~stripe_policy.PAYMENT_ROUTER_NOTICE` to the ``messages`` list.
+It allows passing a custom ``openai_client`` for easy testing.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from .prompt_notice import prepend_payment_notice
+
+try:  # pragma: no cover - optional dependency
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    openai = None  # type: ignore
+
+
+def chat_completion_create(
+    messages: List[Dict[str, str]],
+    *,
+    openai_client: Optional[Any] = None,
+    **kwargs: Any,
+) -> Any:
+    """Proxy ``openai.ChatCompletion.create`` with payment notice injection."""
+
+    client = openai_client or openai
+    if client is None:  # pragma: no cover - import guard
+        raise RuntimeError("openai library not available")
+    msgs = prepend_payment_notice(messages)
+    return client.ChatCompletion.create(messages=msgs, **kwargs)
+
+
+__all__ = ["chat_completion_create"]

--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -39,7 +39,7 @@ from vector_service import ContextBuilder, FallbackResult, ErrorResult
 from .codex_output_analyzer import (
     validate_stripe_usage,
 )
-from billing.prompt_notice import prepend_payment_notice
+from billing.openai_wrapper import chat_completion_create
 
 try:  # pragma: no cover - optional dependency
     from . import codex_db_helpers as cdh
@@ -907,11 +907,13 @@ class BotDevelopmentBot:
         self, model: str, messages: list[dict[str, str]]
     ) -> Any:
         """Call either local or cloud Codex API and return the raw response."""
-        messages = prepend_payment_notice(list(messages))
         if openai and os.getenv("OPENAI_API_KEY"):
             openai.api_key = os.getenv("OPENAI_API_KEY")
-            return openai.ChatCompletion.create(
-                model=model, messages=messages, temperature=0.1
+            return chat_completion_create(
+                list(messages),
+                model=model,
+                temperature=0.1,
+                openai_client=openai,
             )
         url = os.getenv("LOCAL_CODEX_URL")
         if url and requests:

--- a/enhancement_bot.py
+++ b/enhancement_bot.py
@@ -19,7 +19,7 @@ from .chatgpt_enhancement_bot import (
 )
 from .micro_models.diff_summarizer import summarize_diff
 from .micro_models.prefix_injector import inject_prefix
-from billing.prompt_notice import prepend_payment_notice
+from billing.openai_wrapper import chat_completion_create
 import stripe_billing_router  # noqa: F401
 
 try:  # pragma: no cover - optional dependency
@@ -141,12 +141,12 @@ class EnhancementBot:
                 confidence,
                 role="system",
             )
-        messages = prepend_payment_notice(messages)
         try:
-            resp = openai.ChatCompletion.create(
+            resp = chat_completion_create(
+                messages,
                 model="gpt-3.5-turbo",
-                messages=messages,
                 temperature=0.2,
+                openai_client=openai,
             )
             return resp["choices"][0]["message"]["content"].strip()
         except Exception:

--- a/neurosales/neurosales/external_integrations.py
+++ b/neurosales/neurosales/external_integrations.py
@@ -22,7 +22,7 @@ try:  # optional dependency
 except Exception:  # pragma: no cover - optional dep
     GraphDatabase = None  # type: ignore
 
-from billing.prompt_notice import prepend_payment_notice
+from billing.openai_wrapper import chat_completion_create
 import stripe_billing_router  # noqa: F401
 logger = logging.getLogger(__name__)
 
@@ -129,9 +129,11 @@ class GPT4Client:
             {"role": "system", "content": system_msg},
             {"role": "user", "content": text},
         ]
-        messages = prepend_payment_notice(messages)
-        resp = openai.ChatCompletion.create(
-            model="gpt-4", messages=messages, stream=True
+        resp = chat_completion_create(
+            messages,
+            model="gpt-4",
+            stream=True,
+            openai_client=openai,
         )
         for chunk in resp:
             delta = chunk["choices"][0]["delta"].get("content")

--- a/neurosales/scripts/check_external_services.py
+++ b/neurosales/scripts/check_external_services.py
@@ -1,7 +1,7 @@
 import sys
 from dotenv import load_dotenv
 from neurosales import config
-from billing.prompt_notice import prepend_payment_notice
+from billing.openai_wrapper import chat_completion_create
 
 load_dotenv()
 
@@ -17,12 +17,11 @@ def check_openai(cfg: config.ServiceConfig) -> bool:
         return False
     openai.api_key = cfg.openai_key  # type: ignore[arg-type]
     try:
-        openai.ChatCompletion.create(
+        chat_completion_create(
+            [{"role": "user", "content": "ping"}],
             model="gpt-3.5-turbo",
-            messages=prepend_payment_notice(
-                [{"role": "user", "content": "ping"}]
-            ),
             max_tokens=1,
+            openai_client=openai,
         )
         print("OpenAI reachable")
         return True


### PR DESCRIPTION
## Summary
- add `billing.openai_wrapper.chat_completion_create` to prepend PAYMENT_ROUTER_NOTICE
- use wrapper instead of direct `openai.ChatCompletion.create` in bots and neurosales tools
- extend lint script to flag raw `ChatCompletion.create` calls
- add regression tests for wrapper and GPT4Client

## Testing
- `python scripts/check_stripe_imports.py bot_development_bot.py neurosales/neurosales/external_integrations.py neurosales/scripts/check_external_services.py enhancement_bot.py`
- `pytest tests/test_payment_notice.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba1d10811c832e84431e690f02a250