### PR TITLE
Use resolve_path for workflow spec lookup

### DIFF
--- a/tools/workflow_diff_cli.py
+++ b/tools/workflow_diff_cli.py
@@ -20,6 +20,7 @@ import os
 import difflib
 from pathlib import Path
 from typing import Tuple
+from dynamic_path_router import resolve_path
 
 
 def _load_spec(base: Path, workflow_id: str) -> Tuple[Path, dict]:
@@ -53,8 +54,16 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    base_dir = Path(args.dir)
-    workflows_dir = base_dir / "workflows" if base_dir.name != "workflows" else base_dir
+    base_dir = resolve_path(args.dir)
+    workflows_dir = (
+        base_dir
+        if base_dir.name == "workflows"
+        else resolve_path("workflows", root=args.dir)
+    )
+    try:
+        workflows_dir.relative_to(base_dir)
+    except ValueError:
+        workflows_dir = resolve_path(base_dir / "workflows")
 
     child_path, child_data = _load_spec(workflows_dir, str(args.child_id))
     md = child_data.get("metadata", {})


### PR DESCRIPTION
## Summary
- resolve workflow spec and workdir paths using `dynamic_path_router.resolve_path`
- fall back to local `workflows` directory when resolution escapes target directory

## Testing
- `pytest tests/test_workflow_diff_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba872486d8832e91f13e2bda0b9be0