### PR TITLE
Refactor prompt strategy stats and selection

### DIFF
--- a/prompt_optimizer.py
+++ b/prompt_optimizer.py
@@ -686,32 +686,10 @@ def rank_formats() -> List[Dict[str, Any]]:
 def load_strategy_stats(path: str | Path | None = None) -> Dict[str, Dict[str, float]]:
     """Return per-strategy statistics including scores."""
 
-    p = Path(path) if path is not None else DEFAULT_STRATEGY_PATH
-    if not p.exists():
-        return {}
-    try:
-        data = json.loads(p.read_text(encoding="utf-8"))
-    except Exception:
-        return {}
-    stats: Dict[str, Dict[str, float]] = {}
-    for k, v in data.items():
-        total = max(int(v.get("total", 0)), 1)
-        success = int(v.get("success", 0))
-        roi_sum = float(v.get("roi_sum", 0.0))
-        weighted_roi_sum = float(v.get("weighted_roi_sum", 0.0))
-        weight_sum = float(v.get("weight_sum", 0.0))
-        success_rate = success / total
-        if weight_sum:
-            weighted_roi = weighted_roi_sum / weight_sum
-        else:
-            weighted_roi = roi_sum / total
-        score = success_rate * max(weighted_roi, 0.0)
-        stats[str(k)] = {
-            "success_rate": success_rate,
-            "weighted_roi": weighted_roi,
-            "score": score,
-        }
-    return stats
+    from self_improvement.prompt_strategy_manager import PromptStrategyManager
+
+    p = path if path is not None else DEFAULT_STRATEGY_PATH
+    return PromptStrategyManager.load_strategy_stats(p)
 
 
 def select_strategy(path: str | Path | None = None) -> str | None:

--- a/self_improvement/tests/test_strategy_roi_stats.py
+++ b/self_improvement/tests/test_strategy_roi_stats.py
@@ -1,7 +1,7 @@
-import types
 import sys
-from pathlib import Path
+import types
 import json
+from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
@@ -12,53 +12,21 @@ sys.modules.setdefault(
     "dynamic_path_router",
     types.SimpleNamespace(resolve_path=lambda p: p, repo_root=lambda: ROOT),
 )
+
 boot = types.ModuleType("sandbox_runner.bootstrap")
 boot.initialize_autonomous_sandbox = lambda *a, **k: None
 sys.modules.setdefault("sandbox_runner.bootstrap", boot)
+
 pkg = types.ModuleType("menace_sandbox.self_improvement")
 pkg.__path__ = [str(ROOT / "self_improvement")]
 sys.modules["menace_sandbox.self_improvement"] = pkg
 
-from menace_sandbox.sandbox_settings import SandboxSettings  # noqa: E402
 import menace_sandbox.prompt_optimizer as prompt_optimizer  # noqa: E402
+from menace_sandbox.self_improvement.prompt_strategy_manager import (  # noqa: E402
+    PromptStrategyManager,
+)
+from menace_sandbox.self_improvement import prompt_memory  # noqa: E402
 from dynamic_path_router import resolve_path  # noqa: E402
-
-
-class MiniEngine:
-    def __init__(self):
-        self.deprioritized_strategies = set()
-
-    def _select_prompt_strategy(self, strategies):
-        penalties = {}
-        settings = SandboxSettings()
-        threshold = settings.prompt_failure_threshold
-        eligible = []
-        penalised = []
-        stats = prompt_optimizer.load_strategy_stats()
-        for strat in strategies:
-            if strat in self.deprioritized_strategies:
-                continue
-            count = penalties.get(str(strat), 0)
-            weight = (
-                settings.prompt_penalty_multiplier
-                if threshold and count >= threshold
-                else 1.0
-            )
-            rs = stats.get(str(strat))
-            if rs:
-                score = rs.get("score", 0.0)
-                score = score if score > 0 else 0.1
-                weight *= score
-            target = penalised if threshold and count >= threshold else eligible
-            target.append((strat, weight))
-        pool = eligible or penalised
-        best = None
-        best_weight = -1.0
-        for strat, weight in pool:
-            if weight > best_weight:
-                best_weight = weight
-                best = strat
-        return best
 
 
 def test_roi_weighted_selection(tmp_path, monkeypatch):
@@ -83,10 +51,10 @@ def test_roi_weighted_selection(tmp_path, monkeypatch):
     monkeypatch.setattr(prompt_optimizer, "DEFAULT_STRATEGY_PATH", path)
     stats = prompt_optimizer.load_strategy_stats()
     assert stats["s1"]["weighted_roi"] > 1.9
-    monkeypatch.setattr(
-        prompt_optimizer, "load_strategy_stats", lambda p=None: stats
-    )
-    eng = MiniEngine()
-    assert eng._select_prompt_strategy(["s1", "s2"]) == "s1"
-    eng2 = MiniEngine()
-    assert eng2._select_prompt_strategy(["s1", "s2"]) == "s1"
+    monkeypatch.setattr(prompt_memory, "load_prompt_penalties", lambda: {})
+    mgr = PromptStrategyManager(stats_path=path)
+    mgr.set_strategies(["s1", "s2"])
+    assert mgr.best_strategy(["s1", "s2"]) == "s1"
+    mgr2 = PromptStrategyManager(stats_path=path)
+    mgr2.set_strategies(["s1", "s2"])
+    assert mgr2.best_strategy(["s1", "s2"]) == "s1"

--- a/tests/test_prompt_strategy_manager.py
+++ b/tests/test_prompt_strategy_manager.py
@@ -36,7 +36,7 @@ class MiniEngine:
     def __init__(self, state_path: Path):
         self.logger = logging.getLogger("test")
         self.prompt_strategy_manager = PromptStrategyManager(
-            ["s1", "s2"], state_path=state_path
+            ["s1", "s2"], state_path=state_path, stats_path=state_path.with_name("stats.json")
         )
 
     def next_strategy(self) -> str | None:
@@ -68,7 +68,10 @@ def test_strategy_rotation_persists(tmp_path):
 
 
 def test_failure_reason_selects_keyword_strategy(tmp_path):
-    mgr = PromptStrategyManager(state_path=Path(resolve_path(tmp_path / "state.json")))
+    mgr = PromptStrategyManager(
+        state_path=Path(resolve_path(tmp_path / "state.json")),
+        stats_path=Path(resolve_path(tmp_path / "stats.json")),
+    )
     mgr.set_strategies(["strict_fix", "delete_rebuild", "unit_test_rewrite"])
     mgr.index = mgr.strategies.index("delete_rebuild")
     nxt = mgr.record_failure("delete_rebuild", "needs refactor")
@@ -79,6 +82,7 @@ def test_roi_fallback_used_when_no_keyword(tmp_path, monkeypatch):
     mgr = PromptStrategyManager(
         ["strict_fix", "delete_rebuild"],
         state_path=Path(resolve_path(tmp_path / "state.json")),
+        stats_path=Path(resolve_path(tmp_path / "stats.json")),
     )
 
     called = {}


### PR DESCRIPTION
## Summary
- consolidate strategy ROI tracking into `_strategy_stats.json`
- expose weighted `best_strategy` from `PromptStrategyManager`
- rely on unified manager for prompt strategy selection

## Testing
- `pre-commit run --files prompt_optimizer.py self_improvement/engine.py self_improvement/prompt_strategy_manager.py self_improvement/tests/test_select_prompt_strategy_roi.py self_improvement/tests/test_strategy_roi_stats.py tests/test_prompt_strategy_manager.py`
- `pytest tests/test_prompt_strategy_manager.py self_improvement/tests/test_select_prompt_strategy_roi.py self_improvement/tests/test_strategy_roi_stats.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba2bff9c80832e88ae6f5ea3952685