### PR TITLE
Use dynamic paths for CLI orphan references

### DIFF
--- a/sandbox_runner/cli.py
+++ b/sandbox_runner/cli.py
@@ -13,7 +13,7 @@ import math
 import platform
 import subprocess
 from sandbox_settings import SandboxSettings, load_sandbox_settings
-from dynamic_path_router import resolve_path
+from dynamic_path_router import resolve_path, path_for_prompt
 try:  # optional dependency
     from scipy.stats import pearsonr, t, levene
 except Exception:  # pragma: no cover - fallback when scipy is missing
@@ -1311,7 +1311,10 @@ def main(argv: List[str] | None = None) -> None:
         action="store_false",
         dest="include_orphans",
         default=None,
-        help="skip modules listed in sandbox_data/orphan_modules.json",
+        help=(
+            "skip modules listed in "
+            f"{path_for_prompt('sandbox_data')}/orphan_modules.json"
+        ),
     )
     parser.add_argument(
         "--offline-suggestions",

--- a/tests/integration/test_self_coding_path_resolution.py
+++ b/tests/integration/test_self_coding_path_resolution.py
@@ -107,6 +107,7 @@ def test_scheduler_resolves_paths_from_menace_roots(monkeypatch, tmp_path):
     dpr.clear_cache()
     resolved = dpr.resolve_path("auto_helpers.py")
     assert resolved == helper.resolve()
+    assert dpr.path_for_prompt("auto_helpers.py") == helper.resolve().as_posix()
 
     class DummyManager:
         bot_name = "bot"

--- a/tests/test_run_sandbox.py
+++ b/tests/test_run_sandbox.py
@@ -4,7 +4,8 @@ import sys
 import os
 from pathlib import Path
 import asyncio
-from dynamic_path_router import resolve_dir, resolve_path
+import pytest
+from dynamic_path_router import resolve_dir, resolve_path, path_for_prompt
 
 os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
 import types
@@ -823,3 +824,17 @@ def test_run_sandbox_cli_recursion_default(monkeypatch):
     cli.main([])
     assert capture.get("recursive_orphans") is True
     assert os.getenv("SANDBOX_RECURSIVE_ORPHANS") == "1"
+
+
+def test_cli_help_resolves_orphan_path(monkeypatch, capsys):
+    import dynamic_path_router as dpr
+
+    dpr.clear_cache()
+    monkeypatch.delenv("MENACE_ROOTS", raising=False)
+    import sandbox_runner.cli as cli
+
+    with pytest.raises(SystemExit):
+        cli.main(["--help"])
+    out = capsys.readouterr().out
+    expected = f"{path_for_prompt('sandbox_data')}/orphan_modules.json"
+    assert expected in out


### PR DESCRIPTION
## Summary
- use `path_for_prompt` to display the `sandbox_data` orphan list in `sandbox_runner.cli`
- cover `path_for_prompt` in self-coding and CLI help tests

## Testing
- `pytest tests/integration/test_self_coding_path_resolution.py::test_scheduler_resolves_paths_from_menace_roots tests/test_run_sandbox.py::test_cli_help_resolves_orphan_path -q`


------
https://chatgpt.com/codex/tasks/task_e_68baacc42218832e9df24f331327d787