### PR TITLE
Add module metadata to Stripe watchdog anomalies

### DIFF
--- a/stripe_watchdog.py
+++ b/stripe_watchdog.py
@@ -131,6 +131,10 @@ SEVERITY_MAP = {
     "revenue_mismatch": 4.0,
 }
 
+# Module identifiers used for targeted remediation by downstream consumers.
+BILLING_ROUTER_MODULE = "stripe_billing_router"
+WATCHDOG_MODULE = "stripe_watchdog"
+
 #: Default log file for anomaly summaries.
 _LOG_DIR = resolve_path("finance_logs")
 #: JSON lines file used for anomaly audit records.
@@ -639,6 +643,7 @@ def detect_missing_charges(
                 "id": cid,
                 "bot_id": bot_id,
                 "account_id": charge.get("account"),
+                "module": BILLING_ROUTER_MODULE,
             }
             anomalies.append(anomaly)
             _emit_anomaly(
@@ -668,6 +673,7 @@ def detect_missing_charges(
             "email": charge.get("receipt_email"),
             "timestamp": charge.get("created"),
             "account_id": charge.get("account"),
+            "module": BILLING_ROUTER_MODULE,
         }
         anomalies.append(anomaly)
         _emit_anomaly(
@@ -712,6 +718,7 @@ def detect_missing_refunds(
                 "refund_id": rid,
                 "bot_id": bot_id,
                 "account_id": refund.get("account"),
+                "module": BILLING_ROUTER_MODULE,
             }
             anomalies.append(anomaly)
             _emit_anomaly(
@@ -740,6 +747,7 @@ def detect_missing_refunds(
             "amount": refund.get("amount"),
             "charge": refund.get("charge"),
             "account_id": refund.get("account"),
+            "module": BILLING_ROUTER_MODULE,
         }
         anomalies.append(anomaly)
         _emit_anomaly(
@@ -786,6 +794,7 @@ def detect_failed_events(
                 "event_id": eid,
                 "bot_id": bot_id,
                 "account_id": event.get("account"),
+                "module": BILLING_ROUTER_MODULE,
             }
             anomalies.append(anomaly)
             _emit_anomaly(
@@ -813,6 +822,7 @@ def detect_failed_events(
             "event_id": eid,
             "event_type": event.get("type"),
             "account_id": event.get("account"),
+            "module": BILLING_ROUTER_MODULE,
         }
         anomalies.append(anomaly)
         _emit_anomaly(
@@ -871,6 +881,7 @@ def check_webhook_endpoints(
                 "webhook_url": url,
                 "status": status,
                 "account_id": ep_dict.get("account"),
+                "module": WATCHDOG_MODULE,
             }
             _emit_anomaly(
                 record,


### PR DESCRIPTION
## Summary
- tag anomaly records with module identifiers for downstream remediation
- ensure webhook endpoint checks include module metadata
- verify module metadata in anomaly tests

## Testing
- `pytest tests/test_stripe_watchdog.py::test_orphan_charge_triggers_audit_and_codex tests/test_stripe_watchdog.py::test_unknown_webhook_endpoint tests/test_stripe_watchdog.py::test_disabled_webhook_endpoint tests/test_stripe_watchdog.py::test_unexpected_refund tests/test_stripe_watchdog.py::test_failed_event_missing_logs -q`
- `pytest tests/integration/test_sanity_consumer_flow.py::test_watchdog_anomaly_reaches_consumer -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb124fd584832eabba5ad0717be8b0