### PR TITLE
chore: expand stripe anomaly instructions

### DIFF
--- a/menace_sanity_layer.py
+++ b/menace_sanity_layer.py
@@ -81,27 +81,28 @@ _GPT_MEMORY: GPTMemoryManager | None = None
 # Mapping of event types to corrective instructions.
 EVENT_TYPE_INSTRUCTIONS: Dict[str, str] = {
     "missing_charge": (
-        "Avoid generating bots that make Stripe charges without proper logging or "
-        "central routing."
+        "Avoid creating Stripe charges without billing log entries or central routing."
     ),
-    "missing_refund": "Avoid missing Stripe refund records; log and route all refunds.",
+    "missing_refund": (
+        "Avoid issuing refunds without corresponding ledger entries."
+    ),
     "missing_failure_log": (
-        "Avoid missing failure logs for Stripe operations; capture each error."
+        "Avoid handling Stripe failures without logging the event."
     ),
     "unapproved_workflow": (
-        "Avoid running unapproved workflows; obtain approval before execution."
+        "Avoid running Stripe workflows without explicit approval."
     ),
     "unknown_webhook": (
-        "Avoid using unknown Stripe webhooks; register endpoints or flag for review."
+        "Avoid unregistered Stripe webhooks; register endpoints before use."
     ),
     "disabled_webhook": (
-        "Avoid disabled Stripe webhooks; keep required endpoints active."
+        "Avoid relying on disabled Stripe webhook endpoints."
     ),
     "revenue_mismatch": (
-        "Avoid revenue mismatches; reconcile Stripe totals with internal records."
+        "Avoid revenue figures that diverge from ledger or ROI projections."
     ),
     "account_mismatch": (
-        "Avoid Stripe destination account mismatches; centralize charge routing."
+        "Avoid routing charges to unexpected Stripe accounts."
     ),
 }
 

--- a/tests/test_menace_sanity_layer.py
+++ b/tests/test_menace_sanity_layer.py
@@ -30,6 +30,13 @@ SEVERITY_MAP = _severity_map()
 SEVERITY_KEYS = sorted(SEVERITY_MAP.keys())
 
 
+@pytest.mark.parametrize("event_type", SEVERITY_KEYS)
+def test_anomaly_instruction_returns_mapping(event_type):
+    expected = msl.EVENT_TYPE_INSTRUCTIONS[event_type]
+    instruction = msl._anomaly_instruction(event_type, {}, expected)
+    assert instruction == expected
+
+
 def test_record_payment_anomaly_writes_db_and_memory(monkeypatch):
     db_calls: list[tuple[str, float, dict]] = []
     mem_calls: list[tuple[str, dict, list[str]]] = []


### PR DESCRIPTION
## Summary
- expand sanity layer instructions for Stripe anomalies
- test instruction mapping across all Stripe anomaly codes

## Testing
- `PYTHONPATH=. pytest tests/test_menace_sanity_layer.py tests/test_stripe_watchdog.py -q`
- `PYTHONPATH=. pre-commit run --files menace_sanity_layer.py tests/test_menace_sanity_layer.py tests/test_stripe_watchdog.py` *(fails: static path 'unified_event_bus.py' not wrapped with resolve_path; Payment keywords without stripe_billing_router detected)*

------
https://chatgpt.com/codex/tasks/task_e_68baf89469f4832e97b846874124895d