### PR TITLE
Enforce explicit ContextBuilder for AutomatedReviewer

### DIFF
--- a/automated_reviewer.py
+++ b/automated_reviewer.py
@@ -37,6 +37,8 @@ class AutomatedReviewer:
             escalation_manager = AutoEscalationManager()
         self.escalation_manager = escalation_manager
         self.logger = logging.getLogger(self.__class__.__name__)
+        if context_builder is None:
+            raise ValueError("context_builder is required")
         if not hasattr(context_builder, "build"):
             raise TypeError("context_builder must implement build()")
         self.context_builder = context_builder

--- a/tests/test_automated_reviewer_context_builder_invocation.py
+++ b/tests/test_automated_reviewer_context_builder_invocation.py
@@ -1,0 +1,37 @@
+import types
+import sys
+import importlib
+
+
+class RecordingBuilder:
+    def __init__(self, *_, **__):
+        self.calls = []
+
+    def build(self, payload, **_):  # pragma: no cover - simple stub
+        self.calls.append(payload)
+        return "ctx"
+
+
+class DummyCognitionLayer:
+    def __init__(self, *, context_builder=None, **__):
+        self.context_builder = context_builder
+
+
+sys.modules["vector_service"] = types.SimpleNamespace(
+    CognitionLayer=DummyCognitionLayer, ContextBuilder=RecordingBuilder
+)
+import menace_sandbox.automated_reviewer as ar
+importlib.reload(ar)
+
+
+def test_reviewer_uses_context_builder():
+    builder = RecordingBuilder(
+        bot_db="bots.db", code_db="code.db", error_db="errors.db", workflow_db="workflows.db"
+    )
+    db = types.SimpleNamespace(update_bot=lambda *a, **k: None)
+    esc = types.SimpleNamespace(handle=lambda *a, **k: None)
+
+    reviewer = ar.AutomatedReviewer(context_builder=builder, bot_db=db, escalation_manager=esc)
+    reviewer.handle({"bot_id": "99", "severity": "critical"})
+
+    assert builder.calls, "context_builder.build was not invoked"


### PR DESCRIPTION
## Summary
- require a non-null `ContextBuilder` in `AutomatedReviewer` and validate `build` implementation
- add unit test ensuring `AutomatedReviewer` calls `context_builder.build` for critical events

## Testing
- `pytest tests/test_automated_reviewer.py tests/test_missing_context_builder.py tests/test_automated_reviewer_context_builder_invocation.py`

------
https://chatgpt.com/codex/tasks/task_e_68bc09e976ec832ea1470243cf10491e