### PR TITLE
Ensure QuickFixEngine builds context by default

### DIFF
--- a/quick_fix_engine.py
+++ b/quick_fix_engine.py
@@ -367,14 +367,7 @@ class QuickFixEngine:
         self.retriever = retriever
         logger = logging.getLogger(self.__class__.__name__)
         if context_builder is None:
-            if retriever is not None:
-                try:
-                    context_builder = ContextBuilder(retriever=retriever)
-                except Exception as exc:
-                    logger.warning("context builder instantiation failed: %s", exc)
-                    context_builder = None
-            else:
-                logger.warning("vector_service retriever unavailable; context builder disabled")
+            context_builder = ContextBuilder(retriever=retriever)
         self.context_builder = context_builder
         if patch_logger is None:
             try:
@@ -469,16 +462,15 @@ class QuickFixEngine:
         context_meta = {"error_type": etype, "module": prompt_path, "bot": bot}
         builder = self.context_builder
         ctx_block = ""
-        if builder is not None:
-            cb_session = uuid.uuid4().hex
-            context_meta["context_session_id"] = cb_session
-            try:
-                query = f"{etype} in {prompt_path}"
-                ctx_block = builder.build(query, session_id=cb_session)
-                if isinstance(ctx_block, (FallbackResult, ErrorResult)):
-                    ctx_block = ""
-            except Exception:
+        cb_session = uuid.uuid4().hex
+        context_meta["context_session_id"] = cb_session
+        try:
+            query = f"{etype} in {prompt_path}"
+            ctx_block = builder.build(query, session_id=cb_session)
+            if isinstance(ctx_block, (FallbackResult, ErrorResult)):
                 ctx_block = ""
+        except Exception:
+            ctx_block = ""
         desc = f"quick fix {etype}"
         if ctx_block:
             desc += "\n\n" + ctx_block
@@ -572,16 +564,15 @@ class QuickFixEngine:
             meta = {"module": prompt_path, "reason": "preemptive_patch"}
             builder = self.context_builder
             ctx = ""
-            if builder is not None:
-                cb_session = uuid.uuid4().hex
-                meta["context_session_id"] = cb_session
-                try:
-                    query = f"preemptive patch {prompt_path}"
-                    ctx = builder.build(query, session_id=cb_session)
-                    if isinstance(ctx, (FallbackResult, ErrorResult)):
-                        ctx = ""
-                except Exception:
+            cb_session = uuid.uuid4().hex
+            meta["context_session_id"] = cb_session
+            try:
+                query = f"preemptive patch {prompt_path}"
+                ctx = builder.build(query, session_id=cb_session)
+                if isinstance(ctx, (FallbackResult, ErrorResult)):
                     ctx = ""
+            except Exception:
+                ctx = ""
             desc = "preemptive_patch"
             if ctx:
                 desc += "\n\n" + ctx

--- a/tests/integration/test_quick_fix_engine_chunked_patch.py
+++ b/tests/integration/test_quick_fix_engine_chunked_patch.py
@@ -25,10 +25,28 @@ kg.KnowledgeGraph = object
 sys.modules["menace_sandbox.knowledge_graph"] = kg
 
 vec = types.ModuleType("vector_service")
-vec.ContextBuilder = object
+
+
+class _DummyContextBuilder:
+    def __init__(self, *a, retriever=None, **k):
+        self.retriever = retriever
+
+    def build(self, *a, **k):
+        return ""
+
+
+class _DummyBackfill:
+    def __init__(self, *a, **k):
+        pass
+
+    def run(self, *a, **k):
+        return None
+
+
+vec.ContextBuilder = _DummyContextBuilder
 vec.Retriever = object
 vec.FallbackResult = object
-vec.EmbeddingBackfill = object
+vec.EmbeddingBackfill = _DummyBackfill
 sys.modules["vector_service"] = vec
 
 pp = types.ModuleType("patch_provenance")
@@ -42,6 +60,7 @@ spec = importlib.util.spec_from_file_location(
 quick_fix = importlib.util.module_from_spec(spec)
 sys.modules["menace_sandbox.quick_fix_engine"] = quick_fix
 spec.loader.exec_module(quick_fix)
+
 
 def test_chunked_patch_generation(tmp_path, monkeypatch):
     path = tmp_path / "big.py"  # path-ignore


### PR DESCRIPTION
## Summary
- Instantiate a `ContextBuilder` automatically when `QuickFixEngine` is created without one.
- Simplify error processing to assume context is always available.
- Add regression tests and update stubs to verify automatic context building.

## Testing
- `PYTHONPATH=. pre-commit run --files quick_fix_engine.py tests/test_quick_fix_engine.py tests/integration/test_quick_fix_engine_chunked_patch.py`
- `pytest -q` *(fails: 624 errors during collection, segmentation fault)*
- `pytest tests/test_quick_fix_engine.py::test_init_auto_builds_context_builder -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbd474a7d4832e9640fc717d82dd50