### PR TITLE
Use resolve_path for workflow test modules

### DIFF
--- a/tests/test_workflow_evolution_behaviour.py
+++ b/tests/test_workflow_evolution_behaviour.py
@@ -162,7 +162,8 @@ def _load_manager(variant_rois, generate_calls=None, diminishing=0.05):
     sys.modules["menace_sandbox.evolution_history_db"] = evol_hist_mod
 
     spec = importlib.util.spec_from_file_location(
-        "menace_sandbox.workflow_evolution_manager", "workflow_evolution_manager.py"
+        "menace_sandbox.workflow_evolution_manager",
+        resolve_path("workflow_evolution_manager.py"),
     )
     wem = importlib.util.module_from_spec(spec)
     sys.modules["menace_sandbox.workflow_evolution_manager"] = wem
@@ -177,7 +178,7 @@ def _load_manager(variant_rois, generate_calls=None, diminishing=0.05):
 
 def test_variant_generation_obeys_dependencies(tmp_path, monkeypatch):
     base_src = resolve_path("tests/fixtures/workflow_modules")
-    for name in ["mod_a.py", "mod_b.py", "mod_c.py"]:
+    for name in ["mod_a.py", "mod_b.py", "mod_c.py"]:  # path-ignore
         # write modules without extension so ModuleIOAnalyzer resolves them
         (tmp_path / name[:-3]).write_text((base_src / name).read_text())
     monkeypatch.chdir(tmp_path)

--- a/tests/test_workflow_evolution_layer.py
+++ b/tests/test_workflow_evolution_layer.py
@@ -3,6 +3,7 @@ import sys
 from types import ModuleType, SimpleNamespace
 
 import pytest
+from dynamic_path_router import resolve_path
 
 
 @pytest.fixture
@@ -177,7 +178,7 @@ def evolution_setup():
     # finally load workflow evolution manager --------------------------
     spec = importlib.util.spec_from_file_location(
         "menace_sandbox.workflow_evolution_manager",
-        "workflow_evolution_manager.py",
+        resolve_path("workflow_evolution_manager.py"),
     )
     wem = importlib.util.module_from_spec(spec)
     sys.modules["menace_sandbox.workflow_evolution_manager"] = wem

--- a/tests/test_workflow_sim.py
+++ b/tests/test_workflow_sim.py
@@ -1,6 +1,8 @@
 import types
 import sys
 
+from dynamic_path_router import resolve_path
+
 if "filelock" not in sys.modules:
     fl = types.ModuleType("filelock")
 
@@ -142,7 +144,7 @@ def test_workflow_sim(monkeypatch, tmp_path):
     pkg.__path__ = [str(ROOT)]
     spec = importlib.util.spec_from_file_location(
         "menace.task_handoff_bot",
-        ROOT / "task_handoff_bot.py",
+        resolve_path("task_handoff_bot.py"),
         submodule_search_locations=[str(ROOT)],
     )
     thb = importlib.util.module_from_spec(spec)
@@ -260,7 +262,7 @@ def test_workflow_sim_multi_env(monkeypatch, tmp_path):
 
     spec = importlib.util.spec_from_file_location(
         "menace.task_handoff_bot",
-        ROOT / "task_handoff_bot.py",
+        resolve_path("task_handoff_bot.py"),
         submodule_search_locations=[str(ROOT)],
     )
     thb = importlib.util.module_from_spec(spec)
@@ -331,7 +333,7 @@ def test_workflow_sim_combined(monkeypatch, tmp_path):
 
     spec = importlib.util.spec_from_file_location(
         "menace.task_handoff_bot",
-        ROOT / "task_handoff_bot.py",
+        resolve_path("task_handoff_bot.py"),
         submodule_search_locations=[str(ROOT)],
     )
     thb = importlib.util.module_from_spec(spec)
@@ -401,7 +403,7 @@ def test_workflow_function_execution(monkeypatch, tmp_path):
     jinja_mod.Template = lambda *a, **k: None
     monkeypatch.setitem(sys.modules, "jinja2", jinja_mod)
 
-    step_mod = tmp_path / "wf_steps.py"
+    step_mod = tmp_path / "wf_steps.py"  # path-ignore
     step_mod.write_text(
         "import os\n"
         "def mark():\n"
@@ -413,7 +415,7 @@ def test_workflow_function_execution(monkeypatch, tmp_path):
 
     spec = importlib.util.spec_from_file_location(
         "menace.task_handoff_bot",
-        ROOT / "task_handoff_bot.py",
+        resolve_path("task_handoff_bot.py"),
         submodule_search_locations=[str(ROOT)],
     )
     thb = importlib.util.module_from_spec(spec)
@@ -483,7 +485,7 @@ def test_workflow_sim_details(monkeypatch, tmp_path):
 
     spec = importlib.util.spec_from_file_location(
         "menace.task_handoff_bot",
-        ROOT / "task_handoff_bot.py",
+        resolve_path("task_handoff_bot.py"),
         submodule_search_locations=[str(ROOT)],
     )
     thb = importlib.util.module_from_spec(spec)

--- a/tests/test_workflow_synthesizer.py
+++ b/tests/test_workflow_synthesizer.py
@@ -47,7 +47,7 @@ class StubIntent:
 
     def find_modules_related_to(self, _problem: str, top_k: int = 10):  # pragma: no cover - simple
         self.top_k_seen = top_k
-        return [SimpleNamespace(path=str(self.base / "mod_c.py"), score=1.0)]
+        return [SimpleNamespace(path=str(self.base / "mod_c.py"), score=1.0)]  # path-ignore
 
 
 def test_expand_cluster_merges_sources(tmp_path, monkeypatch):
@@ -318,7 +318,7 @@ class StubIntentDB:
         return [0.1]
 
     def search_by_vector(self, _vec, top_k: int = 50):  # pragma: no cover - simple
-        return [(str(self.base / "mod_b.py"), 0.1)]
+        return [(str(self.base / "mod_b.py"), 0.1)]  # path-ignore
 
 
 def test_generate_workflows_intent_db_scoring(tmp_path, monkeypatch):
@@ -353,8 +353,8 @@ def test_scoring_normalisation_and_penalty(tmp_path, monkeypatch):
 
         def find_modules_related_to(self, _problem: str, top_k: int = 10):
             return [
-                SimpleNamespace(path=str(self.base / "mod_b.py"), score=0.5),
-                SimpleNamespace(path=str(self.base / "mod_c.py"), score=1.0),
+                SimpleNamespace(path=str(self.base / "mod_b.py"), score=0.5),  # path-ignore
+                SimpleNamespace(path=str(self.base / "mod_c.py"), score=1.0),  # path-ignore
             ]
 
     intent = MultiIntent(tmp_path)

--- a/tests/test_workflow_synthesizer_cli_subprocess.py
+++ b/tests/test_workflow_synthesizer_cli_subprocess.py
@@ -56,13 +56,13 @@ class WorkflowSynthesizer:
 
 
 def _prepare(tmp_path: Path):
-    for name in ("mod_a.py", "mod_b.py", "mod_c.py"):
+    for name in ("mod_a.py", "mod_b.py", "mod_c.py"):  # path-ignore
         shutil.copy(
             resolve_path(f"tests/fixtures/workflow_modules/{name}"),
             tmp_path / name,
         )
-    (tmp_path / "workflow_synthesizer.py").write_text(STUB_MODULE)
-    (tmp_path / "sitecustomize.py").write_text(
+    (tmp_path / "workflow_synthesizer.py").write_text(STUB_MODULE)  # path-ignore
+    (tmp_path / "sitecustomize.py").write_text(  # path-ignore
         "import sys\n" "sys.stdin.isatty=lambda: True\n"
     )
     env = os.environ.copy()

--- a/tests/test_workflow_synthesizer_functions.py
+++ b/tests/test_workflow_synthesizer_functions.py
@@ -51,7 +51,7 @@ def test_generate_workflows_limit(tmp_path, monkeypatch):
 
 
 def test_synthesize_routing(tmp_path, monkeypatch):
-    (tmp_path / "mod_a.py").write_text("def start():\n    return 1\n")
+    (tmp_path / "mod_a.py").write_text("def start():\n    return 1\n")  # path-ignore
     monkeypatch.chdir(tmp_path)
 
     called = {}

--- a/unit_tests/test_prompt_path_resolution.py
+++ b/unit_tests/test_prompt_path_resolution.py
@@ -32,8 +32,8 @@ def test_error_logger_prompt_resolves_paths():
 def test_prompt_resolves_after_repo_move(tmp_path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()
-    (repo / "error_logger.py").write_text("pass", encoding="utf-8")
+    (repo / "error_logger.py").write_text("pass", encoding="utf-8")  # path-ignore
     monkeypatch.setenv("SANDBOX_REPO_PATH", str(repo))
     clear_cache()
     body = _visual_agent_prompt(path_for_prompt("error_logger.py"))
-    assert str(repo / "error_logger.py") in body
+    assert str(repo / "error_logger.py") in body  # path-ignore


### PR DESCRIPTION
## Summary
- resolve workflow manager and task handoff bot modules using dynamic_path_router
- flag temporary `.py` filenames with `# path-ignore` to satisfy static path checks

## Testing
- `python tools/check_static_paths.py tests/test_workflow_evolution_behaviour.py`
- `python tools/check_static_paths.py tests/test_workflow_evolution_layer.py`
- `python tools/check_static_paths.py tests/test_workflow_sim.py`
- `python tools/check_static_paths.py tests/test_workflow_synthesizer.py`
- `python tools/check_static_paths.py tests/test_workflow_synthesizer_cli_subprocess.py`
- `python tools/check_static_paths.py tests/test_workflow_synthesizer_functions.py`
- `python tools/check_static_paths.py unit_tests/test_prompt_path_resolution.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba55f5207c832ea12cf23f33771910