### PR TITLE
Validate Stripe allowed keys against master account

### DIFF
--- a/tests/test_stripe_allowed_keys.py
+++ b/tests/test_stripe_allowed_keys.py
@@ -1,0 +1,21 @@
+import pytest
+
+from .test_stripe_billing_router import _import_module
+
+
+def test_foreign_keys_excluded(monkeypatch, tmp_path):
+    sbr = _import_module(monkeypatch, tmp_path)
+    monkeypatch.setenv("STRIPE_ALLOWED_SECRET_KEYS", "sk_live_dummy,sk_foreign")
+
+    def fake_get_account_id(key: str) -> str:
+        return sbr.STRIPE_MASTER_ACCOUNT_ID if key == "sk_live_dummy" else "acct_foreign"
+
+    monkeypatch.setattr(sbr, "_get_account_id", fake_get_account_id)
+    assert sbr._load_allowed_keys() == {"sk_live_dummy"}
+
+
+def test_only_foreign_keys(monkeypatch, tmp_path):
+    sbr = _import_module(monkeypatch, tmp_path)
+    monkeypatch.setenv("STRIPE_ALLOWED_SECRET_KEYS", "sk_foreign")
+    monkeypatch.setattr(sbr, "_get_account_id", lambda k: "acct_foreign")
+    assert sbr._load_allowed_keys() == set()

--- a/tests/test_stripe_billing_router.py
+++ b/tests/test_stripe_billing_router.py
@@ -82,6 +82,18 @@ def _import_module(monkeypatch, tmp_path, secrets=None):
     # environment does not leak an alternative value into tests.
     monkeypatch.delenv("STRIPE_MASTER_ACCOUNT_ID", raising=False)
     monkeypatch.delenv("STRIPE_ALLOWED_SECRET_KEYS", raising=False)
+    fake_stripe = types.SimpleNamespace(
+        StripeClient=lambda api_key: types.SimpleNamespace(
+            Account=types.SimpleNamespace(
+                retrieve=lambda: {"id": "acct_1H123456789ABCDEF"}
+            )
+        ),
+        Account=types.SimpleNamespace(
+            retrieve=lambda api_key: {"id": "acct_1H123456789ABCDEF"}
+        ),
+    )
+    sys.modules["stripe"] = fake_stripe
+    sys.modules["sbrpkg.stripe"] = fake_stripe
     sbr = _load("stripe_billing_router")
     monkeypatch.setattr(sbr.billing_logger, "log_event", lambda **kw: None)
     monkeypatch.setattr(sbr, "log_billing_event", lambda *a, **k: None)

--- a/tests/test_stripe_billing_router_logging.py
+++ b/tests/test_stripe_billing_router_logging.py
@@ -85,6 +85,18 @@ def _import_module(monkeypatch, tmp_path, secrets=None):
     monkeypatch.delenv("STRIPE_PUBLIC_KEY", raising=False)
     monkeypatch.delenv("STRIPE_ACCOUNT_ID", raising=False)
     monkeypatch.delenv("STRIPE_ALLOWED_SECRET_KEYS", raising=False)
+    fake_stripe = types.SimpleNamespace(
+        StripeClient=lambda api_key: types.SimpleNamespace(
+            Account=types.SimpleNamespace(
+                retrieve=lambda: {"id": "acct_1H123456789ABCDEF"}
+            )
+        ),
+        Account=types.SimpleNamespace(
+            retrieve=lambda api_key: {"id": "acct_1H123456789ABCDEF"}
+        ),
+    )
+    sys.modules["stripe"] = fake_stripe
+    sys.modules["sbrpkg.stripe"] = fake_stripe
     sbr = _load("stripe_billing_router")
     return sbr
 

--- a/tests/test_stripe_ledger_logging.py
+++ b/tests/test_stripe_ledger_logging.py
@@ -76,6 +76,18 @@ def _import_module(monkeypatch, tmp_path, secrets=None):
     monkeypatch.delenv("STRIPE_PUBLIC_KEY", raising=False)
     monkeypatch.delenv("STRIPE_ACCOUNT_ID", raising=False)
     monkeypatch.delenv("STRIPE_ALLOWED_SECRET_KEYS", raising=False)
+    fake_stripe = types.SimpleNamespace(
+        StripeClient=lambda api_key: types.SimpleNamespace(
+            Account=types.SimpleNamespace(
+                retrieve=lambda: {"id": "acct_1H123456789ABCDEF"}
+            )
+        ),
+        Account=types.SimpleNamespace(
+            retrieve=lambda api_key: {"id": "acct_1H123456789ABCDEF"}
+        ),
+    )
+    sys.modules["stripe"] = fake_stripe
+    sys.modules["sbrpkg.stripe"] = fake_stripe
     # Stub db_router to avoid filesystem interactions during import
     class _StubRouter:
         def get_connection(self, name: str, mode: str | None = None):  # pragma: no cover - simple stub


### PR DESCRIPTION
## Summary
- Verify each configured Stripe key against the master account and drop any foreign keys
- Delay allowed key initialisation until Stripe client helpers are available
- Add tests covering foreign-key rejection

## Testing
- `pytest tests/test_stripe_allowed_keys.py tests/test_stripe_billing_router_account_id_mismatch.py tests/test_stripe_billing_router_destination_mismatch.py tests/test_stripe_billing_router_mismatch.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba772c5dd0832e9e75e31eb6ecb7e1