### PR TITLE
feat: monitor Stripe webhook endpoints

### DIFF
--- a/config/stripe_watchdog.yaml
+++ b/config/stripe_watchdog.yaml
@@ -1,2 +1,2 @@
-allowed_endpoints:
+authorized_webhooks:
   - https://example.com/stripe/webhook

--- a/docs/stripe_billing_router.md
+++ b/docs/stripe_billing_router.md
@@ -213,3 +213,18 @@ if not validate_webhook_account(event):
 When a mismatch is detected the router dispatches the standard alert via
 ``_alert_mismatch`` allowing callers to pause the bot or trigger additional
 review steps.
+
+## Watchdog Webhook Configuration
+
+The companion `stripe_watchdog` module verifies the set of webhook endpoints
+registered in Stripe.  Authorized endpoints are listed in
+`config/stripe_watchdog.yaml`:
+
+```yaml
+authorized_webhooks:
+  - https://example.com/stripe/webhook
+```
+
+During a watchdog run, the output of `stripe.WebhookEndpoint.list()` is compared
+against this list. Any unrecognized endpoint results in a
+`stripe_unknown_endpoint` alert being logged.

--- a/docs/stripe_watchdog.md
+++ b/docs/stripe_watchdog.md
@@ -15,11 +15,11 @@ billing ledger and alerts on discrepancies.
 
 ## Configuration
 
-Allowed webhook endpoints are defined in
+Authorized webhook endpoints are defined in
 `config/stripe_watchdog.yaml`:
 
 ```yaml
-allowed_endpoints:
+authorized_webhooks:
   - https://example.com/stripe/webhook
 ```
 

--- a/scripts/check_stripe_imports.py
+++ b/scripts/check_stripe_imports.py
@@ -41,6 +41,7 @@ ALLOWED = {
     resolve_path("codex_output_analyzer.py").resolve(),
     resolve_path("stripe_detection.py").resolve(),
     resolve_path("billing/openai_wrapper.py").resolve(),
+    resolve_path("stripe_watchdog.py").resolve(),
 }
 # Detect exposures of Stripe keys, including partially redacted ones with ``*``.
 KEY_PATTERN = re.compile(

--- a/tests/test_stripe_watchdog.py
+++ b/tests/test_stripe_watchdog.py
@@ -50,7 +50,7 @@ def test_check_events_detects_orphan_charge(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(sw, "stripe", fake_stripe)
     monkeypatch.setattr(sw, "load_api_key", lambda: "sk_test_dummy")
-    monkeypatch.setattr(sw, "_load_allowed_endpoints", lambda path=sw.CONFIG_PATH: set())
+    monkeypatch.setattr(sw, "_load_authorized_webhooks", lambda path=sw.CONFIG_PATH: set())
 
     anomalies = sw.check_events()
     assert anomalies == [
@@ -75,7 +75,7 @@ def test_check_events_writes_log_and_summary(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(sw, "stripe", fake_stripe)
     monkeypatch.setattr(sw, "load_api_key", lambda: "sk_test_dummy")
-    monkeypatch.setattr(sw, "_load_allowed_endpoints", lambda path=sw.CONFIG_PATH: set())
+    monkeypatch.setattr(sw, "_load_authorized_webhooks", lambda path=sw.CONFIG_PATH: set())
 
     records = []
 
@@ -135,7 +135,7 @@ def test_check_revenue_projection_detects_mismatch(monkeypatch):
 def test_check_webhook_endpoints_alerts_unauthorized(monkeypatch, tmp_path):
     cfg = tmp_path / "stripe_watchdog.yaml"  # path-ignore
     cfg.write_text(
-        "allowed_endpoints:\n  - https://good.example.com/webhook\n"
+        "authorized_webhooks:\n  - https://good.example.com/webhook\n"
     )
     monkeypatch.setattr(sw, "CONFIG_PATH", cfg)
 


### PR DESCRIPTION
## Summary
- load allowed webhook endpoints from config
- alert on unrecognized Stripe webhook endpoints and revenue mismatches
- document authorized webhook configuration

## Testing
- `PYTHONPATH=$PWD pre-commit run --files config/stripe_watchdog.yaml stripe_watchdog.py docs/stripe_watchdog.md docs/stripe_billing_router.md tests/test_stripe_watchdog.py scripts/check_stripe_imports.py` *(fails: Prevent raw Stripe keys or endpoints)*
- `pytest tests/test_stripe_watchdog.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba96c35ecc832e9eb1cbefc1a8a0fc