### PR TITLE
Use dynamic path resolver for prompt evolution memory

### DIFF
--- a/prompt_evolution_memory.py
+++ b/prompt_evolution_memory.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from filelock import FileLock
+from dynamic_path_router import resolve_path
 
 try:  # pragma: no cover - optional dependency
     from llm_interface import Prompt  # type: ignore
@@ -22,7 +23,7 @@ except Exception:  # pragma: no cover - llm_interface unavailable
         ) from exc
 
 
-_ROOT = Path(__file__).resolve().parent
+_ROOT = resolve_path(".")
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- use `dynamic_path_router.resolve_path` to determine project root for prompt evolution logs

## Testing
- `python -m py_compile prompt_evolution_memory.py`
- `pytest tests/test_prompt_evolution_memory.py unit_tests/test_prompt_evolution_memory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba1e5d8dec832e80f9ab72da08b23a