### PR TITLE
Use fixed Stripe master account ID

### DIFF
--- a/stripe_billing_router.py
+++ b/stripe_billing_router.py
@@ -143,10 +143,10 @@ def _validate_destination(bot_id: str, destination_account: str) -> None:
 
     The Stripe API may return events with a ``destination`` or ``on_behalf_of``
     account.  This helper validates that the account matches
-    ``STRIPE_REGISTERED_ACCOUNT_ID`` and raises an exception if it does not.
+    ``STRIPE_MASTER_ACCOUNT_ID`` and raises an exception if it does not.
     """
 
-    if destination_account and destination_account != STRIPE_REGISTERED_ACCOUNT_ID:
+    if destination_account and destination_account != STRIPE_MASTER_ACCOUNT_ID:
         logger.error(
             "Stripe destination mismatch for bot '%s': %s",
             bot_id,
@@ -524,8 +524,8 @@ def _verify_route(bot_id: str, route: Mapping[str, str]) -> None:
     if not key or key not in ALLOWED_SECRET_KEYS:
         log_critical_discrepancy(bot_id, "Stripe account mismatch")
         raise RuntimeError("Stripe account mismatch")
-    account_id = route.get("account_id", STRIPE_REGISTERED_ACCOUNT_ID)
-    if account_id != STRIPE_REGISTERED_ACCOUNT_ID:
+    account_id = route.get("account_id", STRIPE_MASTER_ACCOUNT_ID)
+    if account_id != STRIPE_MASTER_ACCOUNT_ID:
         log_critical_discrepancy(bot_id, "Stripe account mismatch")
         raise RuntimeError("Stripe account mismatch")
 
@@ -603,11 +603,11 @@ def _resolve_route(
     _validate_no_api_keys(route)
     route.setdefault("secret_key", STRIPE_SECRET_KEY)
     route.setdefault("public_key", STRIPE_PUBLIC_KEY)
-    route.setdefault("account_id", STRIPE_REGISTERED_ACCOUNT_ID)
+    route.setdefault("account_id", STRIPE_MASTER_ACCOUNT_ID)
     route.setdefault("currency", "usd")
     for strategy in _STRATEGIES:
         route = strategy.apply(bot_id, dict(route))
-    route.setdefault("account_id", STRIPE_REGISTERED_ACCOUNT_ID)
+    route.setdefault("account_id", STRIPE_MASTER_ACCOUNT_ID)
     route.setdefault("currency", "usd")
     secret = route.get("secret_key", "")
     public = route.get("public_key", "")
@@ -649,7 +649,7 @@ def charge(
     client = _client(api_key)
 
     account_id = _get_account_id(api_key) or ""
-    if account_id != STRIPE_REGISTERED_ACCOUNT_ID or not route.get("secret_key"):
+    if account_id != STRIPE_MASTER_ACCOUNT_ID or not route.get("secret_key"):
         _alert_mismatch(bot_id, account_id, amount=amount)
         raise RuntimeError("Stripe account mismatch")
 
@@ -903,7 +903,7 @@ def create_subscription(
     key_hash = _hash_api_key(api_key)
     client = _client(api_key)
     account_id = _get_account_id(api_key) or ""
-    if account_id != STRIPE_REGISTERED_ACCOUNT_ID or not route.get("secret_key"):
+    if account_id != STRIPE_MASTER_ACCOUNT_ID or not route.get("secret_key"):
         _alert_mismatch(bot_id, account_id)
         raise RuntimeError("Stripe account mismatch")
     price = price_id or route.get("price_id")
@@ -1036,7 +1036,7 @@ def refund(
     key_hash = _hash_api_key(api_key)
     client = _client(api_key)
     account_id = _get_account_id(api_key) or ""
-    if account_id != STRIPE_REGISTERED_ACCOUNT_ID or not route.get("secret_key"):
+    if account_id != STRIPE_MASTER_ACCOUNT_ID or not route.get("secret_key"):
         _alert_mismatch(bot_id, account_id, amount=amount)
         raise RuntimeError("Stripe account mismatch")
     refund_params: dict[str, Any] = {"payment_intent": payment_intent_id, **params}
@@ -1165,7 +1165,7 @@ def create_checkout_session(
     key_hash = _hash_api_key(api_key)
     client = _client(api_key)
     account_id = _get_account_id(api_key) or ""
-    if account_id != STRIPE_REGISTERED_ACCOUNT_ID or not route.get("secret_key"):
+    if account_id != STRIPE_MASTER_ACCOUNT_ID or not route.get("secret_key"):
         _alert_mismatch(bot_id, account_id)
         raise RuntimeError("Stripe account mismatch")
     final_params: dict[str, Any] = {"line_items": list(line_items), **params}


### PR DESCRIPTION
## Summary
- hard-code Stripe master account ID and drop any env or secret lookups
- use STRIPE_MASTER_ACCOUNT_ID throughout billing helpers

## Testing
- `pytest tests/test_stripe_billing_router.py tests/test_stripe_billing_router_destination_mismatch.py unit_tests/test_validate_webhook_account.py`
- `pytest tests/test_stripe_billing_router.py tests/test_stripe_billing_router_logging.py tests/test_stripe_ledger_logging.py tests/test_billing_router_logging.py tests/test_stripe_billing_router_destination_mismatch.py tests/test_investment_engine.py tests/test_finance_router_bot.py unit_tests/test_validate_webhook_account.py` *(fails: AttributeError: module 'billing' has no attribute '__path__')*


------
https://chatgpt.com/codex/tasks/task_e_68ba70afae94832e888b116626ce9ec0