### PR TITLE
Use account ID for Stripe logging fallback

### DIFF
--- a/stripe_billing_router.py
+++ b/stripe_billing_router.py
@@ -606,7 +606,9 @@ def charge(
                 or (event.get("transfer_data") or {}).get("destination")
             )
         if destination is None:
-            destination = route.get("secret_key")
+            destination = route.get("account_id")
+            if destination is None:
+                destination = _get_account_id(api_key)
 
         logged_amount = amt
         if logged_amount is None and isinstance(event, Mapping):
@@ -785,7 +787,9 @@ def create_subscription(
                 or (event.get("transfer_data") or {}).get("destination")
             )
         if destination is None:
-            destination = route.get("secret_key")
+            destination = route.get("account_id")
+            if destination is None:
+                destination = _get_account_id(api_key)
         raw_json = None
         if isinstance(event, Mapping):
             try:
@@ -917,7 +921,9 @@ def refund(
                 except (TypeError, ValueError):
                     logged_amount = None
         if destination is None:
-            destination = route.get("secret_key")
+            destination = route.get("account_id")
+            if destination is None:
+                destination = _get_account_id(api_key)
         raw_json = None
         if isinstance(event, Mapping):
             try:
@@ -1025,7 +1031,9 @@ def create_checkout_session(
                 except (TypeError, ValueError):
                     logged_amount = None
         if destination is None:
-            destination = route.get("secret_key")
+            destination = route.get("account_id")
+            if destination is None:
+                destination = _get_account_id(api_key)
         raw_json = None
         if isinstance(event, Mapping):
             try:


### PR DESCRIPTION
## Summary
- ensure Stripe events fallback to the account ID rather than secret keys when destination is missing
- propagate account IDs through billing logs and payment records

## Testing
- `pre-commit run --files stripe_billing_router.py` *(fails: Payment keywords without stripe_billing_router detected)*
- `pytest stripe_billing_router.py` *(fails: No such file or directory: '')*


------
https://chatgpt.com/codex/tasks/task_e_68ba480d98a8832ea0c7c0df8511e336