### PR TITLE
Refactor script root resolution to use dynamic path router

### DIFF
--- a/scripts/check_governed_embeddings.py
+++ b/scripts/check_governed_embeddings.py
@@ -12,27 +12,27 @@ from pathlib import Path
 import re
 import sys
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from dynamic_path_router import get_project_root, resolve_path
 
-# Match ``SentenceTransformer(...).encode(`` or ``SentenceTransformer.encode(``
+# Determine repository root once for use throughout the script
+REPO_ROOT = get_project_root()
+
+# Match ``SentenceTransformer(...).encode`` or ``SentenceTransformer.encode``
 # directly.  The ``.*`` is non-greedy so multi-line constructions are handled.
 DIRECT_ST_ENCODE = re.compile(
     r"SentenceTransformer\s*(?:\([^)]*\)\s*)?\.encode\(", re.DOTALL
 )
 
-# Match ``something.encode(`` but ignore ``tokenizer.encode`` which is valid
+# Match ``something.encode`` but ignore ``tokenizer.encode`` which is valid
 # for token counting.  Additional exclusions can be added as needed.
 ENCODE_CALL = re.compile(r"\b(?!tokenizer\.)[A-Za-z_][A-Za-z0-9_]*\.encode\(")
 
 
 def main() -> int:
-    from dynamic_path_router import get_project_root, resolve_path
-
-    root = get_project_root()
     wrapper = resolve_path("governed_embeddings.py").name
     offenders: list[str] = []
     this_file = Path(__file__).resolve()
-    for path in root.rglob("*.py"):
+    for path in REPO_ROOT.rglob("*.py"):
         # Ignore tests, the governed_embeddings module that implements the
         # wrapper around SentenceTransformer.encode, and this check script
         # itself.
@@ -50,7 +50,7 @@ def main() -> int:
         for match in DIRECT_ST_ENCODE.finditer(text):
             lineno = text[: match.start()].count("\n") + 1
             line = text.splitlines()[lineno - 1].strip()
-            offenders.append(f"{path.relative_to(root)}:{lineno}:{line}")
+            offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}:{line}")
             flagged_lines.add(lineno)
 
         if "SentenceTransformer" not in text:
@@ -59,7 +59,7 @@ def main() -> int:
             if lineno in flagged_lines or "encode(" not in line:
                 continue
             if ENCODE_CALL.search(line):
-                offenders.append(f"{path.relative_to(root)}:{lineno}:{line.strip()}")
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}:{line.strip()}")
     if offenders:
         print("Ungoverned embedding calls detected:")
         for off in offenders:

--- a/scripts/check_raw_stripe_usage.py
+++ b/scripts/check_raw_stripe_usage.py
@@ -7,11 +7,10 @@ import subprocess
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-from dynamic_path_router import resolve_path  # noqa: E402
-from stripe_detection import PAYMENT_KEYWORDS  # noqa: E402
+from dynamic_path_router import get_project_root, resolve_path
+from stripe_detection import PAYMENT_KEYWORDS
 
-REPO_ROOT = resolve_path(".")
+REPO_ROOT = get_project_root()
 # Exclude specific paths (resolved absolute)
 EXCLUDED = {
     resolve_path("stripe_billing_router.py").resolve(),

--- a/scripts/check_sqlite_connections.py
+++ b/scripts/check_sqlite_connections.py
@@ -10,13 +10,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+from dynamic_path_router import get_project_root, resolve_path
+
 PATTERN = "sqlite3.connect("
-
-# Ensure dynamic_path_router is importable regardless of the CWD.
-REPO_ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(REPO_ROOT))
-
-from dynamic_path_router import get_project_root, resolve_path  # noqa: E402
 
 # Resolve repository root so the check works regardless of the current working
 # directory. Paths in ``ALLOWLIST`` are defined relative to this directory.

--- a/scripts/check_stripe_imports.py
+++ b/scripts/check_stripe_imports.py
@@ -27,12 +27,8 @@ import re
 import sys
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(REPO_ROOT))
-
-from dynamic_path_router import resolve_path, get_project_root  # noqa: E402
-from stripe_detection import HTTP_LIBRARIES  # noqa: E402
-from stripe_detection import contains_payment_keyword  # noqa: E402
+from dynamic_path_router import get_project_root, resolve_path
+from stripe_detection import HTTP_LIBRARIES, contains_payment_keyword
 
 REPO_ROOT = get_project_root()
 


### PR DESCRIPTION
## Summary
- use dynamic_path_router's get_project_root/resolve_path instead of manual `Path(__file__).resolve()` logic in pre-commit scripts
- centralize REPO_ROOT calculations through get_project_root

## Testing
- `python -m scripts.check_governed_embeddings`
- `python -m scripts.check_sqlite_connections dynamic_path_router.py`
- `python -m scripts.check_raw_stripe_usage`
- `python -m scripts.check_stripe_imports dynamic_path_router.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba2122d860832e9aa29d08fa0f989b