### PR TITLE
Add Stripe account validation and configuration

### DIFF
--- a/config/stripe_billing_router.yaml
+++ b/config/stripe_billing_router.yaml
@@ -1,3 +1,6 @@
+master_account_id: acct_master
+allowed_secret_keys:
+  - sk_live_dummy
 stripe:
   default:
     finance:


### PR DESCRIPTION
## Summary
- allow configuring Stripe master account ID and allowed secret keys via env, vault or config
- add `_validate_account` to ensure API keys belong to the expected master account
- verify API keys and account ownership before processing Stripe payments

## Testing
- `pytest tests/test_stripe_billing_router.py tests/test_finance_router_bot.py tests/test_investment_engine.py tests/test_stripe_ledger_logging.py tests/test_payment_validator.py tests/test_startup_checks.py -q`
- `pytest tests/test_stripe_billing_router.py tests/test_finance_router_bot.py tests/test_investment_engine.py tests/test_stripe_ledger_logging.py tests/test_payment_validator.py tests/test_startup_checks.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba2aeeb40c832e804a23200327e4ca