### PR TITLE
test: expand stripe watchdog coverage

### DIFF
--- a/docs/stripe_watchdog.md
+++ b/docs/stripe_watchdog.md
@@ -1,0 +1,38 @@
+# Stripe Watchdog
+
+The Stripe Watchdog cross-checks recent Stripe activity against the local
+billing ledger and alerts on discrepancies.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Provide the Stripe secret key through environment configuration or a
+   compatible `VaultSecretProvider` entry.
+3. Ensure billing events are appended to `finance_logs/stripe_ledger.jsonl`.
+
+## Configuration
+
+Allowed webhook endpoints are defined in
+`config/stripe_watchdog.yaml`:
+
+```yaml
+allowed_endpoints:
+  - https://example.com/stripe/webhook
+```
+
+Endpoints not listed here will trigger an alert.
+
+## Cron scheduling
+
+The watchdog can run continuously via APScheduler, or it may be scheduled
+with cron. To run hourly using cron:
+
+```
+0 * * * * cd /path/to/repo && python stripe_watchdog.py >> stripe_watchdog.log 2>&1
+```
+
+This command invokes the watchdog every hour and logs output for later
+inspection.


### PR DESCRIPTION
## Summary
- add tests for orphan charges, revenue mismatches, and unauthorized webhooks
- document Stripe watchdog setup, configuration, and scheduling

## Testing
- `pytest tests/test_stripe_watchdog.py -q`
- `PYTHONPATH=. pre-commit run --files tests/test_stripe_watchdog.py docs/stripe_watchdog.md` *(fails: Payment keywords without stripe_billing_router detected)*

------
https://chatgpt.com/codex/tasks/task_e_68ba912424f0832eb4379c30e4d661ef