### PR TITLE
Add stripe dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ configuration. The generated file includes stub values for critical settings:
 
 ### Billing router
 
-`stripe_billing_router` is the **sole payment interface** for all billing and
+The project depends on the official Stripe SDK (`stripe` Python package) for
+billing features. `stripe_billing_router` is the **sole payment interface** for
+all billing and
 monetisation features.  The router owns the Stripe API keys, resolves per‑bot
 identifiers, supports region overrides and strategy hooks, and aborts if keys or
 routing rules are missing.  The routing configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
     ,"cryptography"
     ,"tiktoken"
     ,"vaderSentiment"
-    ,"stripe"
+    ,"stripe>=12.5.0"
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- specify stripe package in pyproject dependencies
- document stripe SDK requirement in README

## Testing
- `PYTHONPATH=$(pwd) python -m pre_commit run --files pyproject.toml README.md`
- `PYTHONPATH=$(pwd) pytest -q` *(fails: ModuleNotFoundError: No module named 'DBRouter', plus many similar import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9c5ff500832e86b9afd19b683df1