### PR TITLE
Integrate strategy analytics for prompt selection

### DIFF
--- a/self_improvement/strategy_analytics.py
+++ b/self_improvement/strategy_analytics.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+"""Utilities for computing prompt strategy analytics.
+
+This module aggregates success and failure logs to derive per-strategy
+return-on-investment (ROI) metrics.  The resulting statistics are applied to
+:class:`~self_improvement.prompt_strategy_manager.PromptStrategyManager`
+which is then able to select the most promising strategy via its
+:meth:`best_strategy` method.
+"""
+
+from pathlib import Path
+from typing import Dict
+import json
+import time
+
+try:  # pragma: no cover - allow flat imports
+    from ..dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback for flat layout
+    from dynamic_path_router import resolve_path  # type: ignore
+
+from sandbox_settings import SandboxSettings
+from .prompt_strategy_manager import PromptStrategyManager
+
+
+class StrategyAnalytics:
+    """Aggregate per-strategy ROI statistics from prompt logs."""
+
+    def __init__(
+        self,
+        *,
+        manager: PromptStrategyManager | None = None,
+        success_log: str | Path | None = None,
+        failure_log: str | Path | None = None,
+        refresh_interval: float = 300.0,
+    ) -> None:
+        settings = SandboxSettings()
+        self.success_log = Path(resolve_path(success_log or settings.prompt_success_log_path))
+        self.failure_log = Path(resolve_path(failure_log or settings.prompt_failure_log_path))
+        self.manager = manager or PromptStrategyManager()
+        self.refresh_interval = float(refresh_interval)
+        self._last_refresh = 0.0
+
+    # ------------------------------------------------------------------
+    def refresh_if_stale(self) -> None:
+        """Refresh analytics if the configured interval has elapsed."""
+
+        if time.time() - self._last_refresh >= self.refresh_interval:
+            self.refresh()
+
+    # ------------------------------------------------------------------
+    def refresh(self) -> None:
+        """Read logs, compute ROI stats and update ``manager``."""
+
+        stats: Dict[str, Dict[str, float]] = {}
+        for path, success in ((self.success_log, True), (self.failure_log, False)):
+            if not path.exists():
+                continue
+            try:
+                fh = path.open("r", encoding="utf-8")
+            except Exception:  # pragma: no cover - best effort
+                continue
+            with fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        data = json.loads(line)
+                    except Exception:
+                        continue
+                    strat = data.get("strategy")
+                    if not strat:
+                        strat = data.get("metadata", {}).get("strategy")
+                    if not strat:
+                        continue
+                    roi = 0.0
+                    meta = data.get("roi_meta")
+                    if isinstance(meta, dict):
+                        roi = float(meta.get("roi_delta") or meta.get("roi", 0.0))
+                    elif data.get("roi") is not None:
+                        try:
+                            roi = float(data.get("roi", 0.0))
+                        except Exception:
+                            roi = 0.0
+                    rec = stats.setdefault(
+                        str(strat),
+                        {
+                            "total": 0,
+                            "success": 0,
+                            "roi_sum": 0.0,
+                            "weighted_roi_sum": 0.0,
+                            "weight_sum": 0.0,
+                        },
+                    )
+                    rec["total"] += 1
+                    if success:
+                        rec["success"] += 1
+                    rec["roi_sum"] += roi
+                    rec["weighted_roi_sum"] += roi
+                    rec["weight_sum"] += 1.0
+        self.manager.stats = stats
+        try:
+            self.manager._save_stats()
+        except Exception:  # pragma: no cover - best effort
+            pass
+        self._last_refresh = time.time()
+
+
+__all__ = ["StrategyAnalytics"]

--- a/tests/test_prompt_strategy_manager.py
+++ b/tests/test_prompt_strategy_manager.py
@@ -43,7 +43,8 @@ class MiniEngine:
         return self.prompt_strategy_manager.select(self._select_prompt_strategy)
 
     def _select_prompt_strategy(self, strategies):
-        return strategies[0] if strategies else None
+        best = self.prompt_strategy_manager.best_strategy(strategies)
+        return best if best else (strategies[0] if strategies else None)
 
     def _record_snapshot_delta(self, prompt, delta):
         success = not (delta.get("roi", 0.0) < 0 or delta.get("entropy", 0.0) < 0)


### PR DESCRIPTION
## Summary
- add StrategyAnalytics module to derive per-strategy ROI from prompt logs
- refresh analytics before each strategy pick and switch selection to StrategyManager
- update tests to exercise StrategyManager-based strategy selection

## Testing
- `PYTHONPATH=. pre-commit run --files self_improvement/strategy_analytics.py self_improvement/engine.py tests/self_improvement/test_prompt_strategy_behavior.py tests/test_prompt_strategy_manager.py`
- `pytest tests/self_improvement/test_prompt_strategy_behavior.py tests/test_prompt_strategy_manager.py self_improvement/tests/test_select_prompt_strategy_roi.py self_improvement/tests/test_strategy_roi_stats.py self_improvement/tests/test_strategy_rotator_sequential.py self_improvement/tests/test_strategy_rotation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba40ff8d90832ead042991b1823d12