### PR TITLE
Use resolve_path for workflow merging

### DIFF
--- a/workflow_branch_manager.py
+++ b/workflow_branch_manager.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 """Manage sibling workflow branches and offer automatic merging."""
 
+import json
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 import logging
 
-from . import workflow_lineage
-from .workflow_merger import merge_workflows, MergeConflictError
+import workflow_lineage
+from dynamic_path_router import resolve_path
+from workflow_merger import merge_workflows, MergeConflictError
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +18,8 @@ class WorkflowBranchManager:
     """Discover and merge sibling workflow branches."""
 
     def __init__(self, directory: str | Path = "workflows"):
-        self.directory = Path(directory)
+        self.directory = resolve_path(directory)
+        self._repo_root = resolve_path(".")
 
     # ------------------------------------------------------------------
     def _sibling_map(self) -> Dict[str, List[str]]:
@@ -53,20 +56,45 @@ class WorkflowBranchManager:
             if not base.exists():
                 continue
 
-            current = self.directory / f"{children[0]}.workflow.json"
+            try:
+                base_spec = json.loads(base.read_text())
+            except Exception:
+                continue
+
+            current = self._ensure_base_steps(base_spec, self.directory / f"{children[0]}.workflow.json")
             for child in children[1:]:
-                branch_b = self.directory / f"{child}.workflow.json"
+                branch_b = self._ensure_base_steps(base_spec, self.directory / f"{child}.workflow.json")
                 out_name = f"{Path(current).stem}_{child}.workflow.json"
                 out_path = self.directory / out_name
                 try:
                     current = merge_workflows(base, current, branch_b, out_path)
-                    merged.append(current)
+                    try:
+                        merged.append(current.relative_to(self._repo_root))
+                    except ValueError:
+                        merged.append(current)
                 except MergeConflictError:
                     logger.info(
                         "merge conflict for parent %s between %s and %s", parent, Path(current).stem, child
                     )
                     break
         return merged
+
+    # ------------------------------------------------------------------
+    def _ensure_base_steps(self, base_spec: Dict[str, Any], path: Path) -> Path:
+        """Ensure workflow at ``path`` contains steps from ``base_spec``."""
+
+        try:
+            data = json.loads(path.read_text())
+        except Exception:
+            return path
+
+        base_steps = base_spec.get("steps") or []
+        steps = data.get("steps") or []
+        if isinstance(base_steps, list) and isinstance(steps, list):
+            if steps[: len(base_steps)] != base_steps:
+                data["steps"] = list(base_steps) + list(steps)
+                path.write_text(json.dumps(data, indent=2, sort_keys=True))
+        return path
 
 
 def merge_sibling_branches(


### PR DESCRIPTION
## Summary
- resolve workflow directories relative to the repo
- return repo-relative paths for merged workflows
- normalize branch specs to include base steps before merging

## Testing
- `pytest tests/test_workflow_branch_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba99055f40832e839dd8c666c0948c