### PR TITLE
Add anomaly suppression with severity thresholds

### DIFF
--- a/config/stripe_watchdog.yaml
+++ b/config/stripe_watchdog.yaml
@@ -7,3 +7,7 @@ log_rotation:
   maxBytes: 5242880
   backupCount: 5
 sanity_layer_feedback: true
+anomaly_suppression:
+  window_seconds: 60
+  max_occurrences: 1
+  severity_threshold: 0.0


### PR DESCRIPTION
## Summary
- prevent rapid duplicate anomaly events via in-memory cache
- honor severity thresholds and new configuration from stripe_watchdog.yaml
- test that identical anomalies only emit one feedback event per window

## Testing
- `pytest tests/test_menace_sanity_layer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb0dcedf4c832eb5ee3e9282ad191a