### PR TITLE
Add master account checks to Stripe billing router

### DIFF
--- a/billing/billing_logger.py
+++ b/billing/billing_logger.py
@@ -29,6 +29,7 @@ _COLUMNS = [
     "bot_id",
     "destination_account",
     "raw_event_json",
+    "error",
 ]
 
 
@@ -49,7 +50,8 @@ def _get_connection():
                 user_email TEXT,
                 bot_id TEXT,
                 destination_account TEXT,
-                raw_event_json TEXT
+                raw_event_json TEXT,
+                error INTEGER
             )
             """
         )


### PR DESCRIPTION
## Summary
- safeguard Stripe billing by whitelisting secret keys and enforcing master account ID
- log and alert on critical billing discrepancies with automatic rollback
- track error state in billing logger and adapt tests

## Testing
- `pytest tests/test_stripe_billing_router.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba23961554832e94a9b40046d13bfe