### PR TITLE
Use dynamic path helpers for module resolution

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,6 +19,7 @@ sys.modules.setdefault(
     types.SimpleNamespace(
         resolve_path=lambda p: Path(p),
         resolve_dir=lambda p: Path(p),
+        resolve_module_path=lambda m: Path(m.replace(".", "/") + ".py"),
         path_for_prompt=lambda p: Path(p).as_posix(),
     ),
 )
@@ -161,7 +162,7 @@ sys.modules.setdefault("menace.alert_dispatcher", _alert_dispatcher)
 _readiness_index = importlib.import_module(__name__ + ".readiness_index")
 sys.modules.setdefault("readiness_index", _readiness_index)
 sys.modules.setdefault("menace.readiness_index", _readiness_index)
-from .dynamic_path_router import resolve_path, get_project_root
+from .dynamic_path_router import resolve_path, resolve_module_path, resolve_dir, get_project_root
 
 _sk_dir = get_project_root() / "sklearn"
 _extra_dir = get_project_root() / "menace"

--- a/dynamic_module_mapper.py
+++ b/dynamic_module_mapper.py
@@ -8,7 +8,7 @@ from typing import Dict, Iterable
 from orphan_analyzer import analyze_redundancy
 
 from module_graph_analyzer import build_import_graph, cluster_modules
-from dynamic_path_router import resolve_path
+from dynamic_path_router import resolve_path, resolve_module_path
 
 
 def discover_module_groups(
@@ -29,13 +29,7 @@ def discover_module_groups(
     )
     groups: Dict[int, list[str]] = {}
     for mod, cid in mapping.items():
-        try:
-            path = Path(resolve_path(root / f"{mod}.py"))
-        except FileNotFoundError:
-            try:
-                path = Path(resolve_path(root / mod / "__init__.py"))
-            except FileNotFoundError:
-                path = Path(resolve_path(root / f"{mod}.py"))
+        path = resolve_module_path(mod.replace("/", "."))
         if "/" in mod:
             groups.setdefault(cid, []).append(mod)
             continue
@@ -73,13 +67,7 @@ def build_module_map(
     if mapping and len(mapping) > 1 and algorithm != "hdbscan":
         filtered: Dict[str, int] = {}
         for mod, grp in mapping.items():
-            try:
-                path = Path(resolve_path(root / f"{mod}.py"))
-            except FileNotFoundError:
-                try:
-                    path = Path(resolve_path(root / mod / "__init__.py"))
-                except FileNotFoundError:
-                    path = Path(resolve_path(root / f"{mod}.py"))
+            path = resolve_module_path(mod.replace("/", "."))
             if "/" in mod:
                 filtered[mod] = grp
                 continue

--- a/intent_db.py
+++ b/intent_db.py
@@ -16,9 +16,9 @@ except Exception:  # pragma: no cover - top level import fallback
     from db_router import DBRouter, GLOBAL_ROUTER, init_db_router  # type: ignore
 
 try:  # pragma: no cover - support package and flat layouts
-    from .dynamic_path_router import resolve_path
+    from .dynamic_path_router import resolve_path, resolve_module_path
 except Exception:  # pragma: no cover - fallback when executed directly
-    from dynamic_path_router import resolve_path  # type: ignore
+    from dynamic_path_router import resolve_path, resolve_module_path  # type: ignore
 
 from intent_vectorizer import IntentVectorizer
 
@@ -147,11 +147,10 @@ class IntentDB(EmbeddableDBMixin):
         if not cluster:
             return None
 
-        root = grapher.root or Path.cwd()
         vectors: List[List[float]] = []
         members: List[str] = []
         for mod in cluster:
-            path = Path(resolve_path(root / f"{mod}.py"))
+            path = resolve_module_path(mod.replace("/", "."))
             try:
                 text = self._vectorizer.bundle(path)
             except Exception:

--- a/module_graph_analyzer.py
+++ b/module_graph_analyzer.py
@@ -9,7 +9,7 @@ from typing import Dict, Iterable
 
 import networkx as nx
 
-from dynamic_path_router import resolve_path
+from dynamic_path_router import resolve_path, resolve_module_path
 
 try:  # optional dependency
     import hdbscan  # type: ignore
@@ -126,7 +126,7 @@ def cluster_modules(
     if use_semantic and root is not None:
         docs: Dict[str, str] = {}
         for node in graph.nodes:
-            path = Path(resolve_path(root / f"{node}.py"))
+            path = resolve_module_path(node.replace("/", "."))
             try:
                 tree = ast.parse(path.read_text())
             except Exception:

--- a/module_synergy_grapher.py
+++ b/module_synergy_grapher.py
@@ -30,7 +30,7 @@ from governed_embeddings import governed_embed
 from module_graph_analyzer import build_import_graph
 from vector_utils import cosine_similarity
 from retry_utils import with_retry
-from dynamic_path_router import resolve_path, get_project_root
+from dynamic_path_router import resolve_path, get_project_root, resolve_module_path
 
 try:  # synergy history DB may need package import
     import synergy_history_db as shd  # type: ignore
@@ -461,7 +461,7 @@ class ModuleSynergyGrapher:
         updated = False
 
         def _worker(mod: str) -> tuple[str, dict[str, object] | None, dict[str, object] | None, bool]:
-            file = Path(resolve_path(root / f"{mod}.py"))
+            file = resolve_module_path(mod.replace("/", "."))
             if not file.exists():
                 return mod, None, None, False
             mtime = file.stat().st_mtime

--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -62,9 +62,9 @@ from .init import (
     get_default_synergy_weights,
 )
 try:  # pragma: no cover - allow flat imports
-    from ..dynamic_path_router import resolve_path
+    from ..dynamic_path_router import resolve_path, resolve_module_path
 except Exception:  # pragma: no cover - fallback for flat layout
-    from dynamic_path_router import resolve_path  # type: ignore
+    from dynamic_path_router import resolve_path, resolve_module_path  # type: ignore
 from ..metrics_exporter import (
     synergy_weight_updates_total,
     synergy_weight_update_failures_total,
@@ -4466,7 +4466,7 @@ class SelfImprovementEngine:
                     seen: set[int] = set()
                     for step in getattr(wf, "workflow", []):
                         mod = step.split(":")[0]
-                        file = resolve_path(mod.replace(".", "/") + ".py")
+                        file = resolve_module_path(mod)
                         try:
                             gid = idx.get(file.as_posix())
                         except Exception:
@@ -6239,7 +6239,7 @@ class SelfImprovementEngine:
                     "relevancy audit log failed", extra=log_record(module=mod)
                 )
             try:
-                analyze_redundancy(resolve_path(mod.replace(".", "/") + ".py"))
+                analyze_redundancy(resolve_module_path(mod))
             except Exception:
                 self.logger.exception(
                     "redundancy analysis failed", extra=log_record(module=mod)

--- a/tests/test_dynamic_path_router_nested.py
+++ b/tests/test_dynamic_path_router_nested.py
@@ -39,6 +39,13 @@ def test_resolve_path_in_nested_clone(monkeypatch):
         assert dpr.resolve_path("prompt_engine.py") == (
             repo / "prompts" / "prompt_engine.py"
         ).resolve()
+        assert dpr.resolve_module_path("sandbox_runner") == (
+            repo / "sandbox_runner.py"
+        ).resolve()
+        assert dpr.resolve_module_path("patches.patch_provenance") == (
+            repo / "patches" / "patch_provenance.py"
+        ).resolve()
+        assert dpr.resolve_dir("prompts") == (repo / "prompts").resolve()
 
 
 def test_resolve_path_with_relocated_root(monkeypatch):
@@ -67,3 +74,10 @@ def test_resolve_path_with_relocated_root(monkeypatch):
         assert dpr.resolve_path("prompt_engine.py") == (
             repo / "prompts" / "prompt_engine.py"
         ).resolve()
+        assert dpr.resolve_module_path("sandbox_runner") == (
+            repo / "sandbox_runner.py"
+        ).resolve()
+        assert dpr.resolve_module_path("patches.patch_provenance") == (
+            repo / "patches" / "patch_provenance.py"
+        ).resolve()
+        assert dpr.resolve_dir("patches") == (repo / "patches").resolve()


### PR DESCRIPTION
## Summary
- Export `resolve_module_path` and `resolve_dir` from package init stub
- Replace manual path joins with `resolve_module_path` across module analyzers
- Test nested repo resolution of modules and directories

## Testing
- `pytest tests/test_dynamic_path_router_nested.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba3bcc89d8832ea1facc43709320d1