### PR TITLE
Propagate self-coding and telemetry hooks through Stripe watchdog

### DIFF
--- a/tests/test_sanity_feedback.py
+++ b/tests/test_sanity_feedback.py
@@ -1,0 +1,45 @@
+
+def test_anomaly_triggers_self_coding_update(monkeypatch):
+    import stripe_watchdog as sw
+    import menace_sanity_layer as msl
+
+    # Enable sanity layer feedback and silence IO
+    monkeypatch.setattr(sw, "SANITY_LAYER_FEEDBACK_ENABLED", True)
+    monkeypatch.setattr(sw.audit_logger, "log_event", lambda *a, **k: None)
+    monkeypatch.setattr(sw.ANOMALY_TRAIL, "record", lambda *a, **k: None)
+    monkeypatch.setattr(msl, "_get_gpt_memory", lambda: None)
+
+    calls: list[dict] = []
+
+    class DummyEngine:
+        def update_generation_params(self, metadata):
+            calls.append(metadata)
+
+    class DummyTelemetry:
+        def __init__(self):
+            self.events: list[tuple[str, dict]] = []
+            self.checked = False
+
+        def record_event(self, event_type, metadata):
+            self.events.append((event_type, metadata))
+
+        def check(self):
+            self.checked = True
+
+    engine = DummyEngine()
+    telemetry = DummyTelemetry()
+
+    charges = [{"id": "ch_1", "amount": 5, "receipt_email": "a@example.com", "created": 1}]
+
+    sw.detect_missing_charges(
+        charges,
+        [],
+        [],
+        write_codex=False,
+        export_training=False,
+        self_coding_engine=engine,
+        telemetry_feedback=telemetry,
+    )
+
+    assert calls, "SelfCodingEngine was not updated"
+    assert telemetry.events and telemetry.checked


### PR DESCRIPTION
## Summary
- Allow stripe watchdog to initialize optional SelfCodingEngine and telemetry feedback
- Thread self-coding and telemetry hooks through detection helpers
- Add integration test confirming anomalies drive self-coding updates

## Testing
- `pytest tests/test_sanity_feedback.py tests/test_sanity_layer_hooks.py::test_emit_anomaly_triggers_record_event unit_tests/test_stripe_watchdog.py::test_detect_missing_charges_id_matching -q`


------
https://chatgpt.com/codex/tasks/task_e_68bafc4e6618832eb7e36ed626681120