### PR TITLE
Use immutable Stripe account constant

### DIFF
--- a/docs/billing_router.md
+++ b/docs/billing_router.md
@@ -93,10 +93,11 @@ unavailable—and **must** contain the following fields:
 - ``raw_event_json`` – Raw JSON payload returned by Stripe.
 - ``error`` – ``1`` when a critical discrepancy occurs, otherwise ``0``.
 
-### Master account, allowed keys and rollback alerts
+### Registered account, allowed keys and rollback alerts
 
-The platform's Stripe master account identifier is hard coded as
-``stripe_billing_router.STRIPE_MASTER_ACCOUNT_ID``.  Secret keys that may be
+The platform's Stripe account identifier is hard coded as
+``stripe_billing_router.STRIPE_REGISTERED_ACCOUNT_ID`` and must not be
+overridden via environment variables or secret storage. Secret keys that may be
 used on behalf of the platform are enumerated via ``STRIPE_ALLOWED_SECRET_KEYS``
 (comma separated) or the ``allowed_secret_keys`` list in the routing
 configuration.
@@ -106,8 +107,8 @@ export STRIPE_ALLOWED_SECRET_KEYS=sk_prod_main,sk_prod_backup
 ```
 
 If an unknown key is supplied or a route's ``account_id`` differs from the
-master account, the router records the discrepancy in ``DiscrepancyDB``, sends a
-``critical_discrepancy`` alert and
+registered account, the router records the discrepancy in ``DiscrepancyDB``,
+sends a ``critical_discrepancy`` alert and
 ``AutomatedRollbackManager.auto_rollback`` reverts the most recent sandbox
 changes for the offending bot.
 

--- a/docs/stripe_billing_router.md
+++ b/docs/stripe_billing_router.md
@@ -173,10 +173,10 @@ following fields:
 Allowed secret keys are provided via the ``STRIPE_ALLOWED_SECRET_KEYS``
 environment variable (comma separated) or the ``allowed_secret_keys`` list in
 ``config/stripe_billing_router.yaml``. Routes may also include an
-``account_id`` which is cross‑checked against the configured master account.
+``account_id`` which is cross‑checked against the registered account.
 Before any Stripe action is executed, the router ensures the resolved
 ``secret_key`` is in the allowed list and that the route's ``account_id``
-matches the master account. If either check fails the router:
+matches the registered account. If either check fails the router:
 
 1. Records the discrepancy in :class:`DiscrepancyDB`.
 2. Dispatches a ``critical_discrepancy`` alert.
@@ -185,9 +185,10 @@ matches the master account. If either check fails the router:
 Investigate these alerts by inspecting the discrepancy record; they typically
 indicate a misconfigured key or account.
 
-The platform's master account identifier is embedded in
-``stripe_billing_router.STRIPE_MASTER_ACCOUNT_ID`` and no longer sourced from
-an environment variable.
+The platform's registered account identifier is hard coded as
+``stripe_billing_router.STRIPE_REGISTERED_ACCOUNT_ID``. This value is immutable
+and must never be overridden or sourced from environment variables or secret
+storage.
 
 A ``critical_discrepancy`` alert signals the automatic rollback described
 above; resolve the configuration issue before retrying the billing operation.

--- a/tests/test_billing_router_logging.py
+++ b/tests/test_billing_router_logging.py
@@ -53,7 +53,7 @@ import menace_sandbox.stripe_billing_router as sbr
 
 SECRET = "sk_live_123"
 PUBLIC = "pk_live_123"
-ACCOUNT = sbr.STRIPE_MASTER_ACCOUNT_ID
+ACCOUNT = sbr.STRIPE_REGISTERED_ACCOUNT_ID
 
 def test_charge_logs_events(monkeypatch):
     bot_id = "stripe:cat:bot"
@@ -64,7 +64,7 @@ def test_charge_logs_events(monkeypatch):
         "currency": "usd",
         "user_email": "user@example.com",
     }
-    event = {"id": "pi_1", "amount": 5000, "account": "acct_dest"}
+    event = {"id": "pi_1", "amount": 5000, "account": ACCOUNT}
 
     monkeypatch.setattr(sbr, "_resolve_route", lambda b, overrides=None: route)
     monkeypatch.setattr(sbr, "_verify_route", lambda b, r: None)
@@ -91,13 +91,13 @@ def test_charge_logs_events(monkeypatch):
     assert kwargs["timestamp_ms"] == 1_700_000_000_000
     assert kwargs["user_email"] == "user@example.com"
     assert kwargs["bot_id"] == bot_id
-    assert kwargs["destination_account"] == "acct_dest"
+    assert kwargs["destination_account"] == ACCOUNT
 
     kw = log_billing.call_args.kwargs
     assert kw["amount"] == 50.0
     assert kw["bot_id"] == bot_id
     assert kw["user_email"] == "user@example.com"
-    assert kw["destination_account"] == "acct_dest"
+    assert kw["destination_account"] == ACCOUNT
 
     ledger_args = ledger_log.call_args[0]
     assert ledger_args[0] == "charge"
@@ -116,7 +116,7 @@ def test_subscription_logs_events(monkeypatch):
         "currency": "usd",
         "user_email": "user@example.com",
     }
-    event = {"id": "sub_1", "account": "acct_dest"}
+    event = {"id": "sub_1", "account": ACCOUNT}
 
     class Client:
         Subscription = type("Sub", (), {"create": staticmethod(lambda **kw: event)})
@@ -148,7 +148,7 @@ def test_subscription_logs_events(monkeypatch):
     kwargs = log_event.call_args.kwargs
     assert kwargs["bot_id"] == bot_id
     assert kwargs["user_email"] == "user@example.com"
-    assert kwargs["destination_account"] == "acct_dest"
+    assert kwargs["destination_account"] == ACCOUNT
     assert kwargs["timestamp_ms"] == 1_700_000_000_000
     assert "amount" in kwargs
 
@@ -156,7 +156,7 @@ def test_subscription_logs_events(monkeypatch):
     assert kw["amount"] == pytest.approx(12.34)
     assert kw["bot_id"] == bot_id
     assert kw["user_email"] == "user@example.com"
-    assert kw["destination_account"] == "acct_dest"
+    assert kw["destination_account"] == ACCOUNT
 
     ledger_args = ledger_log.call_args[0]
     assert ledger_args[0] == "subscription"
@@ -175,7 +175,7 @@ def test_refund_logs_events(monkeypatch):
         "currency": "usd",
         "user_email": "user@example.com",
     }
-    event = {"id": "re_1", "amount": 5000, "account": "acct_dest"}
+    event = {"id": "re_1", "amount": 5000, "account": ACCOUNT}
 
     class Client:
         Refund = type("Refund", (), {"create": staticmethod(lambda **kw: event)})
@@ -200,14 +200,14 @@ def test_refund_logs_events(monkeypatch):
     assert kwargs["amount"] == 50.0
     assert kwargs["user_email"] == "user@example.com"
     assert kwargs["bot_id"] == bot_id
-    assert kwargs["destination_account"] == "acct_dest"
+    assert kwargs["destination_account"] == ACCOUNT
     assert kwargs["timestamp_ms"] == 1_700_000_000_000
 
     kw = log_billing.call_args.kwargs
     assert kw["amount"] == 50.0
     assert kw["bot_id"] == bot_id
     assert kw["user_email"] == "user@example.com"
-    assert kw["destination_account"] == "acct_dest"
+    assert kw["destination_account"] == ACCOUNT
 
     ledger_args = ledger_log.call_args[0]
     assert ledger_args[0] == "refund"
@@ -226,7 +226,7 @@ def test_checkout_session_logs_events(monkeypatch):
         "currency": "usd",
         "user_email": "user@example.com",
     }
-    event = {"id": "cs_1", "amount_total": 7000, "account": "acct_dest"}
+    event = {"id": "cs_1", "amount_total": 7000, "account": ACCOUNT}
 
     class Client:
         checkout = type(
@@ -255,14 +255,14 @@ def test_checkout_session_logs_events(monkeypatch):
     assert kwargs["amount"] == 70.0
     assert kwargs["user_email"] == "user@example.com"
     assert kwargs["bot_id"] == bot_id
-    assert kwargs["destination_account"] == "acct_dest"
+    assert kwargs["destination_account"] == ACCOUNT
     assert kwargs["timestamp_ms"] == 1_700_000_000_000
 
     kw = log_billing.call_args.kwargs
     assert kw["amount"] == 70.0
     assert kw["bot_id"] == bot_id
     assert kw["user_email"] == "user@example.com"
-    assert kw["destination_account"] == "acct_dest"
+    assert kw["destination_account"] == ACCOUNT
 
     ledger_args = ledger_log.call_args[0]
     assert ledger_args[0] == "checkout"

--- a/tests/test_finance_router_bot.py
+++ b/tests/test_finance_router_bot.py
@@ -219,6 +219,8 @@ def _load_stripe_router(monkeypatch, tmp_path, routes):
     )
     monkeypatch.setitem(sys.modules, "vault_secret_provider", vsp)
     monkeypatch.setenv("STRIPE_ALLOWED_SECRET_KEYS", "sk_live_dummy")
+    monkeypatch.delenv("STRIPE_SECRET_KEY", raising=False)
+    monkeypatch.delenv("STRIPE_PUBLIC_KEY", raising=False)
     cfg = tmp_path / "routes.yaml"
     cfg.write_text(yaml.safe_dump(routes))
     monkeypatch.setenv("STRIPE_ROUTING_CONFIG", str(cfg))
@@ -239,7 +241,7 @@ def _load_stripe_router(monkeypatch, tmp_path, routes):
     assert spec.loader is not None
     spec.loader.exec_module(module)
     monkeypatch.setattr(
-        module, "_get_account_id", lambda api_key: module.STRIPE_MASTER_ACCOUNT_ID
+        module, "_get_account_id", lambda api_key: module.STRIPE_REGISTERED_ACCOUNT_ID
     )
     monkeypatch.setattr(module.billing_logger, "log_event", lambda **kw: None)
     monkeypatch.setattr(module, "_verify_route", lambda *a, **k: None)

--- a/tests/test_investment_engine.py
+++ b/tests/test_investment_engine.py
@@ -183,6 +183,8 @@ def _load_stripe_router(monkeypatch, tmp_path, routes):
     )
     monkeypatch.setitem(sys.modules, "vault_secret_provider", vsp)
     monkeypatch.setenv("STRIPE_ALLOWED_SECRET_KEYS", "sk_live_dummy")
+    monkeypatch.delenv("STRIPE_SECRET_KEY", raising=False)
+    monkeypatch.delenv("STRIPE_PUBLIC_KEY", raising=False)
     cfg = tmp_path / "routes.yaml"
     cfg.write_text(yaml.safe_dump(routes))
     monkeypatch.setenv("STRIPE_ROUTING_CONFIG", str(cfg))
@@ -195,7 +197,7 @@ def _load_stripe_router(monkeypatch, tmp_path, routes):
     assert spec.loader is not None
     spec.loader.exec_module(module)
     monkeypatch.setattr(
-        module, "_get_account_id", lambda api_key: module.STRIPE_MASTER_ACCOUNT_ID
+        module, "_get_account_id", lambda api_key: module.STRIPE_REGISTERED_ACCOUNT_ID
     )
     monkeypatch.setattr(module.billing_logger, "log_event", lambda **kw: None)
     monkeypatch.setattr(module, "_verify_route", lambda *a, **k: None)

--- a/tests/test_stripe_billing_router.py
+++ b/tests/test_stripe_billing_router.py
@@ -84,7 +84,7 @@ def _import_module(monkeypatch, tmp_path, secrets=None):
     monkeypatch.setattr(sbr.billing_logger, "log_event", lambda **kw: None)
     monkeypatch.setattr(sbr, "log_billing_event", lambda *a, **k: None)
     monkeypatch.setattr(
-        sbr, "_get_account_id", lambda api_key: sbr.STRIPE_MASTER_ACCOUNT_ID
+        sbr, "_get_account_id", lambda api_key: sbr.STRIPE_REGISTERED_ACCOUNT_ID
     )
     return sbr
 

--- a/tests/test_stripe_billing_router_logging.py
+++ b/tests/test_stripe_billing_router_logging.py
@@ -107,7 +107,7 @@ def sbr_file_logger(monkeypatch, tmp_path):
     monkeypatch.setattr(sbr, "billing_logger", bl)
     monkeypatch.setattr(sbr, "record_payment", ledger_mod.record_payment)
     monkeypatch.setattr(
-        sbr, "_get_account_id", lambda api_key: sbr.STRIPE_MASTER_ACCOUNT_ID
+        sbr, "_get_account_id", lambda api_key: sbr.STRIPE_REGISTERED_ACCOUNT_ID
     )
     return sbr, ledger_file
 
@@ -116,7 +116,7 @@ def sbr_file_logger(monkeypatch, tmp_path):
 def sbr_basic(monkeypatch, tmp_path):
     sbr = _import_module(monkeypatch, tmp_path)
     monkeypatch.setattr(
-        sbr, "_get_account_id", lambda api_key: sbr.STRIPE_MASTER_ACCOUNT_ID
+        sbr, "_get_account_id", lambda api_key: sbr.STRIPE_REGISTERED_ACCOUNT_ID
     )
     monkeypatch.setattr(sbr, "record_payment", lambda *a, **k: None)
     monkeypatch.setattr(sbr, "_log_payment", lambda *a, **k: None)
@@ -141,7 +141,7 @@ def test_charge_logs_to_file(monkeypatch, sbr_file_logger):
         return {
             "id": invoice_id,
             "amount_paid": 1250,
-            "on_behalf_of": sbr.STRIPE_MASTER_ACCOUNT_ID,
+            "on_behalf_of": sbr.STRIPE_REGISTERED_ACCOUNT_ID,
         }
 
     fake_stripe = types.SimpleNamespace(
@@ -174,7 +174,7 @@ def test_refund_logs_to_file(monkeypatch, sbr_file_logger):
         return {
             "id": "rf_test",
             "amount": 500,
-            "on_behalf_of": sbr.STRIPE_MASTER_ACCOUNT_ID,
+            "on_behalf_of": sbr.STRIPE_REGISTERED_ACCOUNT_ID,
         }
 
     fake_stripe = types.SimpleNamespace(
@@ -202,7 +202,7 @@ def test_create_subscription_logs_to_file(monkeypatch, sbr_file_logger):
     sbr, ledger = sbr_file_logger
 
     def fake_create(*, api_key, **params):
-        return {"id": "sub_test", "on_behalf_of": sbr.STRIPE_MASTER_ACCOUNT_ID}
+        return {"id": "sub_test", "on_behalf_of": sbr.STRIPE_REGISTERED_ACCOUNT_ID}
 
     fake_stripe = types.SimpleNamespace(
         api_key="orig", Subscription=types.SimpleNamespace(create=fake_create)
@@ -230,7 +230,7 @@ def test_create_checkout_session_logs_to_file(monkeypatch, sbr_file_logger):
         return {
             "id": "cs_test",
             "amount_total": 1000,
-            "on_behalf_of": sbr.STRIPE_MASTER_ACCOUNT_ID,
+            "on_behalf_of": sbr.STRIPE_REGISTERED_ACCOUNT_ID,
         }
 
     fake_stripe = types.SimpleNamespace(
@@ -354,14 +354,14 @@ def test_logs_use_account_id_no_secret(monkeypatch, sbr_basic, setup_stripe, inv
     assert (
         captured_log_event
         and captured_log_event[-1]["destination_account"]
-        == sbr.STRIPE_MASTER_ACCOUNT_ID
+        == sbr.STRIPE_REGISTERED_ACCOUNT_ID
     )
     assert "sk_live_dummy" not in str(captured_log_event[-1])
     rec_args, rec_kwargs = captured_record[-1]
-    assert rec_args[3] == sbr.STRIPE_MASTER_ACCOUNT_ID
+    assert rec_args[3] == sbr.STRIPE_REGISTERED_ACCOUNT_ID
     assert "sk_live_dummy" not in (str(rec_args) + str(rec_kwargs))
     action, billing_kwargs = captured_billing[-1]
-    assert billing_kwargs["destination_account"] == sbr.STRIPE_MASTER_ACCOUNT_ID
+    assert billing_kwargs["destination_account"] == sbr.STRIPE_REGISTERED_ACCOUNT_ID
     assert "sk_live_dummy" not in str(billing_kwargs)
 
 

--- a/tests/test_stripe_ledger_logging.py
+++ b/tests/test_stripe_ledger_logging.py
@@ -99,7 +99,7 @@ def _import_module(monkeypatch, tmp_path, secrets=None):
 
     sbr = _load("stripe_billing_router")
     monkeypatch.setattr(
-        sbr, "_get_account_id", lambda api_key: sbr.STRIPE_MASTER_ACCOUNT_ID
+        sbr, "_get_account_id", lambda api_key: sbr.STRIPE_REGISTERED_ACCOUNT_ID
     )
     return sbr
 
@@ -134,7 +134,7 @@ def test_charge_writes_ledger(monkeypatch, sbr_with_db):
         return {
             "id": invoice_id,
             "amount_paid": 1250,
-            "on_behalf_of": sbr.STRIPE_MASTER_ACCOUNT_ID,
+            "on_behalf_of": sbr.STRIPE_REGISTERED_ACCOUNT_ID,
         }
 
     def fake_customer_retrieve(customer_id, *, api_key=None, **_):
@@ -161,14 +161,14 @@ def test_charge_writes_ledger(monkeypatch, sbr_with_db):
     assert events and events[0][0] == ("charge",)
     assert events[0][1]["amount"] == 12.5
     assert events[0][1]["user_email"] == "cust@example.com"
-    assert events[0][1]["destination_account"] == sbr.STRIPE_MASTER_ACCOUNT_ID
+    assert events[0][1]["destination_account"] == sbr.STRIPE_REGISTERED_ACCOUNT_ID
 
 
 def test_create_subscription_writes_ledger(monkeypatch, sbr_with_db):
     sbr, conn = sbr_with_db
 
     def fake_create(*, api_key, **params):
-        return {"id": "sub_test", "on_behalf_of": sbr.STRIPE_MASTER_ACCOUNT_ID}
+        return {"id": "sub_test", "on_behalf_of": sbr.STRIPE_REGISTERED_ACCOUNT_ID}
 
     def fake_customer_retrieve(customer_id, *, api_key=None, **_):
         return {"email": "cust@example.com"}
@@ -197,7 +197,7 @@ def test_create_subscription_writes_ledger(monkeypatch, sbr_with_db):
     assert events and events[0][0] == ("subscription",)
     assert events[0][1]["amount"] == 12.5
     assert events[0][1]["user_email"] == "cust@example.com"
-    assert events[0][1]["destination_account"] == sbr.STRIPE_MASTER_ACCOUNT_ID
+    assert events[0][1]["destination_account"] == sbr.STRIPE_REGISTERED_ACCOUNT_ID
 
 
 def test_refund_writes_ledger(monkeypatch, sbr_with_db):
@@ -207,7 +207,7 @@ def test_refund_writes_ledger(monkeypatch, sbr_with_db):
         return {
             "id": "rf_test",
             "amount": 500,
-            "on_behalf_of": sbr.STRIPE_MASTER_ACCOUNT_ID,
+            "on_behalf_of": sbr.STRIPE_REGISTERED_ACCOUNT_ID,
         }
 
     fake_stripe = types.SimpleNamespace(
@@ -228,7 +228,7 @@ def test_create_checkout_session_writes_ledger(monkeypatch, sbr_with_db):
         return {
             "id": "cs_test",
             "amount_total": 1000,
-            "on_behalf_of": sbr.STRIPE_MASTER_ACCOUNT_ID,
+            "on_behalf_of": sbr.STRIPE_REGISTERED_ACCOUNT_ID,
         }
 
     fake_stripe = types.SimpleNamespace(


### PR DESCRIPTION
## Summary
- hard-code STRIPE_REGISTERED_ACCOUNT_ID and use it for all route validation
- drop environment/secret fallbacks for master account
- document the immutability requirement for the Stripe account ID

## Testing
- `pytest tests/test_stripe_billing_router.py tests/test_stripe_billing_router_logging.py tests/test_stripe_ledger_logging.py tests/test_investment_engine.py tests/test_billing_router_logging.py tests/test_finance_router_bot.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba5f86916c832eabe6823671e37dfe