### PR TITLE
Validate Stripe account in billing responses

### DIFF
--- a/stripe_billing_router.py
+++ b/stripe_billing_router.py
@@ -669,8 +669,6 @@ def charge(
                 or (event.get("transfer_data") or {}).get("destination")
                 or destination
             )
-        _validate_destination(bot_id, destination)
-
         logged_amount = amt
         if logged_amount is None and isinstance(event, Mapping):
             possible = event.get("amount") or event.get("amount_paid")
@@ -679,6 +677,12 @@ def charge(
                     logged_amount = float(possible) / 100.0
                 except (TypeError, ValueError):
                     logged_amount = None
+
+        mismatch = False
+        if destination and destination != STRIPE_REGISTERED_ACCOUNT_ID:
+            _alert_mismatch(bot_id, destination, amount=logged_amount)
+            had_error = True
+            mismatch = True
 
         raw_json = None
         if isinstance(event, Mapping):
@@ -743,6 +747,8 @@ def charge(
             account_id,
             timestamp_ms,
         )
+        if mismatch:
+            raise RuntimeError("Stripe account mismatch")
 
 
 # Backward compatibility
@@ -855,7 +861,11 @@ def create_subscription(
                 or (event.get("transfer_data") or {}).get("destination")
                 or destination
             )
-        _validate_destination(bot_id, destination)
+        mismatch = False
+        if destination and destination != STRIPE_REGISTERED_ACCOUNT_ID:
+            _alert_mismatch(bot_id, destination)
+            had_error = True
+            mismatch = True
         raw_json = None
         if isinstance(event, Mapping):
             try:
@@ -917,6 +927,8 @@ def create_subscription(
             account_id,
             timestamp_ms,
         )
+        if mismatch:
+            raise RuntimeError("Stripe account mismatch")
 
 
 def refund(
@@ -994,7 +1006,11 @@ def refund(
                     logged_amount = float(possible) / 100.0
                 except (TypeError, ValueError):
                     logged_amount = None
-        _validate_destination(bot_id, destination)
+        mismatch = False
+        if destination and destination != STRIPE_REGISTERED_ACCOUNT_ID:
+            _alert_mismatch(bot_id, destination, amount=logged_amount)
+            had_error = True
+            mismatch = True
         raw_json = None
         if isinstance(event, Mapping):
             try:
@@ -1040,6 +1056,8 @@ def refund(
             account_id,
             timestamp_ms,
         )
+        if mismatch:
+            raise RuntimeError("Stripe account mismatch")
 
 
 def create_checkout_session(
@@ -1109,7 +1127,11 @@ def create_checkout_session(
                     logged_amount = float(possible) / 100.0
                 except (TypeError, ValueError):
                     logged_amount = None
-        _validate_destination(bot_id, destination)
+        mismatch = False
+        if destination and destination != STRIPE_REGISTERED_ACCOUNT_ID:
+            _alert_mismatch(bot_id, destination, amount=logged_amount)
+            had_error = True
+            mismatch = True
         raw_json = None
         if isinstance(event, Mapping):
             try:
@@ -1155,6 +1177,8 @@ def create_checkout_session(
             account_id,
             timestamp_ms,
         )
+        if mismatch:
+            raise RuntimeError("Stripe account mismatch")
 
 
 __all__ = [

--- a/tests/test_stripe_billing_router_destination_mismatch.py
+++ b/tests/test_stripe_billing_router_destination_mismatch.py
@@ -1,0 +1,131 @@
+import types
+
+import pytest
+
+from .test_stripe_billing_router_logging import _import_module
+
+
+@pytest.fixture
+def sbr(monkeypatch, tmp_path):
+    sbr = _import_module(monkeypatch, tmp_path)
+    monkeypatch.setattr(sbr, "_get_account_id", lambda api_key: sbr.STRIPE_REGISTERED_ACCOUNT_ID)
+    monkeypatch.setattr(sbr, "record_payment", lambda *a, **k: None)
+    monkeypatch.setattr(sbr, "_log_payment", lambda *a, **k: None)
+    monkeypatch.setattr(sbr, "log_billing_event", lambda *a, **k: None)
+    monkeypatch.setattr(sbr, "_client", lambda api_key: None)
+    return sbr
+
+
+def _get_action_log(calls, action):
+    for call in calls:
+        if call.get("action_type") == action:
+            return call
+    return {}
+
+
+def test_charge_blocks_on_mismatch(monkeypatch, sbr):
+    sbr.ROUTING_TABLE[("stripe", "default", "finance", "finance_router_bot")].pop(
+        "price_id", None
+    )
+    fake_stripe = types.SimpleNamespace(
+        PaymentIntent=types.SimpleNamespace(
+            create=lambda **kw: {"id": "pi", "on_behalf_of": "acct_bad"}
+        )
+    )
+    monkeypatch.setattr(sbr, "stripe", fake_stripe)
+    alerts = []
+    monkeypatch.setattr(
+        sbr,
+        "_alert_mismatch",
+        lambda bot_id, account_id, message="Stripe account mismatch", amount=None: alerts.append(
+            (bot_id, account_id, amount)
+        ),
+    )
+    logs = []
+    monkeypatch.setattr(sbr.billing_logger, "log_event", lambda **kw: logs.append(kw))
+    with pytest.raises(RuntimeError, match="Stripe account mismatch"):
+        sbr.charge("finance:finance_router_bot", amount=5.0, description="d")
+    assert alerts == [("finance:finance_router_bot", "acct_bad", 5.0)]
+    log = _get_action_log(logs, "charge")
+    assert log["error"] is True and log["destination_account"] == "acct_bad"
+
+
+def test_subscription_blocks_on_mismatch(monkeypatch, sbr):
+    fake_stripe = types.SimpleNamespace(
+        Subscription=types.SimpleNamespace(
+            create=lambda **kw: {"id": "sub", "account": "acct_bad"}
+        )
+    )
+    monkeypatch.setattr(sbr, "stripe", fake_stripe)
+    alerts = []
+    monkeypatch.setattr(
+        sbr,
+        "_alert_mismatch",
+        lambda bot_id, account_id, message="Stripe account mismatch", amount=None: alerts.append(
+            (bot_id, account_id)
+        ),
+    )
+    logs = []
+    monkeypatch.setattr(sbr.billing_logger, "log_event", lambda **kw: logs.append(kw))
+    with pytest.raises(RuntimeError, match="Stripe account mismatch"):
+        sbr.create_subscription("finance:finance_router_bot")
+    assert alerts == [("finance:finance_router_bot", "acct_bad")]
+    log = _get_action_log(logs, "subscription")
+    assert log["error"] is True and log["destination_account"] == "acct_bad"
+
+
+def test_refund_blocks_on_mismatch(monkeypatch, sbr):
+    fake_stripe = types.SimpleNamespace(
+        Refund=types.SimpleNamespace(
+            create=lambda **kw: {"id": "rf", "amount": 500, "on_behalf_of": "acct_bad"}
+        )
+    )
+    monkeypatch.setattr(sbr, "stripe", fake_stripe)
+    alerts = []
+    monkeypatch.setattr(
+        sbr,
+        "_alert_mismatch",
+        lambda bot_id, account_id, message="Stripe account mismatch", amount=None: alerts.append(
+            (bot_id, account_id, amount)
+        ),
+    )
+    logs = []
+    monkeypatch.setattr(sbr.billing_logger, "log_event", lambda **kw: logs.append(kw))
+    with pytest.raises(RuntimeError, match="Stripe account mismatch"):
+        sbr.refund("finance:finance_router_bot", "pi", amount=5.0)
+    assert alerts == [("finance:finance_router_bot", "acct_bad", 5.0)]
+    log = _get_action_log(logs, "refund")
+    assert log["error"] is True and log["destination_account"] == "acct_bad"
+
+
+def test_checkout_session_blocks_on_mismatch(monkeypatch, sbr):
+    fake_stripe = types.SimpleNamespace(
+        checkout=types.SimpleNamespace(
+            Session=types.SimpleNamespace(
+                create=lambda **kw: {
+                    "id": "cs",
+                    "account": "acct_bad",
+                    "amount_total": 500,
+                }
+            )
+        )
+    )
+    monkeypatch.setattr(sbr, "stripe", fake_stripe)
+    alerts = []
+    monkeypatch.setattr(
+        sbr,
+        "_alert_mismatch",
+        lambda bot_id, account_id, message="Stripe account mismatch", amount=None: alerts.append(
+            (bot_id, account_id, amount)
+        ),
+    )
+    logs = []
+    monkeypatch.setattr(sbr.billing_logger, "log_event", lambda **kw: logs.append(kw))
+    with pytest.raises(RuntimeError, match="Stripe account mismatch"):
+        sbr.create_checkout_session(
+            "finance:finance_router_bot",
+            line_items=[{"price": "price_finance_standard", "quantity": 1}],
+        )
+    assert alerts == [("finance:finance_router_bot", "acct_bad", 5.0)]
+    log = _get_action_log(logs, "checkout_session")
+    assert log["error"] is True and log["destination_account"] == "acct_bad"


### PR DESCRIPTION
## Summary
- Ensure charge, subscription, refund and checkout helpers verify the destination account in Stripe responses
- Alert and raise on Stripe account mismatches while flagging billing log entries
- Add tests covering account mismatch handling for each helper

## Testing
- `pytest tests/test_stripe_billing_router_logging.py tests/test_stripe_billing_router_mismatch.py tests/test_stripe_billing_router_destination_mismatch.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba6138e158832ea8a3d8dad72c5e68