### PR TITLE
Use resolve_path for micro model assets

### DIFF
--- a/micro_models/diff_summarizer.py
+++ b/micro_models/diff_summarizer.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Tuple
 
-_MODEL_PATH = Path(__file__).with_suffix("").parent / "diff_summarizer_model"
+from dynamic_path_router import resolve_path
+
+try:
+    _MODEL_PATH = resolve_path("micro_models/diff_summarizer_model")
+except FileNotFoundError:  # pragma: no cover - model may be absent in tests
+    _MODEL_PATH = Path("micro_models/diff_summarizer_model")
 _tokenizer = None
 _model = None
 

--- a/micro_models/error_classifier.py
+++ b/micro_models/error_classifier.py
@@ -13,13 +13,18 @@ import re
 from pathlib import Path
 from typing import Tuple
 
+from dynamic_path_router import resolve_path
+
 try:  # pragma: no cover - optional heavy dependency
     from transformers import AutoModelForCausalLM, AutoTokenizer  # type: ignore
 except Exception:  # pragma: no cover - fall back to heuristics
     AutoModelForCausalLM = AutoTokenizer = None  # type: ignore
 
 _MODEL_CACHE: tuple | None = None
-DEFAULT_PATH = Path(__file__).with_name("error_classifier_model")
+try:
+    DEFAULT_PATH = resolve_path("micro_models/error_classifier_model")
+except FileNotFoundError:  # pragma: no cover - model may be missing in tests
+    DEFAULT_PATH = Path("micro_models/error_classifier_model")
 
 
 def _load_model(path: Path) -> tuple | None:

--- a/micro_models/tool_predictor.py
+++ b/micro_models/tool_predictor.py
@@ -10,12 +10,19 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Tuple
 
+from dynamic_path_router import resolve_path
+
 try:  # pragma: no cover - optional heavy dependency
     from transformers import AutoModelForCausalLM, AutoTokenizer  # type: ignore
 except Exception:  # pragma: no cover - allow heuristic fallback
     AutoModelForCausalLM = AutoTokenizer = None  # type: ignore
 
-DEFAULT_PATH = Path(__file__).with_name("tool_predictor_model")
+# ``resolve_path`` ensures model files are located relative to the project root
+# while falling back to a simple Path when the model directory is absent.
+try:
+    DEFAULT_PATH = resolve_path("micro_models/tool_predictor_model")
+except FileNotFoundError:  # pragma: no cover - model may be missing in tests
+    DEFAULT_PATH = Path("micro_models/tool_predictor_model")
 _MODEL_CACHE: tuple | None = None
 
 

--- a/tests/test_micro_model_paths.py
+++ b/tests/test_micro_model_paths.py
@@ -1,0 +1,53 @@
+import importlib
+from pathlib import Path
+
+
+def test_tool_predictor_uses_resolve_path(monkeypatch, tmp_path):
+    import micro_models.tool_predictor as tp
+
+    called = {}
+
+    def fake_resolve(name: str) -> Path:
+        called["name"] = name
+        return tmp_path / "model"
+
+    with monkeypatch.context() as m:
+        m.setattr("dynamic_path_router.resolve_path", fake_resolve)
+        tp = importlib.reload(tp)
+        assert called["name"] == "micro_models/tool_predictor_model"
+        assert tp.DEFAULT_PATH == tmp_path / "model"
+    importlib.reload(tp)
+
+
+def test_diff_summarizer_uses_resolve_path(monkeypatch, tmp_path):
+    import micro_models.diff_summarizer as ds
+
+    called = {}
+
+    def fake_resolve(name: str) -> Path:
+        called["name"] = name
+        return tmp_path / "model"
+
+    with monkeypatch.context() as m:
+        m.setattr("dynamic_path_router.resolve_path", fake_resolve)
+        ds = importlib.reload(ds)
+        assert called["name"] == "micro_models/diff_summarizer_model"
+        assert ds._MODEL_PATH == tmp_path / "model"
+    importlib.reload(ds)
+
+
+def test_error_classifier_uses_resolve_path(monkeypatch, tmp_path):
+    import micro_models.error_classifier as ec
+
+    called = {}
+
+    def fake_resolve(name: str) -> Path:
+        called["name"] = name
+        return tmp_path / "model"
+
+    with monkeypatch.context() as m:
+        m.setattr("dynamic_path_router.resolve_path", fake_resolve)
+        ec = importlib.reload(ec)
+        assert called["name"] == "micro_models/error_classifier_model"
+        assert ec.DEFAULT_PATH == tmp_path / "model"
+    importlib.reload(ec)


### PR DESCRIPTION
## Summary
- Switch micro models to resolve model paths via `dynamic_path_router.resolve_path`
- Handle missing model directories gracefully by falling back to plain `Path`
- Add tests asserting each micro model uses the resolver

## Testing
- `python - <<'PY'
import types, sys, pathlib, pytest
root = pathlib.Path('.').resolve()
pkg = types.ModuleType('menace_sandbox')
pkg.__path__ = [str(root)]
pkg.RAISE_ERRORS = False
sys.modules['menace_sandbox'] = pkg
vs = types.SimpleNamespace(ContextBuilder=type('ContextBuilder', (), {}), FallbackResult=list, ErrorResult=Exception)
sys.modules['vector_service'] = vs
sys.exit(pytest.main(['tests/test_micro_model_paths.py', 'tests/test_code_summarizer.py', 'tests/test_payment_notice.py', '-q']))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ba1f04dec8832e85ebf6b5febd4769