### PR TITLE
Use resolve_path for pyproject location

### DIFF
--- a/startup_checks.py
+++ b/startup_checks.py
@@ -35,7 +35,7 @@ CRITICAL_LIBS: Dict[str, str] = {
 }
 
 # Default path to the repository's ``pyproject.toml``
-PYPROJECT_PATH = Path(__file__).resolve().with_name("pyproject.toml")
+PYPROJECT_PATH = resolve_path("pyproject.toml")
 
 REQUIRED_VARS = [
     "DATABASE_URL",


### PR DESCRIPTION
## Summary
- resolve `pyproject.toml` using `resolve_path` in startup checks

## Testing
- `pytest menace_sandbox/tests/test_startup_checks.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba61563354832e83b3bbc687c0244d