### PR TITLE
Use resolve_path for sandbox meta directory

### DIFF
--- a/sandbox_runner/cli.py
+++ b/sandbox_runner/cli.py
@@ -169,7 +169,7 @@ def _run_sandbox(args: argparse.Namespace, sandbox_main=None) -> None:
     sandbox_main(preset, args)
     if _SandboxMetaLogger is not None:
         try:
-            data_dir = Path(os.getenv("SANDBOX_DATA_DIR", "sandbox_data"))
+            data_dir = Path(resolve_path(os.getenv("SANDBOX_DATA_DIR", "sandbox_data")))
             meta = _SandboxMetaLogger(data_dir / "sandbox_meta.log")
             for cyc, roi, succ, fail, dur, cov in meta.rankings():
                 total = succ + fail


### PR DESCRIPTION
## Summary
- use `resolve_path` when locating sandbox meta log directory

## Testing
- `pre-commit run --files sandbox_runner/cli.py` *(fails: E305, E501, E203, E731)*
- `pytest tests/test_cli_full_autonomous_run.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba3f234d10832e8a066bea74536baf