### PR TITLE
Handle Stripe key mismatches with rollback and error logs

### DIFF
--- a/tests/test_stripe_billing_router_mismatch.py
+++ b/tests/test_stripe_billing_router_mismatch.py
@@ -1,0 +1,39 @@
+from .test_stripe_billing_router_logging import _import_module
+
+
+def test_alert_mismatch_logs_error_and_rolls_back(monkeypatch, tmp_path):
+    sbr = _import_module(monkeypatch, tmp_path)
+
+    monkeypatch.setattr(sbr, "log_critical_discrepancy", lambda m, b: None)
+
+    rollback_info = {}
+
+    class DummyRM:
+        def rollback(self, tag, requesting_bot=None):
+            rollback_info["args"] = (tag, requesting_bot)
+
+    monkeypatch.setattr(sbr.rollback_manager, "RollbackManager", lambda: DummyRM())
+
+    log_event_data = {}
+    monkeypatch.setattr(
+        sbr.billing_logger, "log_event", lambda **kw: log_event_data.update(kw)
+    )
+
+    billing_event_data = {}
+    monkeypatch.setattr(
+        sbr, "log_billing_event", lambda action, **kw: billing_event_data.update({"action": action, **kw})
+    )
+
+    sbr._alert_mismatch("bot123", "acct_bad", amount=7.5)
+
+    assert rollback_info["args"] == ("latest", "bot123")
+    assert log_event_data["error"] is True
+    assert log_event_data["bot_id"] == "bot123"
+    assert log_event_data["destination_account"] == "acct_bad"
+    assert log_event_data["amount"] == 7.5
+    assert billing_event_data == {
+        "action": "mismatch",
+        "bot_id": "bot123",
+        "amount": 7.5,
+        "destination_account": "acct_bad",
+    }


### PR DESCRIPTION
## Summary
- trigger real rollbacks on Stripe account mismatches
- log billing mismatches with `error=1` and persist to billing ledger
- add test covering rollback and error logging

## Testing
- `python -m pytest tests/test_stripe_billing_router_mismatch.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba4eb99dfc832ea4ffc07d1b6cbb37