### PR TITLE
Return LLMResult from fallback and adjust engine

### DIFF
--- a/codex_fallback_handler.py
+++ b/codex_fallback_handler.py
@@ -53,19 +53,22 @@ def reroute_to_gpt35(prompt: Prompt) -> LLMResult:
 
 def handle(
     prompt: Prompt, reason: str, *, queue_path: Optional[Path] = None
-) -> Optional[LLMResult]:
+) -> LLMResult:
     """Attempt to reroute ``prompt`` and queue it on persistent failure.
 
-    On success the :class:`LLMResult` from :func:`reroute_to_gpt35` is returned.
-    If rerouting raises an exception, the prompt and failure ``reason`` are
-    written to the queue and ``None`` is returned.
+    Returns
+    -------
+    LLMResult
+        Result from :func:`reroute_to_gpt35`.  When rerouting fails, the prompt
+        is queued for later inspection and an empty :class:`LLMResult` is
+        returned with ``raw`` detailing the failure ``reason``.
     """
 
     try:
         return reroute_to_gpt35(prompt)
-    except Exception:
+    except Exception as exc:
         queue_failed(prompt, reason, path=queue_path or _QUEUE_FILE)
-        return None
+        return LLMResult(text="", raw={"error": str(exc), "reason": reason})
 
 
 __all__ = ["queue_failed", "reroute_to_gpt35", "handle"]

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -1057,6 +1057,10 @@ class SelfCodingEngine:
         whose raw code is provided to the model; other chunks are represented by
         their summaries.  ``strategy`` allows callers to inject an optional
         instruction snippet from the strategy templates.
+
+        If the primary Codex call fails to produce valid code, the prompt is
+        retried via :func:`codex_fallback_handler.handle`, which returns an
+        :class:`LLMResult` capturing the rerouted output and metadata.
         """
         snippets = self.suggest_snippets(description, limit=3)
         snippet_context = "\n\n".join(s.code for s in snippets)
@@ -1325,8 +1329,6 @@ class SelfCodingEngine:
                 "codex fallback", extra={"reason": reason, "description": description, "tags": ["degraded"]}
             )
             alt = codex_fallback_handler.handle(prompt_obj, reason)
-            if alt is None:
-                return _fallback()
             ok, checked = _validate(alt.text)
             if not ok:
                 self.logger.warning(

--- a/tests/test_codex_fallback.py
+++ b/tests/test_codex_fallback.py
@@ -61,6 +61,9 @@ def make_engine(mock_llm, monkeypatch):
     engine._last_prompt_metadata = {}
     engine._last_prompt = None
     engine._last_retry_trace = None
+    monkeypatch.setattr(
+        self_coding_engine, "_settings", types.SimpleNamespace(codex_retry_delays=[2, 5, 10])
+    )
     return engine
 
 
@@ -127,7 +130,7 @@ def test_codex_fallback_queue_on_malformed(monkeypatch):
 
     def handle(prompt, reason, **_):
         self_coding_engine.codex_fallback_handler.queue_for_retry(prompt)
-        return None
+        return LLMResult(text="")
 
     monkeypatch.setattr(
         self_coding_engine.codex_fallback_handler, "handle", handle

--- a/tests/test_self_coding_codex_fallback.py
+++ b/tests/test_self_coding_codex_fallback.py
@@ -69,6 +69,7 @@ def make_engine(mock_llm):
     engine._last_prompt_metadata = {}
     engine._last_prompt = None
     engine._last_retry_trace = None
+    self_coding_engine._settings = types.SimpleNamespace(codex_retry_delays=[2, 5, 10])
     return engine
 
 

--- a/tests/test_self_coding_engine.py
+++ b/tests/test_self_coding_engine.py
@@ -568,6 +568,7 @@ def test_codex_fallback_handler_invoked(monkeypatch, tmp_path):
 
     monkeypatch.setattr(sce.codex_fallback_handler, "handle", handle)
 
+    monkeypatch.setattr(sce, "_settings", types.SimpleNamespace(codex_retry_delays=[2, 5, 10]))
     code = engine.generate_helper("demo")
     assert "def good" in code
     assert len(calls) == 1

--- a/unit_tests/test_codex_fallback_handler.py
+++ b/unit_tests/test_codex_fallback_handler.py
@@ -41,7 +41,9 @@ def test_handle_queues_on_failure(tmp_path, monkeypatch):
     monkeypatch.setattr(cf, "reroute_to_gpt35", boom)
 
     result = cf.handle(Prompt("bye"), "bad news")
-    assert result is None
+    assert isinstance(result, LLMResult)
+    assert result.text == ""
+    assert result.raw["reason"] == "bad news"
 
     record = json.loads(queue_path.read_text().strip())
     assert record["prompt"] == "bye"


### PR DESCRIPTION
## Summary
- always return `LLMResult` from `codex_fallback_handler.handle`
- document and consume new result type in `SelfCodingEngine`
- update tests for LLMResult-based fallback

## Testing
- `pytest unit_tests/test_codex_fallback_handler.py tests/test_codex_fallback.py::test_codex_fallback_retries_and_simplified_prompt tests/test_codex_fallback.py::test_codex_fallback_queue_on_malformed tests/test_self_coding_codex_fallback.py::test_empty_output_triggers_fallback tests/test_self_coding_codex_fallback.py::test_malformed_output_triggers_fallback tests/test_self_coding_engine.py::test_codex_fallback_handler_invoked -q`


------
https://chatgpt.com/codex/tasks/task_e_68baeca165e8832eb2ac866b8cb33323