### PR TITLE
Handle malformed LLM results in SelfCodingEngine

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -1260,7 +1260,30 @@ class SelfCodingEngine:
                 if alt is None or not alt.text.strip():
                     return _fallback()
                 result = alt
-        text = result.text.strip()
+        text = result.text
+        if not text.strip():
+            alt = codex_fallback_handler.handle_failure(
+                prompt_obj, result, "empty completion"
+            )
+            if alt is None or not alt.text.strip():
+                return _fallback()
+            result = alt
+            text = result.text
+        try:
+            ast.parse(text)
+        except Exception as exc:
+            alt = codex_fallback_handler.handle_failure(
+                prompt_obj, result, f"syntax error: {exc}"
+            )
+            if alt is None or not alt.text.strip():
+                return _fallback()
+            result = alt
+            try:
+                ast.parse(result.text)
+            except Exception:
+                return _fallback()
+            text = result.text
+        text = text.strip()
         if text:
             if self.gpt_memory:
                 try:


### PR DESCRIPTION
## Summary
- Validate LLM completions in `SelfCodingEngine.generate_helper` and treat empty or syntactically invalid results as malformed
- Route malformed completions through `codex_fallback_handler.handle_failure` and fall back to minimal helper when reroute fails

## Testing
- `pytest` *(fails: FileNotFoundError: 'training_data/stripe_anomalies.jsonl' not found under /workspace ...; 603 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bac6795558832ea34f46e2522d1680