### PR TITLE
Use resolve_path for SANDBOX_DATA_DIR in meta logging

### DIFF
--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -4962,7 +4962,7 @@ async def _section_worker(
                 metrics = runner.run(lambda: exec(snip, {}), **rc)
                 if _SandboxMetaLogger:
                     try:
-                        data_dir = Path(os.getenv("SANDBOX_DATA_DIR", "sandbox_data"))
+                        data_dir = Path(resolve_path(os.getenv("SANDBOX_DATA_DIR", "sandbox_data")))
                         meta = _SandboxMetaLogger(data_dir / "sandbox_meta.log")
                         succ = sum(1 for m in metrics.modules if m.success)
                         fail = sum(1 for m in metrics.modules if not m.success)


### PR DESCRIPTION
## Summary
- resolve SANDBOX_DATA_DIR before creating sandbox_meta.log during capture

## Testing
- `pytest tests/test_data_dir_resolution.py::test_module_index_db_resolves_paths -q`
- `pytest tests/test_exporter_restart.py::test_exporter_auto_restart -q` (fails: ImportError: cannot import name 'get_project_root')
- `pytest tests/test_menace_cli_resolve_path.py::test_handle_new_db_uses_resolved_path -q` (fails: FileNotFoundError)


------
https://chatgpt.com/codex/tasks/task_e_68ba436bf348832e80f8610d63064307