### PR TITLE
ci: run path validation scripts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ on:
         default: 'false'
 
 jobs:
-  static-paths:
+  path-checks:
     runs-on: ubuntu-latest
     env:
       MENACE_SAFE: "1"
@@ -32,6 +32,8 @@ jobs:
           python-version: '3.11'
       - name: Check for static path references
         run: "python tools/check_static_paths.py $(git ls-files '*.py')"
+      - name: Check for dynamic path references
+        run: "python tools/check_dynamic_paths.py $(git ls-files '*.py')"
 
   tests:
     runs-on: ubuntu-latest

--- a/tests/integration/test_self_coding_path_resolution.py
+++ b/tests/integration/test_self_coding_path_resolution.py
@@ -15,6 +15,7 @@ wsr_stub = types.ModuleType("sandbox_runner.workflow_sandbox_runner")
 class WorkflowSandboxRunner:
     def run(self, func, safe_mode=False):
         func()
+
         class Result:
             modules = []
         return Result()
@@ -84,12 +85,14 @@ sys.modules.setdefault("menace.cross_model_scheduler", cms_stub)
 
 # Load real dynamic_path_router before importing scheduler
 root_dir = Path(__file__).resolve().parents[2]
-spec = importlib.util.spec_from_file_location("dynamic_path_router", root_dir / "dynamic_path_router.py")
+spec = importlib.util.spec_from_file_location(
+    "dynamic_path_router", root_dir / "dynamic_path_router.py"  # path-ignore
+)
 dpr = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(dpr)
 sys.modules["dynamic_path_router"] = dpr
 
-from menace.self_coding_scheduler import SelfCodingScheduler
+from menace.self_coding_scheduler import SelfCodingScheduler  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -98,7 +101,7 @@ def test_scheduler_resolves_paths_from_menace_roots(monkeypatch, tmp_path):
     (repo_a / ".git").mkdir(parents=True)
     repo_b = tmp_path / "repo_b"
     (repo_b / ".git").mkdir(parents=True)
-    helper = repo_b / "auto_helpers.py"
+    helper = repo_b / "auto_helpers.py"  # path-ignore
     helper.write_text("# helper\n")
     metrics = repo_b / "sandbox_metrics.yaml"
     metrics.write_text("extra_metrics: {}\n")


### PR DESCRIPTION
## Summary
- run static and dynamic path check scripts on all tracked Python files in CI
- whitelist explicit test path literals

## Testing
- `pre-commit run flake8 --files tests/integration/test_self_coding_path_resolution.py`
- `pre-commit run check-dynamic-paths --files tests/integration/test_self_coding_path_resolution.py`
- `python tools/check_dynamic_paths.py $(git ls-files '*.py')` *(fails: missing resolve_path for many files)*

------
https://chatgpt.com/codex/tasks/task_e_68baadf951bc832eae8cccd333b587e7