### PR TITLE
Use resolve_path for vector metrics database

### DIFF
--- a/vector_metrics_db.py
+++ b/vector_metrics_db.py
@@ -10,6 +10,7 @@ import json
 import logging
 
 from db_router import GLOBAL_ROUTER, LOCAL_TABLES, init_db_router
+from dynamic_path_router import resolve_path
 
 try:  # pragma: no cover - optional dependency
     from . import metrics_exporter as _me
@@ -67,7 +68,7 @@ class VectorMetricsDB:
     def __init__(self, path: Path | str = "vector_metrics.db") -> None:
         LOCAL_TABLES.add("vector_metrics")
         p = Path(path).resolve()
-        default_path = Path("vector_metrics.db").resolve()
+        default_path = resolve_path("vector_metrics.db")
         if GLOBAL_ROUTER is not None and p == default_path:
             self.router = GLOBAL_ROUTER
         else:


### PR DESCRIPTION
## Summary
- use dynamic_path_router.resolve_path when determining the default vector metrics database path
- add resolve_path import

## Testing
- `pre-commit run --files vector_metrics_db.py`
- `pytest tests/test_vector_metrics_db.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba8eb0b308832eb2ced94b021ef4f9