### PR TITLE
Log Stripe anomalies to payment sanity layer

### DIFF
--- a/tests/test_stripe_watchdog.py
+++ b/tests/test_stripe_watchdog.py
@@ -51,6 +51,9 @@ def capture_anomalies(monkeypatch, tmp_path):
     monkeypatch.setattr(sw, "ANOMALY_TRAIL", AuditTrail(str(log_path), handler=handler))
     resolve_path("config/stripe_watchdog.yaml")
     monkeypatch.setattr(sw.alert_dispatcher, "dispatch_alert", lambda *a, **k: None)
+    monkeypatch.setattr(
+        sw.menace_sanity_layer, "record_payment_anomaly", lambda *a, **k: None
+    )
 
     return events, samples
 

--- a/unit_tests/test_stripe_watchdog.py
+++ b/unit_tests/test_stripe_watchdog.py
@@ -27,6 +27,9 @@ def capture(monkeypatch, tmp_path):
         "dispatch_alert",
         lambda *a, **k: events.append(("alert", a, k)),
     )
+    monkeypatch.setattr(
+        sw.menace_sanity_layer, "record_payment_anomaly", lambda *a, **k: None
+    )
 
     class DummyTrail:
         def __init__(self, path):


### PR DESCRIPTION
## Summary
- Report Stripe watchdog anomalies to `menace_sanity_layer.record_payment_anomaly` with instructional context
- Carry `write_codex` and `export_training` flags through anomaly logging for Sanity Layer awareness
- Stub Sanity Layer in tests to avoid side effects

## Testing
- `pytest tests/test_stripe_watchdog.py unit_tests/test_stripe_watchdog.py`

------
https://chatgpt.com/codex/tasks/task_e_68bac0aa5254832e861ae9b5987e4aca