### PR TITLE
Fix mismatch alert rollback handling

### DIFF
--- a/stripe_billing_router.py
+++ b/stripe_billing_router.py
@@ -110,11 +110,7 @@ def _alert_mismatch(
 ) -> None:
     """Backward-compatible wrapper for critical discrepancy handling."""
 
-    log_critical_discrepancy(message, bot_id)
-    try:  # pragma: no cover - rollback side effects
-        rollback_manager.RollbackManager().rollback("latest", requesting_bot=bot_id)
-    except Exception:
-        logger.exception("rollback failed for bot '%s'", bot_id)
+    log_critical_discrepancy(bot_id, message)
     timestamp_ms = int(time.time() * 1000)
     billing_logger.log_event(
         error=True,


### PR DESCRIPTION
## Summary
- fix argument order when invoking `log_critical_discrepancy`
- avoid duplicate rollbacks by letting `log_critical_discrepancy` handle it
- adjust mismatch test to verify single rollback and correct alert invocation

## Testing
- `pytest tests/test_stripe_billing_router_mismatch.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba5330e6bc832ea093114b0be1b18e