### PR TITLE
docs: document self-coding engine fallback mechanisms

### DIFF
--- a/docs/implementation_optimiser_bot.md
+++ b/docs/implementation_optimiser_bot.md
@@ -23,5 +23,11 @@ Shell tasks receive a simple `#!/bin/sh` template with a `main` function that ca
 
 ## Using `SelfCodingEngine`
 
-If an instance of `SelfCodingEngine` is passed to the bot, `fill_missing()` first calls `engine.generate_helper(desc)` to produce an implementation based on task metadata. When generation fails or the engine is absent the templates above are used instead.
+If an instance of `SelfCodingEngine` is passed to the bot, `fill_missing()` first
+calls `engine.generate_helper(desc)` to produce an implementation based on task
+metadata.  The engine retries with `CODEX_RETRY_DELAYS`, simplifies the prompt
+on persistent failures and falls back to queueing or rerouting to
+`CODEX_FALLBACK_MODEL` depending on `CODEX_FALLBACK_STRATEGY`.  Even when a
+prompt is queued the bot proceeds with a stub so optimisation continues in
+degraded mode.  When the engine is absent the templates above are used instead.
 

--- a/docs/self_improvement_engine.md
+++ b/docs/self_improvement_engine.md
@@ -33,7 +33,12 @@ print(resolve_path('sandbox_runner.py', repo_hint='/repo/alt'))
 PY
 ```
 
-When a `SelfCodingEngine` is supplied, the engine may patch helper code before running the automation pipeline. See [self_coding_engine.md](self_coding_engine.md) for more information.
+When a `SelfCodingEngine` is supplied, the engine may patch helper code before
+running the automation pipeline.  The helper generator retries requests using
+`CODEX_RETRY_DELAYS`, simplifies prompts when failures persist and falls back to
+queueing or rerouting requests to `CODEX_FALLBACK_MODEL` depending on
+`CODEX_FALLBACK_STRATEGY`.  Even in this degraded mode the cycle continues.  See
+[self_coding_engine.md](self_coding_engine.md) for more information.
 
 Persisting cycle data across runs is possible by providing `state_path` when creating the engine. ROI deltas, an exponential moving average of those deltas (`roi_delta_ema`) and the timestamp of the last cycle are written to this JSON file and reloaded on startup. The smoothing factor for the EMA can be set with `roi_ema_alpha` (default `0.1`). Recent cycle outcomes are also stored in `success_history` to derive a momentum coefficient that influences future scheduling.
 


### PR DESCRIPTION
## Summary
- document retry backoff, prompt simplification and fallback routing for `SelfCodingEngine`
- note degraded-mode behaviour and configuration knobs in related docs
- remove accidental binary database change

## Testing
- `pytest -q` *(fails: ImportError and missing modules; 609 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68badabbd664832ebcad7ccf7b82bffe