### PR TITLE
Use resolve_path for self-improvement engine path

### DIFF
--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -3914,7 +3914,7 @@ class SelfImprovementEngine:
 
             with tempfile.TemporaryDirectory() as before_dir, tempfile.TemporaryDirectory() as after_dir:
                 repo = _repo_path().resolve()
-                src = Path(__file__).resolve()
+                src = resolve_path("self_improvement/engine.py")
                 try:
                     module_rel = src.relative_to(repo).as_posix()
                 except Exception:
@@ -3925,7 +3925,7 @@ class SelfImprovementEngine:
                 shutil.copy2(src, before_target)
                 start_time = time.perf_counter()
                 patch_id, reverted, delta = self.self_coding_engine.apply_patch(
-                    Path(__file__),
+                    resolve_path("self_improvement/engine.py"),
                     "self_improvement",
                     parent_patch_id=self._last_patch_id,
                     reason="self_improvement",


### PR DESCRIPTION
## Summary
- Use `resolve_path("self_improvement/engine.py")` for self-referential file operations in the self-improvement engine.
- Maintain existing patch and diff logic when applying self-generated code changes.

## Testing
- `python -m py_compile self_improvement/engine.py`
- `pre-commit run --files self_improvement/engine.py` *(fails: command not found)*
- `pytest self_improvement/tests/test_utils_cache_cleanup.py -q` *(fails: KeyboardInterrupt due to heavy dependency imports)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2271ead0832e9bcf062496aa1521