### PR TITLE
Allow configurable Codex fallback model

### DIFF
--- a/unit_tests/test_codex_fallback_handler.py
+++ b/unit_tests/test_codex_fallback_handler.py
@@ -1,4 +1,5 @@
 import json
+import types
 
 import menace.codex_fallback_handler as cf
 from menace.prompt_types import Prompt
@@ -19,17 +20,19 @@ def test_handle_reroutes(monkeypatch):
 
     called = {}
 
+    cf._settings = types.SimpleNamespace(codex_fallback_model="alt-model")
+
     def fake_reroute(p: Prompt) -> LLMResult:
         called["prompt"] = p.user
-        return LLMResult(text="ok", raw={"model": "gpt-3.5-turbo"})
+        return LLMResult(text="ok", raw={"model": cf._settings.codex_fallback_model})
 
-    monkeypatch.setattr(cf, "reroute_to_gpt35", fake_reroute)
+    monkeypatch.setattr(cf, "reroute_to_fallback_model", fake_reroute)
 
     result = cf.handle(prompt, "oops")
     assert called["prompt"] == "hi"
     assert isinstance(result, LLMResult)
     assert result.text == "ok"
-    assert result.raw["model"] == "gpt-3.5-turbo"
+    assert result.raw["model"] == "alt-model"
 
 
 def test_handle_queues_on_failure(tmp_path, monkeypatch):
@@ -39,7 +42,7 @@ def test_handle_queues_on_failure(tmp_path, monkeypatch):
     def boom(_: Prompt) -> LLMResult:
         raise RuntimeError("fail")
 
-    monkeypatch.setattr(cf, "reroute_to_gpt35", boom)
+    monkeypatch.setattr(cf, "reroute_to_fallback_model", boom)
 
     result = cf.handle(Prompt("bye"), "bad news")
     assert isinstance(result, LLMResult)
@@ -56,9 +59,9 @@ def test_handle_returns_reason_on_empty_completion(tmp_path, monkeypatch):
     monkeypatch.setattr(cf, "_QUEUE_FILE", queue_path)
 
     def empty(_: Prompt) -> LLMResult:
-        return LLMResult(text="", raw={"model": "gpt-3.5-turbo"})
+        return LLMResult(text="", raw={"model": cf._settings.codex_fallback_model})
 
-    monkeypatch.setattr(cf, "reroute_to_gpt35", empty)
+    monkeypatch.setattr(cf, "reroute_to_fallback_model", empty)
 
     result = cf.handle(Prompt("zap"), "no text")
     assert isinstance(result, LLMResult)
@@ -69,3 +72,23 @@ def test_handle_returns_reason_on_empty_completion(tmp_path, monkeypatch):
     assert record["prompt"] == "zap"
     assert record["reason"] == "no text"
 
+
+def test_reroute_uses_configured_model(monkeypatch):
+    captured = {}
+
+    class DummyClient:
+        def __init__(self, *, model: str):
+            captured["model"] = model
+            self.model = model
+
+        def generate(self, prompt: Prompt) -> LLMResult:
+            captured["prompt"] = prompt.user
+            return LLMResult(text="ok", raw={"model": self.model})
+
+    monkeypatch.setattr(cf, "LLMClient", DummyClient)
+    cf._settings = types.SimpleNamespace(codex_fallback_model="dummy-model")
+
+    result = cf.reroute_to_fallback_model(Prompt("hi"))
+    assert captured["model"] == "dummy-model"
+    assert captured["prompt"] == "hi"
+    assert result.raw["model"] == "dummy-model"


### PR DESCRIPTION
## Summary
- make Codex fallback handler read fallback model from settings
- rename reroute helper to `reroute_to_fallback_model`
- update tests to configure `codex_fallback_model`

## Testing
- `PYTHONPATH=. pre-commit run --files codex_fallback_handler.py unit_tests/test_codex_fallback_handler.py tests/test_self_coding_codex_fallback.py`
- `pytest unit_tests/test_codex_fallback_handler.py tests/test_self_coding_codex_fallback.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb03d6d630832e9d5b142231b213b8