### PR TITLE
Require explicit ContextBuilder for bots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,14 @@ def test_example():
 Run `pre-commit run check-static-paths --all-files` before committing to ensure
 no hard-coded `.py` paths slip through.
 
+## ContextBuilder dependency
+
+Bots or services that assemble prompts or invoke LLMs must take a
+`ContextBuilder` parameter. Instantiate the builder with local database paths
+at the call site and pass it explicitly rather than relying on internal
+defaults or silent fallbacks. Tests should assert that these components fail
+fast when the builder is omitted.
+
 ## Stripe integration
 
 To centralize billing logic and API configuration, the `stripe` Python package

--- a/scalability_pipeline.py
+++ b/scalability_pipeline.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable
 
 from .bot_development_bot import BotDevelopmentBot, BotSpec
 from .bot_testing_bot import BotTestingBot
@@ -26,13 +26,17 @@ class ScalabilityPipeline:
 
     def __init__(
         self,
+        *,
+        context_builder: ContextBuilder,
         developer: BotDevelopmentBot | None = None,
         tester: BotTestingBot | None = None,
         scaler: ScalabilityAssessmentBot | None = None,
         deployer: DeploymentBot | None = None,
         max_iters: int = 3,
     ) -> None:
-        self.context_builder = ContextBuilder()
+        if context_builder is None:
+            raise ValueError("ContextBuilder is required")
+        self.context_builder = context_builder
         self.developer = developer or BotDevelopmentBot(
             context_builder=self.context_builder
         )

--- a/tests/test_context_builder_required.py
+++ b/tests/test_context_builder_required.py
@@ -1,0 +1,84 @@
+import sys
+import types
+import importlib
+import pytest
+
+
+class _DummyBuilder:
+    def refresh_db_weights(self):
+        return None
+
+
+def test_module_retirement_service_requires_builder(tmp_path):
+    from module_retirement_service import ModuleRetirementService
+
+    ModuleRetirementService(tmp_path, context_builder=_DummyBuilder())
+    with pytest.raises(ValueError):
+        ModuleRetirementService(tmp_path, context_builder=None)  # type: ignore[arg-type]
+
+
+def test_scalability_pipeline_requires_builder(monkeypatch):
+    class DummyDev:
+        def __init__(self, *a, **k):
+            pass
+
+    class DummyTester:
+        pass
+
+    class DummyScaler:
+        pass
+
+    class DummyDeployer:
+        db = {}
+
+        def deploy(self, *a, **k):
+            return 1
+
+        def __init__(self, *a, **k):
+            pass
+
+    monkeypatch.setitem(
+        sys.modules,
+        "vector_service",
+        types.SimpleNamespace(ContextBuilder=_DummyBuilder),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "menace.bot_development_bot",
+        types.SimpleNamespace(BotDevelopmentBot=DummyDev, BotSpec=object),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "menace.bot_testing_bot",
+        types.SimpleNamespace(BotTestingBot=DummyTester),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "menace.scalability_assessment_bot",
+        types.SimpleNamespace(ScalabilityAssessmentBot=DummyScaler, TaskInfo=object),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "menace.deployment_bot",
+        types.SimpleNamespace(DeploymentBot=DummyDeployer, DeploymentSpec=object),
+    )
+
+    sp = importlib.import_module("menace.scalability_pipeline")
+    pipeline_cls = sp.ScalabilityPipeline
+    builder = _DummyBuilder()
+    pipeline_cls(
+        context_builder=builder,
+        developer=DummyDev(),
+        tester=DummyTester(),
+        scaler=DummyScaler(),
+        deployer=DummyDeployer(),
+    )
+
+    with pytest.raises(ValueError):
+        pipeline_cls(
+            context_builder=None,  # type: ignore[arg-type]
+            developer=DummyDev(),
+            tester=DummyTester(),
+            scaler=DummyScaler(),
+            deployer=DummyDeployer(),
+        )

--- a/tests/test_module_retirement_service_replace.py
+++ b/tests/test_module_retirement_service_replace.py
@@ -5,6 +5,7 @@ fake_qfe = types.ModuleType("quick_fix_engine")
 fake_qfe.generate_patch = lambda path, context_builder=None: 1
 sys.modules["quick_fix_engine"] = fake_qfe
 
+
 class _DummyBuilder:
     def __init__(self, *a, **k):
         pass
@@ -12,10 +13,11 @@ class _DummyBuilder:
     def refresh_db_weights(self):
         return None
 
+
 sys.modules.setdefault("vector_service", types.SimpleNamespace(ContextBuilder=_DummyBuilder))
 
-import module_retirement_service
-from module_retirement_service import ModuleRetirementService
+import module_retirement_service  # noqa: E402
+from module_retirement_service import ModuleRetirementService  # noqa: E402
 
 
 def _stub_build_graph(root):
@@ -46,7 +48,7 @@ def test_replace_module(monkeypatch, tmp_path):
     gauge = DummyGauge()
     monkeypatch.setattr(module_retirement_service, "replaced_modules_total", gauge)
 
-    service = ModuleRetirementService(tmp_path)
+    service = ModuleRetirementService(tmp_path, context_builder=_DummyBuilder())
     assert service.replace_module("demo")
     assert called["path"] == str(module)
     assert gauge.count == 1.0
@@ -83,7 +85,7 @@ def test_process_flags_replace(monkeypatch, tmp_path):
 
     monkeypatch.setattr(module_retirement_service, "update_module_retirement_metrics", fake_update)
 
-    service = ModuleRetirementService(tmp_path)
+    service = ModuleRetirementService(tmp_path, context_builder=_DummyBuilder())
     res = service.process_flags({"demo": "replace"})
     assert res == {"demo": "replaced"}
     assert called["path"] == str(module)
@@ -119,7 +121,7 @@ def test_process_flags_replace_skipped(monkeypatch, tmp_path, caplog):
 
     monkeypatch.setattr(module_retirement_service, "update_module_retirement_metrics", fake_update)
 
-    service = ModuleRetirementService(tmp_path)
+    service = ModuleRetirementService(tmp_path, context_builder=_DummyBuilder())
     with caplog.at_level("INFO"):
         res = service.process_flags({"demo": "replace"})
     assert res == {"demo": "skipped"}


### PR DESCRIPTION
## Summary
- require explicit ContextBuilder for module retirement and scalability pipeline bots
- add regression tests ensuring components fail without a builder
- document ContextBuilder usage in contributing guidelines

## Testing
- `pre-commit run --files module_retirement_service.py scalability_pipeline.py tests/test_module_retirement_service.py tests/test_module_retirement_service_replace.py tests/test_relevancy_retirement_flow.py tests/test_context_builder_required.py CONTRIBUTING.md`
- `pytest tests/test_module_retirement_service.py tests/test_module_retirement_service_replace.py tests/test_relevancy_retirement_flow.py tests/test_context_builder_required.py`

------
https://chatgpt.com/codex/tasks/task_e_68bbfc81b5ec832e8b34a342a3dd3dec