### PR TITLE
Normalize sandbox path handling for relocatable repos

### DIFF
--- a/run_autonomous.py
+++ b/run_autonomous.py
@@ -579,7 +579,8 @@ def load_previous_synergy(
 ) -> tuple[list[dict[str, float]], list[dict[str, float]]]:
     """Return synergy history and moving averages from ``synergy_history.db``."""
 
-    path = Path(data_dir) / "synergy_history.db"
+    data_dir = Path(resolve_path(data_dir))
+    path = data_dir / "synergy_history.db"
     if not path.exists():
         return [], []
     history: list[dict[str, float]] = []
@@ -597,7 +598,11 @@ def load_previous_synergy(
             if isinstance(data, dict):
                 history.append({str(k): float(v) for k, v in data.items()})
     except Exception as exc:  # pragma: no cover - unexpected errors
-        logger.warning("failed to load synergy history %s: %s", path, exc)
+        logger.warning(
+            "failed to load synergy history %s: %s",
+            path_for_prompt(path),
+            exc,
+        )
         history = []
 
     ma_history: list[dict[str, float]] = []

--- a/sandbox_runner.py
+++ b/sandbox_runner.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING
 
 from db_router import init_db_router
 from scope_utils import Scope, build_scope_clause, apply_scope
-from dynamic_path_router import resolve_path, repo_root
+from dynamic_path_router import resolve_path, repo_root, path_for_prompt
 
 # Initialise a router for this process with a unique menace_id so
 # ``GLOBAL_ROUTER`` becomes available to imported modules.  Import modules that
@@ -342,10 +342,10 @@ def simulate_meta_workflow(meta_spec, workflows=None, runner=None):
 # ----------------------------------------------------------------------
 def load_modified_code(code_path: str) -> str:
     path = resolve_path(code_path)
-    logger.debug("loading code from %s", path)
+    logger.debug("loading code from %s", path_for_prompt(path))
     with path.open("r", encoding="utf-8") as fh:
         content = fh.read()
-    logger.debug("loaded %d bytes from %s", len(content), path)
+    logger.debug("loaded %d bytes from %s", len(content), path_for_prompt(path))
     return content
 
 
@@ -994,7 +994,9 @@ def _sandbox_init(preset: Dict[str, Any], args: argparse.Namespace) -> SandboxCo
         try:
             res_db = ROIHistoryDB(res_path)
         except Exception:
-            logger.exception("failed to load resource db: %s", res_path)
+            logger.exception(
+                "failed to load resource db: %s", path_for_prompt(res_path)
+            )
 
     pre_roi_bot = None
     if PreExecutionROIBot:
@@ -1166,7 +1168,9 @@ def _sandbox_init(preset: Dict[str, Any], args: argparse.Namespace) -> SandboxCo
             if isinstance(cache_data, dict):
                 suggestion_cache = cache_data
         except Exception:
-            logger.exception("failed to load suggestion cache: %s", cache_path)
+            logger.exception(
+                "failed to load suggestion cache: %s", path_for_prompt(cache_path)
+            )
             suggestion_cache = {}
     global _SUGGESTION_DB
     suggestion_db_path = suggestion_cache.get("db", str(data_dir / "module_suggestions.db"))

--- a/sandbox_runner/bootstrap.py
+++ b/sandbox_runner/bootstrap.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Iterable
 from logging_utils import get_logger, set_correlation_id, log_record
 
 from packaging.version import Version
-from dynamic_path_router import resolve_path, repo_root
+from dynamic_path_router import resolve_path, repo_root, path_for_prompt
 
 from menace.auto_env_setup import ensure_env
 from menace.default_config_manager import DefaultConfigManager
@@ -432,7 +432,9 @@ def sandbox_health() -> dict[str, bool | dict[str, str]]:
             conn.execute("PRAGMA schema_version")
             conn.close()
         except Exception as exc:
-            logger.error("failed to access database %s: %s", db_path, exc)
+            logger.error(
+                "failed to access database %s: %s", path_for_prompt(db_path), exc
+            )
             db_errors[name] = str(exc)
 
     db_ok = not db_errors

--- a/sandbox_runner/cycle.py
+++ b/sandbox_runner/cycle.py
@@ -23,7 +23,7 @@ from log_tags import FEEDBACK, IMPROVEMENT_PATH, INSIGHT, ERROR_FIX
 from foresight_tracker import ForesightTracker
 from db_router import GLOBAL_ROUTER, init_db_router
 from alert_dispatcher import dispatch_alert
-from dynamic_path_router import resolve_path
+from dynamic_path_router import resolve_path, path_for_prompt
 from error_parser import ErrorParser
 
 
@@ -1167,7 +1167,9 @@ def _sandbox_cycle_runner(
                         with open(path, "r", encoding="utf-8", errors="ignore") as fh:
                             total_lines += sum(1 for _ in fh)
                     except Exception:
-                        logger.exception("failed counting lines for %s", path)
+                        logger.exception(
+                            "failed counting lines for %s", path_for_prompt(path)
+                        )
                 if total_lines:
                     coverage_percent = 100.0 * exec_lines / float(total_lines)
                     adaptability = coverage_percent

--- a/sandbox_runner/generative_stub_provider.py
+++ b/sandbox_runner/generative_stub_provider.py
@@ -17,7 +17,7 @@ import re
 import warnings
 import uuid
 from pathlib import Path
-from dynamic_path_router import resolve_path
+from dynamic_path_router import resolve_path, path_for_prompt
 from collections import Counter, OrderedDict, defaultdict
 import atexit
 import importlib
@@ -47,8 +47,6 @@ from .input_history_db import InputHistoryDB
 from sandbox_settings import SandboxSettings
 from model_registry import get_client
 from llm_interface import Prompt
-
-
 
 # Optional dependencies loaded lazily
 pipeline = None  # type: ignore
@@ -668,7 +666,9 @@ def cleanup_cache_files(config: StubProviderConfig | None = None) -> None:
         except FileNotFoundError:
             continue
         except Exception as exc:  # pragma: no cover - best effort
-            logger.debug("failed to remove cache file %s: %s", path, exc)
+            logger.debug(
+                "failed to remove cache file %s: %s", path_for_prompt(path), exc
+            )
     logger.info(
         "cleanup cache files complete", extra=log_record(event="shutdown")
     )

--- a/sandbox_runner/meta_logger.py
+++ b/sandbox_runner/meta_logger.py
@@ -13,6 +13,7 @@ import json
 import math
 
 from logging_utils import get_logger, log_record
+from dynamic_path_router import path_for_prompt
 from audit_trail import AuditTrail
 
 try:  # optional dependency
@@ -98,7 +99,9 @@ class _SandboxMetaLogger:
                         self.module_entropy_deltas[m] = deltas
             except (OSError, json.JSONDecodeError) as exc:  # pragma: no cover - best effort
                 logger.exception("failed to load sandbox history", exc_info=exc)
-        logger.debug("SandboxMetaLogger initialised at %s", path)
+        logger.debug(
+            "SandboxMetaLogger initialised at %s", path_for_prompt(path)
+        )
 
     def log_cycle(
         self,

--- a/sandbox_runner/metrics_plugins.py
+++ b/sandbox_runner/metrics_plugins.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import importlib.util
 import json
-import logging
 import os
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence
 
 from logging_utils import get_logger, setup_logging
-from dynamic_path_router import resolve_path
+from dynamic_path_router import resolve_path, path_for_prompt
 
 logger = get_logger(__name__)
 
@@ -29,7 +28,7 @@ def _load_plugin_dirs_from_file(path: str | Path) -> List[str]:
             with open(p, "r", encoding="utf-8") as fh:
                 data = yaml.safe_load(fh)
     except Exception:
-        logger.exception("failed to load metrics config %s", p)
+        logger.exception("failed to load metrics config %s", path_for_prompt(p))
         return []
     dirs = data.get("plugin_dirs", []) if isinstance(data, dict) else []
     if isinstance(dirs, str):
@@ -46,9 +45,11 @@ def load_metrics_plugins(directories: str | Path | Sequence[str] | None) -> List
     dirs = [directories] if isinstance(directories, (str, Path)) else list(directories)
     plugins: List[MetricsFunc] = []
     for d in dirs:
-        path = Path(d)
+        path = Path(resolve_path(str(d)))
         if not path.is_dir():
-            logger.warning("metrics plugin directory %s does not exist", path)
+            logger.warning(
+                "metrics plugin directory %s does not exist", path_for_prompt(path)
+            )
             continue
         for file in path.glob("*.py"):
             try:
@@ -60,9 +61,14 @@ def load_metrics_plugins(directories: str | Path | Sequence[str] | None) -> List
                     if callable(func):
                         plugins.append(func)
                     else:
-                        logger.warning("plugin %s missing collect_metrics", file)
+                        logger.warning(
+                            "plugin %s missing collect_metrics",
+                            path_for_prompt(file),
+                        )
             except Exception:
-                logger.exception("failed to load metrics plugin %s", file)
+                logger.exception(
+                    "failed to load metrics plugin %s", path_for_prompt(file)
+                )
     return plugins
 
 

--- a/sandbox_runner/test_harness.py
+++ b/sandbox_runner/test_harness.py
@@ -21,7 +21,7 @@ import json
 import urllib.parse
 from typing import Any
 
-from dynamic_path_router import resolve_path
+from dynamic_path_router import resolve_path, path_for_prompt
 
 
 from ..error_parser import ErrorParser
@@ -270,7 +270,11 @@ def _run_once(
                     try:
                         rel_paths = [p.relative_to(repo_path) for p in rel_paths]
                     except Exception as exc:
-                        logger.warning("Failed to resolve relative paths %s: %s", rel_paths, exc)
+                        logger.warning(
+                            "Failed to resolve relative paths %s: %s",
+                            [path_for_prompt(p) for p in rel_paths],
+                            exc,
+                        )
                     if len(rel_paths) == 1:
                         rel = rel_paths[0]
                         selected = rel.as_posix()
@@ -318,7 +322,11 @@ def _run_once(
                     try:
                         rel_paths = [p.relative_to(repo_path) for p in rel_paths]
                     except Exception as exc:
-                        logger.warning("Failed to resolve relative paths %s: %s", rel_paths, exc)
+                        logger.warning(
+                            "Failed to resolve relative paths %s: %s",
+                            [path_for_prompt(p) for p in rel_paths],
+                            exc,
+                        )
                     if len(rel_paths) == 1:
                         rel = rel_paths[0]
                         selected = rel.as_posix()

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -849,7 +849,9 @@ class SelfCodingEngine:
                         line_ranges=[(start, end)],
                     )
                 except Exception:
-                    self.logger.exception("failed to split %s", path)
+                    self.logger.exception(
+                        "failed to split %s", path_for_prompt(path)
+                    )
                     return "", None
                 summaries: List[str] = []
                 for i, ch in enumerate(chunks):
@@ -866,7 +868,9 @@ class SelfCodingEngine:
                     path, threshold, self.llm_client
                 )
             except Exception:
-                self.logger.exception("failed to summarise %s", path)
+                self.logger.exception(
+                    "failed to summarise %s", path_for_prompt(path)
+                )
                 return "", None
 
             lines = code.splitlines()
@@ -1525,12 +1529,16 @@ class SelfCodingEngine:
             )
             if not generated.strip():
                 return None, False, 0.0
-            if _verify(generated):
-                if not self._apply_region_patch(path, original_lines, target_region, generated):
-                    if target_region.function:
-                        func_region = self._find_function_region(original_lines, target_region.function)
-                    else:
-                        func_region = None
+                if _verify(generated):
+                    if not self._apply_region_patch(
+                        path, original_lines, target_region, generated
+                    ):
+                        if target_region.function:
+                            func_region = self._find_function_region(
+                                original_lines, target_region.function
+                            )
+                        else:
+                            func_region = None
                     if func_region is None:
                         return None, False, 0.0
                     generated = self.generate_helper(

--- a/tests/test_run_autonomous_relocation.py
+++ b/tests/test_run_autonomous_relocation.py
@@ -1,0 +1,68 @@
+import ast
+import json
+import sqlite3
+import sys
+import types
+from pathlib import Path
+
+RA_PATH = Path(__file__).resolve().parents[1] / "run_autonomous.py"
+
+sys.modules.pop("dynamic_path_router", None)
+import dynamic_path_router as dpr  # noqa: E402
+
+clear_cache = dpr.clear_cache
+
+
+def _load_previous_synergy():
+    src = RA_PATH.read_text()
+    tree = ast.parse(src)
+    func = next(
+        n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "load_previous_synergy"
+    )
+    module = ast.Module([func], type_ignores=[])
+    ns: dict[str, object] = {}
+
+    class _Conn:
+        def __init__(self, p: Path):
+            self.conn = sqlite3.connect(p)  # noqa: SQL001
+
+        def __enter__(self):  # noqa: D401 - context manager protocol
+            return self.conn
+
+        def __exit__(self, *_exc):
+            self.conn.close()
+            return False
+
+    cli = types.SimpleNamespace(_ema=lambda vals: (vals[-1], 0.0))
+    exec(
+        compile(module, "ra_subset", "exec"),
+        {
+            "Path": Path,
+            "json": json,
+            "connect_locked": lambda p: _Conn(Path(p)),
+            "cli": cli,
+            "resolve_path": dpr.resolve_path,
+        },
+        ns,
+    )
+    return ns["load_previous_synergy"]
+
+
+def test_load_previous_synergy_uses_repo_path(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    data_dir = repo / "data"
+    data_dir.mkdir(parents=True)
+    db_path = data_dir / "synergy_history.db"
+    conn = sqlite3.connect(db_path)  # noqa: SQL001
+    conn.execute("CREATE TABLE synergy_history (id INTEGER PRIMARY KEY, entry TEXT)")
+    conn.execute("INSERT INTO synergy_history(entry) VALUES (?)", [json.dumps({"x": 1.0})])
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("SANDBOX_REPO_PATH", str(repo))
+    clear_cache()
+    func = _load_previous_synergy()
+
+    history, ma = func("data")
+    assert history == [{"x": 1.0}]
+    assert ma and isinstance(ma[0], dict)


### PR DESCRIPTION
## Summary
- ensure self-coding and sandbox runners resolve file paths via resolve_path
- normalize logged paths with path_for_prompt across engines and runners
- add relocation tests for prompt building and synergy history loading

## Testing
- `pytest unit_tests/test_prompt_path_resolution.py tests/test_run_autonomous_relocation.py -q`
- `pre-commit run --files run_autonomous.py sandbox_runner.py sandbox_runner/bootstrap.py sandbox_runner/cycle.py sandbox_runner/environment.py sandbox_runner/generative_stub_provider.py sandbox_runner/meta_logger.py sandbox_runner/metrics_plugins.py sandbox_runner/test_harness.py sandbox_runner/workflow_sandbox_runner.py self_coding_engine.py unit_tests/test_prompt_path_resolution.py tests/test_run_autonomous_relocation.py` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*


------
https://chatgpt.com/codex/tasks/task_e_68ba497a4f28832ea05d34963ed1b2a6