### PR TITLE
Add prompt strategy templates and renderer

### DIFF
--- a/self_improvement/prompt_strategies.py
+++ b/self_improvement/prompt_strategies.py
@@ -1,0 +1,81 @@
+"""Prompt strategy definitions and template rendering helpers."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Callable, Dict, Mapping
+
+
+class PromptStrategy(str, Enum):
+    """Enumeration of supported prompt tuning strategies."""
+
+    STRICT_FIX = "strict_fix"
+    DELETE_REBUILD = "delete_rebuild"
+    COMMENT_REFACTOR = "comment_refactor"
+    UNIT_TEST_REWRITE = "unit_test_rewrite"
+
+
+TemplateBuilder = Callable[[Mapping[str, Any]], str]
+
+
+def _module_name(ctx: Mapping[str, Any]) -> str:
+    """Extract a human readable module name from ``ctx``."""
+
+    return str(ctx.get("module") or ctx.get("module_name") or ctx.get("name") or "the module")
+
+
+def _strict_fix(ctx: Mapping[str, Any]) -> str:
+    mod = _module_name(ctx)
+    return (
+        f"Apply the smallest change necessary in {mod} to address the issue without "
+        "altering unrelated code."
+    )
+
+
+def _delete_rebuild(ctx: Mapping[str, Any]) -> str:
+    mod = _module_name(ctx)
+    return f"Remove the existing implementation of {mod} entirely and recreate it from scratch."
+
+
+def _comment_refactor(ctx: Mapping[str, Any]) -> str:
+    mod = _module_name(ctx)
+    return (
+        f"Restructure or improve comments in {mod} without modifying the runtime behaviour "
+        "of the code."
+    )
+
+
+def _unit_test_rewrite(ctx: Mapping[str, Any]) -> str:
+    mod = _module_name(ctx)
+    return (
+        f"Rewrite or expand unit tests for {mod} to clarify intent while avoiding changes "
+        "to production code."
+    )
+
+
+TEMPLATE_BUILDERS: Dict[PromptStrategy, TemplateBuilder] = {
+    PromptStrategy.STRICT_FIX: _strict_fix,
+    PromptStrategy.DELETE_REBUILD: _delete_rebuild,
+    PromptStrategy.COMMENT_REFACTOR: _comment_refactor,
+    PromptStrategy.UNIT_TEST_REWRITE: _unit_test_rewrite,
+}
+
+
+def render_prompt(strategy: PromptStrategy, module_ctx: Mapping[str, Any]) -> str:
+    """Render the template for ``strategy`` using ``module_ctx``.
+
+    Parameters
+    ----------
+    strategy:
+        The :class:`PromptStrategy` to render a prompt for.
+    module_ctx:
+        Mapping providing details about the target module. Keys such as
+        ``module``, ``module_name`` or ``name`` are inspected for a human
+        friendly description.
+    """
+
+    builder = TEMPLATE_BUILDERS[strategy]
+    return builder(module_ctx)
+
+
+__all__ = ["PromptStrategy", "TEMPLATE_BUILDERS", "render_prompt"]

--- a/self_improvement/tests/test_prompt_strategies_module.py
+++ b/self_improvement/tests/test_prompt_strategies_module.py
@@ -1,0 +1,22 @@
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+pkg = types.ModuleType("menace_sandbox.self_improvement")
+pkg.__path__ = [str(ROOT / "self_improvement")]
+sys.modules["menace_sandbox.self_improvement"] = pkg
+
+from menace_sandbox.self_improvement.prompt_strategies import (  # noqa: E402
+    PromptStrategy,
+    render_prompt,
+)
+
+
+def test_render_prompt_includes_module_name():
+    ctx = {"module": "demo.py"}
+    out = render_prompt(PromptStrategy.STRICT_FIX, ctx)
+    assert "demo.py" in out


### PR DESCRIPTION
## Summary
- define `PromptStrategy` enum for self-improvement strategies
- add template builders and `render_prompt` helper
- test prompt strategy template rendering

## Testing
- `pytest tests/test_prompt_strategy_manager.py tests/self_improvement/test_prompt_strategy_behavior.py self_improvement/tests/test_prompt_strategies_module.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba1ed3cde0832eb692d77654df3342