### PR TITLE
docs: clarify dynamic path router helpers and caching

### DIFF
--- a/docs/dynamic_path_router.md
+++ b/docs/dynamic_path_router.md
@@ -20,6 +20,21 @@ order:
 If the direct lookup fails the router performs a recursive walk of the
 repository to locate the file.
 
+When the multi-root variables are present they take precedence over the single
+root overrides.  Each entry is searched in order and the first matching root is
+stored for reuse so subsequent lookups avoid repeated filesystem walks.
+
+## Additional helpers
+
+- `get_project_root` and `get_project_roots` expose the discovered repository
+  roots, optionally selecting one via the `repo_hint` parameter.
+- `resolve_module_path` resolves dotted module names to their source file or
+  package `__init__.py` across all registered roots.
+- `resolve_dir` resolves and validates directory locations.
+
+All resolutions and discovered roots are cached behind a thread-safe lock to
+keep repeated lookups inexpensive.
+
 ## Caching
 
 Successful resolutions are cached in-memory to avoid repeated scans.  Call


### PR DESCRIPTION
## Summary
- clarify dynamic path router docstring and helper docstrings
- document environment variable precedence and helper usage in `docs/dynamic_path_router.md`

## Testing
- `PYTHONPATH=. pre-commit run --files dynamic_path_router.py docs/dynamic_path_router.md` *(fails: forbid-raw-stripe-usage)*
- `pytest unit_tests/test_sandbox_repo_path_env.py unit_tests/test_prompt_path_resolution.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba4ce66a08832eab61acd3496d477d