### PR TITLE
Use dynamic path resolution in setup scripts

### DIFF
--- a/scripts/install_pinned_dependencies.sh
+++ b/scripts/install_pinned_dependencies.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 set -e
 
-# Install pinned Python dependencies for Menace Sandbox.
-# Execute this script from the repository root.
+# Ensure repository root on PYTHONPATH so dynamic_path_router is importable
+script_dir="$(cd "$(dirname "$0")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+export PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}"
 
-if [ ! -f requirements.txt ]; then
-    echo "requirements.txt not found. Run this script from the repository root." >&2
-    exit 1
-fi
+# Install pinned Python dependencies for Menace Sandbox.
+# Locate requirements.txt dynamically so the script works from any directory.
+
+req_file=$(python - <<'PY'
+from dynamic_path_router import resolve_path
+print(resolve_path('requirements.txt'))
+PY
+)
 
 python -m pip install --upgrade pip
-python -m pip install -r requirements.txt
+python -m pip install -r "$req_file"

--- a/scripts/setup_autonomous.sh
+++ b/scripts/setup_autonomous.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 set -e
 
+# Ensure repository root on PYTHONPATH so dynamic_path_router is importable
+script_dir="$(cd "$(dirname "$0")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+export PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}"
+
 # Install system packages unless offline mode is enabled
 offline="${MENACE_OFFLINE_INSTALL:-0}"
-wheel_dir="${MENACE_WHEEL_DIR:-}" 
+wheel_dir="${MENACE_WHEEL_DIR:-}"
 
 if [ "$offline" != "1" ] && command -v apt-get >/dev/null 2>&1; then
     sudo apt-get update
@@ -16,7 +21,7 @@ if [ "$offline" = "1" ] && [ -n "$wheel_dir" ]; then
 fi
 
 python -m pip install --upgrade pip
-pip install "${pip_opts[@]}" -e .
+pip install "${pip_opts[@]}" -e "$repo_root"
 # Install pytest as run_autonomous.py expects
 pip install "${pip_opts[@]}" pytest
 

--- a/scripts/setup_personal.sh
+++ b/scripts/setup_personal.sh
@@ -1,16 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Ensure repository root on PYTHONPATH so dynamic_path_router is importable
+script_dir="$(cd "$(dirname "$0")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+export PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}"
+
 # Run base Python environment setup
 setup_env=$(python - <<'PY'
 from dynamic_path_router import resolve_path
 print(resolve_path('setup_env.sh'))
 PY
 )
-"$setup_env"
+
+(cd "$repo_root" && bash "$setup_env")
 
 # Install and verify project dependencies
-python setup_dependencies.py
+(cd "$repo_root" && python setup_dependencies.py)
 
 # Create a .env file with sensible defaults
 python - <<'PY'

--- a/scripts/setup_tests.sh
+++ b/scripts/setup_tests.sh
@@ -1,14 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Ensure repository root on PYTHONPATH so dynamic_path_router is importable
+script_dir="$(cd "$(dirname "$0")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+export PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}"
+
 # Ensure pip is up to date
 python -m pip install --upgrade pip
 
 # Install pinned runtime dependencies
-pip install --no-cache-dir -r requirements.txt
+req_file=$(python - <<'PY'
+from dynamic_path_router import resolve_path
+print(resolve_path('requirements.txt'))
+PY
+)
+pip install --no-cache-dir -r "$req_file"
 
 # Install the package itself in editable mode
-pip install --no-cache-dir -e .
+pip install --no-cache-dir -e "$repo_root"
 
 # Install core testing utilities
 pip install --no-cache-dir pytest hypothesis


### PR DESCRIPTION
## Summary
- ensure setup scripts locate the project root dynamically
- resolve `requirements.txt` and other resources with `dynamic_path_router`

## Testing
- `PIP_CONFIG_FILE=/tmp/pip.conf bash /workspace/menace_sandbox/scripts/install_pinned_dependencies.sh`
- `PIP_CONFIG_FILE=/tmp/pip.conf MENACE_OFFLINE_INSTALL=1 MENACE_WHEEL_DIR=/tmp/testdir bash /workspace/menace_sandbox/scripts/setup_autonomous.sh` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*
- `PIP_CONFIG_FILE=/tmp/pip.conf MENACE_OFFLINE_INSTALL=1 MENACE_WHEEL_DIR=/tmp/testdir bash /workspace/menace_sandbox/scripts/setup_personal.sh` *(fails: Cannot import 'setuptools.build_meta')*
- `PIP_CONFIG_FILE=/tmp/pip.conf bash /workspace/menace_sandbox/scripts/setup_tests.sh` *(fails: Cannot import 'setuptools.build_meta')*


------
https://chatgpt.com/codex/tasks/task_e_68baa16d4670832eac9389638c64e0c7