### PR TITLE
Use vector context in quick fix patches

### DIFF
--- a/error_logger.py
+++ b/error_logger.py
@@ -60,15 +60,14 @@ except Exception:  # pragma: no cover - package fallback
 
 try:  # pragma: no cover - optional dependency
     from .quick_fix_engine import generate_patch
+    from vector_service import ContextBuilder
 except Exception:
     try:
         from quick_fix_engine import generate_patch  # type: ignore
+        from vector_service import ContextBuilder  # type: ignore
     except Exception:
         generate_patch = None  # type: ignore
-try:
-    from vector_service import ContextBuilder
-except Exception:  # pragma: no cover - optional dependency
-    ContextBuilder = None  # type: ignore
+        ContextBuilder = None  # type: ignore
 
 from governed_embeddings import governed_embed, get_embedder
 try:  # pragma: no cover - allow flat imports
@@ -741,13 +740,9 @@ class ErrorLogger:
 
             if generate_patch is not None and resolved_module:
                 try:
-                    builder = ContextBuilder() if ContextBuilder else None
-                    if builder is None:
-                        self.logger.warning(
-                            "ContextBuilder unavailable; quick fix without vector context"
-                        )
                     patch_id = generate_patch(
-                        resolved_module, context_builder=builder
+                        resolved_module,
+                        context_builder=ContextBuilder() if ContextBuilder else None,
                     )
                     if patch_id is not None:
                         try:


### PR DESCRIPTION
## Summary
- import `ContextBuilder` alongside quick fix `generate_patch`
- pass a `ContextBuilder` instance to `generate_patch` when generating quick fixes

## Testing
- `python -m py_compile error_logger.py`
- `pytest tests/test_error_logger_fix_suggestions.py::test_log_fix_suggestions_emits_events_and_triggers_patch_and_codex -q` *(fails: ImportError: cannot import name 'get_project_root')*

------
https://chatgpt.com/codex/tasks/task_e_68bbc3860254832eb5b760ecb101dda4