### PR TITLE
Use dynamic path resolver for snippet cache

### DIFF
--- a/chunking.py
+++ b/chunking.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, TYPE_CHECKING, Dict
+from typing import Dict, List, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
     from llm_interface import LLMClient
@@ -24,6 +24,7 @@ try:  # pragma: no cover - optional settings dependency
 except Exception:  # pragma: no cover - allow running without settings
     SandboxSettings = None  # type: ignore
 
+from dynamic_path_router import resolve_path
 from chunk_summary_cache import ChunkSummaryCache
 
 _ENCODER = None
@@ -36,7 +37,7 @@ if tiktoken is not None:  # pragma: no branch - simple import logic
 # Directory used for caching summaries of individual code snippets.  Sharing the
 # directory with :class:`ChunkSummaryCache` keeps cache files in one place and
 # mirrors the behaviour of the removed ``chunk_summarizer`` module.
-SNIPPET_CACHE_DIR = Path(__file__).resolve().parent / "chunk_summary_cache"
+SNIPPET_CACHE_DIR = resolve_path("chunk_summary_cache")
 
 
 def _ensure_snippet_cache_dir() -> None:


### PR DESCRIPTION
## Summary
- resolve snippet cache directory via `resolve_path` instead of relying on `Path(__file__)`

## Testing
- `pytest tests/test_chunking_cache.py -q`
- `pytest tests/test_chunk_summary_cache.py -q`
- `pytest tests/test_chunking_split.py -q`
- `pytest tests/test_chunk_workflow.py -q`
- `pytest tests/test_prompt_engine_chunk_summaries.py -q`
- `pytest unit_tests/test_chunking.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba601854f8832e9ac99d24d6b5f903