### PR TITLE
Document dynamic path routing usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # Contributor Guidelines
 
+## Path resolution
+
+All new code should locate files through `dynamic_path_router`. Use
+`resolve_path` or `path_for_prompt` instead of hard-coded relative paths so the
+project remains portable across different checkouts.
+
 ## SQLite connections
 
 Use `DBRouter` for all database access. Direct calls to `sqlite3.connect` are not

--- a/README.md
+++ b/README.md
@@ -602,7 +602,11 @@ A new `menace` CLI wraps common workflows so you no longer need to remember indi
 Apply a patch to a module and log provenance:
 
 ```bash
-python menace_cli.py patch path/to/module.py --desc "Fix bug" --context '{"foo": "bar"}'
+python menace_cli.py patch "$(python - <<'PY'
+from dynamic_path_router import path_for_prompt
+print(path_for_prompt('bots/example.py'))
+PY
+)" --desc "Fix bug" --context '{"foo": "bar"}'
 ```
 
 The command prints the patch ID and affected files. The `--context` value must be valid JSON.
@@ -823,7 +827,11 @@ python scripts/launch_personal.py
 ```
 Alternatively start the agent on demand and run the sandbox with:
 ```bash
-python scripts/run_personal_sandbox.py
+python "$(python - <<'PY'
+from dynamic_path_router import resolve_path
+print(resolve_path('sandbox_runner.py'))
+PY
+)" --visual-agent
 ```
 
 To run the sandbox directly with metrics visualisation, use the convenience

--- a/docs/self_improvement.md
+++ b/docs/self_improvement.md
@@ -13,16 +13,20 @@ self-improvement mode.
   `pip install sandbox_runner quick_fix_engine`.
 - Optional: `prometheus-client` exposes metrics via HTTP.
 
-## Launch `start_autonomous_sandbox.py`
+## Launch `sandbox_runner.py`
 
-Start the sandbox with an optional log level:
+Start the sandbox with an optional log level using `dynamic_path_router.resolve_path`:
 
 ```bash
-python start_autonomous_sandbox.py --log-level INFO
+python "$(python - <<'PY'
+from dynamic_path_router import resolve_path
+print(resolve_path('sandbox_runner.py'))
+PY
+)" --log-level INFO
 ```
 
-The wrapper forwards control to `sandbox_runner.bootstrap.launch_sandbox` and
-exits with a non-zero status when initialisation fails.
+The entry script forwards control to `sandbox_runner.bootstrap.launch_sandbox`
+and exits with a non-zero status when initialisation fails.
 
 ## Environment variables
 


### PR DESCRIPTION
## Summary
- demonstrate `path_for_prompt` and `resolve_path` in README examples
- show launching the sandbox via `resolve_path` in self-improvement docs
- clarify in CONTRIBUTING that files must use `dynamic_path_router`

## Testing
- `pytest` *(fails: AttributeError: 'str' object has no attribute 'open')*

------
https://chatgpt.com/codex/tasks/task_e_68ba3d7a3d1c832e9386117b2d265eff