### PR TITLE
Resolve prompt path references via dynamic path router

### DIFF
--- a/prompt_db.py
+++ b/prompt_db.py
@@ -4,9 +4,9 @@ import json
 import os
 import sqlite3
 from datetime import datetime
-from pathlib import Path
 from typing import Any, Dict, List
 
+from dynamic_path_router import resolve_path
 from db_router import DBRouter, LOCAL_TABLES
 from llm_interface import Completion, Prompt
 
@@ -17,8 +17,7 @@ from llm_interface import Completion, Prompt
 # Ensure the prompts table is treated as local by DBRouter
 LOCAL_TABLES.add("prompts")
 
-
-DB_PATH = Path(os.getenv("PROMPT_DB_PATH", "prompts.db"))
+DB_PATH = resolve_path(os.environ.get("PROMPT_DB_PATH", "prompts.db"))
 _CONN: sqlite3.Connection | None = None
 
 
@@ -236,7 +235,7 @@ class PromptDB:
         self, model: str, path: str | None = None, router: DBRouter | None = None
     ) -> None:
         self.model = model
-        db_path = Path(path or os.getenv("PROMPT_DB_PATH", "prompts.db"))
+        db_path = resolve_path(path or os.environ.get("PROMPT_DB_PATH", "prompts.db"))
         self.router = router or DBRouter("prompts", str(db_path), str(db_path))
         self.conn = self.router.get_connection("prompts", operation="write")
         # Ensure schema exists for this connection as well

--- a/prompt_optimizer.py
+++ b/prompt_optimizer.py
@@ -612,8 +612,8 @@ class PromptOptimizer:
         return self.aggregate()
 
 
-DEFAULT_WEIGHTS_PATH = Path("prompt_format_weights.json")
-DEFAULT_STRATEGY_PATH = Path("_strategy_stats.json")
+DEFAULT_WEIGHTS_PATH = resolve_path("prompt_format_weights.json")
+DEFAULT_STRATEGY_PATH = resolve_path("_strategy_stats.json")
 
 
 def load_logs(success_path: str | Path, failure_path: str | Path) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- use `resolve_path` for default prompt database path and PromptDB initialization
- resolve default optimizer weight and strategy paths via `resolve_path`

## Testing
- `PYTHONPATH=. SKIP=forbid-stripe-imports,forbid-stripe-keys,forbid-raw-stripe-usage pre-commit run --files prompt_db.py prompt_optimizer.py`

------
https://chatgpt.com/codex/tasks/task_e_68baa008c308832e9c6ee26c1b0c28dd