### PR TITLE
Ensure all Stripe anomalies record billing events

### DIFF
--- a/tests/integration/test_sanity_consumer_flow.py
+++ b/tests/integration/test_sanity_consumer_flow.py
@@ -135,6 +135,9 @@ def test_watchdog_anomaly_reaches_consumer(monkeypatch, tmp_path):
 
     # Emit anomaly
     record = {"type": "missing_charge", "id": "ch_1", "amount": 5}
+    monkeypatch.setattr(sw, "record_billing_event", lambda *a, **k: None)
+    monkeypatch.setattr(sw.menace_sanity_layer, "record_payment_anomaly", lambda *a, **k: None)
+    monkeypatch.setattr(sw, "load_api_key", lambda: None)
     sw._emit_anomaly(record, False, False)
 
     # Sanity layer persisted and published event

--- a/tests/integration/test_sanity_pipeline.py
+++ b/tests/integration/test_sanity_pipeline.py
@@ -103,6 +103,8 @@ def test_anomaly_threshold_triggers_engine(monkeypatch, tmp_path):
 
     record = {"type": "missing_charge", "id": "ch_1"}
     threshold = msl.PAYMENT_ANOMALY_THRESHOLD
+    monkeypatch.setattr(sw, "record_billing_event", lambda *a, **k: None)
+    monkeypatch.setattr(sw, "load_api_key", lambda: None)
 
     for _ in range(threshold + 1):
         sw._emit_anomaly(record, False, False, self_coding_engine=engine)

--- a/tests/test_menace_sanity_layer.py
+++ b/tests/test_menace_sanity_layer.py
@@ -181,6 +181,8 @@ def test_watchdog_anomaly_updates_db_memory_and_event_bus(monkeypatch, tmp_path)
     msl._MEMORY_MANAGER = mm
 
     record = {"type": "overcharge", "id": "ch_1", "amount": 5}
+    monkeypatch.setattr(sw, "record_billing_event", lambda *a, **k: None)
+    monkeypatch.setattr(sw, "load_api_key", lambda: None)
     sw._emit_anomaly(record, False, False)
 
     anomalies = msl.list_anomalies()

--- a/tests/test_stripe_watchdog.py
+++ b/tests/test_stripe_watchdog.py
@@ -89,6 +89,7 @@ def capture_anomalies(monkeypatch, tmp_path):
 
     monkeypatch.setattr(sw, "record_billing_anomaly", fake_billing)
     monkeypatch.setattr(sw.menace_sanity_layer, "record_payment_anomaly", fake_payment)
+    monkeypatch.setattr(sw, "record_billing_event", lambda *a, **k: None)
 
     return events, samples, billing_calls, payment_calls
 


### PR DESCRIPTION
## Summary
- Record every anomaly in `stripe_watchdog._emit_anomaly` via `record_billing_event`
- Remove duplicate billing event loop in `check_events`
- Add coverage ensuring refunds, failed events, webhook issues, and revenue mismatches emit billing events

## Testing
- `pytest unit_tests/test_stripe_watchdog.py tests/test_stripe_watchdog.py tests/test_sanity_layer_hooks.py tests/integration/test_sanity_consumer_flow.py tests/integration/test_sanity_pipeline.py tests/test_menace_sanity_layer.py tests/test_refund_anomaly_detector.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb794baac4832e92facca5dd43e4da