### PR TITLE
Use _env_path fallback for coverage cleanup

### DIFF
--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -427,7 +427,7 @@ def cleanup_artifacts(extra_paths: Iterable[Path] | None = None) -> None:
         try:
             cov_files.append(_env_path(env_name, default))
         except FileNotFoundError:
-            cov_files.append(Path(os.getenv(env_name, default)))
+            cov_files.append(_env_path(env_name, default))
     cov_files.extend([Path(".coverage"), Path("cov.json")])
     for path in cov_files:
         try:


### PR DESCRIPTION
## Summary
- resolve coverage cleanup paths via `_env_path` fallback to ensure repo-relative resolution

## Testing
- `SKIP=forbid-stripe-imports,forbid-stripe-keys,forbid-raw-stripe-usage PYTHONPATH=. pre-commit run --files sandbox_runner/environment.py`
- `PYTHONPATH=. pytest tests/test_environment_support_functions.py` *(fails: ImportError: cannot import name 'sandbox_crashes_total')*

------
https://chatgpt.com/codex/tasks/task_e_68ba4018982c832e8a85c5e60069d3b0