### PR TITLE
Forward anomaly hooks to sanity layer

### DIFF
--- a/docs/menace_sanity_layer.md
+++ b/docs/menace_sanity_layer.md
@@ -34,7 +34,9 @@ earlier issues.
 * `record_billing_anomaly` stores events in the `billing_anomalies`
   table and publishes them on the `"billing.anomaly"` topic.
 * `record_payment_anomaly` logs contextual guidance to
-  `MenaceMemoryManager`, allowing behaviour to be refined over time.
+  `MenaceMemoryManager`, allowing behaviour to be refined over time. Optional
+  ``self_coding_engine`` and ``telemetry_feedback`` hooks can adjust generation
+  parameters and emit telemetry when anomalies occur.
 * Optional `GPT_MEMORY_MANAGER` and `DiscrepancyDB` integrations provide
   additional audit trails when available.
 * `record_billing_event` captures general billing issues, storing a

--- a/stripe_watchdog.py
+++ b/stripe_watchdog.py
@@ -663,6 +663,7 @@ def _emit_anomaly(
             write_codex=write_codex,
             export_training=export_training,
             self_coding_engine=self_coding_engine,
+            telemetry_feedback=telemetry_feedback,
         )
 
 

--- a/unit_tests/test_stripe_watchdog.py
+++ b/unit_tests/test_stripe_watchdog.py
@@ -58,13 +58,13 @@ def test_orphan_charge_logged(capture, monkeypatch):
     monkeypatch.setattr(sw, "record_event", fake_record_event)
     monkeypatch.setattr(sw, "SANITY_LAYER_FEEDBACK_ENABLED", True)
     billing_calls: list[tuple[str, float]] = []
-    payment_calls: list[tuple[str, float]] = []
+    payment_calls: list[tuple[str, float, dict]] = []
 
     def fake_billing(event_type, metadata, *, severity=1.0, **kwargs):
         billing_calls.append((event_type, severity))
 
     def fake_payment(event_type, metadata, instruction=None, *, severity=1.0, **kwargs):
-        payment_calls.append((event_type, severity))
+        payment_calls.append((event_type, severity, kwargs))
 
     monkeypatch.setattr(sw, "record_billing_anomaly", fake_billing)
     monkeypatch.setattr(sw.menace_sanity_layer, "record_payment_anomaly", fake_payment)
@@ -95,6 +95,8 @@ def test_orphan_charge_logged(capture, monkeypatch):
     assert record_calls[0][2]["telemetry_feedback"] is telemetry
     assert billing_calls and billing_calls[0][1] == sw.SEVERITY_MAP["missing_charge"]
     assert payment_calls and payment_calls[0][1] == sw.SEVERITY_MAP["missing_charge"]
+    assert payment_calls[0][2]["self_coding_engine"] is engine
+    assert payment_calls[0][2]["telemetry_feedback"] is telemetry
 
 
 def test_record_billing_event_called(capture, monkeypatch):


### PR DESCRIPTION
## Summary
- forward self-coding and telemetry hooks to `record_payment_anomaly`
- let `record_payment_anomaly` adjust generation params and telemetry via hooks
- document anomaly hooks and cover with tests

## Testing
- `pytest tests/test_sanity_layer_hooks.py::test_emit_anomaly_triggers_record_event tests/test_sanity_layer_hooks.py::test_record_payment_anomaly_telemetry_feedback tests/test_stripe_watchdog.py::test_emit_anomaly_triggers_sanity_layer unit_tests/test_stripe_watchdog.py::test_orphan_charge_logged -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb728d8520832ea96690e8bcf7897f