### PR TITLE
Improve prompt attempt logging and utilities

### DIFF
--- a/docs/prompt_evolution_memory.md
+++ b/docs/prompt_evolution_memory.md
@@ -9,8 +9,8 @@ runs to analyse what formatting strategies yield the best return on investment
 ## Log format
 
 Entries are appended to line-delimited JSON files. Successful executions are
-written to `prompt_success_log.json` while failures go to
-`prompt_failure_log.json`.
+written to `sandbox_data/prompt_success_log.jsonl` while failures go to
+`sandbox_data/prompt_failure_log.jsonl`.
 
 ```json
 {
@@ -88,9 +88,9 @@ prompts, continually improving style and section ordering.
 ### PromptEvolutionMemory
 
 * `success_path` – destination for successful execution logs
-  (default: `prompt_success_log.json`).
+  (default: `sandbox_data/prompt_success_log.jsonl`).
 * `failure_path` – destination for failed execution logs
-  (default: `prompt_failure_log.json`).
+  (default: `sandbox_data/prompt_failure_log.jsonl`).
 
 ### PromptOptimizer
 
@@ -110,7 +110,7 @@ below prints the average ROI for successful prompts:
 import json
 from pathlib import Path
 
-success_log = Path("prompt_success_log.json")
+success_log = Path("sandbox_data/prompt_success_log.jsonl")
 entries = [json.loads(l) for l in success_log.read_text().splitlines() if l]
 avg_roi = sum(e.get("roi", {}).get("roi_delta", 0) for e in entries) / len(entries)
 print(f"average ROI: {avg_roi:.2f}")

--- a/docs/sandbox_environment.md
+++ b/docs/sandbox_environment.md
@@ -31,8 +31,8 @@ data_dir = resolve_path(os.getenv("SANDBOX_DATA_DIR", "sandbox_data"))
 
 These optional variables control where prompt execution results are stored:
 
-- `PROMPT_SUCCESS_LOG_PATH` – path for successful prompt logs (default `prompt_success_log.json`).
-- `PROMPT_FAILURE_LOG_PATH` – path for failed prompt logs (default `prompt_failure_log.json`).
+- `PROMPT_SUCCESS_LOG_PATH` – path for successful prompt logs (default `sandbox_data/prompt_success_log.jsonl`).
+- `PROMPT_FAILURE_LOG_PATH` – path for failed prompt logs (default `sandbox_data/prompt_failure_log.jsonl`).
 
 ## Container execution variables
 

--- a/docs/sandbox_settings.md
+++ b/docs/sandbox_settings.md
@@ -96,8 +96,8 @@ settings = load_sandbox_settings("docs/sandbox_config.sample.yaml")
 These weights influence the risk score produced by `_analyse_module`.
 
 ## Prompt logging defaults
-- `prompt_success_log_path`: `prompt_success_log.json` (`PROMPT_SUCCESS_LOG_PATH`)
-- `prompt_failure_log_path`: `prompt_failure_log.json` (`PROMPT_FAILURE_LOG_PATH`)
+- `prompt_success_log_path`: `sandbox_data/prompt_success_log.jsonl` (`PROMPT_SUCCESS_LOG_PATH`)
+- `prompt_failure_log_path`: `sandbox_data/prompt_failure_log.jsonl` (`PROMPT_FAILURE_LOG_PATH`)
 
 ## Prompt chunking defaults
 - `prompt_chunk_token_threshold`: `3500` (`PROMPT_CHUNK_TOKEN_THRESHOLD`)

--- a/prompt_evolution_memory.py
+++ b/prompt_evolution_memory.py
@@ -31,15 +31,14 @@ class PromptEvolutionMemory:
     """Append prompt execution records to JSONL logs.
 
     The memory stores each prompt attempt in line-delimited JSON files.
-    Successful executions are written to ``prompt_success_log.json`` while
-    failures are appended to ``prompt_failure_log.json``. Each record captures
-    the prompt contents, optional formatting metadata, execution results and
-    ROI metrics. The files are JSONL formatted regardless of the ``.json``
-    extension.
+    Successful executions are written to ``sandbox_data/prompt_success_log.jsonl``
+    while failures are appended to ``sandbox_data/prompt_failure_log.jsonl``.
+    Each record captures the prompt contents, optional formatting metadata,
+    execution results and ROI metrics.
     """
 
-    success_path: Path = _ROOT / "prompt_success_log.json"
-    failure_path: Path = _ROOT / "prompt_failure_log.json"
+    success_path: Path = _ROOT / "sandbox_data" / "prompt_success_log.jsonl"
+    failure_path: Path = _ROOT / "sandbox_data" / "prompt_failure_log.jsonl"
 
     def __post_init__(self) -> None:  # pragma: no cover - trivial
         for path in (self.success_path, self.failure_path):

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -745,12 +745,12 @@ class SandboxSettings(BaseSettings):
         description="Base64-encoded private key for signing audit entries.",
     )
     prompt_success_log_path: str = Field(
-        "prompt_success_log.json",
+        "sandbox_data/prompt_success_log.jsonl",
         env="PROMPT_SUCCESS_LOG_PATH",
         description="Path for recording successful prompt executions.",
     )
     prompt_failure_log_path: str = Field(
-        "prompt_failure_log.json",
+        "sandbox_data/prompt_failure_log.jsonl",
         env="PROMPT_FAILURE_LOG_PATH",
         description="Path for recording failed prompt executions.",
     )

--- a/tests/self_improvement/test_prompt_strategy_behavior.py
+++ b/tests/self_improvement/test_prompt_strategy_behavior.py
@@ -54,9 +54,9 @@ def dummy_prompt(strategy_templates):
 
 
 def test_failure_reason_logged(tmp_path, monkeypatch, dummy_prompt):
-    monkeypatch.setattr(prompt_memory, "_repo_path", lambda: tmp_path)
-    monkeypatch.setattr(prompt_memory._settings, "prompt_failure_log_path", "fail.json")
-    monkeypatch.setattr(prompt_memory._settings, "prompt_success_log_path", "succ.json")
+    monkeypatch.setattr(prompt_memory, "resolve_path", lambda p: str(tmp_path / p))
+    monkeypatch.setattr(prompt_memory._settings, "prompt_failure_log_path", "fail.jsonl")
+    monkeypatch.setattr(prompt_memory._settings, "prompt_success_log_path", "succ.jsonl")
 
     prompt_memory.log_prompt_attempt(
         dummy_prompt,
@@ -66,7 +66,7 @@ def test_failure_reason_logged(tmp_path, monkeypatch, dummy_prompt):
         sandbox_metrics={"s": 2},
     )
 
-    log_path = tmp_path / "fail.json"
+    log_path = tmp_path / "fail.jsonl"
     entry = json.loads(log_path.read_text().splitlines()[0])
     assert entry["failure_reason"] == "api_error"
     assert entry["sandbox_metrics"] == {"s": 2}
@@ -120,7 +120,7 @@ def test_high_roi_favored_over_penalized(strategy_templates, mock_roi_stats, mon
 
 def test_roi_stats_logged(tmp_path, monkeypatch, dummy_prompt):
     path = Path(resolve_path(str(tmp_path / "stats.json")))
-    monkeypatch.setattr(prompt_memory, "_repo_path", lambda: tmp_path)
+    monkeypatch.setattr(prompt_memory, "resolve_path", lambda p: str(tmp_path / p))
     monkeypatch.setattr(prompt_memory, "_strategy_stats_path", path)
     from filelock import FileLock
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- log prompt attempts with strategy, sandbox metrics, raw prompt, and auto-generated IDs
- write success and failure logs to sandbox_data JSONL files and provide load_failures helper
- document new logging locations and update prompt evolution defaults

## Testing
- `pre-commit run --files self_improvement/prompt_memory.py sandbox_settings.py prompt_evolution_memory.py docs/sandbox_settings.md docs/sandbox_environment.md docs/prompt_evolution_memory.md tests/self_improvement/test_prompt_strategy_behavior.py self_improvement/tests/test_log_prompt_failure_reason.py`
- `python - <<'PY'
import types, sys, pathlib, pytest
ROOT = pathlib.Path('.').resolve()
pkg = types.ModuleType('menace_sandbox')
pkg.__path__ = [str(ROOT)]
sys.modules['menace_sandbox'] = pkg
pytest.main(['self_improvement/tests/test_log_prompt_failure_reason.py','tests/self_improvement/test_prompt_strategy_behavior.py'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ba3f5b6fdc832e973770a2b40649c6