### PR TITLE
Add systemd timer and cron fallback for Stripe watchdog

### DIFF
--- a/scripts/install_stripe_watchdog_cron.sh
+++ b/scripts/install_stripe_watchdog_cron.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Install an hourly cron entry for stripe_watchdog.py when systemd isn't available.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+
+CRON_LINE="0 * * * * cd $REPO_ROOT && /usr/bin/python stripe_watchdog.py >> finance_logs/stripe_watchdog.log 2>&1"
+( crontab -l 2>/dev/null | grep -v 'stripe_watchdog.py'; echo "$CRON_LINE" ) | crontab -
+
+echo "Installed stripe_watchdog cron entry."

--- a/systemd/stripe_watchdog.service
+++ b/systemd/stripe_watchdog.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Stripe Watchdog
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/menace
+ExecStart=/usr/bin/python stripe_watchdog.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/stripe_watchdog.timer
+++ b/systemd/stripe_watchdog.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run Stripe Watchdog hourly
+
+[Timer]
+OnCalendar=hourly
+Unit=stripe_watchdog.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- add stripe_watchdog systemd service and hourly timer
- provide script to install an hourly cron job when systemd is unavailable
- document how to enable the timer or install the cron job

## Testing
- `PYTHONPATH=$(pwd) pre-commit run --files systemd/stripe_watchdog.service systemd/stripe_watchdog.timer scripts/install_stripe_watchdog_cron.sh docs/stripe_watchdog.md`

------
https://chatgpt.com/codex/tasks/task_e_68baba372ee4832e976c10e6d24283c1