### PR TITLE
Add charge_id tracking to billing logs

### DIFF
--- a/billing/billing_ledger.py
+++ b/billing/billing_ledger.py
@@ -42,6 +42,7 @@ def log_action(
     account_id: str,
     email: Optional[str] = None,
     ts: Optional[int] = None,
+    charge_id: Optional[str] = None,
     **extra: Any,
 ) -> None:
     """Append a log entry describing a billing ``action``.
@@ -58,6 +59,7 @@ def log_action(
         "bot_id": bot_id,
         "account_id": account_id,
         "email": email,
+        "charge_id": charge_id,
     }
     record.update(extra)
 
@@ -75,11 +77,21 @@ def record_payment(
     *,
     email: Optional[str] = None,
     ts: Optional[int] = None,
+    charge_id: Optional[str] = None,
     **extra: Any,
 ) -> None:
     """Public helper to record a payment related ``action``."""
 
-    log_action(action, amount, bot_id, account_id, email=email, ts=ts, **extra)
+    log_action(
+        action,
+        amount,
+        bot_id,
+        account_id,
+        email=email,
+        ts=ts,
+        charge_id=charge_id,
+        **extra,
+    )
 
 
 __all__ = ["log_action", "record_payment"]

--- a/billing/refund_anomaly_detector.py
+++ b/billing/refund_anomaly_detector.py
@@ -105,6 +105,7 @@ def detect_anomalies(
                 user_email=email,
                 bot_id=bot_id,
                 destination_account=destination,
+                charge_id=event.id,
                 raw_event_json=raw_json,
                 error=1,
             )
@@ -130,6 +131,7 @@ def detect_anomalies(
                 user_email=email,
                 bot_id=bot_id,
                 destination_account=destination,
+                charge_id=event.id,
                 raw_event_json=raw_json,
                 error=1,
             )

--- a/tests/test_billing_router_logging.py
+++ b/tests/test_billing_router_logging.py
@@ -107,6 +107,7 @@ def test_charge_logs_events(monkeypatch):
     assert ledger_args[4] == "user@example.com"
     assert ledger_args[5] == ACCOUNT
     assert ledger_args[6] == 1_700_000_000_000
+    assert ledger_args[7] == "pi_1"
 
 def test_subscription_logs_events(monkeypatch):
     bot_id = "stripe:cat:bot"
@@ -166,6 +167,7 @@ def test_subscription_logs_events(monkeypatch):
     assert ledger_args[4] == "user@example.com"
     assert ledger_args[5] == ACCOUNT
     assert ledger_args[6] == 1_700_000_000_000
+    assert ledger_args[7] == "sub_1"
 
 def test_refund_logs_events(monkeypatch):
     bot_id = "stripe:cat:bot"
@@ -217,6 +219,7 @@ def test_refund_logs_events(monkeypatch):
     assert ledger_args[4] == "user@example.com"
     assert ledger_args[5] == ACCOUNT
     assert ledger_args[6] == 1_700_000_000_000
+    assert ledger_args[7] == "re_1"
 
 def test_checkout_session_logs_events(monkeypatch):
     bot_id = "stripe:cat:bot"
@@ -272,6 +275,7 @@ def test_checkout_session_logs_events(monkeypatch):
     assert ledger_args[4] == "user@example.com"
     assert ledger_args[5] == ACCOUNT
     assert ledger_args[6] == 1_700_000_000_000
+    assert ledger_args[7] == "cs_1"
 
 def test_alert_mismatch_invalid_key(monkeypatch):
     log_crit = MagicMock(wraps=sbr.log_critical_discrepancy)

--- a/tests/test_stripe_ledger_fetch.py
+++ b/tests/test_stripe_ledger_fetch.py
@@ -13,8 +13,12 @@ def _setup_ledger(monkeypatch, tmp_path):
 
 def test_fetch_events(monkeypatch, tmp_path):
     ledger = _setup_ledger(monkeypatch, tmp_path)
-    stripe_ledger.log_event("charge", "bot1", 10.0, "usd", "u1@example.com", "acct1", 100)
-    stripe_ledger.log_event("refund", "bot2", 5.0, "usd", None, "acct2", 200)
+    stripe_ledger.log_event(
+        "charge", "bot1", 10.0, "usd", "u1@example.com", "acct1", 100, "ch_1"
+    )
+    stripe_ledger.log_event(
+        "refund", "bot2", 5.0, "usd", None, "acct2", 200, "ch_2"
+    )
 
     events = stripe_ledger.get_events(50, 150)
     assert [e["action"] for e in events] == ["charge"]
@@ -30,13 +34,16 @@ def test_fetch_events(monkeypatch, tmp_path):
         "currency",
         "user_email",
         "account_id",
+        "charge_id",
         "timestamp",
     }
 
 
 def test_fetch_events_empty(monkeypatch, tmp_path):
     _setup_ledger(monkeypatch, tmp_path)
-    stripe_ledger.log_event("charge", "bot1", 10.0, "usd", "u1@example.com", "acct1", 100)
+    stripe_ledger.log_event(
+        "charge", "bot1", 10.0, "usd", "u1@example.com", "acct1", 100, "ch_1"
+    )
 
     events = stripe_ledger.get_events(200, 300)
     assert events == []


### PR DESCRIPTION
## Summary
- track Stripe charge IDs in billing ledger JSON entries
- expand SQLite ledgers and logger to store charge_id with migrations
- log charge_id from stripe_billing_router and adjust tests
- restore menace.db to avoid binary changes

## Testing
- `pytest tests/test_stripe_ledger_fetch.py tests/test_billing_router_logging.py::test_charge_logs_events tests/test_billing_router_logging.py::test_subscription_logs_events tests/test_billing_router_logging.py::test_refund_logs_events tests/test_billing_router_logging.py::test_checkout_session_logs_events tests/test_stripe_billing_router_logging.py::test_charge_logs_to_file tests/test_stripe_billing_router_logging.py::test_refund_logs_to_file tests/test_stripe_billing_router_logging.py::test_create_subscription_logs_to_file tests/test_stripe_billing_router_logging.py::test_create_checkout_session_logs_to_file`
- `pytest tests/test_refund_anomaly_detector.py`

------
https://chatgpt.com/codex/tasks/task_e_68baae3ebef0832e80b6de0a4719c27e