### PR TITLE
Ensure workflow spec paths resolve relative to repo root

### DIFF
--- a/workflow_spec.py
+++ b/workflow_spec.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any, Iterable
 from datetime import datetime, timezone
 from uuid import uuid4
+from dynamic_path_router import resolve_path
 
 
 MAX_ID_ATTEMPTS = 5
@@ -133,15 +134,23 @@ def save_spec(spec: dict, path: Path, *, summary_path: Path | str | None = None)
     # Ensure metadata block is present with required fields
     metadata = dict(spec.get("metadata") or {})
     if summary_path is not None:
-        metadata["summary_path"] = str(summary_path)
+        spath = Path(summary_path)
+        if not spath.is_absolute():
+            spath = Path(resolve_path(".")) / spath
+        metadata["summary_path"] = str(spath)
     elif "summary_path" in metadata and metadata["summary_path"] is not None:
-        metadata["summary_path"] = str(metadata["summary_path"])
+        spath = Path(str(metadata["summary_path"]))
+        if not spath.is_absolute():
+            spath = Path(resolve_path(".")) / spath
+        metadata["summary_path"] = str(spath)
     metadata.setdefault("workflow_id", str(uuid4()))
     metadata.setdefault("parent_id", None)
     metadata.setdefault("mutation_description", "")
     metadata.setdefault("created_at", datetime.now(timezone.utc).isoformat())
 
     path = Path(path)
+    if not path.is_absolute():
+        path = Path(resolve_path(".")) / path
     parent = path.parent
     if parent.name != "workflows":
         parent = parent / "workflows"


### PR DESCRIPTION
## Summary
- normalize user-provided paths in `save_spec` by resolving them against the repository root
- store resolved `summary_path` in workflow metadata
- use dynamic path routing utilities

## Testing
- `PYTHONPATH=. pre-commit run --files workflow_spec.py` *(fails: Payment keywords without stripe_billing_router detected)*
- `pytest tests/test_workflow_spec.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba9c563000832ea7cde3201dfd9c77