### PR TITLE
Integrate ContextBuilder into patch generation

### DIFF
--- a/self_debugger_sandbox.py
+++ b/self_debugger_sandbox.py
@@ -427,7 +427,14 @@ class SelfDebuggerSandbox(AutomatedDebugger):
                     before_target = Path(before_dir) / rel
                     before_target.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(src, before_target)
-                    patch_id = generate_patch(mod, self.engine)
+                    builder = ContextBuilder() if ContextBuilder else None
+                    if builder is None:
+                        self.logger.warning(
+                            "ContextBuilder unavailable; proceeding without vector context"
+                        )
+                    patch_id = generate_patch(
+                        mod, self.engine, context_builder=builder
+                    )
                     if patch_id is not None:
                         try:
                             post_round_orphan_scan(


### PR DESCRIPTION
## Summary
- Use ContextBuilder in SelfDebuggerSandbox to supply vector context for preemptive patches
- Pass ContextBuilder to ModuleRetirementService compression and replacement patch generation
- Add ContextBuilder and defensive logging to ErrorLogger quick fix generation

## Testing
- `PYTHONPATH=. pre-commit run --files self_debugger_sandbox.py module_retirement_service.py error_logger.py` *(fails: check-static-paths, forbid-raw-stripe-usage)*
- `pytest self_debugger_sandbox.py module_retirement_service.py error_logger.py` *(fails: ModuleNotFoundError: No module named 'audit')*


------
https://chatgpt.com/codex/tasks/task_e_68bba9c81544832ea4a096e756e83576