### PR TITLE
Use resolve_path in orphan metrics test

### DIFF
--- a/unit_tests/test_orphan_handling_metrics.py
+++ b/unit_tests/test_orphan_handling_metrics.py
@@ -10,6 +10,8 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 # Ensure root directory is on sys.path for absolute imports
 sys.path.append(str(ROOT))
 
+from dynamic_path_router import resolve_path
+
 # Create package structure without executing heavy initialisers
 root_pkg = types.ModuleType("menace_sandbox")
 root_pkg.__path__ = [str(ROOT)]
@@ -20,7 +22,7 @@ self_pkg.__path__ = [str(ROOT / "self_improvement")]
 sys.modules.setdefault("menace_sandbox.self_improvement", self_pkg)
 
 me_spec = importlib.util.spec_from_file_location(
-    "menace_sandbox.metrics_exporter", ROOT / "metrics_exporter.py"
+    "menace_sandbox.metrics_exporter", resolve_path("metrics_exporter.py")
 )
 metrics_exporter = importlib.util.module_from_spec(me_spec)
 sys.modules[me_spec.name] = metrics_exporter
@@ -29,7 +31,7 @@ me_spec.loader.exec_module(metrics_exporter)
 
 spec = importlib.util.spec_from_file_location(
     "menace_sandbox.self_improvement.orphan_handling",
-    ROOT / "self_improvement" / "orphan_handling.py",
+    resolve_path("self_improvement/orphan_handling.py"),
 )
 orphan_handling = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = orphan_handling


### PR DESCRIPTION
## Summary
- use resolve_path for module paths in orphan handling metrics test

## Testing
- `pytest unit_tests/test_orphan_handling_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba323b9e38832eb99e464e49cd8e72