### PR TITLE
feat: log standardized sandbox metrics

### DIFF
--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -1686,13 +1686,18 @@ class SelfImprovementEngine:
             if "roi" not in meta and "roi_delta" in meta:
                 meta["roi"] = meta.get("roi_delta", 0.0)
             log_success = success and failure_reason is None
+            metrics_to_log = None
+            if not log_success:
+                metrics_to_log = dict(sandbox_metrics or {})
+                if "tests_passed" in roi_meta:
+                    metrics_to_log.setdefault("tests_passed", roi_meta["tests_passed"])
             log_prompt_attempt(
                 prompt_obj,
                 log_success,
                 exec_res,
                 roi_meta,
                 failure_reason=None if log_success else failure_reason,
-                sandbox_metrics=None if log_success else sandbox_metrics,
+                sandbox_metrics=metrics_to_log,
             )
         except Exception:
             self.logger.exception("log_prompt_attempt failed")

--- a/self_improvement/tests/test_log_prompt_failure_reason.py
+++ b/self_improvement/tests/test_log_prompt_failure_reason.py
@@ -38,13 +38,22 @@ def test_log_prompt_attempt_records_failure_reason(tmp_path, monkeypatch):
         success=True,
         exec_result={"detail": "x"},
         failure_reason="bad_result",
-        sandbox_metrics={"m": 1},
+        sandbox_metrics={"m": 1, "sandbox_score": 0.2, "tests_passed": False, "entropy": 0.3},
     )
 
     failure_log = tmp_path / "failure.jsonl"
     assert failure_log.exists()
     entry = json.loads(failure_log.read_text().strip())
     assert entry["failure_reason"] == "bad_result"
-    assert entry["sandbox_metrics"] == {"m": 1}
+    assert entry["sandbox_metrics"] == {
+        "m": 1,
+        "sandbox_score": 0.2,
+        "tests_passed": False,
+        "entropy": 0.3,
+    }
+    assert entry["score_delta"] == 0.2
+    assert entry["test_status"] is False
+    assert entry["entropy_delta"] == 0.3
+    assert entry["m"] == 1
     # No success log should be written
     assert not (tmp_path / "success.jsonl").exists()

--- a/tests/self_improvement/test_prompt_strategy_behavior.py
+++ b/tests/self_improvement/test_prompt_strategy_behavior.py
@@ -76,6 +76,7 @@ def test_failure_reason_logged(tmp_path, monkeypatch, dummy_prompt):
     entry = json.loads(log_path.read_text().splitlines()[0])
     assert entry["failure_reason"] == "api_error"
     assert entry["sandbox_metrics"] == {"s": 2}
+    assert entry["s"] == 2
     assert entry["prompt_id"] == dummy_prompt.metadata["prompt_id"]
 
 


### PR DESCRIPTION
## Summary
- expose score_delta, entropy_delta and test_status alongside sandbox metrics in failure logs
- include test status in engine sandbox metrics for failed attempts
- ensure downstream consumers handle flattened metrics

## Testing
- `pytest self_improvement/tests/test_log_prompt_failure_reason.py tests/self_improvement/test_prompt_strategy_behavior.py`
- `pytest self_improvement/tests/test_snapshot_delta_logging.py` *(fails: No module named 'sandbox_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68ba285db7dc832e8c4dfeaabaf04abb