### PR TITLE
Require explicit ContextBuilder for AutomatedReviewer

### DIFF
--- a/docs/context_builder.md
+++ b/docs/context_builder.md
@@ -95,7 +95,8 @@ summariser also operates offline, so even without the optional memory manager
 
 ## Integration
 
-`SelfCodingEngine`, `QuickFixEngine`, `BotDevelopmentBot` and
-`AutomatedReviewer` instantiate `ContextBuilder` automatically when available to
-enrich their prompts with historical context.
+`SelfCodingEngine`, `QuickFixEngine` and `BotDevelopmentBot` instantiate
+`ContextBuilder` automatically when available to enrich their prompts with
+historical context. `AutomatedReviewer` now requires an explicit
+`ContextBuilder` instance to provide similar context during reviews.
 


### PR DESCRIPTION
## Summary
- require a ContextBuilder when constructing AutomatedReviewer and surface vector service errors
- update tests to pass builders with explicit DB paths
- document new requirement for AutomatedReviewer

## Testing
- `pytest tests/test_automated_reviewer.py -q`
- `pytest tests/test_unified_event_bus.py::test_automated_reviewer_called -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbf8717ad0832ea34053c5cd6a4b42