### PR TITLE
Fix static path usage in tests

### DIFF
--- a/tests/test_async_scheduler.py
+++ b/tests/test_async_scheduler.py
@@ -5,6 +5,8 @@ import os
 import types
 import pytest
 
+from dynamic_path_router import resolve_path
+
 ROOT = Path(__file__).resolve().parents[1]
 
 def load_mod(name, file):
@@ -20,8 +22,8 @@ def load_mod(name, file):
     spec.loader.exec_module(mod)
     return mod
 
-cms = load_mod('cross_model_scheduler', 'cross_model_scheduler.py')
-sts = load_mod('self_test_service', 'self_test_service.py')
+cms = load_mod('cross_model_scheduler', resolve_path('cross_model_scheduler.py'))
+sts = load_mod('self_test_service', resolve_path('self_test_service.py'))
 
 class DummyThread:
     def __init__(self, target=None, daemon=None):

--- a/tests/test_async_track_usage_warning.py
+++ b/tests/test_async_track_usage_warning.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from dynamic_path_router import resolve_path
 
 
 def test_meta_logger_requires_telemetry(monkeypatch):
@@ -12,7 +13,7 @@ def test_meta_logger_requires_telemetry(monkeypatch):
     monkeypatch.setitem(sys.modules, "sandbox_runner", pkg)
     monkeypatch.delitem(sys.modules, "sandbox_runner.cycle", raising=False)
 
-    path = Path(__file__).resolve().parent.parent / "sandbox_runner" / "meta_logger.py"
+    path = resolve_path("sandbox_runner/meta_logger.py")
     spec = importlib.util.spec_from_file_location("sandbox_runner.meta_logger", path)
     mod = importlib.util.module_from_spec(spec)
     monkeypatch.setitem(sys.modules, "sandbox_runner.meta_logger", mod)

--- a/tests/test_auto_include_isolated_cycle.py
+++ b/tests/test_auto_include_isolated_cycle.py
@@ -16,8 +16,8 @@ _integrate_orphans, _update_orphan_modules, _refresh_module_map, _test_orphan_mo
 def test_auto_include_isolated_cycle(monkeypatch, tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
-    (repo / "iso.py").write_text("import dep\n")
-    (repo / "dep.py").write_text("x = 1\n")
+    (repo / "iso.py").write_text("import dep\n")  # path-ignore
+    (repo / "dep.py").write_text("x = 1\n")  # path-ignore
 
     data_dir = tmp_path / "sandbox_data"
     data_dir.mkdir()
@@ -33,7 +33,7 @@ def test_auto_include_isolated_cycle(monkeypatch, tmp_path):
     def discover(path, *, recursive=True):
         called["recursive"] = recursive
         assert Path(path) == repo
-        return ["iso.py", "dep.py"]
+        return ["iso.py", "dep.py"]  # path-ignore
 
     mod.discover_isolated_modules = discover
     pkg = types.ModuleType("scripts")
@@ -55,7 +55,7 @@ def test_auto_include_isolated_cycle(monkeypatch, tmp_path):
     _update_orphan_modules(engine)
 
     data = json.loads((data_dir / "module_map.json").read_text())
-    assert set(data.get("modules", {})) == {"iso.py", "dep.py"}
+    assert set(data.get("modules", {})) == {"iso.py", "dep.py"}  # path-ignore
     orphans = json.loads((data_dir / "orphan_modules.json").read_text())
     assert orphans == []
     assert called.get("recursive") is True

--- a/tests/test_auto_include_metrics.py
+++ b/tests/test_auto_include_metrics.py
@@ -4,6 +4,7 @@ import types
 from pathlib import Path
 
 import sandbox_runner.environment as env
+from dynamic_path_router import resolve_path
 
 
 class DummyTracker:
@@ -43,10 +44,11 @@ def test_auto_include_modules_saves_roi(monkeypatch, tmp_path):
         ),
     )
 
-    result, tested = env.auto_include_modules(["mod.py"])
+    MOD = resolve_path("mod.py").as_posix()
+    result, tested = env.auto_include_modules([MOD])
 
     assert result is tracker
-    assert tested == {"added": ["mod.py"], "failed": [], "redundant": []}
+    assert tested == {"added": [MOD], "failed": [], "redundant": []}
     assert calls.get("run") is True
     history = Path(tmp_path, "roi_history.json")
     assert history.exists()

--- a/tests/test_autonomous_full_run.py
+++ b/tests/test_autonomous_full_run.py
@@ -4,11 +4,11 @@ import types
 import json
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+from dynamic_path_router import resolve_path
 
 
 def load_module():
-    path = ROOT / "run_autonomous.py"
+    path = resolve_path("run_autonomous.py")
     sys.modules.pop("menace", None)
     spec = importlib.util.spec_from_file_location("run_autonomous", str(path))
     mod = importlib.util.module_from_spec(spec)

--- a/tests/test_cli_cleanup.py
+++ b/tests/test_cli_cleanup.py
@@ -3,6 +3,8 @@ import sys
 import subprocess
 from pathlib import Path
 
+from dynamic_path_router import resolve_path
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -11,9 +13,9 @@ def test_cli_cleanup(tmp_path):
     sr = pkg / "sandbox_runner"
     sr.mkdir(parents=True)
     (sr / "__init__.py").write_text("")
-    cli_src = ROOT / "sandbox_runner" / "cli.py"
-    (sr / "cli.py").write_text(cli_src.read_text())
-    (sr / "environment.py").write_text(
+    cli_src = resolve_path("sandbox_runner/cli.py")
+    (sr / "cli.py").write_text(cli_src.read_text())  # path-ignore
+    (sr / "environment.py").write_text(  # path-ignore
         """
 import os
 from pathlib import Path
@@ -48,8 +50,8 @@ def retry_failed_cleanup():
     mn = pkg / "menace"
     mn.mkdir()
     (mn / "__init__.py").write_text("")
-    (mn / "metrics_dashboard.py").write_text("class MetricsDashboard: pass")
-    (mn / "environment_generator.py").write_text(
+    (mn / "metrics_dashboard.py").write_text("class MetricsDashboard: pass")  # path-ignore
+    (mn / "environment_generator.py").write_text(  # path-ignore
         "def generate_presets(n=None):\n    return [{}]\n"
     )
 


### PR DESCRIPTION
## Summary
- use dynamic_path_router.resolve_path for module references in tests
- mark temporary fixture files with `# path-ignore` comments

## Testing
- `python tools/check_static_paths.py tests/test_async_scheduler.py tests/test_async_track_usage_warning.py tests/test_auto_include_isolated_cycle.py tests/test_auto_include_metrics.py tests/test_auto_include_module_map.py tests/test_auto_include_recursive_validation.py tests/test_cli_cleanup.py tests/test_autonomous_full_run.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba58b10cf4832e8c2cac1172497dbd