### PR TITLE
Lock stripe mismatches

### DIFF
--- a/stripe_billing_router.py
+++ b/stripe_billing_router.py
@@ -111,6 +111,9 @@ def _alert_mismatch(
 ) -> None:
     """Backward-compatible wrapper for critical discrepancy handling."""
 
+    from evolution_lock_flag import trigger_lock
+
+    trigger_lock(f"Stripe account mismatch for {bot_id}", severity=5)
     log_critical_discrepancy(bot_id, message)
     # Pause the bot in the sandbox so further actions require review.
     try:


### PR DESCRIPTION
## Summary
- Trigger global evolution lock when a Stripe account mismatch occurs
- Verify lock trigger alongside existing rollback and alert flows

## Testing
- `pytest tests/test_stripe_billing_router_mismatch.py tests/test_billing_router_logging.py tests/test_stripe_billing_router_destination_mismatch.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba644467f0832ebb53947b4f9d0fd9