### PR TITLE
Use project root for bootstrap config and test repo path override

### DIFF
--- a/run_autonomous.py
+++ b/run_autonomous.py
@@ -2044,7 +2044,9 @@ def main(argv: List[str] | None = None) -> None:
 
 
 
-def bootstrap(config_path: str = "config/bootstrap.yaml") -> None:
+def bootstrap(
+    config_path: str | Path = get_project_root() / "config" / "bootstrap.yaml",
+) -> None:
     """Bootstrap the autonomous sandbox using configuration from ``config_path``.
 
     The helper loads :class:`SandboxSettings`, initialises core databases and the

--- a/unit_tests/test_sandbox_repo_path_env.py
+++ b/unit_tests/test_sandbox_repo_path_env.py
@@ -1,0 +1,34 @@
+import importlib
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def test_modules_respect_sandbox_repo_path(tmp_path, monkeypatch):
+    sys.modules.pop("dynamic_path_router", None)
+    dpr = importlib.import_module("dynamic_path_router")
+    clone = tmp_path / "clone"
+    shutil.copytree(dpr.get_project_root(), clone)
+    monkeypatch.setenv("SANDBOX_REPO_PATH", str(clone))
+    dpr.clear_cache()
+
+    for name in [
+        "patch_branch_manager.py",
+        "patch_provenance_service.py",
+        "patch_attempt_tracker.py",
+        "sandbox_runner.py",
+        "run_autonomous.py",
+    ]:
+        resolved = dpr.resolve_path(name)
+        assert str(resolved).startswith(str(clone))
+
+    prompt_path = dpr.path_for_prompt("sandbox_runner.py")
+    assert prompt_path.startswith(str(clone))
+
+    pbm_mod = importlib.import_module("patch_branch_manager")
+    manager = pbm_mod.PatchBranchManager()
+    assert str(manager.repo).startswith(str(clone))


### PR DESCRIPTION
## Summary
- use `get_project_root` when bootstrapping to avoid hardcoded paths
- add regression test ensuring SANDBOX_REPO_PATH is respected by path helpers

## Testing
- `pytest unit_tests/test_sandbox_repo_path_env.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba39984d50832e99f94479dc02bafc