### PR TITLE
feat: source codex retry queue path from settings

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -1402,8 +1402,11 @@ class SelfCodingEngine:
             extra={"reason": reason, "description": description, "tags": ["degraded"]},
         )
 
+        queue_path = Path(
+            getattr(_settings, "codex_retry_queue_path", "codex_retry_queue.jsonl")
+        )
         alt = codex_fallback_handler.handle(
-            self.simplify_prompt(prompt), reason
+            self.simplify_prompt(prompt), reason, queue_path=queue_path
         )
         if not getattr(alt, "text", "").strip():
             return result, None


### PR DESCRIPTION
## Summary
- derive Codex retry queue file path from SandboxSettings
- pass configured queue path through self-coding engine fallback
- adapt tests to configure and assert queue file usage

## Testing
- `PYTHONPATH=. pytest unit_tests/test_codex_fallback_handler.py -q`
- `pytest tests/test_codex_fallback_behavior.py::test_handle_returns_llmresult_used_by_engine -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb05d66c54832e8f22da7cc238edb6