### PR TITLE
Require ContextBuilder for automated reviewer

### DIFF
--- a/automated_reviewer.py
+++ b/automated_reviewer.py
@@ -9,14 +9,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
     from .auto_escalation_manager import AutoEscalationManager
     from .bot_database import BotDB
-# Optional dependency: vector_service
+
+# ``vector_service`` is required.  Fail fast if the import is unavailable.
 try:  # pragma: no cover - optional dependency used in runtime
     from vector_service import CognitionLayer, ContextBuilder
-except Exception:  # pragma: no cover - fallback when dependency missing
-    CognitionLayer = ContextBuilder = None  # type: ignore
-    logging.getLogger(__name__).warning(
-        "vector_service import failed; cognition features disabled"
-    )
+except Exception as exc:  # pragma: no cover - dependency missing or broken
+    raise RuntimeError("vector_service import failed") from exc
 
 
 class AutomatedReviewer:
@@ -39,13 +37,11 @@ class AutomatedReviewer:
             escalation_manager = AutoEscalationManager()
         self.escalation_manager = escalation_manager
         self.logger = logging.getLogger(self.__class__.__name__)
-        if CognitionLayer is None:
-            raise RuntimeError(
-                "CognitionLayer unavailable due to missing vector_service dependency"
-            )
+        if not hasattr(context_builder, "build"):
+            raise TypeError("context_builder must implement build()")
         self.context_builder = context_builder
         try:
-            self.cognition_layer = CognitionLayer(context_builder=self.context_builder)
+            self.cognition_layer = CognitionLayer(context_builder=context_builder)
         except Exception:  # pragma: no cover - optional dependency failed
             self.logger.error("failed to initialise CognitionLayer", exc_info=True)
             raise
@@ -67,13 +63,12 @@ class AutomatedReviewer:
             except Exception:
                 self.logger.exception("failed disabling bot %s", bot_id)
             ctx = ""
-            if self.cognition_layer is not None:
-                try:
-                    ctx, _sid = self.cognition_layer.query(
-                        json.dumps({"bot_id": bot_id, "severity": severity})
-                    )
-                except Exception:
-                    ctx = ""
+            try:
+                ctx = self.context_builder.build(
+                    json.dumps({"bot_id": bot_id, "severity": severity})
+                )
+            except Exception:
+                ctx = ""
             try:
                 self.escalation_manager.handle(
                     f"review for bot {bot_id}", attachments=[ctx]


### PR DESCRIPTION
## Summary
- enforce `vector_service` as a hard dependency in `AutomatedReviewer`
- require provided context builders to implement `build()` and build escalation context via this interface
- update tests to use stubbed context builders with the new API

## Testing
- `python -m pre_commit run --files automated_reviewer.py tests/test_automated_reviewer.py`
- `pytest tests/test_automated_reviewer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc039e3030832ea3eff2eb5e1b2d7c