### PR TITLE
Handle empty Codex outputs with explicit fallback

### DIFF
--- a/docs/self_coding_engine.md
+++ b/docs/self_coding_engine.md
@@ -100,9 +100,10 @@ fail the prompt is simplified – examples are trimmed and system text is remove
 – before one final attempt.
 
 If no code is produced, `codex_fallback_handler.handle` either queues the prompt
-or reroutes it to a lower‑cost model.  The function now returns an
-`LLMResult`—use `result.text` to access any rerouted completion and inspect
-`result.raw` for provider metadata or failure reasons.  Select the behaviour via
+or reroutes it to a lower‑cost model.  The function returns an `LLMResult` only
+when rerouting yields usable text; otherwise it returns `None` so callers can
+trigger their own fallback logic.  Inspect `result.text` for the alternate
+completion and `result.raw` for provider metadata.  Select the behaviour via
 `CODEX_FALLBACK_STRATEGY` (`"queue"` or `"reroute"`; default) and specify the
 alternate model with `CODEX_FALLBACK_MODEL` (defaults to `gpt-3.5-turbo`).
 Queued prompts are written to `CODEX_RETRY_QUEUE` (`codex_retry_queue_path`).


### PR DESCRIPTION
## Summary
- log Codex fallback reasons and return `None` when reroute yields no usable completion
- add `_validate` helper in `SelfCodingEngine` to reroute or fallback on empty/syntax-invalid text
- document updated fallback behavior

## Testing
- `pytest tests/test_codex_fallback.py::test_codex_fallback_retries_and_simplified_prompt tests/test_codex_fallback.py::test_codex_fallback_queue_on_malformed tests/test_codex_fallback_behavior.py::test_timeout_error_prompts_simplified_and_builtin_fallback tests/test_codex_fallback_behavior.py::test_empty_completion_reroutes_and_queues tests/test_codex_fallback_behavior.py::test_handle_returns_llmresult_used_by_engine -q`


------
https://chatgpt.com/codex/tasks/task_e_68baf94f3950832e9f4d5b5e92109e49