### PR TITLE
Persist strategy failure counts with configurable limits

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -769,6 +769,20 @@ class SandboxSettings(BaseSettings):
         env="PROMPT_PENALTY_MULTIPLIER",
         description="Multiplier applied to value estimates of penalised prompts.",
     )
+    strategy_failure_limits: dict[str, int] = Field(
+        default_factory=dict,
+        env="STRATEGY_FAILURE_LIMITS",
+        description="Consecutive failure limits per strategy before rotation.",
+    )
+
+    @field_validator("strategy_failure_limits", mode="before")
+    def _parse_strategy_failure_limits(cls, v: Any) -> Any:
+        if isinstance(v, str):
+            try:
+                return json.loads(v)
+            except Exception:
+                return {}
+        return v
     failure_fingerprint_path: str = Field(
         "failure_fingerprints.jsonl",
         env="FAILURE_FINGERPRINT_PATH",

--- a/self_improvement/strategy_rotator.py
+++ b/self_improvement/strategy_rotator.py
@@ -2,9 +2,25 @@ from __future__ import annotations
 
 """Helper for prompt strategy rotation."""
 
-from .prompt_strategy_manager import PromptStrategyManager
+from pathlib import Path
 
-manager = PromptStrategyManager()
+from ..sandbox_settings import SandboxSettings
+from .prompt_strategy_manager import (
+    KEYWORD_MAP as BASE_KEYWORD_MAP,
+    PromptStrategyManager,
+)
+
+
+KEYWORD_MAP = dict(BASE_KEYWORD_MAP)
+KEYWORD_MAP.update({
+    "tests_failed": "unit_test_rewrite",
+    "comment": "comment_refactor",
+})
+
+STATE_PATH = Path(SandboxSettings().sandbox_data_dir) / "strategy_rotator_state.json"
+settings = SandboxSettings()
+manager = PromptStrategyManager(state_path=STATE_PATH, keyword_map=KEYWORD_MAP)
+manager.failure_limits.update(settings.strategy_failure_limits)
 
 
 def next_strategy(strategy: str | None, failure_reason: str | None = None) -> str | None:


### PR DESCRIPTION
## Summary
- store strategy failure counts in sandbox data and reload on startup
- allow strategy rotation to respond to failure keywords
- make per-strategy failure limits configurable via `SandboxSettings`

## Testing
- `python -m pytest self_improvement/tests/test_strategy_rotation.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba3749e504832e889bae319a550a2b