### PR TITLE
Add destination mismatch tests for Stripe payments

### DIFF
--- a/tests/test_stripe_billing_router_mismatch.py
+++ b/tests/test_stripe_billing_router_mismatch.py
@@ -3,6 +3,12 @@ from .test_stripe_billing_router_logging import _import_module
 
 def test_alert_mismatch_logs_error_and_rolls_back(monkeypatch, tmp_path):
     sbr = _import_module(monkeypatch, tmp_path)
+    # Prevent any environment-derived account identifiers from influencing the
+    # module under test and force ``_get_account_id`` to return the hardcoded
+    # master account.
+    monkeypatch.setattr(
+        sbr, "_get_account_id", lambda api_key: sbr.STRIPE_MASTER_ACCOUNT_ID
+    )
 
     sbr.sandbox_review.reset()
     rollback_calls = []


### PR DESCRIPTION
## Summary
- ensure test fixtures respect hardcoded `STRIPE_MASTER_ACCOUNT_ID`
- cover each payment helper when Stripe returns a mismatched destination
- capture `_alert_mismatch` calls and verify no payment records are written

## Testing
- `pytest tests/test_stripe_billing_router.py tests/test_stripe_billing_router_mismatch.py tests/test_stripe_billing_router_destination_mismatch.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba751ee784832eb1ed19f7f42f3d1d