### PR TITLE
Log billing anomalies to Sanity Layer

### DIFF
--- a/stripe_watchdog.py
+++ b/stripe_watchdog.py
@@ -45,6 +45,7 @@ from logging.handlers import RotatingFileHandler
 import gzip
 import shutil
 import menace_sanity_layer
+from menace_sanity_layer import record_billing_anomaly
 
 try:  # Optional dependency – Stripe API client
     import stripe  # type: ignore
@@ -483,6 +484,11 @@ def _emit_anomaly(
             TrainingSample(source="stripe_watchdog", content=json.dumps(record))
         except Exception:
             logger.exception("Failed to create Codex training sample")
+
+    try:
+        record_billing_anomaly(record["type"], record)
+    except Exception:
+        logger.exception("Failed to record billing anomaly", extra={"record": record})
 
     metadata = {k: v for k, v in record.items() if k != "type"}
     if "id" in metadata:


### PR DESCRIPTION
## Summary
- Record billing anomalies via menace_sanity_layer
- Guard Sanity Layer calls so watchdog continues on failure

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'SHARED_QUEUE_DIR')*
- `pytest tests/test_stripe_watchdog.py::test_orphan_charge_triggers_audit_and_codex -q` *(fails: ImportError: attempted relative import with no known parent package)*


------
https://chatgpt.com/codex/tasks/task_e_68bacbcec568832eb1dbace23b8a3a01