### PR TITLE
Handle codex fallback failures via empty LLMResult

### DIFF
--- a/docs/self_coding_engine.md
+++ b/docs/self_coding_engine.md
@@ -103,10 +103,10 @@ To override the schedule set `CODEX_RETRY_DELAYS` in the environment to a
 comma‑separated list or JSON array (e.g. `"1,2,4"` or `[1,2,4]`).
 
 If no code is produced, `codex_fallback_handler.handle` either queues the prompt
-or reroutes it to a lower‑cost model.  The function returns an `LLMResult` only
-when rerouting yields usable text; otherwise it returns `None` so callers can
-trigger their own fallback logic.  Inspect `result.text` for the alternate
-completion and `result.raw` for provider metadata.  Select the behaviour via
+or reroutes it to a lower‑cost model.  The function always returns an
+`LLMResult`; when rerouting fails, the result has an empty `text` field and the
+failure reason in `result.raw`.  Inspect `result.text` for alternate completions
+and `result.raw` for provider metadata.  Select the behaviour via
 `CODEX_FALLBACK_STRATEGY` (`"queue"` or `"reroute"`; default) and specify the
 alternate model with `CODEX_FALLBACK_MODEL` (defaults to `gpt-3.5-turbo`).
 Queued prompts are written to `CODEX_RETRY_QUEUE` (`codex_retry_queue_path`).

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -1405,7 +1405,7 @@ class SelfCodingEngine:
         alt = codex_fallback_handler.handle(
             self.simplify_prompt(prompt), reason
         )
-        if alt is None:
+        if not getattr(alt, "text", "").strip():
             return result, None
 
         alt_validation: ValidationResult = validate_completion(alt.text)
@@ -1415,13 +1415,8 @@ class SelfCodingEngine:
             )
             return alt, alt_validation.text
 
-        event = (
-            "codex fallback queued prompt"
-            if not getattr(alt, "text", "").strip()
-            else "codex fallback invalid result"
-        )
         self.logger.warning(
-            event,
+            "codex fallback invalid result",
             extra={
                 "reason": alt_validation.reason,
                 "description": description,


### PR DESCRIPTION
## Summary
- Return an empty `LLMResult` with a reason when `codex_fallback_handler` fails to reroute or gets no completion
- Treat empty `LLMResult` responses as failed reroutes in `SelfCodingEngine._validate`
- Document new fallback contract and cover empty completion in tests

## Testing
- `pytest unit_tests/test_codex_fallback_handler.py -q`
- `pytest unit_tests/test_self_coding_engine.py -k codex -q` *(fails: No module named 'scope_utils')*

------
https://chatgpt.com/codex/tasks/task_e_68bb01913c54832eac5e45f80aabd2c5