### PR TITLE
Add sanity layer test and docs for Stripe watchdog

### DIFF
--- a/docs/menace_sanity_layer.md
+++ b/docs/menace_sanity_layer.md
@@ -29,6 +29,31 @@ feeds them back into future generations of bots.
   `DiscrepancyRecord` and logging feedback to `GPTMemoryManager`.
 * `fetch_recent_billing_issues` returns recent feedback snippets that can be
   used to bias future prompts or code generation.
+* The ``write_codex`` and ``export_training`` flags determine whether anomalies
+  are exported as Codex samples or appended to the training dataset.
+* Supplying ``config_path`` to :func:`record_billing_event` merges suggested
+  configuration updates into the referenced JSON file.
+
+## Usage
+
+```python
+from menace_sanity_layer import record_payment_anomaly, list_anomalies
+
+record_payment_anomaly(
+    "missing_charge",
+    {"id": "ch_1", "amount": 5},
+    "Avoid generating bots that make Stripe charges without proper logging or central routing.",
+    write_codex=True,
+    export_training=False,
+)
+
+print(list_anomalies(1))
+```
+
+The ``instruction`` field provides a short guideline describing how to prevent
+similar issues in the future.  These snippets are stored in GPT memory and can
+be retrieved via :func:`fetch_recent_billing_issues` to bias subsequent code
+generation.
 
 ## Improving Future Generations
 

--- a/docs/stripe_watchdog.md
+++ b/docs/stripe_watchdog.md
@@ -55,3 +55,27 @@ bash scripts/install_stripe_watchdog_cron.sh
 ```
 
 The script registers an hourly cron entry running `stripe_watchdog.py`.
+
+## Sanity layer integration
+
+Detected discrepancies are forwarded to the Menace Sanity Layer which records
+them in SQLite and logs corrective guidance to GPT memory.  A minimal example
+invocation looks like:
+
+```python
+from db_router import init_db_router
+from stripe_watchdog import detect_missing_charges
+
+init_db_router("ba", "local.db", "shared.db")
+charges = [{"id": "ch_1", "amount": 5}]
+detect_missing_charges(charges, [], write_codex=True, export_training=False)
+```
+
+Each anomaly is logged with the instruction:
+
+```
+Avoid generating bots that make Stripe charges without proper logging or central routing.
+```
+
+Use the `write_codex` and `export_training` flags to control whether anomalies
+are exported as Codex samples or appended to the training dataset.

--- a/tests/integration/test_anomaly_to_memory_flow.py
+++ b/tests/integration/test_anomaly_to_memory_flow.py
@@ -1,0 +1,47 @@
+from db_router import init_db_router
+
+
+def test_detect_missing_charge_records_memory(monkeypatch, tmp_path):
+    """End-to-end anomaly detection to GPT memory logging."""
+
+    # Configure temporary databases for anomaly logging
+    init_db_router("ba", str(tmp_path / "local.db"), str(tmp_path / "shared.db"))
+
+    import menace_sanity_layer as msl
+
+    # Avoid external side effects
+    msl._DISCREPANCY_DB = None
+    msl.GPT_MEMORY_MANAGER = None
+    monkeypatch.setattr(msl.audit_logger, "log_event", lambda *a, **k: None)
+    msl._EVENT_BUS = msl.UnifiedEventBus()
+
+    class DummyMM:
+        def __init__(self) -> None:
+            self.stored: list[tuple[str, dict, str]] = []
+
+        def query(self, key, limit):  # pragma: no cover - unused
+            return []
+
+        def store(self, key, data, tags=""):
+            self.stored.append((key, data, tags))
+
+    mm = DummyMM()
+    msl._MEMORY_MANAGER = mm
+
+    import stripe_watchdog as sw
+
+    # Prevent file I/O during anomaly emission
+    monkeypatch.setattr(sw.audit_logger, "log_event", lambda *a, **k: None)
+    monkeypatch.setattr(sw.ANOMALY_TRAIL, "record", lambda *a, **k: None)
+
+    charges = [
+        {"id": "ch_1", "amount": 5, "receipt_email": "a@example.com", "created": 1}
+    ]
+
+    # No ledger entries so the charge is considered missing
+    anomalies = sw.detect_missing_charges(
+        charges, [], write_codex=False, export_training=False
+    )
+
+    assert anomalies and anomalies[0]["type"] == "missing_charge"
+    assert mm.stored and mm.stored[0][0] == "billing:missing_charge"


### PR DESCRIPTION
## Summary
- cover anomaly detection to GPT memory flow with an integration test
- document Stripe watchdog and Sanity Layer setup, usage, and configuration options

## Testing
- `pytest tests/integration/test_anomaly_to_memory_flow.py tests/test_menace_sanity_layer.py::test_watchdog_anomaly_updates_db_memory_and_event_bus -q`

------
https://chatgpt.com/codex/tasks/task_e_68badff0ffcc832e845458ca74bd0e72