### PR TITLE
Verify Codex output and trigger fallback handler

### DIFF
--- a/codex_fallback_handler.py
+++ b/codex_fallback_handler.py
@@ -125,4 +125,16 @@ def handle_failure(
         return None
 
 
-__all__ = ["handle_failure", "queue_for_retry", "route_to_alt_model"]
+def handle(prompt: str | Prompt, reason: str, *, strategy: str | None = None) -> LLMResult | None:
+    """Queue or reroute *prompt* because of *reason*.
+
+    This wrapper emits a log entry so upstream components can detect when the
+    system is operating in a degraded state.  It then delegates to
+    :func:`handle_failure` for the actual queue or reroute behaviour.
+    """
+
+    logger.warning("codex fallback engaged", extra={"reason": reason})
+    return handle_failure(prompt, exc=reason, strategy=strategy)
+
+
+__all__ = ["handle_failure", "queue_for_retry", "route_to_alt_model", "handle"]

--- a/tests/test_codex_fallback.py
+++ b/tests/test_codex_fallback.py
@@ -84,7 +84,7 @@ def test_codex_fallback_retries_and_simplified_prompt(monkeypatch):
 
     alt_result = LLMResult(text="print('hi')")
     handle_mock = MagicMock(return_value=alt_result)
-    monkeypatch.setattr(self_coding_engine.codex_fallback_handler, "handle_failure", handle_mock)
+    monkeypatch.setattr(self_coding_engine.codex_fallback_handler, "handle", handle_mock)
 
     call_delays = []
 
@@ -122,12 +122,12 @@ def test_codex_fallback_queue_on_malformed(monkeypatch):
         self_coding_engine.codex_fallback_handler, "queue_for_retry", queue_mock
     )
 
-    def handle_failure(prompt, exc=None, result=None):
+    def handle(prompt, reason, **_):
         self_coding_engine.codex_fallback_handler.queue_for_retry(prompt)
         return None
 
     monkeypatch.setattr(
-        self_coding_engine.codex_fallback_handler, "handle_failure", handle_failure
+        self_coding_engine.codex_fallback_handler, "handle", handle
     )
     patch_history(monkeypatch)
 

--- a/tests/test_self_coding_codex_fallback.py
+++ b/tests/test_self_coding_codex_fallback.py
@@ -92,7 +92,7 @@ def test_empty_output_triggers_fallback(monkeypatch):
 
     alt_result = LLMResult(text="print('hi')")
     handle_mock = MagicMock(return_value=alt_result)
-    monkeypatch.setattr(self_coding_engine.codex_fallback_handler, "handle_failure", handle_mock)
+    monkeypatch.setattr(self_coding_engine.codex_fallback_handler, "handle", handle_mock)
 
     sleeps: list[float] = []
     monkeypatch.setattr(time, "sleep", lambda s: sleeps.append(s))
@@ -137,7 +137,7 @@ def test_malformed_output_triggers_fallback(monkeypatch):
 
     alt_result = LLMResult(text="print('fixed')")
     handle_mock = MagicMock(return_value=alt_result)
-    monkeypatch.setattr(self_coding_engine.codex_fallback_handler, "handle_failure", handle_mock)
+    monkeypatch.setattr(self_coding_engine.codex_fallback_handler, "handle", handle_mock)
 
     sleeps: list[float] = []
     monkeypatch.setattr(time, "sleep", lambda s: sleeps.append(s))

--- a/tests/test_self_coding_engine.py
+++ b/tests/test_self_coding_engine.py
@@ -541,13 +541,13 @@ def test_codex_fallback_handler_invoked(monkeypatch, tmp_path):
 
     calls: list[str] = []
 
-    def handle_failure(prompt, exc="", result=None):
-        calls.append(exc)
+    def handle(prompt, reason, **_):
+        calls.append(reason)
         if len(calls) == 1:
             return LLMResult(text="def bad(")
         return LLMResult(text="def good():\n    pass\n")
 
-    monkeypatch.setattr(sce.codex_fallback_handler, "handle_failure", handle_failure)
+    monkeypatch.setattr(sce.codex_fallback_handler, "handle", handle)
 
     code = engine.generate_helper("demo")
     assert "def good" in code


### PR DESCRIPTION
## Summary
- validate Codex generations in `generate_helper` via `ast.parse` and strip
- add `codex_fallback_handler.handle` wrapper to queue or reroute failed prompts
- update tests for new fallback API

## Testing
- `pytest tests/test_codex_fallback.py::test_codex_fallback_retries_and_simplified_prompt -q` *(fails: missing transformers/huggingface_hub)*

------
https://chatgpt.com/codex/tasks/task_e_68bae1d26aa4832eb750475ae827bda8