### PR TITLE
Handle failure keywords in prompt strategy manager

### DIFF
--- a/self_improvement/tests/test_strategy_rotator_sequential.py
+++ b/self_improvement/tests/test_strategy_rotator_sequential.py
@@ -24,12 +24,16 @@ PromptStrategyManager = importlib.import_module(
 ).PromptStrategyManager
 
 
-def test_next_strategy_rotates_through_templates():
+def test_next_strategy_uses_roi_selection():
     mgr = PromptStrategyManager()
+    captured: list[list[str]] = []
+
+    def fake_best(seq):
+        captured.append(list(seq))
+        return seq[0] if seq else None
+
+    mgr.best_strategy = fake_best
     current = mgr.strategies[0]
-    sequence = []
-    for _ in range(len(mgr.strategies)):
-        nxt = mgr.record_failure(current, "fail")
-        sequence.append(nxt)
-        current = nxt
-    assert sequence == mgr.strategies[1:] + [mgr.strategies[0]]
+    nxt = mgr.record_failure(current, "fail")
+    assert captured[0] == mgr.strategies[1:]
+    assert nxt == mgr.strategies[1]


### PR DESCRIPTION
## Summary
- map failure keywords like `refactor` to the `strict_fix` strategy
- fall back to ROI-based strategy selection when no keywords match
- add tests for keyword selection and ROI fallback

## Testing
- `pytest tests/test_prompt_strategy_manager.py -q`
- `pytest self_improvement/tests/test_strategy_rotation.py -q`
- `pytest self_improvement/tests/test_strategy_rotator_sequential.py -q`
- `pytest self_improvement/tests/test_strategy_deprioritization.py -q`
- `pytest tests/self_improvement/test_prompt_strategy_behavior.py -q`
- `pytest tests/test_snapshot_tracker_confidence.py -q`
- `pytest tests/test_strategy_deprioritization.py -q`
- `pre-commit run --files self_improvement/prompt_strategy_manager.py tests/test_prompt_strategy_manager.py` *(fails: Payment keywords without stripe_billing_router detected)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2998dcdc832eb1ee3ab1f5bf05a2