### PR TITLE
Return LLMResult from Codex fallback handler

### DIFF
--- a/codex_fallback_handler.py
+++ b/codex_fallback_handler.py
@@ -65,7 +65,10 @@ def handle(
     """
 
     try:
-        return reroute_to_gpt35(prompt)
+        result = reroute_to_gpt35(prompt)
+        # Expose the routed model's text via ``result.text`` while preserving
+        # provider specific metadata under ``result.raw``.
+        return result
     except Exception as exc:
         queue_failed(prompt, reason, path=queue_path or _QUEUE_FILE)
         return LLMResult(text="", raw={"error": str(exc), "reason": reason})

--- a/docs/self_coding_engine.md
+++ b/docs/self_coding_engine.md
@@ -99,13 +99,15 @@ LLM calls are retried with backoff.  The delay between attempts is controlled by
 fail the prompt is simplified – examples are trimmed and system text is removed
 – before one final attempt.
 
-If no code is produced, `codex_fallback_handler` either queues the prompt or
-reroutes it to a lower‑cost model.  Select the behaviour via
+If no code is produced, `codex_fallback_handler.handle` either queues the prompt
+or reroutes it to a lower‑cost model.  The function now returns an
+`LLMResult`—use `result.text` to access any rerouted completion and inspect
+`result.raw` for provider metadata or failure reasons.  Select the behaviour via
 `CODEX_FALLBACK_STRATEGY` (`"queue"` or `"reroute"`; default) and specify the
 alternate model with `CODEX_FALLBACK_MODEL` (defaults to `gpt-3.5-turbo`).
 Queued prompts are written to `CODEX_RETRY_QUEUE` (`codex_retry_queue_path`).
 
-Queued requests return a minimal stub so the patch loop carries on, while
+Queued requests provide an empty `LLMResult` so the patch loop carries on, while
 rerouted completions are marked as degraded but still allow the cycle to
 proceed.  These fallbacks keep the self‑coding loop running even when the
 primary model is unavailable.

--- a/unit_tests/test_codex_fallback_handler.py
+++ b/unit_tests/test_codex_fallback_handler.py
@@ -21,7 +21,7 @@ def test_handle_reroutes(monkeypatch):
 
     def fake_reroute(p: Prompt) -> LLMResult:
         called["prompt"] = p.user
-        return LLMResult(text="ok")
+        return LLMResult(text="ok", raw={"model": "gpt-3.5-turbo"})
 
     monkeypatch.setattr(cf, "reroute_to_gpt35", fake_reroute)
 
@@ -29,6 +29,7 @@ def test_handle_reroutes(monkeypatch):
     assert called["prompt"] == "hi"
     assert isinstance(result, LLMResult)
     assert result.text == "ok"
+    assert result.raw["model"] == "gpt-3.5-turbo"
 
 
 def test_handle_queues_on_failure(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Ensure `codex_fallback_handler.handle` returns the full `LLMResult`, preserving response metadata
- Update fallback handler tests to assert routed text and metadata via `LLMResult`
- Document new return type and usage in self-coding engine docs

## Testing
- `pytest unit_tests/test_codex_fallback_handler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68baf6f6f280832e871904aa1b7f87ee