### PR TITLE
Add strategy-aware prompt optimizer and selection weighting

### DIFF
--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -164,8 +164,8 @@ from .patch_application import generate_patch, apply_patch
 from .prompt_memory import (
     log_prompt_attempt,
     load_prompt_penalties,
-    load_strategy_roi_stats,
 )
+from prompt_optimizer import load_strategy_stats
 from .prompt_strategies import PromptStrategy
 from . import strategy_rotator
 from .snapshot_tracker import (
@@ -6594,7 +6594,7 @@ class SelfImprovementEngine:
         """Pick the best prompt strategy given historical ROI and penalties."""
 
         penalties = load_prompt_penalties()
-        stats = load_strategy_roi_stats()
+        stats = load_strategy_stats()
         settings = SandboxSettings()
         threshold = settings.prompt_failure_threshold
         mult = settings.prompt_penalty_multiplier
@@ -6607,9 +6607,9 @@ class SelfImprovementEngine:
             weight = mult if threshold and count >= threshold else 1.0
             rec = stats.get(str(strat))
             if rec:
-                roi_factor = rec.get("avg_roi", 0.0)
-                roi_factor = roi_factor if roi_factor > 0 else 0.1
-                weight *= roi_factor
+                score = rec.get("score", 0.0)
+                score = score if score > 0 else 0.1
+                weight *= score
             target = penalised if threshold and count >= threshold else eligible
             target.append((strat, weight))
         pool = eligible or penalised

--- a/self_improvement/tests/test_select_prompt_strategy_roi.py
+++ b/self_improvement/tests/test_select_prompt_strategy_roi.py
@@ -1,7 +1,7 @@
 import ast
 import sys
 import types
-import importlib
+import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -21,20 +21,24 @@ pkg = types.ModuleType("menace_sandbox.self_improvement")
 pkg.__path__ = [str(ROOT / "self_improvement")]
 sys.modules["menace_sandbox.self_improvement"] = pkg
 
-from menace_sandbox.sandbox_settings import SandboxSettings
-from filelock import FileLock
-
-prompt_memory = importlib.import_module("menace_sandbox.self_improvement.prompt_memory")
+from menace_sandbox.sandbox_settings import SandboxSettings  # noqa: E402
+import menace_sandbox.prompt_optimizer as prompt_optimizer  # noqa: E402
+from dynamic_path_router import resolve_path  # noqa: E402
 
 
 def _load_select_prompt_strategy(namespace):
-    eng_path = ROOT / "self_improvement" / "engine.py"
+    eng_path = Path(resolve_path(str(ROOT / "self_improvement" / "engine.py")))
     mod = ast.parse(eng_path.read_text())
     class_def = next(
-        n for n in mod.body if isinstance(n, ast.ClassDef) and n.name == "SelfImprovementEngine"
+        n
+        for n in mod.body
+        if isinstance(n, ast.ClassDef) and n.name == "SelfImprovementEngine"
     )
     func_node = next(
-        n for n in class_def.body if isinstance(n, ast.FunctionDef) and n.name == "_select_prompt_strategy"
+        n
+        for n in class_def.body
+        if isinstance(n, ast.FunctionDef)
+        and n.name == "_select_prompt_strategy"
     )
     future = ast.ImportFrom(module="__future__", names=[ast.alias("annotations", None)], level=0)
     module = ast.Module([future, func_node], type_ignores=[])
@@ -45,15 +49,27 @@ def _load_select_prompt_strategy(namespace):
 
 def test_select_prompt_strategy_prefers_high_roi(tmp_path, monkeypatch):
     stats_path = tmp_path / "stats.json"
-    monkeypatch.setattr(prompt_memory, "_strategy_stats_path", stats_path)
-    monkeypatch.setattr(prompt_memory, "_strategy_lock", FileLock(str(stats_path) + ".lock"))
-
-    prompt_memory.update_strategy_roi("s1", 0.5)
-    prompt_memory.update_strategy_roi("s2", 1.5)
+    data = {
+        "s1": {
+            "success": 1,
+            "total": 1,
+            "roi_sum": 0.5,
+            "weighted_roi_sum": 0.5,
+            "weight_sum": 1.0,
+        },
+        "s2": {
+            "success": 1,
+            "total": 1,
+            "roi_sum": 1.5,
+            "weighted_roi_sum": 1.5,
+            "weight_sum": 1.0,
+        },
+    }
+    stats_path.write_text(json.dumps(data))
 
     namespace = {
         "load_prompt_penalties": lambda: {},
-        "load_strategy_roi_stats": prompt_memory.load_strategy_roi_stats,
+        "load_strategy_stats": lambda: prompt_optimizer.load_strategy_stats(stats_path),
         "SandboxSettings": SandboxSettings,
     }
     select = _load_select_prompt_strategy(namespace)


### PR DESCRIPTION
## Summary
- track strategy-level performance in PromptOptimizer and persist stats
- expose `select_strategy` API and utilities for scoring strategies
- weight prompt strategy selection by combined success and ROI metrics

## Testing
- `pytest self_improvement/tests/test_select_prompt_strategy_roi.py self_improvement/tests/test_strategy_roi_stats.py tests/self_improvement/test_prompt_strategy_behavior.py tests/test_prompt_optimizer.py`
- `PYTHONPATH=$(pwd) python -m pre_commit run --files prompt_optimizer.py self_improvement/engine.py self_improvement/tests/test_select_prompt_strategy_roi.py self_improvement/tests/test_strategy_roi_stats.py tests/self_improvement/test_prompt_strategy_behavior.py tests/test_prompt_optimizer.py` *(fails: Payment keywords without stripe_billing_router detected)*

------
https://chatgpt.com/codex/tasks/task_e_68ba23229574832eb6671b8b4a897afc