### PR TITLE
Add Stripe ID tracking for billing logs

### DIFF
--- a/migrations/upgrade_billing_log_db.py
+++ b/migrations/upgrade_billing_log_db.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+from billing.billing_log_db import BillingLogDB
+
+
+def upgrade(path: str | Path | None = None) -> None:
+    """Ensure billing_logs table has the stripe_id column."""
+    BillingLogDB(path or BillingLogDB().path)
+
+
+if __name__ == "__main__":
+    upgrade(sys.argv[1] if len(sys.argv) > 1 else None)

--- a/stripe_billing_router.py
+++ b/stripe_billing_router.py
@@ -852,6 +852,7 @@ def charge(
                 user_email=email,
                 destination_account=destination,
                 key_hash=key_hash,
+                stripe_id=event_id,
                 ts=datetime.utcnow().isoformat(),
             )
         _log_payment(
@@ -1047,6 +1048,7 @@ def create_subscription(
                 user_email=email,
                 destination_account=destination,
                 key_hash=key_hash,
+                stripe_id=event_id,
                 ts=datetime.utcnow().isoformat(),
             )
         _log_payment(
@@ -1193,6 +1195,7 @@ def refund(
             user_email=email,
             destination_account=destination,
             key_hash=key_hash,
+            stripe_id=event_id,
             ts=datetime.utcnow().isoformat(),
         )
         _log_payment(
@@ -1331,6 +1334,7 @@ def create_checkout_session(
             user_email=email,
             destination_account=destination,
             key_hash=key_hash,
+            stripe_id=event_id,
             ts=datetime.utcnow().isoformat(),
         )
         _log_payment(


### PR DESCRIPTION
## Summary
- extend billing logs schema and events with a `stripe_id` field and migration helper
- log Stripe event IDs for charges, refunds and sessions
- use `stripe_id` for watchdog loading and detection logic; add matching tests

## Testing
- `python - <<'PY'
import types, sys, pytest, pathlib
pkg = types.ModuleType('menace_sandbox')
pkg.__path__ = [str(pathlib.Path('.').resolve())]
sys.modules['menace_sandbox'] = pkg
pytest.main(['unit_tests/test_stripe_watchdog.py'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bab650d934832e9b890a3560d62975