### PR TITLE
Use resolve_path for prompt template loading

### DIFF
--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -322,7 +322,7 @@ class BotDevelopmentBot:
         )
         self.prompt_templates_version = 1
         try:
-            with open(PROMPT_TEMPLATES_PATH) as fh:
+            with PROMPT_TEMPLATES_PATH.open() as fh:
                 data = json.load(fh)
             self.prompt_templates = data.get(TEMPLATE_SECTION_KEY, data)
             self.prompt_templates_version = int(data.get(TEMPLATE_VERSION_KEY, 1))


### PR DESCRIPTION
## Summary
- load prompt templates using resolve_path

## Testing
- `pre-commit run --files bot_development_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba6ebc0ddc832e81dc6a93c02252da