### PR TITLE
refactor tests to use resolve_path for fixtures

### DIFF
--- a/tests/integration/test_run_scenarios.py
+++ b/tests/integration/test_run_scenarios.py
@@ -1,8 +1,9 @@
 import json
-from pathlib import Path
+
 import pytest
 from tests.test_menace_master import _setup_mm_stubs
 from tests.test_scenario_roi_deltas import _setup_tracker
+from dynamic_path_router import resolve_path
 
 
 def test_run_scenarios_all_paths(monkeypatch):
@@ -10,9 +11,8 @@ def test_run_scenarios_all_paths(monkeypatch):
     rt = _setup_tracker(monkeypatch)
     import sandbox_runner.environment as env
 
-    fixtures = Path(__file__).resolve().parents[1] / "fixtures"
-    hostile = json.loads((fixtures / "hostile_input.json").read_text())
-    flaky = json.loads((fixtures / "flaky_upstream.json").read_text())
+    hostile = json.loads(resolve_path("tests/fixtures/hostile_input.json").read_text())
+    flaky = json.loads(resolve_path("tests/fixtures/flaky_upstream.json").read_text())
 
     scenario_data = {
         "normal": (3.0, 2.0),

--- a/tests/test_composite_workflow_scorer.py
+++ b/tests/test_composite_workflow_scorer.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Dict
 
 import pytest
+from dynamic_path_router import resolve_path
 
 
 class _StubDBRouter:
@@ -61,14 +62,14 @@ sys.modules[
 )
 
 
-FIXTURES = Path(__file__).parent / "fixtures" / "workflow_modules"
-
-
 def _copy_fixture_modules(tmp_path: Path) -> None:
     """Copy minimal workflow modules into ``tmp_path``."""
 
     for name in ("mod_a.py", "mod_b.py", "mod_c.py"):
-        shutil.copy(FIXTURES / name, tmp_path / name)
+        shutil.copy(
+            resolve_path(f"tests/fixtures/workflow_modules/{name}"),
+            tmp_path / name,
+        )
 
 
 def _stub_calculator_factory():

--- a/tests/test_dynamic_module_mapper.py
+++ b/tests/test_dynamic_module_mapper.py
@@ -1,11 +1,15 @@
 import json
 from pathlib import Path
 
+import json
+from pathlib import Path
+
 import pytest
 
 pytest.importorskip("networkx")
 
 import dynamic_module_mapper as dmm
+from dynamic_path_router import resolve_path
 
 
 def _read_map(path: Path) -> dict:
@@ -87,8 +91,9 @@ def test_semantic_group_no_imports(tmp_path):
 
 
 def test_semantic_fixture_grouping(tmp_path):
-    src = Path(__file__).parent / "fixtures" / "semantic"
     import shutil
+
+    src = resolve_path("tests/fixtures/semantic")
     shutil.copytree(src, tmp_path / "mods")
     plain = dmm.build_module_map(tmp_path / "mods", algorithm="label")
     idxs = {plain["a"], plain["b"], plain["c"]}

--- a/tests/test_dynamic_path_router.py
+++ b/tests/test_dynamic_path_router.py
@@ -1,3 +1,4 @@
+import importlib
 import importlib.util
 import shutil
 from pathlib import Path
@@ -5,6 +6,7 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
+from dynamic_path_router import resolve_path
 
 
 def _load_router(path: Path):
@@ -32,7 +34,7 @@ def test_resolve_path_with_env_override(monkeypatch, env_var):
         (repo / ".git").mkdir(parents=True)
         shutil.copy(project_root / "dynamic_path_router.py", repo / "dynamic_path_router.py")
         shutil.copy(
-            project_root / "tests" / "fixtures" / "patch_outcomes.jsonl",
+            resolve_path("tests/fixtures/patch_outcomes.jsonl"),
             repo / "patch_outcomes.jsonl",
         )
 
@@ -60,7 +62,7 @@ def test_resolve_path_jsonl_in_nested_repo(monkeypatch):
 
         shutil.copy(project_root / "dynamic_path_router.py", repo / "dynamic_path_router.py")
         shutil.copy(
-            project_root / "tests" / "fixtures" / "patch_outcomes.jsonl",
+            resolve_path("tests/fixtures/patch_outcomes.jsonl"),
             repo / "patch_outcomes.jsonl",
         )
 

--- a/tests/test_generate_variant_orphan_integration.py
+++ b/tests/test_generate_variant_orphan_integration.py
@@ -5,13 +5,15 @@ import shutil
 from pathlib import Path
 
 from workflow_synthesizer import generate_variants
-
-FIXTURES = Path(__file__).parent / "fixtures" / "workflow_modules"
+from dynamic_path_router import resolve_path
 
 
 def _copy_modules(tmp_path: Path) -> None:
     for name in ("mod_a.py", "mod_b.py"):
-        shutil.copy(FIXTURES / name, tmp_path / name)
+        shutil.copy(
+            resolve_path(f"tests/fixtures/workflow_modules/{name}"),
+            tmp_path / name,
+        )
 
 
 def test_generate_variants_integrates_orphans(monkeypatch, tmp_path):

--- a/tests/test_orphan_auto_indexing.py
+++ b/tests/test_orphan_auto_indexing.py
@@ -5,13 +5,12 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import workflow_synthesizer as ws
-
-FIXTURES = Path(__file__).parent / "fixtures" / "workflow_modules"
+from dynamic_path_router import resolve_path
 
 
 def _copy_modules(tmp_path: Path) -> None:
     """Copy fixture workflow modules into *tmp_path* for testing."""
-    for mod in FIXTURES.glob("*.py"):
+    for mod in resolve_path("tests/fixtures/workflow_modules").glob("*.py"):
         shutil.copy(mod, tmp_path / mod.name)
 
 

--- a/tests/test_orphan_inclusion_after_synthesis.py
+++ b/tests/test_orphan_inclusion_after_synthesis.py
@@ -5,12 +5,11 @@ import types
 from pathlib import Path
 
 import workflow_synthesizer as ws
-
-FIXTURES = Path(__file__).parent / "fixtures" / "workflow_modules"
+from dynamic_path_router import resolve_path
 
 
 def _copy_modules(tmp_path: Path) -> None:
-    for mod in FIXTURES.glob("*.py"):
+    for mod in resolve_path("tests/fixtures/workflow_modules").glob("*.py"):
         shutil.copy(mod, tmp_path / mod.name)
 
 

--- a/tests/test_orphan_integration_rounds.py
+++ b/tests/test_orphan_integration_rounds.py
@@ -6,13 +6,12 @@ import importlib
 from pathlib import Path
 
 import workflow_synthesizer as ws
-
-FIXTURES = Path(__file__).parent / "fixtures" / "workflow_modules"
+from dynamic_path_router import resolve_path
 
 
 def _copy_modules(tmp_path: Path) -> None:
     """Copy fixture workflow modules into *tmp_path* for testing."""
-    for mod in FIXTURES.glob("*.py"):
+    for mod in resolve_path("tests/fixtures/workflow_modules").glob("*.py"):
         shutil.copy(mod, tmp_path / mod.name)
 
 

--- a/tests/test_redaction_utils.py
+++ b/tests/test_redaction_utils.py
@@ -1,8 +1,7 @@
-from pathlib import Path
-
+from dynamic_path_router import resolve_path
 from redaction_utils import redact_text
 
-FIXTURE_DIR = Path("tests/fixtures/semantic")
+FIXTURE_DIR = resolve_path("tests/fixtures/semantic")
 
 
 def test_redact_text_on_fixtures():

--- a/tests/test_sandbox_execution_regression.py
+++ b/tests/test_sandbox_execution_regression.py
@@ -7,7 +7,7 @@ import sys
 import types
 from pathlib import Path
 
-FIXTURES = Path(__file__).resolve().parent / "fixtures" / "regression"
+from dynamic_path_router import resolve_path
 
 
 def _load_runner():
@@ -37,5 +37,7 @@ def test_sandbox_execution_matches_fixture():
         "modules": [{"name": m.name, "success": m.success} for m in metrics.modules],
     }
 
-    expected = json.loads((FIXTURES / "sandbox_metrics.json").read_text())
+    expected = json.loads(
+        resolve_path("tests/fixtures/regression/sandbox_metrics.json").read_text()
+    )
     assert result == expected

--- a/tests/test_self_improvement_cycle_regression.py
+++ b/tests/test_self_improvement_cycle_regression.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 
 import pytest
+from dynamic_path_router import resolve_path
 
-FIXTURES = Path(__file__).resolve().parent / "fixtures" / "regression"
 ROOT = Path(__file__).resolve().parent.parent
 
 
@@ -113,5 +113,7 @@ def test_self_improvement_cycle_matches_fixture():
     with pytest.raises(asyncio.TimeoutError):
         asyncio.run(asyncio.wait_for(run_cycle(), timeout=0.01))
 
-    expected = json.loads((FIXTURES / "self_improvement_events.json").read_text())
+    expected = json.loads(
+        resolve_path("tests/fixtures/regression/self_improvement_events.json").read_text()
+    )
     assert [list(e) for e in bus.events] == expected

--- a/tests/test_stub_generation_regression.py
+++ b/tests/test_stub_generation_regression.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 import sys
 import types
 
@@ -10,9 +9,7 @@ th_stub.run_tests = lambda *a, **k: None
 th_stub.TestHarnessResult = object
 sys.modules.setdefault("sandbox_runner.test_harness", th_stub)
 import sandbox_runner.generative_stub_provider as gsp
-
-
-FIXTURES = Path(__file__).resolve().parent / "fixtures" / "regression"
+from dynamic_path_router import resolve_path
 
 
 def sample_func(name: str, count: int, active: bool) -> None:
@@ -32,5 +29,7 @@ def test_stub_generation_matches_fixture(monkeypatch):
 
     stubs = gsp.generate_stubs([{}], {"target": sample_func})[0]
 
-    expected = json.loads((FIXTURES / "stub_generation.json").read_text())
+    expected = json.loads(
+        resolve_path("tests/fixtures/regression/stub_generation.json").read_text()
+    )
     assert stubs == expected

--- a/tests/test_workflow_evolution_behaviour.py
+++ b/tests/test_workflow_evolution_behaviour.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from workflow_synthesizer import generate_variants, ModuleIOAnalyzer, WorkflowSynthesizer
+from dynamic_path_router import resolve_path
 
 
 # ---------------------------------------------------------------------------
@@ -175,7 +176,7 @@ def _load_manager(variant_rois, generate_calls=None, diminishing=0.05):
 # Tests
 
 def test_variant_generation_obeys_dependencies(tmp_path, monkeypatch):
-    base_src = Path(__file__).with_name("fixtures") / "workflow_modules"
+    base_src = resolve_path("tests/fixtures/workflow_modules")
     for name in ["mod_a.py", "mod_b.py", "mod_c.py"]:
         # write modules without extension so ModuleIOAnalyzer resolves them
         (tmp_path / name[:-3]).write_text((base_src / name).read_text())

--- a/tests/test_workflow_evolution_manager.py
+++ b/tests/test_workflow_evolution_manager.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import types
 import json
 
+from dynamic_path_router import resolve_path
+
 # Ensure package context and stub heavy dependencies before import
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.append(str(ROOT))
@@ -11,11 +13,9 @@ pkg = types.ModuleType("menace_sandbox")
 pkg.__path__ = [str(ROOT / "menace_sandbox")]
 sys.modules.setdefault("menace_sandbox", pkg)
 
-FIX_DIR = Path(__file__).resolve().parent / "fixtures" / "workflows"
-
-
 def _load_steps(name: str) -> list[dict]:
-    return json.loads((FIX_DIR / name).read_text()).get("steps", [])
+    path = resolve_path(f"tests/fixtures/workflows/{name}")
+    return json.loads(path.read_text()).get("steps", [])
 
 
 def _stub(name, **attrs):

--- a/tests/test_workflow_synergy_comparator.py
+++ b/tests/test_workflow_synergy_comparator.py
@@ -6,6 +6,8 @@ import types
 from pathlib import Path
 from typing import List
 
+from dynamic_path_router import resolve_path
+
 import networkx as nx
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -75,11 +77,9 @@ def _force_simple(monkeypatch):
     )
 
 
-FIX_DIR = Path(__file__).resolve().parent / "fixtures" / "workflows"
-
-
 def _load(name: str) -> dict:
-    return json.loads((FIX_DIR / name).read_text())
+    path = resolve_path(f"tests/fixtures/workflows/{name}")
+    return json.loads(path.read_text())
 
 
 def test_similarity_and_entropy(monkeypatch):

--- a/tests/test_workflow_synthesizer.py
+++ b/tests/test_workflow_synthesizer.py
@@ -18,11 +18,9 @@ sys.modules["intent_db"] = SimpleNamespace(IntentDB=None)
 
 import workflow_synthesizer as ws  # noqa: E402
 
-FIXTURES = Path(__file__).parent / "fixtures" / "workflow_modules"
-
 
 def _copy_modules(tmp_path: Path) -> None:
-    for mod in FIXTURES.glob("*.py"):
+    for mod in resolve_path("tests/fixtures/workflow_modules").glob("*.py"):
         shutil.copy(mod, tmp_path / mod.name)
 
 

--- a/tests/test_workflow_synthesizer_cli_subprocess.py
+++ b/tests/test_workflow_synthesizer_cli_subprocess.py
@@ -5,8 +5,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+from dynamic_path_router import resolve_path
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
-FIXTURES = REPO_ROOT / "tests" / "fixtures" / "workflow_modules"
 
 STUB_MODULE = """
 from dataclasses import dataclass
@@ -56,7 +57,10 @@ class WorkflowSynthesizer:
 
 def _prepare(tmp_path: Path):
     for name in ("mod_a.py", "mod_b.py", "mod_c.py"):
-        shutil.copy(FIXTURES / name, tmp_path / name)
+        shutil.copy(
+            resolve_path(f"tests/fixtures/workflow_modules/{name}"),
+            tmp_path / name,
+        )
     (tmp_path / "workflow_synthesizer.py").write_text(STUB_MODULE)
     (tmp_path / "sitecustomize.py").write_text(
         "import sys\n" "sys.stdin.isatty=lambda: True\n"

--- a/tests/test_workflow_synthesizer_functions.py
+++ b/tests/test_workflow_synthesizer_functions.py
@@ -4,12 +4,11 @@ from pathlib import Path
 import networkx as nx
 
 import workflow_synthesizer as ws
-
-FIXTURES = Path(__file__).parent / "fixtures" / "workflow_modules"
+from dynamic_path_router import resolve_path
 
 
 def _copy_modules(tmp_path: Path) -> None:
-    for mod in FIXTURES.glob("*.py"):
+    for mod in resolve_path("tests/fixtures/workflow_modules").glob("*.py"):
         shutil.copy(mod, tmp_path / mod.name)
 
 

--- a/tests/test_workflow_vectorizer.py
+++ b/tests/test_workflow_vectorizer.py
@@ -1,16 +1,17 @@
 import json
 from pathlib import Path
 
+import json
+
 import pytest
 
 from workflow_vectorizer import WorkflowVectorizer
-
-_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "workflow_examples.json"
+from dynamic_path_router import resolve_path
 
 
 @pytest.fixture
 def sample_workflows():
-    with open(_FIXTURE) as fh:
+    with resolve_path("tests/fixtures/workflow_examples.json").open() as fh:
         return json.load(fh)
 
 


### PR DESCRIPTION
## Summary
- refactor tests to use `resolve_path()` for locating fixtures
- adjust helper utilities to resolve logical fixture names internally

## Testing
- `pytest tests/test_redaction_utils.py -q`
- `pytest` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4dcd3e08832ea8af9486beee44b6