### PR TITLE
Incorporate billing issue hints into bot prompts

### DIFF
--- a/bot_creation_bot.py
+++ b/bot_creation_bot.py
@@ -36,6 +36,7 @@ from datetime import datetime
 from .database_manager import DB_PATH, update_model
 from vector_service.cognition_layer import CognitionLayer
 from .roi_tracker import ROITracker
+from .menace_sanity_layer import fetch_recent_billing_issues
 try:  # pragma: no cover - allow flat imports
     from .dynamic_path_router import path_for_prompt
 except Exception:  # pragma: no cover - fallback for flat layout
@@ -443,7 +444,15 @@ class BotCreationBot(AdminBotBase):
                 _ctx, session_id = self.cognition_layer.query(
                     f"self coding patch for {prompt_module}"
                 )
-                self.self_coding_engine.patch_file(file_path, "helper")
+                billing_instructions = fetch_recent_billing_issues()
+                context_meta = (
+                    {"billing_instructions": billing_instructions}
+                    if billing_instructions
+                    else None
+                )
+                self.self_coding_engine.patch_file(
+                    file_path, "helper", context_meta=context_meta
+                )
                 self.cognition_layer.record_patch_outcome(session_id, True, contribution=1.0)
             except Exception as exc:
                 self.cognition_layer.record_patch_outcome(session_id, False, contribution=0.0)

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -62,6 +62,7 @@ except Exception:  # pragma: no cover - fallback for flat layout
         recent_error_fix,
         recent_improvement_path,
     )
+from .menace_sanity_layer import fetch_recent_billing_issues
 try:  # pragma: no cover - optional rollback support
     from .rollback_manager import RollbackManager
 except Exception:  # pragma: no cover - degrade gracefully when missing
@@ -1190,6 +1191,23 @@ class SelfCodingEngine:
             else:
                 rc_text = rc
             prompt_obj.text += "\n\n### Retrieval context\n" + rc_text
+
+        billing_notes = (
+            metadata.get("billing_instructions")
+            if metadata and metadata.get("billing_instructions")
+            else fetch_recent_billing_issues()
+        )
+        if billing_notes:
+            billing_text = (
+                "\n".join(billing_notes)
+                if isinstance(billing_notes, list)
+                else str(billing_notes)
+            )
+            try:
+                prompt_obj.text += "\n\n### Billing issues\n" + billing_text
+            except Exception:
+                if hasattr(prompt_obj, "user"):
+                    prompt_obj.user += "\n\n### Billing issues\n" + billing_text
 
         # Incorporate past patch outcomes from memory
         history = ""

--- a/tests/test_billing_prompt_injection.py
+++ b/tests/test_billing_prompt_injection.py
@@ -1,0 +1,77 @@
+import sys
+import types
+import logging
+import pytest
+
+# Stub heavy dependencies before importing the module under test
+sys.modules["vector_service"] = types.SimpleNamespace(
+    CognitionLayer=object,
+    PatchLogger=object,
+    VectorServiceError=Exception,
+    SharedVectorService=object,
+)
+sys.modules["menace.code_database"] = types.SimpleNamespace(
+    CodeDB=object, CodeRecord=object, PatchHistoryDB=object, PatchRecord=object
+)
+sys.modules["code_database"] = sys.modules["menace.code_database"]
+sys.modules["menace.unified_event_bus"] = types.SimpleNamespace(
+    UnifiedEventBus=object
+)
+sys.modules["unified_event_bus"] = sys.modules["menace.unified_event_bus"]
+sys.modules["menace.trend_predictor"] = types.SimpleNamespace(TrendPredictor=object)
+sys.modules["trend_predictor"] = sys.modules["menace.trend_predictor"]
+sys.modules["menace.shared_gpt_memory"] = types.SimpleNamespace(
+    GPT_MEMORY_MANAGER=None
+)
+sys.modules["shared_gpt_memory"] = sys.modules["menace.shared_gpt_memory"]
+
+import menace.self_coding_engine as sce
+from menace.llm_interface import LLMResult
+
+
+class DummyPrompt:
+    def __init__(self, text: str = "base") -> None:
+        self.text = text
+        self.system = ""
+        self.examples = []
+        self.metadata = {}
+
+    def __str__(self) -> str:  # pragma: no cover - simple repr
+        return self.text
+
+
+def test_billing_instructions_in_prompt(monkeypatch):
+    engine = object.__new__(sce.SelfCodingEngine)
+    engine.prompt_engine = types.SimpleNamespace(
+        build_prompt=lambda *a, **k: DummyPrompt("start")
+    )
+    engine.llm_client = object()
+    engine.logger = logging.getLogger("test")
+    engine.gpt_memory = None
+    engine.knowledge_service = None
+    engine.formal_verifier = None
+    engine.prompt_optimizer = None
+    engine.prompt_evolution_memory = None
+    engine.roi_tracker = None
+    engine.context_builder = None
+    engine.prompt_tone = None
+    engine._last_prompt_metadata = {}
+    engine._last_retry_trace = ""
+    engine.suggest_snippets = lambda *a, **k: []
+    engine._build_file_context = lambda *a, **k: ("", None)
+    engine._extract_statements = lambda *a, **k: []
+    engine._apply_prompt_style = lambda *a, **k: None
+    engine._fetch_retry_trace = lambda meta: ""
+
+    monkeypatch.setattr(sce, "call_codex_with_backoff", lambda *a, **k: LLMResult())
+    monkeypatch.setattr(sce, "get_feedback", lambda *a, **k: [])
+    monkeypatch.setattr(sce, "get_error_fixes", lambda *a, **k: [])
+    monkeypatch.setattr(sce, "recent_feedback", lambda *a, **k: "")
+    monkeypatch.setattr(sce, "recent_improvement_path", lambda *a, **k: "")
+    monkeypatch.setattr(sce, "recent_error_fix", lambda *a, **k: "")
+    monkeypatch.setattr(
+        sce, "fetch_recent_billing_issues", lambda limit=5: ["invoice overdue"]
+    )
+
+    engine.generate_helper("demo task")
+    assert "invoice overdue" in engine._last_prompt.text


### PR DESCRIPTION
## Summary
- factor recent billing issues into BotCreationBot's patch workflow
- surface billing issue notes in SelfCodingEngine prompts
- test that billing guidance is injected into prompts

## Testing
- `pytest tests/test_billing_prompt_injection.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68badc7382ac832eb6b43a1fe2128def