### PR TITLE
Add refund and checkout session helpers

### DIFF
--- a/docs/billing_router.md
+++ b/docs/billing_router.md
@@ -113,11 +113,14 @@ from stripe_billing_router import (
 
 # Each call below automatically appends a row to ``stripe_ledger``
 charge("finance:finance_router_bot", amount=10.0)
-refund("finance:finance_router_bot", "pi_123", amount=5.0)
+refund("finance:finance_router_bot", "ch_123", amount=5.0)
 create_subscription("finance:finance_router_bot")
 create_checkout_session(
     "finance:finance_router_bot",
-    {"success_url": "https://example.com/s", "cancel_url": "https://example.com/c", "mode": "payment"},
+    [{"price": "price_finance_standard", "quantity": 1}],
+    success_url="https://example.com/s",
+    cancel_url="https://example.com/c",
+    mode="payment",
 )
 ```
 

--- a/docs/stripe_billing_router.md
+++ b/docs/stripe_billing_router.md
@@ -67,12 +67,14 @@ charge("finance:finance_router_bot", price_id="price_finance_standard")
 create_subscription("finance:finance_router_bot")
 
 # Issue a refund for a previous payment
-refund("finance:finance_router_bot", "pi_test")
+refund("finance:finance_router_bot", "ch_test")
 
 # Create a Checkout session
 create_checkout_session(
     "finance:finance_router_bot",
-    {"success_url": "https://example.com/s", "cancel_url": "https://example.com/c"},
+    [{"price": "price_finance_standard", "quantity": 1}],
+    success_url="https://example.com/s",
+    cancel_url="https://example.com/c",
 )
 
 create_customer("finance:finance_router_bot", {"email": "bot@example.com"})


### PR DESCRIPTION
## Summary
- extend Stripe billing router with `refund` and `create_checkout_session` helpers
- log payment actions via `record_payment`
- update tests and docs for new billing helpers

## Testing
- `pre-commit run --files stripe_billing_router.py tests/test_stripe_billing_router.py tests/test_stripe_ledger_logging.py docs/billing_router.md docs/stripe_billing_router.md`
- `pytest tests/test_stripe_billing_router.py::test_refund_success tests/test_stripe_billing_router.py::test_create_checkout_session_success tests/test_stripe_ledger_logging.py::test_refund_writes_ledger tests/test_stripe_ledger_logging.py::test_create_checkout_session_writes_ledger -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba2959b480832e8197944dedcbe836