### PR TITLE
feat: instantiate local context builder in quick fix

### DIFF
--- a/quick_fix_engine.py
+++ b/quick_fix_engine.py
@@ -83,7 +83,7 @@ def generate_patch(
     module: str,
     engine: "SelfCodingEngine" | None = None,
     *,
-    context_builder: ContextBuilder,
+    context_builder: ContextBuilder | None = None,
     description: str | None = None,
     strategy: PromptStrategy | None = None,
     patch_logger: PatchLogger | None = None,
@@ -105,8 +105,10 @@ def generate_patch(
         provided, a minimal engine is instantiated on demand.  The function
         tolerates missing dependencies and simply returns ``None`` on failure.
     context_builder:
-        Pre-existing :class:`vector_service.ContextBuilder` configured with
-        local database paths.
+        Optional :class:`vector_service.ContextBuilder`.  When omitted the
+        function instantiates one using local databases ``bots.db``,
+        ``code.db``, ``errors.db`` and ``workflows.db``.  Failure to create
+        the builder raises ``RuntimeError``.
     description:
         Optional patch description.  When omitted, a generic description is
         used.
@@ -126,6 +128,13 @@ def generate_patch(
     """
 
     logger = logging.getLogger("QuickFixEngine")
+    if context_builder is None:
+        try:
+            context_builder = ContextBuilder(
+                "bots.db", "code.db", "errors.db", "workflows.db"
+            )
+        except Exception as exc:  # pragma: no cover - dependency issues
+            raise RuntimeError("ContextBuilder is required") from exc
     try:
         context_builder.refresh_db_weights()
     except Exception as exc:  # pragma: no cover - validation


### PR DESCRIPTION
## Summary
- auto-create a ContextBuilder with local bots, code, errors and workflows databases when generating quick fixes
- raise an error if a ContextBuilder cannot be created or queried
- ensure the same ContextBuilder is propagated to SelfCodingEngine and cognition layer

## Testing
- `pytest tests/test_quick_fix_engine.py::test_preemptive_patch_modules tests/test_quick_fix_engine.py::test_preemptive_patch_falls_back` *(fails: AssertionError: output mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68bc01a62b78832e9cb9b43ee8febf12