### PR TITLE
Use shared ContextBuilder in module retirement

### DIFF
--- a/tests/test_module_retirement_service.py
+++ b/tests/test_module_retirement_service.py
@@ -2,7 +2,7 @@ import sys
 import types
 
 fake_qfe = types.ModuleType("quick_fix_engine")
-fake_qfe.generate_patch = lambda path: 1
+fake_qfe.generate_patch = lambda path, context_builder=None: 1
 sys.modules["quick_fix_engine"] = fake_qfe
 
 import module_retirement_service

--- a/tests/test_module_retirement_service_replace.py
+++ b/tests/test_module_retirement_service_replace.py
@@ -2,7 +2,7 @@ import sys
 import types
 
 fake_qfe = types.ModuleType("quick_fix_engine")
-fake_qfe.generate_patch = lambda path: 1
+fake_qfe.generate_patch = lambda path, context_builder=None: 1
 sys.modules["quick_fix_engine"] = fake_qfe
 
 import module_retirement_service
@@ -21,7 +21,7 @@ def test_replace_module(monkeypatch, tmp_path):
 
     called = {}
 
-    def fake_generate_patch(path):
+    def fake_generate_patch(path, context_builder=None):
         called["path"] = path
         return 1
 
@@ -51,7 +51,7 @@ def test_process_flags_replace(monkeypatch, tmp_path):
 
     called = {}
 
-    def fake_generate_patch(path):
+    def fake_generate_patch(path, context_builder=None):
         called["path"] = path
         return 1
 
@@ -88,7 +88,7 @@ def test_process_flags_replace_skipped(monkeypatch, tmp_path, caplog):
 
     monkeypatch.setattr(module_retirement_service, "build_import_graph", _stub_build_graph)
 
-    def fake_generate_patch(path):
+    def fake_generate_patch(path, context_builder=None):
         return None
 
     monkeypatch.setattr(module_retirement_service, "generate_patch", fake_generate_patch)


### PR DESCRIPTION
## Summary
- import ContextBuilder with optional dependency
- instantiate and reuse a single ContextBuilder in ModuleRetirementService
- update module retirement tests for context builder parameter

## Testing
- `pytest tests/test_module_retirement_service.py tests/test_module_retirement_service_replace.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbc5300a00832ebd6121e92d61ca49