### PR TITLE
Use resolve_path in self-improvement tests

### DIFF
--- a/self_improvement/tests/test_prompt_penalties.py
+++ b/self_improvement/tests/test_prompt_penalties.py
@@ -23,11 +23,13 @@ sys.modules.setdefault("sandbox_runner.bootstrap", boot)
 
 settings_mod = ModuleType("sandbox_settings")
 
+from dynamic_path_router import resolve_path
+
 class DummySettings:
     def __init__(self):
-        self.prompt_penalty_path = "penalties.json"
-        self.prompt_success_log_path = "success.log"
-        self.prompt_failure_log_path = "failure.log"
+        self.prompt_penalty_path = resolve_path("penalties.json")
+        self.prompt_success_log_path = resolve_path("success.log")
+        self.prompt_failure_log_path = resolve_path("failure.log")
         self.sandbox_repo_path = "."
         self.sandbox_data_dir = os.getenv("SANDBOX_DATA_DIR", ".")
         self.prompt_failure_threshold = 3

--- a/self_improvement/tests/test_select_prompt_strategy_roi.py
+++ b/self_improvement/tests/test_select_prompt_strategy_roi.py
@@ -12,6 +12,8 @@ router.resolve_path = lambda p: p
 router.repo_root = lambda: ROOT
 sys.modules.setdefault("dynamic_path_router", router)
 
+from dynamic_path_router import resolve_path
+
 boot = types.ModuleType("sandbox_runner.bootstrap")
 boot.initialize_autonomous_sandbox = lambda *a, **k: None
 sys.modules.setdefault("sandbox_runner.bootstrap", boot)
@@ -25,7 +27,7 @@ from menace_sandbox.self_improvement.prompt_strategy_manager import (  # noqa: E
 )
 
 def test_best_strategy_prefers_high_roi(tmp_path, monkeypatch):
-    stats_path = tmp_path / "stats.json"
+    stats_path = tmp_path / "stats.json"  # path-ignore
     data = {
         "s1": {
             "success": 1,
@@ -43,6 +45,6 @@ def test_best_strategy_prefers_high_roi(tmp_path, monkeypatch):
         },
     }
     stats_path.write_text(json.dumps(data))
-    mgr = PromptStrategyManager(stats_path=stats_path, state_path=tmp_path / "state.json")
+    mgr = PromptStrategyManager(stats_path=stats_path, state_path=tmp_path / "state.json")  # path-ignore
     mgr.set_strategies(["s1", "s2"])
     assert mgr.best_strategy(["s1", "s2"]) == "s2"

--- a/self_improvement/tests/test_strategy_roi_decay.py
+++ b/self_improvement/tests/test_strategy_roi_decay.py
@@ -1,5 +1,4 @@
 import sys
-import sys
 import types
 import time
 import math
@@ -13,6 +12,8 @@ sys.modules.setdefault(
     "dynamic_path_router",
     types.SimpleNamespace(resolve_path=lambda p: p, repo_root=lambda: ROOT),
 )
+
+from dynamic_path_router import resolve_path
 
 boot = types.ModuleType("sandbox_runner.bootstrap")
 boot.initialize_autonomous_sandbox = lambda *a, **k: None
@@ -37,7 +38,7 @@ class DummySettings:
 
 def test_recent_success_outweighs_old(monkeypatch, tmp_path):
     monkeypatch.setattr(settings_mod, "SandboxSettings", DummySettings)
-    mgr = PromptStrategyManager(stats_path=tmp_path / "stats.json", state_path=tmp_path / "state.json")
+    mgr = PromptStrategyManager(stats_path=tmp_path / "stats.json", state_path=tmp_path / "state.json")  # path-ignore
     mgr.set_strategies(["s1", "s2"])
     now = time.time()
     mgr.stats = {

--- a/self_improvement/tests/test_strategy_rotation.py
+++ b/self_improvement/tests/test_strategy_rotation.py
@@ -11,6 +11,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 sys.modules.setdefault("dynamic_path_router", types.SimpleNamespace(resolve_path=lambda p: p))
+from dynamic_path_router import resolve_path
 pkg = types.ModuleType("menace_sandbox.self_improvement")
 pkg.__path__ = [str(ROOT / "self_improvement")]
 sys.modules["menace_sandbox.self_improvement"] = pkg
@@ -78,7 +79,7 @@ def _reload(monkeypatch, tmp_path, **env):
     for key, value in env.items():
         monkeypatch.setenv(key, value)
     sr = importlib.reload(strategy_rotator)
-    sr.manager.stats_path = Path(tmp_path) / "_strategy_stats.json"
+    sr.manager.stats_path = Path(tmp_path) / "_strategy_stats.json"  # path-ignore
     sr.manager._stats_lock = FileLock(str(sr.manager.stats_path) + ".lock")
     return sr
 


### PR DESCRIPTION
## Summary
- import `resolve_path` in self-improvement tests
- replace direct filenames with `resolve_path` or `# path-ignore`

## Testing
- `pytest self_improvement/tests/test_prompt_penalties.py self_improvement/tests/test_select_prompt_strategy_roi.py self_improvement/tests/test_strategy_roi_decay.py self_improvement/tests/test_strategy_rotation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68babaab0130832eafdfd5459bbc3112