### PR TITLE
Resolve VisualAgentWatchdog restart log path

### DIFF
--- a/visual_agent_watchdog.py
+++ b/visual_agent_watchdog.py
@@ -7,6 +7,7 @@ import os
 import time
 
 from visual_agent_manager import VisualAgentManager
+from dynamic_path_router import resolve_path
 
 try:  # optional dependency
     import psutil  # type: ignore
@@ -36,7 +37,10 @@ class VisualAgentWatchdog:
     ) -> None:
         self.manager = manager or VisualAgentManager()
         self.check_interval = float(check_interval)
-        self.restart_log = restart_log
+        try:
+            self.restart_log = str(resolve_path(restart_log))
+        except FileNotFoundError:
+            self.restart_log = str(resolve_path(".") / restart_log)
         self.logger = logging.getLogger(self.__class__.__name__)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- ensure `VisualAgentWatchdog` resolves its restart log via `dynamic_path_router.resolve_path`

## Testing
- `python -m py_compile visual_agent_watchdog.py`
- `pytest tests/test_visual_agent_watchdog.py -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '')*

------
https://chatgpt.com/codex/tasks/task_e_68ba97c0e444832e9f05516564231486