### PR TITLE
Add configurable allowed Stripe webhooks and disabled endpoint check

### DIFF
--- a/config/stripe_watchdog.yaml
+++ b/config/stripe_watchdog.yaml
@@ -1,2 +1,3 @@
-authorized_webhooks:
+allowed_webhooks:
   - https://example.com/stripe/webhook
+  - we_1234567890


### PR DESCRIPTION
## Summary
- allow configuring permitted Stripe webhook IDs/URLs via STRIPE_ALLOWED_WEBHOOKS env var or config file
- flag webhook endpoints that are not whitelisted or are disabled
- expand watchdog tests for new webhook checks

## Testing
- `PYTHONPATH=. pre-commit run --files stripe_watchdog.py config/stripe_watchdog.yaml tests/test_stripe_watchdog.py` *(fails: Payment keywords without stripe_billing_router detected)*
- `pytest tests/test_stripe_watchdog.py`


------
https://chatgpt.com/codex/tasks/task_e_68baa0cf3828832e8bdffd29b59c3310