### PR TITLE
Use resolve_path for prompt template path

### DIFF
--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -137,8 +137,10 @@ class RetryStrategy:
         raise RuntimeError("retry strategy exhausted")
 
 
-DEFAULT_TEMPLATE = Path(__file__).resolve().parent / "config" / "prompt_templates.v2.json"
-PROMPT_TEMPLATES_PATH = Path(os.getenv("PROMPT_TEMPLATES_PATH", DEFAULT_TEMPLATE))
+DEFAULT_TEMPLATE = resolve_path("config/prompt_templates.v2.json")
+PROMPT_TEMPLATES_PATH = resolve_path(
+    os.getenv("PROMPT_TEMPLATES_PATH") or DEFAULT_TEMPLATE
+)
 
 TEMPLATE_SECTION_KEY = "templates"
 TEMPLATE_VERSION_KEY = "version"


### PR DESCRIPTION
## Summary
- use dynamic_path_router.resolve_path for prompt template lookup
- ensure prompt template environment variable is resolved consistently

## Testing
- `python -m py_compile bot_development_bot.py`
- `python - <<'PY'
import sys, types, pytest
m = types.ModuleType('db_router')
m.DBRouter = object
m.init_db_router = lambda *a, **k: None
m.GLOBAL_ROUTER = None
m.MENACE_ID = 0
sys.modules['db_router'] = m
vs = types.ModuleType('vector_service')
class Dummy: pass
vs.ContextBuilder = Dummy
vs.FallbackResult = Dummy
vs.ErrorResult = Dummy
sys.modules['vector_service'] = vs
sys.exit(pytest.main(['tests/test_bot_development_bot.py::test_prompt_includes_standards', '-q']))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ba5f2f4c44832e9fd5f161b9f0870a