### PR TITLE
Use resolve_path for neurosales assets

### DIFF
--- a/neurosales/neurosales/policy_learning.py
+++ b/neurosales/neurosales/policy_learning.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import math
-import os
 import json
 import random
+from pathlib import Path
 from typing import Dict, List, Tuple
+
+from dynamic_path_router import resolve_path
 
 from .rl_integration import ReplayBuffer, Experience
 from .rlhf import RLHFPolicyManager
@@ -94,8 +96,10 @@ class PolicyLearner:
         self.tactics = tactics
         self.brain = PPOBrain(state_dim, actions, lr=lr)
         if weights_path is None:
-            weights_path = os.path.join(os.path.dirname(__file__), "policy_params.json")
-        if os.path.exists(weights_path):
+            weights_path = resolve_path("neurosales") / "policy_params.json"
+        else:
+            weights_path = Path(weights_path)
+        if weights_path.exists():
             try:
                 with open(weights_path) as f:
                     self.brain.params = json.load(f)

--- a/neurosales/neurosales/rl_training.py
+++ b/neurosales/neurosales/rl_training.py
@@ -7,6 +7,7 @@ from typing import Optional, List, Dict
 import csv
 
 from joblib import dump
+from dynamic_path_router import resolve_path
 
 from .sql_db import create_session, RLFeedback, RewardEntry, ensure_schema
 from .rl_integration import DatabaseRLResponseRanker
@@ -107,7 +108,7 @@ def train_models(
         ranker.log_outcome("trainer", state, action, reward, state, actions)
         learner.brain.update(list(state), action, reward)
 
-    weights_path = os.path.join(os.path.dirname(__file__), "policy_params.json")
+    weights_path = resolve_path("neurosales") / "policy_params.json"
     with open(weights_path, "w") as f:
         json.dump(learner.brain.params, f)
     print(f"Policy weights saved to {weights_path}")
@@ -138,7 +139,7 @@ def train_engagement_model(dataset_path: str) -> None:
 
     model = LinearRegression()
     model.fit(np.array(X), np.array(y))
-    model_path = os.path.join(os.path.dirname(__file__), "engagement_model.joblib")
+    model_path = resolve_path("neurosales") / "engagement_model.joblib"
     dump(model, model_path)
     print(f"Engagement model saved to {model_path}")
 

--- a/neurosales/neurosales/scoring.py
+++ b/neurosales/neurosales/scoring.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import heapq
 import json
-import os
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
 import logging
+
+from dynamic_path_router import resolve_path
 
 logger = logging.getLogger(__name__)
 
@@ -96,10 +97,9 @@ class CandidateResponseScorer:
         if self._lr is not None:
             try:
                 from joblib import load  # type: ignore
-                import os
 
-                model_path = os.path.join(os.path.dirname(__file__), "engagement_model.joblib")
-                if os.path.exists(model_path):
+                model_path = resolve_path("neurosales") / "engagement_model.joblib"
+                if model_path.exists():
                     self._lr = load(model_path)
                     self._model_loaded = True
             except Exception:  # pragma: no cover - fallback to heuristic
@@ -113,8 +113,8 @@ class CandidateResponseScorer:
 
         self.policy_params = None
         try:
-            weights_path = os.path.join(os.path.dirname(__file__), "policy_params.json")
-            if os.path.exists(weights_path):
+            weights_path = resolve_path("neurosales") / "policy_params.json"
+            if weights_path.exists():
                 with open(weights_path) as pf:
                     self.policy_params = json.load(pf)
         except Exception:

--- a/neurosales/scripts/train_engagement.py
+++ b/neurosales/scripts/train_engagement.py
@@ -3,6 +3,9 @@ import csv
 from pathlib import Path
 from dotenv import load_dotenv
 
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from dynamic_path_router import resolve_path
+
 import numpy as np
 from sklearn.linear_model import LinearRegression
 from joblib import dump
@@ -22,10 +25,9 @@ def load_data(path: Path):
 
 
 def main() -> None:
-    root = Path(__file__).resolve().parents[1]
-    default_path = root / "tests" / "data" / "engagement_train.csv"
+    default_path = resolve_path("neurosales/tests/data/engagement_train.csv")
     data_path = Path(sys.argv[1]) if len(sys.argv) > 1 else default_path
-    model_path = root / "neurosales" / "engagement_model.joblib"
+    model_path = resolve_path("neurosales") / "engagement_model.joblib"
 
     X, y = load_data(data_path)
     model = LinearRegression()

--- a/neurosales/scripts/train_policy.py
+++ b/neurosales/scripts/train_policy.py
@@ -4,6 +4,8 @@ import sys
 from pathlib import Path
 from dotenv import load_dotenv
 
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from dynamic_path_router import resolve_path
 from neurosales.policy_learning import PolicyLearner
 
 load_dotenv()
@@ -31,8 +33,12 @@ def _infer_spec(records):
 
 
 def main() -> None:
-    root = Path(__file__).resolve().parents[1]
-    dataset = Path(sys.argv[1]) if len(sys.argv) > 1 else root / "tests" / "data" / "policy_train.json"
+    root = resolve_path(".")
+    dataset = (
+        Path(sys.argv[1])
+        if len(sys.argv) > 1
+        else resolve_path("neurosales/tests/data/policy_train.json")
+    )
     records = _load_records(dataset)
     actions, state_dim = _infer_spec(records)
     tactics = {a: "flat" for a in actions}
@@ -42,7 +48,7 @@ def main() -> None:
         json.dump(records, f)
     learner.train_from_dataset(str(tmp_path))
     tmp_path.unlink()
-    weights_path = root / "neurosales" / "policy_params.json"
+    weights_path = resolve_path("neurosales") / "policy_params.json"
     with open(weights_path, "w") as f:
         json.dump(learner.brain.params, f)
     print(f"Weights saved to {weights_path}")

--- a/neurosales/tests/test_candidate_response_scorer.py
+++ b/neurosales/tests/test_candidate_response_scorer.py
@@ -20,7 +20,7 @@ stub_user_prefs.PreferenceProfile = type("PP", (), {"embedding": []})
 
 spec = importlib.util.spec_from_file_location(
     "neurosales.scoring",
-    str(resolve_path("neurosales/scoring.py")),
+    str(resolve_path("neurosales/neurosales/scoring.py")),
 )
 scoring = importlib.util.module_from_spec(spec)
 sys.modules.setdefault("neurosales", types.ModuleType("neurosales"))
@@ -33,8 +33,8 @@ CandidateResponseScorer = scoring.CandidateResponseScorer
 
 
 def test_engagement_prediction_changes_after_training(tmp_path):
-    model_path = os.path.join(os.path.dirname(scoring.__file__), "engagement_model.joblib")
-    if os.path.exists(model_path):
+    model_path = resolve_path("neurosales") / "engagement_model.joblib"
+    if model_path.exists():
         os.remove(model_path)
 
     scorer = CandidateResponseScorer()


### PR DESCRIPTION
## Summary
- rely on `resolve_path` to locate neurosales policy and engagement resources instead of `os.path`
- update training scripts and unit tests to use `resolve_path`

## Testing
- `pytest neurosales/tests/test_candidate_response_scorer.py -q`
- `pytest neurosales/tests/test_policy_learning.py -q` *(fails: module 'sqlalchemy' has no attribute 'Column')*


------
https://chatgpt.com/codex/tasks/task_e_68ba681c18b8832e8cea1ad510d695b5