### PR TITLE
Resolve snippet cache path via dynamic repo roots

### DIFF
--- a/chunking.py
+++ b/chunking.py
@@ -37,7 +37,12 @@ if tiktoken is not None:  # pragma: no branch - simple import logic
 # Directory used for caching summaries of individual code snippets.  Sharing the
 # directory with :class:`ChunkSummaryCache` keeps cache files in one place and
 # mirrors the behaviour of the removed ``chunk_summarizer`` module.
-SNIPPET_CACHE_DIR = resolve_path("chunk_summary_cache")
+try:
+    SNIPPET_CACHE_DIR = resolve_path("chunk_summary_cache")
+except FileNotFoundError:
+    from dynamic_path_router import get_project_root
+
+    SNIPPET_CACHE_DIR = get_project_root() / "chunk_summary_cache"
 
 
 def _ensure_snippet_cache_dir() -> None:
@@ -315,7 +320,7 @@ _SETTINGS = SandboxSettings() if SandboxSettings else None
 # be overridden by reassigning ``CHUNK_CACHE`` or by providing a custom cache
 # instance to :func:`get_chunk_summaries`.
 CHUNK_CACHE = ChunkSummaryCache(
-    (_SETTINGS.chunk_summary_cache_dir if _SETTINGS else Path("chunk_summary_cache"))
+    (_SETTINGS.chunk_summary_cache_dir if _SETTINGS else SNIPPET_CACHE_DIR)
 )
 
 # Per-path locks to avoid duplicate work when multiple threads request summaries

--- a/tests/test_chunking_cache_sandbox_path.py
+++ b/tests/test_chunking_cache_sandbox_path.py
@@ -1,0 +1,21 @@
+import importlib
+import shutil
+import sys
+
+
+def test_snippet_cache_dir_created_with_sandbox_repo_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("SANDBOX_REPO_PATH", str(tmp_path))
+    sys.modules.pop("dynamic_path_router", None)
+    sys.modules.pop("chunking", None)
+    chunking = importlib.import_module("chunking")
+
+    cache_dir = chunking.SNIPPET_CACHE_DIR
+    assert cache_dir == tmp_path / "chunk_summary_cache"
+    assert cache_dir.is_dir()
+
+    shutil.rmtree(cache_dir)
+    assert not cache_dir.exists()
+
+    chunking._store_snippet_summary("deadbeef", "summary")
+    assert cache_dir.is_dir()
+    assert (cache_dir / "deadbeef.json").exists()


### PR DESCRIPTION
## Summary
- resolve snippet cache directory via `resolve_path`, with fallback to `get_project_root`
- align chunk summary cache to reuse resolved snippet cache path
- add regression test ensuring cache creation honors `SANDBOX_REPO_PATH`

## Testing
- `pytest tests/test_chunking_cache_sandbox_path.py -q`
- `pytest tests/test_chunking_summarize_cache.py tests/test_chunking_cache.py tests/test_chunk_summary_cache.py tests/test_chunk_workflow.py tests/test_chunking_split.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba6cdef698832ea6e8ebd82176e8b6