### PR TITLE
Use RotatingFileHandler for Stripe anomaly audits

### DIFF
--- a/config/stripe_watchdog.yaml
+++ b/config/stripe_watchdog.yaml
@@ -3,3 +3,6 @@ allowed_webhooks:
   - we_1234567890
 approved_workflows:
   - billing_bot
+log_rotation:
+  maxBytes: 5242880
+  backupCount: 5


### PR DESCRIPTION
## Summary
- Replace manual anomaly log rotation with `RotatingFileHandler` and gzip backups
- Allow overriding log rotation via `log_rotation.maxBytes` and `backupCount` config
- Extend `AuditTrail` to accept logging handlers and add rotation test

## Testing
- `pytest tests/test_stripe_watchdog.py unit_tests/test_stripe_watchdog.py`


------
https://chatgpt.com/codex/tasks/task_e_68babb0d5134832ea358d72bee661f9e