### PR TITLE
Ensure codex retry backoff runs full delay schedule

### DIFF
--- a/resilience.py
+++ b/resilience.py
@@ -60,7 +60,8 @@ def retry_with_backoff(
 
     if delays is not None:
         schedule = list(delays)
-        attempts = len(schedule)
+        if len(schedule) < attempts - 1:
+            raise ValueError("not enough delay values for requested attempts")
     else:
         schedule = []
         backoff = delay

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -256,7 +256,7 @@ def call_codex_with_backoff(
             return future.result(timeout=timeout_val)
 
     return retry_with_backoff(
-        _attempt, attempts=len(delays), delays=delays, logger=log
+        _attempt, attempts=len(delays) + 1, delays=delays, logger=log
     )
 
 

--- a/tests/test_self_coding_codex_fallback.py
+++ b/tests/test_self_coding_codex_fallback.py
@@ -117,8 +117,8 @@ def test_empty_output_triggers_fallback(monkeypatch):
 
     result = engine.generate_helper("do something")
 
-    assert seen_delays == [[2, 5, 10], [2, 5, 10]]
-    assert sleeps == [2, 5]
+    assert seen_delays == [[2, 5, 10]]
+    assert sleeps == [2, 5, 10]
     assert mock_llm.generate.call_count == 4
     simple_prompt = mock_llm.generate.call_args_list[-1].args[0]
     assert simple_prompt.system == ""
@@ -162,7 +162,7 @@ def test_malformed_output_triggers_fallback(monkeypatch):
 
     result = engine.generate_helper("do something")
 
-    assert seen_delays == [[2, 5, 10], [2, 5, 10]]
-    assert sleeps == [2, 5]
+    assert seen_delays == [[2, 5, 10]]
+    assert sleeps == [2, 5, 10]
     handle_mock.assert_called_once()
     assert result == "print('fixed')\n"

--- a/tests/test_self_coding_engine.py
+++ b/tests/test_self_coding_engine.py
@@ -534,8 +534,8 @@ def test_call_codex_with_backoff_retries(monkeypatch):
     with pytest.raises(sce.RetryError):
         sce.call_codex_with_backoff(client, sce.Prompt("x"))
 
-    assert sleeps == delays[:-1]
-    assert client.calls == len(delays)
+    assert sleeps == delays
+    assert client.calls == len(delays) + 1
 
 
 def test_codex_fallback_handler_invoked(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- allow `retry_with_backoff` to respect explicit attempt counts when custom delays are provided
- run Codex requests with one more attempt than delay entries so the 2s/5s/10s backoff sequence is used entirely
- expand tests for Codex retry behaviour

## Testing
- `pytest tests/test_self_coding_codex_fallback.py::test_empty_output_triggers_fallback tests/test_self_coding_codex_fallback.py::test_malformed_output_triggers_fallback -q`
- `pytest unit_tests/test_self_coding_engine.py::test_call_codex_with_backoff_retries -q` *(fails: No module named 'scope_utils')*


------
https://chatgpt.com/codex/tasks/task_e_68bafec23924832e95fd2cea835e20ee