### PR TITLE
refactor: parameterize codex retry settings

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -749,6 +749,11 @@ class SandboxSettings(BaseSettings):
         env="CODEX_FALLBACK_MODEL",
         description="Fallback model to use when Codex requests fail.",
     )
+    codex_retry_queue_path: str = Field(
+        "codex_retry_queue.jsonl",
+        env="CODEX_RETRY_QUEUE",
+        description="Path for the Codex retry queue file.",
+    )
     if PYDANTIC_V2:
 
         @field_validator("codex_retry_delays", mode="before")

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -237,11 +237,11 @@ def call_codex_with_backoff(
     """Invoke ``llm_client.generate`` with retries and fixed backoff delays.
 
     Each attempt enforces a timeout and exceptions are logged before sleeping
-    for 2s → 5s → 10s between attempts.  A :class:`RetryError` is raised when
-    all retries fail.
+    for the configured delays (defaulting to ``[2, 5, 10]``). A
+    :class:`RetryError` is raised when all retries fail.
     """
 
-    delays = [2, 5, 10]
+    delays = _settings.codex_retry_delays
     log = logger or logging.getLogger(__name__)
 
     def _attempt() -> LLMResult:


### PR DESCRIPTION
## Summary
- add codex retry queue path to sandbox settings
- use codex retry settings in self_coding_engine
- read fallback model and queue path from settings in codex_fallback_handler

## Testing
- `python -m py_compile sandbox_settings.py self_coding_engine.py codex_fallback_handler.py`
- `pytest -q` *(fails: ImportError, FileNotFoundError, RuntimeError)*

------
https://chatgpt.com/codex/tasks/task_e_68bad32660d0832eb31a6b206fcf888a