### PR TITLE
Resolve coverage cleanup paths

### DIFF
--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -432,7 +432,7 @@ def cleanup_artifacts(extra_paths: Iterable[Path] | None = None) -> None:
             cov_files.append(_env_path(env_name, default))
         except FileNotFoundError:
             cov_files.append(_env_path(env_name, default))
-    cov_files.extend([Path(".coverage"), Path("cov.json")])
+    cov_files.extend([resolve_path(".coverage"), resolve_path("cov.json")])
     for path in cov_files:
         try:
             path.unlink(missing_ok=True)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- ensure coverage cleanup uses `resolve_path` for `.coverage` and `cov.json`

## Testing
- `MENACE_LIGHT_IMPORTS=1 pytest tests/test_coverage_summary.py -q`
- `MENACE_LIGHT_IMPORTS=1 pytest tests/test_coverage_summary.py tests/test_purge_leftovers_reporting.py tests/test_cleanup_basic.py -q` *(fails: AttributeError: module 'sandbox_runner.environment' has no attribute 'FAILED_CLEANUP_FILE')*
- `PYTHONPATH=. pre-commit run --files sandbox_runner/environment.py` *(fails: forbid-raw-stripe-usage)*

------
https://chatgpt.com/codex/tasks/task_e_68ba84a82d3c832e9db2855bd195f11e