### PR TITLE
Log Stripe billing events through StripeLedger

### DIFF
--- a/docs/stripe_billing_router.md
+++ b/docs/stripe_billing_router.md
@@ -56,7 +56,7 @@ from stripe_billing_router import (
 )
 
 # Each helper automatically logs to the ``stripe_ledger`` table
-# via ``billing_logger.log_event``.
+# via the internal ``_log_payment`` helper backed by ``StripeLedger``.
 
 # One‑off payment via PaymentIntent
 charge("finance:finance_router_bot", amount=10.0)
@@ -150,9 +150,10 @@ These examples update the price while leaving the base rule unchanged.
 
 ## Ledger Schema and Automatic Logging
 
-All billing helpers call ``billing_logger.log_event`` which persists a record to
-the ``stripe_ledger`` table (falling back to ``finance_logs/stripe_ledger.jsonl``
-if the database is unavailable).  Each log entry **must** populate the
+All billing helpers use the private ``_log_payment`` helper which records
+events via :class:`StripeLedger` to the ``stripe_ledger`` table (falling back to
+``finance_logs/stripe_ledger.jsonl`` if the database is unavailable).  Each log
+entry **must** populate the
 following fields:
 
 - ``id`` – Stripe object identifier or a generated UUID for the event.


### PR DESCRIPTION
## Summary
- centralize Stripe billing event logging with a new `_log_payment` helper backed by `StripeLedger`
- record destination account and customer email for charges, subscriptions, refunds and checkout sessions
- document StripeLedger-backed logging in the Stripe billing router guide

## Testing
- `pytest tests/test_stripe_billing_router_logging.py::test_create_checkout_session_logs_to_file tests/test_stripe_billing_router_logging.py::test_mismatched_account_triggers_alert_and_rollback tests/test_stripe_billing_router_logging.py::test_unknown_key_triggers_alert_and_rollback tests/test_stripe_ledger_logging.py::test_create_checkout_session_writes_ledger tests/test_stripe_ledger_logging.py::test_mismatched_account_dispatches_alert_and_rollbacks` *(fails: DID NOT RAISE <class 'RuntimeError'>)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3a6361a0832ebe9783e5e08c2de9