### PR TITLE
Use _env_path for cleanup log path

### DIFF
--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -568,9 +568,7 @@ def record_module_usage(module_name: str) -> None:
             )
 
 # path to cleanup log file
-_CLEANUP_LOG_PATH = Path(os.getenv("SANDBOX_CLEANUP_LOG", "sandbox_data/cleanup.log"))
-if not _CLEANUP_LOG_PATH.is_absolute():
-    _CLEANUP_LOG_PATH = repo_root() / _CLEANUP_LOG_PATH
+_CLEANUP_LOG_PATH = _env_path("SANDBOX_CLEANUP_LOG", "sandbox_data/cleanup.log")
 _CLEANUP_LOG_LOCK = threading.Lock()
 POOL_LOCK_FILE = _env_path("SANDBOX_POOL_LOCK", "sandbox_data/pool.lock")
 


### PR DESCRIPTION
## Summary
- derive cleanup log path from environment via `_env_path`

## Testing
- `pytest tests/test_cleanup_logging.py tests/test_container_pool_cleanup.py -q` *(fails: <module 'sandbox_runner.environment'> has no attribute '_write_cleanup_log')*

------
https://chatgpt.com/codex/tasks/task_e_68ba411e76dc832e9b84b5e38d43c670