### PR TITLE
Centralize prompt strategy failure mappings

### DIFF
--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -6612,14 +6612,6 @@ class SelfImprovementEngine:
                 except Exception:
                     self.logger.exception("strategy rotation failed")
                     next_template = None
-                if not next_template:
-                    fallback_map = {
-                        "score_drop": "strict_fix",
-                        "test_failed": "delete_rebuild",
-                        "entropy_regression": "comment_refactor",
-                    }
-                    key = "test_failed" if failure_reason == "tests_failed" else failure_reason
-                    next_template = fallback_map.get(key)
                 self.pending_strategy = next_template
 
         if success and strategy and hasattr(self, "strategy_manager"):

--- a/self_improvement/prompt_strategy_manager.py
+++ b/self_improvement/prompt_strategy_manager.py
@@ -21,6 +21,9 @@ DEFAULT_STRATEGIES: list[str] = [
 ]
 
 KEYWORD_MAP: Dict[str, str] = {
+    "score_drop": "strict_fix",
+    "tests_failed": "unit_test_rewrite",
+    "entropy_regression": "comment_refactor",
     "test": "unit_test_rewrite",
     "comment": "comment_refactor",
     "refactor": "strict_fix",


### PR DESCRIPTION
## Summary
- map common failure reasons like score drops and entropy regression directly via `PromptStrategyManager.KEYWORD_MAP`
- remove local fallback map in engine and defer to `PromptStrategyManager.record_failure`
- update strategy rotation tests to use manager-driven failure mapping

## Testing
- `pytest self_improvement/tests/test_strategy_rotation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba43322cec832eaed5fcbed4386c4a