### PR TITLE
Use _env_path for scenario summary path

### DIFF
--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -980,8 +980,8 @@ def save_coverage_data() -> None:
 
 def _scenario_summary_path() -> Path:
     data_dir = _env_path("SANDBOX_DATA_DIR", "sandbox_data")
-    default = data_dir / "scenario_summary.json"
-    return Path(os.getenv("SANDBOX_SCENARIO_SUMMARY", str(default)))
+    default = str(data_dir / "scenario_summary.json")
+    return _env_path("SANDBOX_SCENARIO_SUMMARY", default)
 
 
 def save_scenario_summary(


### PR DESCRIPTION
## Summary
- Resolve SANDBOX_SCENARIO_SUMMARY via `_env_path`

## Testing
- `python -m py_compile sandbox_runner/environment.py`
- `pytest tests/test_username_generator.py::test_generate_username_unique -q`
- `pytest tests/test_environment_helpers.py::test_generate_input_stubs_env -q` *(fails: ImportError: cannot import name 'repo_root' from '<unknown module name>')*


------
https://chatgpt.com/codex/tasks/task_e_68ba42090b0c832ea01356b6b2fd4715