### PR TITLE
Require explicit ContextBuilder for BotDevelopmentBot

### DIFF
--- a/tests/test_scalability_pipeline.py
+++ b/tests/test_scalability_pipeline.py
@@ -1,14 +1,19 @@
+# flake8: noqa
 import pytest
 pytest.skip("optional dependencies not installed", allow_module_level=True)
-import menace.scalability_pipeline as sp
-import menace.bot_development_bot as bdb
-import menace.bot_testing_bot as btb
-import menace.scalability_assessment_bot as sab
-import menace.deployment_bot as dep
+import menace.scalability_pipeline as sp  # noqa: E402
+import menace.bot_development_bot as bdb  # noqa: E402
+import menace.bot_testing_bot as btb  # noqa: E402
+import menace.scalability_assessment_bot as sab  # noqa: E402
+import menace.deployment_bot as dep  # noqa: E402
+
+
+def _ctx_builder():
+    return bdb.ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
 
 
 def test_pipeline_runs(tmp_path):
-    developer = bdb.BotDevelopmentBot(repo_base=tmp_path / "repos")
+    developer = bdb.BotDevelopmentBot(repo_base=tmp_path / "repos", context_builder=_ctx_builder())
     tester = btb.BotTestingBot()
     scaler = sab.ScalabilityAssessmentBot()
     deployer = dep.DeploymentBot(dep.DeploymentDB(tmp_path / "dep.db"))


### PR DESCRIPTION
## Summary
- require callers to supply a ContextBuilder when creating BotDevelopmentBot
- simplify prompt building to always use the provided ContextBuilder
- propagate optional ContextBuilder through ImplementationPipeline and update tests

## Testing
- `pre-commit run --files bot_development_bot.py implementation_pipeline.py tests/test_bot_development_bot.py tests/test_codex_db_helpers.py tests/test_models_repo_workflow.py tests/test_implementation_pipeline.py tests/test_scalability_pipeline.py`
- `pytest tests/test_bot_development_bot.py::test_parse_plan_json tests/test_codex_db_helpers.py::test_bot_development_bot_uses_codex_samples tests/test_implementation_pipeline.py::test_pipeline_runs -q` *(fails: AttributeError: 'NoneType' object has no attribute 'get_connection')*

------
https://chatgpt.com/codex/tasks/task_e_68bbde6fc3b0832eaee8e4d6ed8932b1