### PR TITLE
Log timeout retries in retry_with_backoff

### DIFF
--- a/tests/test_retry_with_backoff_timeouts.py
+++ b/tests/test_retry_with_backoff_timeouts.py
@@ -1,0 +1,34 @@
+import logging
+import asyncio
+import pytest
+import requests
+
+from resilience import retry_with_backoff, RetryError
+
+
+def test_retry_with_backoff_handles_requests_timeout(caplog):
+    calls = {"count": 0}
+
+    def func():
+        calls["count"] += 1
+        raise requests.Timeout("boom")
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(RetryError):
+            retry_with_backoff(func, attempts=2, delay=0)
+    assert calls["count"] == 2
+    assert any("timeout on attempt 1/2" in r.message for r in caplog.records)
+
+
+def test_retry_with_backoff_handles_asyncio_timeout(caplog):
+    calls = {"count": 0}
+
+    def func():
+        calls["count"] += 1
+        raise asyncio.TimeoutError()
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(RetryError):
+            retry_with_backoff(func, attempts=2, delay=0)
+    assert calls["count"] == 2
+    assert any("timeout on attempt 1/2" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- retry_with_backoff now always retries on requests.Timeout and asyncio.TimeoutError
- log timeout occurrences with attempt counters
- test timeout handling for both sync and async scenarios

## Testing
- `pre-commit run --files resilience.py tests/test_retry_with_backoff_timeouts.py` (failed: ModuleNotFoundError: dynamic_path_router)
- `pytest tests/test_retry_with_backoff_timeouts.py`


------
https://chatgpt.com/codex/tasks/task_e_68bae4a5b698832ebe08ebb1c3b98269