### PR TITLE
Extend anomaly hints and tests

### DIFF
--- a/menace_sanity_layer.py
+++ b/menace_sanity_layer.py
@@ -124,6 +124,13 @@ PAYMENT_ANOMALY_THRESHOLD = 3
 # problematic behaviour.
 ANOMALY_HINTS: Dict[str, Dict[str, Any]] = {
     "missing_charge": {"block_unlogged_charges": True},
+    "missing_refund": {"block_unlogged_refunds": True},
+    "missing_failure_log": {"log_stripe_failures": True},
+    "unapproved_workflow": {"enforce_workflow_approval": True},
+    "unknown_webhook": {"register_stripe_webhooks": True},
+    "disabled_webhook": {"reactivate_stripe_webhook": True},
+    "revenue_mismatch": {"reconcile_revenue": True},
+    "account_mismatch": {"verify_stripe_account": True},
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add generation-parameter hints for additional payment anomaly types
- ensure repeated anomalies for each type trigger self-coding engine updates

## Testing
- `python - <<'PY'
import importlib.util, sys, types
from pathlib import Path
import pytest
sys.modules['audit_logger'] = types.SimpleNamespace(log_event=lambda *a, **k: None)
sys.modules['db_router'] = types.SimpleNamespace(GLOBAL_ROUTER=None, LOCAL_TABLES=set())
sys.modules['dynamic_path_router'] = types.SimpleNamespace(resolve_path=lambda p: Path(p))
class DummyMemoryManager:
    def log_interaction(self, *a, **k):
        pass
sys.modules['gpt_memory'] = types.SimpleNamespace(GPTMemoryManager=DummyMemoryManager)
sys.modules['shared_gpt_memory'] = types.SimpleNamespace(GPT_MEMORY_MANAGER=None)
sys.modules['menace_sandbox.unified_event_bus'] = types.SimpleNamespace(UnifiedEventBus=lambda: None)
pkg = types.ModuleType('menace_sandbox')
pkg.__path__ = ['/workspace/menace_sandbox']
sys.modules['menace_sandbox'] = pkg
res = pytest.main(['tests/test_sanity_layer_hooks.py::test_repeated_anomalies_trigger_param_update','-q'])
print('pytest exit code',res)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bb10b1aabc832e889de5eeff2f3b1e