### PR TITLE
Use resolve_path for SQL templates

### DIFF
--- a/scripts/new_db_template.py
+++ b/scripts/new_db_template.py
@@ -37,6 +37,7 @@ import logging
 from embeddable_db_mixin import EmbeddableDBMixin
 from license_detector import detect as detect_license
 from security.secret_redactor import redact_dict
+from dynamic_path_router import resolve_path
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +74,7 @@ class {class_name}(EmbeddableDBMixin):
             embedding_version=embedding_version,
             backend=vector_backend,
         )
-        schema = Path(__file__).with_name("sql_templates").joinpath("create_fts.sql").read_text()
+        schema = resolve_path("sql_templates/create_fts.sql").read_text()
         schema = schema.replace("code_fts", "{snake}_fts")
         self.conn.executescript(schema)
         self.conn.execute(

--- a/scripts/new_vector_module.py
+++ b/scripts/new_vector_module.py
@@ -39,6 +39,7 @@ import logging
 from embeddable_db_mixin import EmbeddableDBMixin
 from license_detector import detect as detect_license
 from security.secret_redactor import redact_dict
+from dynamic_path_router import resolve_path
 
 logger = logging.getLogger(__name__)
 
@@ -75,9 +76,7 @@ class {class_name}(EmbeddableDBMixin):
             embedding_version=embedding_version,
             backend=vector_backend,
         )
-        schema = (
-            Path(__file__).with_name("sql_templates").joinpath("create_fts.sql").read_text()
-        )
+        schema = resolve_path("sql_templates/create_fts.sql").read_text()
         schema = schema.replace("code_fts", "{snake}_fts")
         self.conn.executescript(schema)
         self.conn.execute(

--- a/scripts/scaffold_db.py
+++ b/scripts/scaffold_db.py
@@ -36,6 +36,7 @@ import logging
 from embeddable_db_mixin import EmbeddableDBMixin
 from license_detector import detect as detect_license
 from unsafe_patterns import find_matches as find_unsafe
+from dynamic_path_router import resolve_path
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +67,7 @@ class {class_name}(EmbeddableDBMixin):
             embedding_version=embedding_version,
             backend=vector_backend,
         )
-        schema = Path(__file__).with_name("sql_templates").joinpath("create_fts.sql").read_text()
+        schema = resolve_path("sql_templates/create_fts.sql").read_text()
         schema = schema.replace("code_fts", "{snake}_fts")
         self.conn.executescript(schema)
         self.conn.execute(


### PR DESCRIPTION
## Summary
- load SQL template files via `resolve_path`
- ensure scaffolding modules import `resolve_path`

## Testing
- `MENACE_LOCAL_DB_PATH=./test_local.db MENACE_SHARED_DB_PATH=./test_shared.db pytest -q tests/test_new_db_scaffold.py`
- `MENACE_LOCAL_DB_PATH=./test_local.db MENACE_SHARED_DB_PATH=./test_shared.db pytest -q tests/test_menace_cli_new_db.py` *(fails: ImportError: cannot import name 'load_plugins' from 'menace.plugins')*


------
https://chatgpt.com/codex/tasks/task_e_68ba6ad2126c832ea809d29cc3053fdb