### PR TITLE
feat: integrate ContextBuilder into patch generation

### DIFF
--- a/self_debugger_sandbox.py
+++ b/self_debugger_sandbox.py
@@ -110,6 +110,9 @@ except Exception:  # pragma: no cover - optional dependency
     def record_failed_tags(_tags):  # type: ignore
         return None
 
+# Global ContextBuilder instance for reuse across patch generation calls
+CONTEXT_BUILDER = ContextBuilder() if ContextBuilder else None
+
 
 class CoverageSubprocessError(RuntimeError):
     """Raised when a test subprocess exits with a non-zero code."""
@@ -427,13 +430,12 @@ class SelfDebuggerSandbox(AutomatedDebugger):
                     before_target = Path(before_dir) / rel
                     before_target.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(src, before_target)
-                    builder = ContextBuilder() if ContextBuilder else None
-                    if builder is None:
+                    if CONTEXT_BUILDER is None:
                         self.logger.warning(
                             "ContextBuilder unavailable; proceeding without vector context"
                         )
                     patch_id = generate_patch(
-                        mod, self.engine, context_builder=builder
+                        mod, self.engine, context_builder=CONTEXT_BUILDER
                     )
                     if patch_id is not None:
                         try:


### PR DESCRIPTION
## Summary
- reuse a global `ContextBuilder` instance for patch generation
- pass the builder to `generate_patch` for self-debugger sandbox

## Testing
- `python3 -m py_compile self_debugger_sandbox.py`
- `pytest tests/test_self_debugger_sandbox.py` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '')*


------
https://chatgpt.com/codex/tasks/task_e_68bbc618c0b0832e9f02204eddab0bc1