### PR TITLE
use _alert_mismatch when verifying stripe routes

### DIFF
--- a/stripe_billing_router.py
+++ b/stripe_billing_router.py
@@ -522,11 +522,11 @@ def _verify_route(bot_id: str, route: Mapping[str, str]) -> None:
 
     key = route.get("secret_key")
     if not key or key not in ALLOWED_SECRET_KEYS:
-        log_critical_discrepancy(bot_id, "Stripe account mismatch")
+        _alert_mismatch(bot_id, route.get("account_id") or "unknown")
         raise RuntimeError("Stripe account mismatch")
     account_id = route.get("account_id", STRIPE_MASTER_ACCOUNT_ID)
     if account_id != STRIPE_MASTER_ACCOUNT_ID:
-        log_critical_discrepancy(bot_id, "Stripe account mismatch")
+        _alert_mismatch(bot_id, account_id)
         raise RuntimeError("Stripe account mismatch")
 
 


### PR DESCRIPTION
## Summary
- use `_alert_mismatch` in `_verify_route` so mismatches include account context
- test that `_alert_mismatch` is called for bad API keys and account IDs

## Testing
- `pytest tests/test_stripe_billing_router.py::test_invalid_secret_key_triggers_alert tests/test_stripe_billing_router.py::test_invalid_account_triggers_alert -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba72399780832e8e1dbc9f6f46e708