### PR TITLE
Add webhook Stripe account validation

### DIFF
--- a/docs/stripe_billing_router.md
+++ b/docs/stripe_billing_router.md
@@ -192,3 +192,24 @@ overridden or sourced from environment variables or secret storage.
 
 A ``critical_discrepancy`` alert signals the automatic rollback described
 above; resolve the configuration issue before retrying the billing operation.
+
+## Webhook Account Validation
+
+Stripe webhooks should also be verified to ensure events originate from the
+registered platform account.  The helper
+``stripe_billing_router.validate_webhook_account`` inspects an incoming webhook
+payload and returns ``False`` when the embedded account identifier does not
+match :data:`STRIPE_MASTER_ACCOUNT_ID`:
+
+```python
+from stripe_billing_router import validate_webhook_account
+
+event = json.loads(request.data)
+if not validate_webhook_account(event):
+    # Pause or reject processing until the mismatch is reviewed
+    return "account mismatch", 400
+```
+
+When a mismatch is detected the router dispatches the standard alert via
+``_alert_mismatch`` allowing callers to pause the bot or trigger additional
+review steps.

--- a/unit_tests/test_validate_webhook_account.py
+++ b/unit_tests/test_validate_webhook_account.py
@@ -1,0 +1,107 @@
+import sys
+import types
+from pathlib import Path
+
+# Stub modules to avoid heavy dependencies during import
+billing = types.ModuleType("billing")
+billing.billing_logger = types.SimpleNamespace(log_event=lambda **kwargs: None)
+sys.modules["billing"] = billing
+sys.modules["billing.billing_ledger"] = types.SimpleNamespace(
+    record_payment=lambda *a, **k: None
+)
+sys.modules["billing.billing_log_db"] = types.SimpleNamespace(
+    log_billing_event=lambda *a, **k: None
+)
+sys.modules["billing.stripe_ledger"] = types.SimpleNamespace(
+    StripeLedger=lambda: types.SimpleNamespace(log_event=lambda *a, **k: None)
+)
+
+stub_disc = types.ModuleType("discrepancy_db")
+
+
+class DummyDiscrepancyDB:
+    def add(self, rec):
+        pass
+
+
+class DummyDiscrepancyRecord:
+    def __init__(self, message: str, metadata=None, ts: str = "", id: int = 0):
+        self.message = message
+        self.metadata = metadata or {}
+
+
+stub_disc.DiscrepancyDB = DummyDiscrepancyDB
+stub_disc.DiscrepancyRecord = DummyDiscrepancyRecord
+sys.modules["discrepancy_db"] = stub_disc
+
+vault = types.ModuleType("vault_secret_provider")
+
+
+class DummyVault:
+    def get(self, name):
+        if name == "stripe_secret_key":
+            return "sk_dummy"
+        if name == "stripe_public_key":
+            return "pk_dummy"
+        return None
+
+
+vault.VaultSecretProvider = DummyVault
+sys.modules["vault_secret_provider"] = vault
+
+sys.modules["alert_dispatcher"] = types.SimpleNamespace(
+    dispatch_alert=lambda *a, **k: None
+)
+
+
+class DummyRM:
+    def log_healing_action(self, *a, **k):
+        pass
+
+    def rollback(self, *a, **k):
+        pass
+
+
+dummy_rm_module = types.SimpleNamespace(RollbackManager=DummyRM)
+sys.modules["rollback_manager"] = dummy_rm_module
+sys.modules["sandbox_review"] = types.SimpleNamespace(pause_bot=lambda *a, **k: None)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.modules.pop("stripe_billing_router", None)
+import stripe_billing_router as sbr  # noqa: E402
+
+
+def test_validate_webhook_account_valid(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    def fake_alert(bot_id, account_id, message="", amount=None):
+        calls.append((bot_id, account_id))
+
+    monkeypatch.setattr(sbr, "_alert_mismatch", fake_alert, raising=False)
+    event = {
+        "id": "evt_1",
+        "account": sbr.STRIPE_MASTER_ACCOUNT_ID,
+        "data": {"object": {"metadata": {"bot_id": "finance:bot"}}},
+    }
+    assert sbr.validate_webhook_account(event) is True
+    assert calls == []
+
+
+def test_validate_webhook_account_mismatch(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    def fake_alert(bot_id, account_id, message="", amount=None):
+        calls.append((bot_id, account_id))
+
+    monkeypatch.setattr(sbr, "_alert_mismatch", fake_alert, raising=False)
+    event = {
+        "id": "evt_2",
+        "data": {
+            "object": {
+                "on_behalf_of": "acct_BAD",
+                "metadata": {"bot_id": "finance:bot"},
+            }
+        },
+    }
+    assert sbr.validate_webhook_account(event) is False
+    assert calls == [("finance:bot", "acct_BAD")]


### PR DESCRIPTION
## Summary
- guard against mismatched Stripe accounts in webhook events
- document webhook account validation helper
- test valid and mismatched webhook payloads

## Testing
- `PYTHONPATH=. pre-commit run --files stripe_billing_router.py docs/stripe_billing_router.md unit_tests/test_validate_webhook_account.py` *(fails: Payment keywords without stripe_billing_router detected)*
- `pytest unit_tests/test_validate_webhook_account.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba6ce823f4832eaa4618556fd504ae