### PR TITLE
Use unified Codex retry handler

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -1288,10 +1288,8 @@ class SelfCodingEngine:
 
         result = LLMResult()
         try:
-            result = retry_with_backoff(
-                lambda: self.llm_client.generate(prompt_obj),
-                delays=[2, 5, 10],
-                logger=self.logger,
+            result = call_codex_with_backoff(
+                self.llm_client, prompt_obj, logger=self.logger
             )
         except RetryError as exc:
             self._last_retry_trace = str(exc)

--- a/tests/test_codex_fallback.py
+++ b/tests/test_codex_fallback.py
@@ -88,17 +88,17 @@ def test_codex_fallback_retries_and_simplified_prompt(monkeypatch):
 
     call_delays = []
 
-    def fake_retry(func, *, delays, attempts=None, logger=None, **_kw):
-        call_delays.append(list(delays))
-        attempts = attempts or len(delays)
-        for _ in range(attempts):
+    def fake_call(client, prompt, *, logger=None, timeout=30.0):
+        delays = list(self_coding_engine._settings.codex_retry_delays)
+        call_delays.append(delays)
+        for _ in delays:
             try:
-                return func()
+                client.generate(prompt)
             except Exception:
                 continue
         raise self_coding_engine.RetryError("boom")
 
-    monkeypatch.setattr(self_coding_engine, "retry_with_backoff", fake_retry)
+    monkeypatch.setattr(self_coding_engine, "call_codex_with_backoff", fake_call)
     patch_history(monkeypatch)
 
     result = engine.generate_helper("do something")

--- a/tests/test_self_coding_engine.py
+++ b/tests/test_self_coding_engine.py
@@ -586,13 +586,13 @@ def test_simplified_prompt_after_failure(monkeypatch, tmp_path):
 
     client = types.SimpleNamespace(generate=generate)
 
-    def failing_retry(func, *, delays, attempts=None, logger=None, **_):
+    def failing_call(client, prompt, *, logger=None, timeout=30.0):
         try:
-            return func()
+            return client.generate(prompt)
         except Exception as exc:
             raise sce.RetryError(str(exc))
 
-    monkeypatch.setattr(sce, "retry_with_backoff", failing_retry)
+    monkeypatch.setattr(sce, "call_codex_with_backoff", failing_call)
 
     engine = object.__new__(sce.SelfCodingEngine)
     engine.llm_client = client


### PR DESCRIPTION
## Summary
- Route self-coding engine requests through `call_codex_with_backoff`
- Adjust tests to use unified Codex retry helper

## Testing
- `python - <<'PY'
import sys, types, pytest
sys.path.insert(0, '/tmp/stubs')
cd_stub = types.ModuleType('code_database'); cd_stub.CodeDB=object; cd_stub.CodeRecord=object; cd_stub.PatchHistoryDB=object; cd_stub.PatchRecord=object
sys.modules['code_database']=cd_stub; sys.modules['menace.code_database']=cd_stub
ue_stub=types.ModuleType('unified_event_bus'); ue_stub.UnifiedEventBus=object
sys.modules['unified_event_bus']=ue_stub; sys.modules['menace.unified_event_bus']=ue_stub
sgm_stub=types.ModuleType('shared_gpt_memory'); sgm_stub.GPT_MEMORY_MANAGER=object
sys.modules['shared_gpt_memory']=sgm_stub; sys.modules['menace.shared_gpt_memory']=sgm_stub
gpt_mem_iface_stub=types.ModuleType('gpt_memory_interface'); gpt_mem_iface_stub.GPTMemoryInterface=object
sys.modules['gpt_memory_interface']=gpt_mem_iface_stub
safety_stub=types.ModuleType('safety_monitor'); safety_stub.SafetyMonitor=object
sys.modules['safety_monitor']=safety_stub
llm_router_stub=types.ModuleType('llm_router'); llm_router_stub.client_from_settings=lambda *a, **k: None
sys.modules['llm_router']=llm_router_stub
res_stub=types.ModuleType('resilience');
class RetryError(Exception):
    pass
def retry_with_backoff(func, *, attempts=None, delays=None, logger=None):
    return func()
res_stub.retry_with_backoff=retry_with_backoff; res_stub.RetryError=RetryError
sys.modules['resilience']=res_stub
msl_stub=types.ModuleType('menace_sanity_layer'); msl_stub.fetch_recent_billing_issues=lambda *a, **k: []
sys.modules['menace_sanity_layer']=msl_stub; sys.modules['menace.menace_sanity_layer']=msl_stub
cf_stub=types.ModuleType('codex_fallback_handler'); cf_stub.handle=lambda prompt, reason: None
sys.modules['codex_fallback_handler']=cf_stub; sys.modules['menace.codex_fallback_handler']=cf_stub
vector_stub=types.ModuleType('vector_service'); vector_stub.SharedVectorService=object; vector_stub.CognitionLayer=object; vector_stub.PatchLogger=object; vector_stub.VectorServiceError=Exception
sys.modules['vector_service']=vector_stub; sys.modules['menace.vector_service']=vector_stub
fru_stub=types.ModuleType('failure_retry_utils'); fru_stub.check_similarity_and_warn=lambda *a, **k: None; fru_stub.record_failure=lambda *a, **k: None
sys.modules['failure_retry_utils']=fru_stub; sys.modules['menace.failure_retry_utils']=fru_stub
ffs_stub=types.ModuleType('failure_fingerprint_store'); ffs_stub.FailureFingerprintStore=object
sys.modules['failure_fingerprint_store']=ffs_stub; sys.modules['menace.failure_fingerprint_store']=ffs_stub
args=[
    'tests/test_self_coding_engine.py::test_call_codex_with_backoff_retries',
    'tests/test_self_coding_engine.py::test_simplified_prompt_after_failure',
    'tests/test_codex_fallback.py::test_codex_fallback_retries_and_simplified_prompt',
    'tests/test_codex_fallback.py::test_codex_fallback_queue_on_malformed',
    '-q'
]
ret=pytest.main(args)
print('ret', ret)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bae94dbfe8832eadfe159514a5bb0c