### PR TITLE
Standardize unauthorized billing event types

### DIFF
--- a/billing/refund_anomaly_detector.py
+++ b/billing/refund_anomaly_detector.py
@@ -149,7 +149,7 @@ def detect_anomalies(
                 {"id": event.id, "bot_id": bot_id, "reason": "unauthorized"}
             )
             record_payment_anomaly(
-                "unauthorized",
+                f"unauthorized_{action}",
                 {
                     "stripe_event_id": event.id,
                     "stripe_object_id": obj.get("id"),
@@ -202,7 +202,7 @@ def detect_anomalies(
             )
             anomalies.append({"id": event.id, "bot_id": bot_id, "reason": "unlogged"})
             record_payment_anomaly(
-                "unlogged",
+                "missing_refund" if action == "refund" else "missing_failure_log",
                 {
                     "stripe_event_id": event.id,
                     "stripe_object_id": obj.get("id"),

--- a/config/billing_instructions.yaml
+++ b/config/billing_instructions.yaml
@@ -8,6 +8,8 @@ instructions:
   revenue_mismatch: Avoid revenue figures that diverge from ledger or ROI projections.
   account_mismatch: Avoid routing charges to unexpected Stripe accounts.
   unauthorized_charge: Avoid processing Stripe charges without explicit authorization.
+  unauthorized_refund: Avoid issuing Stripe refunds without explicit authorization.
+  unauthorized_failure: Avoid processing Stripe payment failures without explicit authorization.
 anomaly_hints:
   missing_charge:
     block_unlogged_charges: true
@@ -27,6 +29,10 @@ anomaly_hints:
     verify_stripe_account: true
   unauthorized_charge:
     block_unauthorized_charges: true
+  unauthorized_refund:
+    block_unauthorized_refunds: true
+  unauthorized_failure:
+    block_unauthorized_failures: true
 severity_map:
   missing_charge: 2.5
   missing_refund: 2.0
@@ -37,6 +43,8 @@ severity_map:
   revenue_mismatch: 4.0
   account_mismatch: 3.0
   unauthorized_charge: 3.5
+  unauthorized_refund: 3.5
+  unauthorized_failure: 3.0
 anomaly_thresholds:
   account_mismatch: 3
   unauthorized_charge: 5

--- a/docs/menace_sanity_layer.md
+++ b/docs/menace_sanity_layer.md
@@ -72,6 +72,11 @@ similar issues in the future.  These snippets are stored in GPT memory and can
 be retrieved via :func:`fetch_recent_billing_issues` to bias subsequent code
 generation.
 
+Event types use a unified naming scheme. Unauthorized Stripe activity
+is reported as `unauthorized_charge`, `unauthorized_refund`, or
+`unauthorized_failure`. Unlogged events continue to use
+`missing_charge`, `missing_refund`, and `missing_failure_log`.
+
 ## Improving Future Generations
 
 When the Stripe watchdog or other monitors detect a billing issue they emit an

--- a/docs/stripe_watchdog.md
+++ b/docs/stripe_watchdog.md
@@ -86,5 +86,11 @@ Each anomaly is logged with the instruction:
 Avoid generating bots that make Stripe charges without proper logging or central routing.
 ```
 
+Event types follow a unified naming scheme. For example,
+unauthorized Stripe activity is recorded as `unauthorized_charge`,
+`unauthorized_refund`, or `unauthorized_failure` depending on the
+operation. Missing ledger entries continue to use `missing_charge`,
+`missing_refund`, and `missing_failure_log`.
+
 Use the `write_codex` and `export_training` flags to control whether anomalies
 are exported as Codex samples or appended to the training dataset.

--- a/menace_sanity_layer.py
+++ b/menace_sanity_layer.py
@@ -109,6 +109,12 @@ EVENT_TYPE_INSTRUCTIONS: Dict[str, str] = {
     "unauthorized_charge": (
         "Avoid processing Stripe charges without explicit authorization."
     ),
+    "unauthorized_refund": (
+        "Avoid issuing Stripe refunds without explicit authorization."
+    ),
+    "unauthorized_failure": (
+        "Avoid processing Stripe payment failures without explicit authorization."
+    ),
 }
 
 # Optional overrides loaded from ``config/billing_instructions.yaml``.  The file
@@ -132,6 +138,8 @@ DEFAULT_ANOMALY_HINTS: Dict[str, Dict[str, Any]] = {
     "revenue_mismatch": {"reconcile_revenue": True},
     "account_mismatch": {"verify_stripe_account": True},
     "unauthorized_charge": {"block_unauthorized_charges": True},
+    "unauthorized_refund": {"block_unauthorized_refunds": True},
+    "unauthorized_failure": {"block_unauthorized_failures": True},
 }
 
 PAYMENT_ANOMALY_THRESHOLD = _DEFAULT_PAYMENT_ANOMALY_THRESHOLD

--- a/tests/test_refund_anomaly_detector.py
+++ b/tests/test_refund_anomaly_detector.py
@@ -84,12 +84,16 @@ def test_detects_unlogged_and_unauthorized(tmp_path, monkeypatch):
     assert {a["id"] for a in anomalies} == {"evt_unlogged", "evt_unauth"}
     assert {e["id"] for e in logged} == {"evt_unlogged", "evt_unauth"}
 
-    assert {a[0][0] for a in payment_calls} == {"unlogged", "unauthorized"}
+    assert {a[0][0] for a in payment_calls} == {"missing_refund", "unauthorized_failure"}
     assert {
-        a[0][1]["stripe_event_id"] for a in payment_calls if a[0][0] == "unlogged"
+        a[0][1]["stripe_event_id"]
+        for a in payment_calls
+        if a[0][0] == "missing_refund"
     } == {"evt_unlogged"}
     assert {
-        a[0][1]["stripe_event_id"] for a in payment_calls if a[0][0] == "unauthorized"
+        a[0][1]["stripe_event_id"]
+        for a in payment_calls
+        if a[0][0] == "unauthorized_failure"
     } == {"evt_unauth"}
 
     assert {a[0][0] for a in billing_calls} == {"refund_anomaly", "payment_failure"}

--- a/tests/test_sanity_layer_hooks.py
+++ b/tests/test_sanity_layer_hooks.py
@@ -189,6 +189,16 @@ def test_record_event_logs_instruction_and_tags(monkeypatch):
             {"charge_id": "ch_unauth"},
             {"block_unauthorized_charges": True},
         ),
+        (
+            "unauthorized_refund",
+            {"refund_id": "re_unauth"},
+            {"block_unauthorized_refunds": True},
+        ),
+        (
+            "unauthorized_failure",
+            {"event_id": "evt_unauth"},
+            {"block_unauthorized_failures": True},
+        ),
     ],
 )
 def test_repeated_anomalies_trigger_param_update(event_type, metadata, hint, monkeypatch):


### PR DESCRIPTION
## Summary
- Use dedicated `unauthorized_refund` and `unauthorized_failure` event types in refund anomaly detection
- Map new unauthorized event types and hints in the sanity layer and billing instructions
- Document unified naming for unauthorized events across watchdog components

## Testing
- `pre-commit run --files menace_sanity_layer.py stripe_watchdog.py config/billing_instructions.yaml billing/refund_anomaly_detector.py tests/test_refund_anomaly_detector.py tests/test_sanity_layer_hooks.py docs/stripe_watchdog.md docs/menace_sanity_layer.md` *(fails: check-static-paths, forbid-raw-stripe-usage)*
- `pytest tests/test_refund_anomaly_detector.py tests/test_sanity_layer_hooks.py tests/test_menace_sanity_layer.py` *(fails: attribute errors and sqlite3 operational errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8a0d6428832eb407c16612d5debe