### PR TITLE
Pause bots on Stripe account mismatches

### DIFF
--- a/sandbox_review.py
+++ b/sandbox_review.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import logging
+from typing import Set
+
+logger = logging.getLogger(__name__)
+
+# In-memory record of bots that have been paused for review.
+_PAUSED_BOTS: Set[str] = set()
+
+def pause_bot(bot_id: str) -> bool:
+    """Mark *bot_id* as paused/pending review.
+
+    The operation is idempotent; subsequent calls for the same bot have no
+    effect. Returns ``True`` when the bot was newly paused and ``False`` when it
+    was already paused.
+    """
+    if bot_id in _PAUSED_BOTS:
+        logger.debug("bot '%s' already paused", bot_id)
+        return False
+    _PAUSED_BOTS.add(bot_id)
+    logger.info("bot '%s' paused for review", bot_id)
+    return True
+
+def is_paused(bot_id: str) -> bool:
+    """Return ``True`` if *bot_id* has been paused."""
+    return bot_id in _PAUSED_BOTS
+
+def reset() -> None:
+    """Clear paused bot state (for tests)."""
+    _PAUSED_BOTS.clear()

--- a/stripe_billing_router.py
+++ b/stripe_billing_router.py
@@ -42,6 +42,7 @@ except Exception:  # pragma: no cover - simplified stubs
 from vault_secret_provider import VaultSecretProvider
 import alert_dispatcher
 import rollback_manager
+import sandbox_review
 
 try:  # optional dependency
     import stripe  # type: ignore
@@ -111,6 +112,11 @@ def _alert_mismatch(
     """Backward-compatible wrapper for critical discrepancy handling."""
 
     log_critical_discrepancy(bot_id, message)
+    # Pause the bot in the sandbox so further actions require review.
+    try:
+        sandbox_review.pause_bot(bot_id)
+    except Exception:  # pragma: no cover - pause is best effort
+        logger.exception("failed to pause bot '%s' for review", bot_id)
     timestamp_ms = int(time.time() * 1000)
     billing_logger.log_event(
         error=True,

--- a/tests/test_billing_router_logging.py
+++ b/tests/test_billing_router_logging.py
@@ -284,6 +284,8 @@ def test_alert_mismatch_invalid_key(monkeypatch):
             rollback_called(*a, **kw)
 
     monkeypatch.setattr(sbr.rollback_manager, "RollbackManager", lambda: DummyRollback())
+    pause = MagicMock()
+    monkeypatch.setattr(sbr.sandbox_review, "pause_bot", pause)
     monkeypatch.setattr(sbr.billing_logger, "log_event", MagicMock())
     monkeypatch.setattr(sbr, "log_billing_event", MagicMock())
 
@@ -296,6 +298,7 @@ def test_alert_mismatch_invalid_key(monkeypatch):
         "critical_discrepancy", 5, "Stripe key misconfiguration", {"bot": "stripe:cat:bot"}
     )
     rollback_called.assert_called_once_with("latest", requesting_bot="stripe:cat:bot")
+    pause.assert_called_once_with("stripe:cat:bot")
 
 
 def test_alert_mismatch_account_mismatch(monkeypatch):
@@ -310,6 +313,8 @@ def test_alert_mismatch_account_mismatch(monkeypatch):
             rollback_called(*a, **kw)
 
     monkeypatch.setattr(sbr.rollback_manager, "RollbackManager", lambda: DummyRollback())
+    pause = MagicMock()
+    monkeypatch.setattr(sbr.sandbox_review, "pause_bot", pause)
     monkeypatch.setattr(sbr.billing_logger, "log_event", MagicMock())
     monkeypatch.setattr(sbr, "log_billing_event", MagicMock())
 
@@ -320,4 +325,5 @@ def test_alert_mismatch_account_mismatch(monkeypatch):
         "critical_discrepancy", 5, "Stripe account mismatch", {"bot": "stripe:cat:bot"}
     )
     rollback_called.assert_called_once_with("latest", requesting_bot="stripe:cat:bot")
+    pause.assert_called_once_with("stripe:cat:bot")
 

--- a/tests/test_stripe_billing_router_mismatch.py
+++ b/tests/test_stripe_billing_router_mismatch.py
@@ -4,6 +4,7 @@ from .test_stripe_billing_router_logging import _import_module
 def test_alert_mismatch_logs_error_and_rolls_back(monkeypatch, tmp_path):
     sbr = _import_module(monkeypatch, tmp_path)
 
+    sbr.sandbox_review.reset()
     rollback_calls = []
 
     class DummyRM:
@@ -45,3 +46,4 @@ def test_alert_mismatch_logs_error_and_rolls_back(monkeypatch, tmp_path):
         "amount": 7.5,
         "destination_account": "acct_bad",
     }
+    assert sbr.sandbox_review.is_paused("bot123")


### PR DESCRIPTION
## Summary
- Add sandbox_review.pause_bot utility to track paused bots with audit logging
- Pause bots when Stripe account mismatches occur in stripe_billing_router
- Test pause behaviour ensuring bots are flagged on mismatches

## Testing
- `pytest tests/test_billing_router_logging.py::test_alert_mismatch_invalid_key tests/test_billing_router_logging.py::test_alert_mismatch_account_mismatch tests/test_stripe_billing_router_mismatch.py::test_alert_mismatch_logs_error_and_rolls_back -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba5df2bb7c832e96d7d88ef24122e8