### PR TITLE
Add Sanity Layer watchdog test and docs

### DIFF
--- a/docs/menace_sanity_layer.md
+++ b/docs/menace_sanity_layer.md
@@ -1,0 +1,35 @@
+# Menace Sanity Layer
+
+The Sanity Layer captures billing anomalies detected across Menace services and
+feeds them back into future generations of bots.
+
+## Setup
+
+1. Ensure dependencies are installed:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Configure the database router before recording anomalies:
+   ```python
+   from db_router import init_db_router
+   init_db_router("ba", "local.db", "shared.db")
+   ```
+3. Components listening for anomalies can subscribe via
+   `UnifiedEventBus`.
+
+## Configuration
+
+* `record_billing_anomaly` stores events in the `billing_anomalies`
+  table and publishes them on the `"billing.anomaly"` topic.
+* `record_payment_anomaly` logs contextual guidance to
+  `MenaceMemoryManager`, allowing behaviour to be refined over time.
+* Optional `GPT_MEMORY_MANAGER` and `DiscrepancyDB` integrations provide
+  additional audit trails when available.
+
+## Improving Future Generations
+
+When the Stripe watchdog or other monitors detect a billing issue they emit an
+anomaly through the Sanity Layer.  Each anomaly publishes an event and records a
+short instruction in `MenaceMemoryManager` describing how to avoid the problem.
+The accumulated feedback helps subsequent models steer clear of the same
+mistakes, continuously improving billing reliability.


### PR DESCRIPTION
## Summary
- add end-to-end test that simulates Stripe watchdog anomalies and verifies database persistence, memory logging and event bus notifications
- document Menace Sanity Layer setup, configuration and feedback loop

## Testing
- `pytest tests/test_menace_sanity_layer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bacf360214832e8ec151e375ccd163