### PR TITLE
Clarify Stripe routing policy with logging requirement

### DIFF
--- a/stripe_policy.py
+++ b/stripe_policy.py
@@ -3,5 +3,6 @@
 PAYMENT_ROUTER_NOTICE = (
     "All payment logic must import and use stripe_billing_router. "
     "Direct Stripe SDK calls or raw Stripe keys are forbidden. "
+    "Every Stripe charge must use central routing and log via billing_logger/stripe_ledger. "
     "Missing the import must raise a critical generation failure."
 )

--- a/tests/test_payment_notice.py
+++ b/tests/test_payment_notice.py
@@ -1,3 +1,7 @@
+"""Tests for payment notice injection logic."""
+
+# flake8: noqa
+
 import sys
 import types
 from pathlib import Path
@@ -102,6 +106,13 @@ from menace_sandbox.chatgpt_idea_bot import ChatGPTClient
 from menace_sandbox.bot_development_bot import BotDevelopmentBot
 
 
+def test_payment_router_notice_mentions_central_routing_and_logging():
+    phrase = (
+        "Every Stripe charge must use central routing and log via billing_logger/stripe_ledger."
+    )
+    assert phrase in PAYMENT_ROUTER_NOTICE
+
+
 def test_prepend_payment_notice_helper():
     msgs = [{"role": "user", "content": "hello"}]
     new_msgs = prepend_payment_notice(msgs)
@@ -203,6 +214,9 @@ def test_gpt4client_injects_notice(monkeypatch):
     monkeypatch.syspath_prepend(
         str(Path(__file__).resolve().parents[1] / "neurosales")
     )
+    import importlib
+    ext = importlib.import_module("neurosales.external_integrations")
+    importlib.reload(ext)
     from neurosales.external_integrations import GPT4Client
 
     client = GPT4Client(api_key="k")


### PR DESCRIPTION
## Summary
- Emphasize that every Stripe charge must use central routing and log via billing_logger/stripe_ledger
- Add regression test to assert notice includes central routing and logging requirement
- Reload external integrations during GPT4 client tests to ensure payment notice is injected

## Testing
- `pre-commit run --files stripe_policy.py tests/test_payment_notice.py` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*
- `pytest tests/test_payment_notice.py neurosales/tests/test_external_integrations.py`


------
https://chatgpt.com/codex/tasks/task_e_68bac4542484832e96f98098e7f67b09