### PR TITLE
docs: detail Sanity Layer feedback for Stripe watchdog

### DIFF
--- a/docs/menace_sanity_layer.md
+++ b/docs/menace_sanity_layer.md
@@ -17,6 +17,18 @@ feeds them back into future generations of bots.
 3. Components listening for anomalies can subscribe via
    `UnifiedEventBus`.
 
+## Environment
+
+- `GPT_MEMORY_DB` *(optional)* – path to the SQLite database used for GPT memory
+  entries. Defaults to `gpt_memory.db`.
+- `GPT_MEMORY_RETENTION` and `GPT_MEMORY_MAX_ROWS` *(optional)* – retention
+  policies controlling how long feedback snippets are kept.
+
+Anomalies are persisted in the database configured through
+`init_db_router` (typically `local.db`/`shared.db`).  Feedback instructions are
+logged to the GPT memory database above, allowing subsequent runs to recall
+earlier issues.
+
 ## Configuration
 
 * `record_billing_anomaly` stores events in the `billing_anomalies`
@@ -33,6 +45,9 @@ feeds them back into future generations of bots.
   are exported as Codex samples or appended to the training dataset.
 * Supplying ``config_path`` to :func:`record_billing_event` merges suggested
   configuration updates into the referenced JSON file.
+* Watchdogs such as `stripe_watchdog` respect a `sanity_layer_feedback` setting
+  in their YAML configuration. Disabling it prevents anomalies from being logged
+  to GPT memory and omits the feedback loop.
 
 ## Usage
 

--- a/docs/stripe_watchdog.md
+++ b/docs/stripe_watchdog.md
@@ -20,9 +20,14 @@ Set the following environment variables before execution:
 - `STRIPE\_SECRET_KEY` – Stripe API key used to fetch events.
 - `STRIPE_ALLOWED_WEBHOOKS` *(optional)* – comma-separated list of additional
   authorized webhook endpoints.
+- `GPT_MEMORY_DB` *(optional)* – path to the SQLite file where feedback
+  snippets are stored. Defaults to `gpt_memory.db`.
 
-Anomaly summaries and audit entries are written to
-`finance_logs/stripe_watchdog.log`.
+Anomaly summaries are appended to `finance_logs/stripe_watchdog.log`, while
+structured audit records are written to
+`finance_logs/stripe_watchdog_audit.jsonl`. When Sanity Layer feedback is
+enabled, corrective guidance is logged to the GPT memory database referenced by
+`GPT_MEMORY_DB`.
 
 ## Configuration
 
@@ -35,6 +40,10 @@ authorized_webhooks:
 ```
 
 Endpoints not listed here will trigger an alert.
+
+To enable the Sanity Layer feedback loop, ensure `sanity_layer_feedback` is set
+to `true` in this YAML file (the default). Setting it to `false` disables
+recording anomalies to GPT memory and the corresponding audit trail.
 
 ## Systemd timer
 


### PR DESCRIPTION
## Summary
- explain GPT_MEMORY_DB and audit log locations in Stripe watchdog docs
- clarify Sanity Layer environment variables and config toggle for feedback loop

## Testing
- `PYTHONPATH=. SKIP=check-static-paths pre-commit run --files docs/stripe_watchdog.md docs/menace_sanity_layer.md`
- `pytest tests/test_menace_sanity_layer.py -q`
- `pytest tests/test_stripe_watchdog.py tests/test_menace_sanity_layer.py -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '')*

------
https://chatgpt.com/codex/tasks/task_e_68bae82b9c98832e8b2946a3f3c4144e