### PR TITLE
Replace healing log with rollback for Stripe mismatches

### DIFF
--- a/tests/test_stripe_billing_router.py
+++ b/tests/test_stripe_billing_router.py
@@ -757,14 +757,14 @@ def test_create_checkout_session_success(monkeypatch, sbr_module):
 
 def test_invalid_secret_key_triggers_alert_and_rollback(monkeypatch, sbr_module):
     alerts: list[tuple[tuple, dict]] = []
-    rollbacks: list[tuple[str, list[str]]] = []
+    rollbacks: list[tuple[str, str]] = []
     monkeypatch.setattr(
         sbr_module.alert_dispatcher, "dispatch_alert", lambda *a, **k: alerts.append((a, k))
     )
 
     class DummyRM:
-        def log_healing_action(self, bot_id, action):
-            rollbacks.append((action, [bot_id]))
+        def rollback(self, revision, requesting_bot):
+            rollbacks.append((revision, requesting_bot))
 
     monkeypatch.setattr(
         sbr_module.rollback_manager, "RollbackManager", lambda: DummyRM()
@@ -780,14 +780,14 @@ def test_invalid_secret_key_triggers_alert_and_rollback(monkeypatch, sbr_module)
 
 def test_invalid_account_triggers_alert_and_rollback(monkeypatch, sbr_module):
     alerts: list[tuple[tuple, dict]] = []
-    rollbacks: list[tuple[str, list[str]]] = []
+    rollbacks: list[tuple[str, str]] = []
     monkeypatch.setattr(
         sbr_module.alert_dispatcher, "dispatch_alert", lambda *a, **k: alerts.append((a, k))
     )
 
     class DummyRM:
-        def log_healing_action(self, bot_id, action):
-            rollbacks.append((action, [bot_id]))
+        def rollback(self, revision, requesting_bot):
+            rollbacks.append((revision, requesting_bot))
 
     monkeypatch.setattr(
         sbr_module.rollback_manager, "RollbackManager", lambda: DummyRM()


### PR DESCRIPTION
## Summary
- add `log_critical_discrepancy` helper that rolls back the latest revision
- route mismatch alerts now trigger a rollback instead of logging a healing action
- adjust tests to expect `RollbackManager.rollback`

## Testing
- `pytest tests/test_stripe_billing_router.py::test_invalid_secret_key_triggers_alert_and_rollback tests/test_stripe_billing_router.py::test_invalid_account_triggers_alert_and_rollback -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba45458394832eb841a36e1d410410