### PR TITLE
Handle patch generation errors explicitly

### DIFF
--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -1509,6 +1509,18 @@ class SelfImprovementEngine:
             self.logger.exception(
                 "patch generation failed", extra=log_record(module=module)
             )
+            failure_reason = "generation_error"
+            try:
+                prompt_obj = getattr(self.self_coding_engine, "_last_prompt", None)
+                log_prompt_attempt(
+                    prompt_obj,
+                    False,
+                    {"error": error_trace},
+                    failure_reason=failure_reason,
+                    sandbox_metrics=sandbox_metrics,
+                )
+            except Exception:
+                self.logger.exception("log_prompt_attempt failed")
             patch_id = None
         else:
             if patch_id is not None:
@@ -1528,6 +1540,20 @@ class SelfImprovementEngine:
                     self.logger.exception(
                         "patch application failed", extra=log_record(module=module)
                     )
+                    failure_reason = "apply_error"
+                    try:
+                        prompt_obj = getattr(
+                            self.self_coding_engine, "_last_prompt", None
+                        )
+                        log_prompt_attempt(
+                            prompt_obj,
+                            False,
+                            {"patch_id": patch_id, "error": error_trace},
+                            failure_reason=failure_reason,
+                            sandbox_metrics=sandbox_metrics,
+                        )
+                    except Exception:
+                        self.logger.exception("log_prompt_attempt failed")
                     patch_id = None
                 else:
                     post_snap = capture_snapshot(


### PR DESCRIPTION
## Summary
- log patch generation failures as `generation_error` and record prompt attempt
- log patch apply failures as `apply_error` and record prompt attempt

## Testing
- `pre-commit run --files self_improvement/engine.py`
- `PYTHONPATH=. pytest self_improvement/tests/test_log_prompt_failure_reason.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba329df7ec832ea7614d806fdc0796