### PR TITLE
Add billing ledger and integrate payment logging

### DIFF
--- a/billing/billing_ledger.py
+++ b/billing/billing_ledger.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+"""Lightweight billing ledger for recording payment actions.
+
+This module writes JSON lines entries to ``finance_logs/stripe_ledger.jsonl``.
+It exposes :func:`log_action` for low level logging and :func:`record_payment`
+for convenience when recording payment related events from the Stripe billing
+router.
+"""
+
+import json
+import threading
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+try:  # resolve path dynamically when available
+    from dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - optional dependency
+    resolve_path = None  # type: ignore
+
+# Determine ledger file path and ensure directory exists
+if resolve_path is not None:
+    try:
+        _log_dir = resolve_path("finance_logs")
+    except FileNotFoundError:
+        _log_dir = Path("finance_logs")
+else:
+    _log_dir = Path("finance_logs")
+
+_log_dir.mkdir(parents=True, exist_ok=True)
+_LEDGER_FILE = _log_dir / "stripe_ledger.jsonl"
+
+# Global lock to ensure thread safe appends
+_LOCK = threading.Lock()
+
+
+def log_action(
+    action: str,
+    amount: Optional[float],
+    bot_id: str,
+    account_id: str,
+    email: Optional[str] = None,
+    ts: Optional[int] = None,
+    **extra: Any,
+) -> None:
+    """Append a log entry describing a billing ``action``.
+
+    Parameters mirror the required fields with ``extra`` allowing future
+    expansion without breaking the interface.  ``ts`` defaults to the current
+    time in milliseconds.
+    """
+
+    record = {
+        "ts": int(ts if ts is not None else time.time() * 1000),
+        "action": action,
+        "amount": amount,
+        "bot_id": bot_id,
+        "account_id": account_id,
+        "email": email,
+    }
+    record.update(extra)
+
+    line = json.dumps(record, sort_keys=True)
+    with _LOCK:  # ensure atomic append
+        with _LEDGER_FILE.open("a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+
+
+def record_payment(
+    action: str,
+    amount: Optional[float],
+    bot_id: str,
+    account_id: str,
+    *,
+    email: Optional[str] = None,
+    ts: Optional[int] = None,
+    **extra: Any,
+) -> None:
+    """Public helper to record a payment related ``action``."""
+
+    log_action(action, amount, bot_id, account_id, email=email, ts=ts, **extra)
+
+
+__all__ = ["log_action", "record_payment"]

--- a/stripe_billing_router.py
+++ b/stripe_billing_router.py
@@ -21,6 +21,7 @@ import yaml
 from dynamic_path_router import resolve_path
 
 from billing import billing_logger
+from billing.billing_ledger import record_payment
 from vault_secret_provider import VaultSecretProvider
 import alert_dispatcher
 import rollback_manager
@@ -586,6 +587,14 @@ def charge(
             raw_event_json=raw_json,
             error=False,
         )
+        record_payment(
+            "charge",
+            logged_amount,
+            bot_id,
+            destination,
+            email=user_email,
+            ts=timestamp_ms,
+        )
 
 
 # Backward compatibility
@@ -700,6 +709,14 @@ def create_subscription(
             raw_event_json=raw_json,
             error=False,
         )
+        record_payment(
+            "subscription",
+            None,
+            bot_id,
+            destination,
+            email=user_email,
+            ts=timestamp_ms,
+        )
 
 
 def refund(
@@ -776,6 +793,14 @@ def refund(
             raw_event_json=raw_json,
             error=False,
         )
+        record_payment(
+            "refund",
+            logged_amount,
+            bot_id,
+            destination,
+            email=user_email,
+            ts=timestamp_ms,
+        )
 
 
 def create_checkout_session(
@@ -844,6 +869,14 @@ def create_checkout_session(
             destination_account=destination,
             raw_event_json=raw_json,
             error=False,
+        )
+        record_payment(
+            "checkout",
+            logged_amount,
+            bot_id,
+            destination,
+            email=user_email,
+            ts=timestamp_ms,
         )
 
 


### PR DESCRIPTION
## Summary
- Introduce `billing_ledger` for thread-safe JSONL logging of billing actions
- Use new `record_payment` helper inside Stripe billing router payment flows

## Testing
- `flake8 stripe_billing_router.py billing/billing_ledger.py`
- `pytest tests/test_stripe_billing_router.py tests/test_stripe_ledger_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba28788540832ebc892919cae0e6e2