### PR TITLE
Use resolve_path for strategy rotator state file

### DIFF
--- a/self_improvement/strategy_rotator.py
+++ b/self_improvement/strategy_rotator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from dynamic_path_router import resolve_path
 from ..sandbox_settings import SandboxSettings
 from .prompt_strategy_manager import (
     KEYWORD_MAP as BASE_KEYWORD_MAP,
@@ -24,7 +25,11 @@ TEMPLATES = [
     "unit_test_rewrite",
 ]
 
-STATE_PATH = Path(SandboxSettings().sandbox_data_dir) / "strategy_rotator_state.json"
+STATE_PATH = Path(
+    resolve_path(
+        Path(SandboxSettings().sandbox_data_dir) / "strategy_rotator_state.json"
+    )
+)
 settings = SandboxSettings()
 manager = PromptStrategyManager(
     strategies=TEMPLATES, state_path=STATE_PATH, keyword_map=KEYWORD_MAP


### PR DESCRIPTION
## Summary
- ensure strategy rotator state path resolves relative to project root
- import `resolve_path`

## Testing
- `pytest self_improvement/tests/test_strategy_rotation.py self_improvement/tests/test_strategy_rotator_sequential.py`

------
https://chatgpt.com/codex/tasks/task_e_68bab56404fc832ea89269462f3149da