### PR TITLE
chore: route docs reference through path resolver

### DIFF
--- a/sandbox_runner.py
+++ b/sandbox_runner.py
@@ -149,7 +149,7 @@ def _verify_required_dependencies(settings: "SandboxSettings | None" = None) -> 
 
     if messages:
         messages.append(
-            "Refer to docs/autonomous_sandbox.md for manual setup instructions."
+            f"Refer to {path_for_prompt('docs/autonomous_sandbox.md')} for manual setup instructions."
         )
         msg = "\n".join(messages)
         logging.error(msg)


### PR DESCRIPTION
## Summary
- use `path_for_prompt` for docs link in dependency check message

## Testing
- `pre-commit run --files sandbox_runner.py self_coding_engine.py self_coding_manager.py self_coding_scheduler.py` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*
- `pytest` *(fails: 631 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9eccb9b8832ea180e4d01385cb31