### PR TITLE
test: mark or resolve .py paths

### DIFF
--- a/tests/test_chunking_split.py
+++ b/tests/test_chunking_split.py
@@ -39,7 +39,7 @@ def test_syntax_error_fallback() -> None:
 
 
 def test_get_chunk_summaries_cache_hit(tmp_path, monkeypatch):
-    file = tmp_path / "sample.py"
+    file = tmp_path / "sample.py"  # path-ignore
     file.write_text("def a():\n    return 1\n")
 
     calls = {"n": 0}
@@ -62,7 +62,7 @@ def test_get_chunk_summaries_cache_hit(tmp_path, monkeypatch):
 
 
 def test_get_chunk_summaries_cache_invalidation(tmp_path, monkeypatch):
-    file = tmp_path / "sample.py"
+    file = tmp_path / "sample.py"  # path-ignore
     file.write_text("def a():\n    return 1\n")
 
     calls = {"n": 0}

--- a/tests/test_database_steward_bot.py
+++ b/tests/test_database_steward_bot.py
@@ -33,7 +33,7 @@ def test_audit_and_dedup(tmp_path: Path):
 
 
 def test_error_bot_fix(tmp_path: Path):
-    admin = tmp_path / "admin.py"
+    admin = tmp_path / "admin.py"  # path-ignore
     admin.write_text("print('x')\n")
     err = eb.ErrorDB(tmp_path / "e.db")
     ebot = eb.ErrorBot(err)

--- a/tests/test_dbrouter_workflow_update_menace_integration.py
+++ b/tests/test_dbrouter_workflow_update_menace_integration.py
@@ -7,6 +7,8 @@ import types
 import sys
 from pathlib import Path
 
+from dynamic_path_router import resolve_path
+
 # Load modules without running package __init__
 ROOT = Path(__file__).resolve().parents[1]
 pkg = types.ModuleType("menace")
@@ -15,14 +17,18 @@ sys.modules["menace"] = pkg
 sys.modules.setdefault("pandas", types.ModuleType("pandas"))
 
 spec = importlib.util.spec_from_file_location(
-    "menace.databases", ROOT / "databases.py", submodule_search_locations=[str(ROOT)]
+    "menace.databases",
+    resolve_path("databases.py"),
+    submodule_search_locations=[str(ROOT)],
 )
 mn = importlib.util.module_from_spec(spec)
 sys.modules["menace.databases"] = mn
 spec.loader.exec_module(mn)
 
 spec = importlib.util.spec_from_file_location(
-    "menace.db_router", ROOT / "db_router.py", submodule_search_locations=[str(ROOT)]
+    "menace.db_router",
+    resolve_path("db_router.py"),
+    submodule_search_locations=[str(ROOT)],
 )
 dr = importlib.util.module_from_spec(spec)
 sys.modules["menace.db_router"] = dr

--- a/tests/test_dependency_utils_callbacks.py
+++ b/tests/test_dependency_utils_callbacks.py
@@ -6,8 +6,8 @@ from sandbox_runner.dependency_utils import collect_local_dependencies
 
 
 def _make_repo(tmp_path):
-    a = tmp_path / "a.py"
-    b = tmp_path / "b.py"
+    a = tmp_path / "a.py"  # path-ignore
+    b = tmp_path / "b.py"  # path-ignore
     a.write_text("import b\n")
     b.write_text("x = 1\n")
     return a, b

--- a/tests/test_dqn_synergy_learner_persistence.py
+++ b/tests/test_dqn_synergy_learner_persistence.py
@@ -6,6 +6,8 @@ import os
 import sys
 import types
 
+from dynamic_path_router import resolve_path
+
 import menace
 
 menace.RAISE_ERRORS = False
@@ -44,7 +46,7 @@ sys.modules.setdefault("sandbox_runner.bootstrap", bootstrap_mod)
 
 spec = importlib.util.spec_from_file_location(
     "menace.self_improvement.learners",
-    os.path.join(ROOT, "self_improvement", "learners.py"),
+    resolve_path("self_improvement/learners.py"),
 )
 sie = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = sie

--- a/tests/test_intent_clusterer_async.py
+++ b/tests/test_intent_clusterer_async.py
@@ -39,10 +39,10 @@ async def test_query_async_normalizes_vectors(monkeypatch):
     retr = DummyRetriever()
     clusterer = ic.IntentClusterer(retr)
     clusterer.cluster_map["a"] = [1]
-    retr.add_vector([0.1, 0.0], {"path": "a.py", "cluster_ids": [1]})
+    retr.add_vector([0.1, 0.0], {"path": "a.py", "cluster_ids": [1]})  # path-ignore
     monkeypatch.setattr(ic, "governed_embed", lambda text: [1.0, 1.0])
     res = await clusterer.query_async("anything", threshold=0.5)
-    assert res and res[0].path == "a.py" and res[0].similarity > 0.6
+    assert res and res[0].path == "a.py" and res[0].similarity > 0.6  # path-ignore
 
 
 @pytest.mark.asyncio
@@ -50,17 +50,17 @@ async def test_find_modules_related_to_async(monkeypatch):
     retr = DummyRetriever()
     clusterer = ic.IntentClusterer(retr)
     clusterer.cluster_map["a"] = [1]
-    retr.add_vector([0.1, 0.0], {"path": "a.py", "cluster_ids": [1]})
+    retr.add_vector([0.1, 0.0], {"path": "a.py", "cluster_ids": [1]})  # path-ignore
     monkeypatch.setattr(ic, "governed_embed", lambda text: [1.0, 1.0])
     res = await clusterer.find_modules_related_to_async("anything", top_k=1)
-    assert res and res[0].path == "a.py"
+    assert res and res[0].path == "a.py"  # path-ignore
 
 
 @pytest.mark.asyncio
 async def test_find_clusters_related_to_async_from_existing_store(monkeypatch, tmp_path: Path):
     retr = DummyRetriever()
     clusterer = ic.IntentClusterer(retr)
-    member = tmp_path / "m.py"
+    member = tmp_path / "m.py"  # path-ignore
     member.write_text('"""cluster helper"""')
     monkeypatch.setattr(
         ic,

--- a/tests/test_intent_clusterer_logging.py
+++ b/tests/test_intent_clusterer_logging.py
@@ -33,8 +33,8 @@ def test_load_synergy_groups_logs_failure(tmp_path, caplog, monkeypatch):
 def test_index_clusters_logs_failures(tmp_path, caplog, monkeypatch):
     monkeypatch.setattr(ic, "governed_embed", lambda text: [0.1, 0.2])
     clusterer = _make_clusterer(tmp_path)
-    clusterer.vectors["a.py"] = [0.1, 0.2]
-    groups = {"1": ["a.py"]}
+    clusterer.vectors["a.py"] = [0.1, 0.2]  # path-ignore
+    groups = {"1": ["a.py"]}  # path-ignore
 
     class BoomConn:
         def __enter__(self):
@@ -80,7 +80,7 @@ def test_post_init_logs_registration_failure(tmp_path, caplog, monkeypatch):
 
 
 def test_index_modules_logs_retriever_failure(tmp_path, caplog, monkeypatch):
-    module = tmp_path / "m.py"
+    module = tmp_path / "m.py"  # path-ignore
     module.write_text('"""doc"""\n')
     monkeypatch.setattr(ic, "governed_embed", lambda text: [0.1, 0.2])
     clusterer = _make_clusterer(tmp_path)

--- a/tests/test_local_knowledge_refresh_thread.py
+++ b/tests/test_local_knowledge_refresh_thread.py
@@ -5,6 +5,8 @@ import threading
 import logging
 from pathlib import Path
 
+from dynamic_path_router import resolve_path
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -100,7 +102,10 @@ def _load_run_autonomous(monkeypatch):
     for name, module in modules.items():
         monkeypatch.setitem(sys.modules, name, module)
 
-    spec = importlib.util.spec_from_file_location("run_autonomous", ROOT / "run_autonomous.py")
+    spec = importlib.util.spec_from_file_location(
+        "run_autonomous",
+        resolve_path("run_autonomous.py"),
+    )
     mod = importlib.util.module_from_spec(spec)
     monkeypatch.setitem(sys.modules, "run_autonomous", mod)
     spec.loader.exec_module(mod)

--- a/tests/test_orphan_workflow_integration.py
+++ b/tests/test_orphan_workflow_integration.py
@@ -20,7 +20,7 @@ def test_orphan_module_appends_to_existing_workflow(tmp_path, monkeypatch):
     class DummyIndex:
         def __init__(self, path: Path) -> None:
             self.path = path
-            self._map = {"existing.py": 1}
+            self._map = {"existing.py": 1}  # path-ignore
             self._groups = {"1": 1}
         def refresh(self, modules=None, force=False):
             for m in modules or []:
@@ -35,12 +35,12 @@ def test_orphan_module_appends_to_existing_workflow(tmp_path, monkeypatch):
     data_dir = tmp_path / "sandbox_data"
     data_dir.mkdir()
     map_path = data_dir / "module_map.json"
-    map_path.write_text(json.dumps({"modules": {"existing.py": 1}, "groups": {"1": 1}}))
+    map_path.write_text(json.dumps({"modules": {"existing.py": 1}, "groups": {"1": 1}}))  # path-ignore
 
     index = DummyIndex(map_path)
     engine = types.SimpleNamespace(
         module_index=index,
-        module_clusters={"existing.py": 1},
+        module_clusters={"existing.py": 1},  # path-ignore
         logger=DummyLogger(),
     )
     engine._collect_recursive_modules = lambda mods: set(mods)
@@ -71,8 +71,8 @@ def test_orphan_module_appends_to_existing_workflow(tmp_path, monkeypatch):
     monkeypatch.setitem(sys.modules, "sandbox_runner", sr)
 
     # create modules
-    (tmp_path / "existing.py").write_text("x = 1\n")
-    (tmp_path / "orphan.py").write_text("y = 2\n")
+    (tmp_path / "existing.py").write_text("x = 1\n")  # path-ignore
+    (tmp_path / "orphan.py").write_text("y = 2\n")  # path-ignore
 
     # simple workflow store
     workflows = {1: ["existing"]}
@@ -110,9 +110,9 @@ def test_orphan_module_appends_to_existing_workflow(tmp_path, monkeypatch):
     g["auto_include_modules"] = fake_auto
     g["analyze_redundancy"] = lambda p: False
 
-    engine._refresh_module_map(["orphan.py"])
+    engine._refresh_module_map(["orphan.py"])  # path-ignore
 
     # orphan module appended to existing workflow
     assert workflows[1] == ["existing", "orphan"]
     data = json.loads(map_path.read_text())
-    assert "orphan.py" in data["modules"]
+    assert "orphan.py" in data["modules"]  # path-ignore

--- a/tests/test_patch_history.py
+++ b/tests/test_patch_history.py
@@ -4,7 +4,7 @@ import menace.code_database as cd
 def test_patch_history_roundtrip(tmp_path):
     db = cd.PatchHistoryDB(tmp_path / "p.db")
     rec1 = cd.PatchRecord(
-        "a.py",
+        "a.py",  # path-ignore
         "desc",
         1.0,
         2.0,
@@ -19,7 +19,7 @@ def test_patch_history_roundtrip(tmp_path):
         version="1.0",
     )
     rec2 = cd.PatchRecord(
-        "b.py",
+        "b.py",  # path-ignore
         "bad",
         2.0,
         1.0,
@@ -35,17 +35,17 @@ def test_patch_history_roundtrip(tmp_path):
     db.add(rec1)
     db.add(rec2)
     top = db.top_patches()
-    assert top and top[0].filename == "a.py"
+    assert top and top[0].filename == "a.py"  # path-ignore
     rate = db.success_rate()
     assert rate == 0.5
 
 
 def test_branch_retrieval(tmp_path):
     db = cd.PatchHistoryDB(tmp_path / "p.db")
-    parent_id = db.add(cd.PatchRecord("a.py", "p", 1.0, 2.0))
+    parent_id = db.add(cd.PatchRecord("a.py", "p", 1.0, 2.0))  # path-ignore
     db.add(
         cd.PatchRecord(
-            "b.py",
+            "b.py",  # path-ignore
             "c",
             2.0,
             3.0,
@@ -61,7 +61,7 @@ def test_branch_retrieval(tmp_path):
 
 def test_keyword_features(tmp_path):
     db = cd.PatchHistoryDB(tmp_path / "p.db")
-    db.add(cd.PatchRecord("a.py", "topic ai development", 1.0, 2.0, trending_topic="AI"))
+    db.add(cd.PatchRecord("a.py", "topic ai development", 1.0, 2.0, trending_topic="AI"))  # path-ignore
     count, recency = db.keyword_features()
     assert count > 0
     assert isinstance(recency, int)
@@ -69,8 +69,8 @@ def test_keyword_features(tmp_path):
 
 def test_get_patch_record(tmp_path):
     db = cd.PatchHistoryDB(tmp_path / "p.db")
-    pid = db.add(cd.PatchRecord("a.py", "desc", 1.0, 2.0))
+    pid = db.add(cd.PatchRecord("a.py", "desc", 1.0, 2.0))  # path-ignore
     rec = db.get(pid)
     assert rec is not None
-    assert rec.filename == "a.py"
+    assert rec.filename == "a.py"  # path-ignore
     assert db.get(9999) is None

--- a/tests/test_telemetry_feedback.py
+++ b/tests/test_telemetry_feedback.py
@@ -69,7 +69,7 @@ def _setup(tmp_path, monkeypatch):
     )
     logger = elog.ErrorLogger(db)
     engine = DummyEngine()
-    mod = tmp_path / "bot.py"
+    mod = tmp_path / "bot.py"  # path-ignore
     mod.write_text("def x():\n    pass\n")
     return db, logger, engine, mod
 

--- a/tests/test_vault_secret_provider.py
+++ b/tests/test_vault_secret_provider.py
@@ -1,11 +1,13 @@
 import types
 import importlib.util
 
+from dynamic_path_router import resolve_path
+
 ROOT = __import__('pathlib').Path(__file__).resolve().parents[1]
 
 spec = importlib.util.spec_from_file_location(
     "menace.vault_secret_provider",
-    ROOT / "vault_secret_provider.py",
+    resolve_path("vault_secret_provider.py"),
     submodule_search_locations=[str(ROOT)],
 )
 mod = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
## Summary
- mark placeholder file names as `# path-ignore`
- load modules using `resolve_path` instead of raw file strings

## Testing
- `python tools/check_static_paths.py $(git ls-files 'tests/**/*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ba5a8b30e8832eab22416cb6b73bb5