### PR TITLE
Use event-specific instructions for Stripe anomalies

### DIFF
--- a/stripe_watchdog.py
+++ b/stripe_watchdog.py
@@ -135,10 +135,6 @@ def _sanity_feedback_enabled(path: Path | None = None) -> bool:
 
 SANITY_LAYER_FEEDBACK_ENABLED = _sanity_feedback_enabled()
 
-SANITY_INSTRUCTION = (
-    "Avoid generating bots that make Stripe charges without proper logging or central routing."
-)
-
 BILLING_EVENT_INSTRUCTION = (
     "Avoid generating bots that issue Stripe charges without logging through billing_logger."
 )
@@ -528,10 +524,12 @@ def _emit_anomaly(
         if "id" in payment_meta:
             payment_meta["charge_id"] = payment_meta.pop("id")
         payment_meta.setdefault("reason", record.get("type"))
+        event_type = record.get("type", "unknown")
+        instruction = menace_sanity_layer.EVENT_TYPE_INSTRUCTIONS.get(event_type)
         menace_sanity_layer.record_payment_anomaly(
-            record.get("type", "unknown"),
+            event_type,
             payment_meta,
-            SANITY_INSTRUCTION,
+            instruction,
             write_codex=write_codex,
             export_training=export_training,
         )

--- a/tests/test_stripe_watchdog.py
+++ b/tests/test_stripe_watchdog.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import json
 from types import SimpleNamespace
+import sys
+import tempfile
+from pathlib import Path
 
 import pytest
 from logging.handlers import RotatingFileHandler
@@ -19,6 +22,26 @@ import os
 
 from dynamic_path_router import resolve_path
 from audit_trail import AuditTrail
+
+# Stub heavy optional dependencies before importing stripe_watchdog
+sys.modules.setdefault("vector_service", SimpleNamespace(CognitionLayer=lambda: None))
+
+_TEMP_DIR = tempfile.TemporaryDirectory()
+_STUB_UEB = Path(_TEMP_DIR.name) / "unified_event_bus.py"
+_STUB_UEB.write_text("class UnifiedEventBus:\n    pass\n")
+
+import dynamic_path_router as _dpr
+_orig_resolve = _dpr.resolve_path
+
+def _fake_resolve(name, root=None):
+    if name == "unified_event_bus.py":
+        return _STUB_UEB
+    try:
+        return _orig_resolve(name, root)
+    except TypeError:
+        return _orig_resolve(name)
+
+_dpr.resolve_path = _fake_resolve
 
 import stripe_watchdog as sw
 
@@ -126,7 +149,7 @@ def test_unknown_webhook_endpoint(monkeypatch, capture_anomalies):
         line = fh.readline()
         logged = json.loads(line.split(" ", 1)[1])
     assert logged["type"] == "unknown_webhook"
-    assert logged["metadata"]["id"] == "we_evil"
+    assert logged["metadata"]["webhook_id"] == "we_evil"
 
 
 def test_disabled_webhook_endpoint(monkeypatch, capture_anomalies):
@@ -160,7 +183,7 @@ def test_disabled_webhook_endpoint(monkeypatch, capture_anomalies):
         line = fh.readline()
         logged = json.loads(line.split(" ", 1)[1])
     assert logged["type"] == "disabled_webhook"
-    assert logged["metadata"]["id"] == "we_disabled"
+    assert logged["metadata"]["webhook_id"] == "we_disabled"
 
 
 def test_env_allowed_webhook(monkeypatch):
@@ -292,3 +315,27 @@ def test_emit_anomaly_triggers_sanity_layer(monkeypatch):
 
     assert calls and calls[0][0] == "missing_charge"
     assert calls[0][1]["charge_id"] == "ch_test"
+
+
+def test_emit_anomaly_instruction_varies_by_event_type(monkeypatch):
+    calls: list[tuple[str, dict, str | None]] = []
+
+    monkeypatch.setattr(
+        sw.menace_sanity_layer,
+        "record_payment_anomaly",
+        lambda *a, **k: calls.append(a),
+    )
+    monkeypatch.setattr(sw.audit_logger, "log_event", lambda *a, **k: None)
+    monkeypatch.setattr(sw, "ANOMALY_TRAIL", SimpleNamespace(record=lambda entry: None))
+
+    sw._emit_anomaly({"type": "missing_charge", "id": "ch1"}, False, False)
+    sw._emit_anomaly({"type": "unknown_webhook", "id": "wh1"}, False, False)
+
+    assert len(calls) == 2
+    inst1 = calls[0][2]
+    inst2 = calls[1][2]
+    expected1 = sw.menace_sanity_layer.EVENT_TYPE_INSTRUCTIONS["missing_charge"]
+    expected2 = sw.menace_sanity_layer.EVENT_TYPE_INSTRUCTIONS["unknown_webhook"]
+    assert inst1 == expected1
+    assert inst2 == expected2
+    assert inst1 != inst2


### PR DESCRIPTION
## Summary
- Derive Stripe anomaly guidance from menace_sanity_layer.EVENT_TYPE_INSTRUCTIONS instead of a global constant
- Add test ensuring instructions differ for each event type and update webhook log expectations

## Testing
- `python -m pytest tests/test_stripe_watchdog.py -q`
- `python -m pytest tests/test_sanity_layer_hooks.py::test_emit_anomaly_triggers_record_event -q`
- `python -m pytest tests/test_menace_sanity_layer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68baeb73d71c832eb02b06f7fcb6f8a2