### PR TITLE
Wrap startup check scripts with dynamic path routing

### DIFF
--- a/startup_checks.py
+++ b/startup_checks.py
@@ -16,6 +16,7 @@ from .audit_trail import AuditTrail
 import tomllib
 
 from .dependency_verifier import verify_dependencies, verify_modules
+from .dynamic_path_router import resolve_path
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +114,6 @@ def verify_stripe_router(mandatory_bot_ids: Iterable[str] | None = None) -> None
     any lookup fails.
     """
     repo_root = Path(__file__).resolve().parent
-    scripts = repo_root / "scripts"
     try:
         files = subprocess.check_output(
             ["git", "ls-files", "*.py"],
@@ -124,8 +124,15 @@ def verify_stripe_router(mandatory_bot_ids: Iterable[str] | None = None) -> None
         raise RuntimeError(f"git ls-files failed: {exc}") from exc
 
     checks = [
-        [sys.executable, str(scripts / "check_stripe_imports.py"), *files],
-        [sys.executable, str(scripts / "check_raw_stripe_usage.py")],
+        [
+            sys.executable,
+            str(resolve_path("scripts/check_stripe_imports.py")),
+            *files,
+        ],
+        [
+            sys.executable,
+            str(resolve_path("scripts/check_raw_stripe_usage.py")),
+        ],
     ]
     for cmd in checks:
         result = subprocess.run(


### PR DESCRIPTION
## Summary
- use dynamic_path_router.resolve_path in `verify_stripe_router` to call helper scripts via repo-aware paths

## Testing
- `python tools/check_static_paths.py $(git ls-files '*.py') | head -n 20`
- `python tools/check_dynamic_paths.py $(git ls-files '*.py') | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68ba48906254832e9e8614b2783503c5