### PR TITLE
Require explicit ContextBuilder for bot development prompts

### DIFF
--- a/bot_creation_bot.py
+++ b/bot_creation_bot.py
@@ -428,7 +428,9 @@ class BotCreationBot(AdminBotBase):
         spec.name = safe_name
         _ctx, session_id = self.cognition_layer.query(f"build bot {spec.name}")
         try:
-            file_path = self.developer.build_bot(spec)
+            file_path = self.developer.build_bot(
+                spec, context_builder=self.developer.context_builder
+            )
             self.cognition_layer.record_patch_outcome(session_id, True, contribution=1.0)
         except Exception as exc:
             self.cognition_layer.record_patch_outcome(session_id, False, contribution=0.0)

--- a/ipo_implementation_pipeline.py
+++ b/ipo_implementation_pipeline.py
@@ -58,7 +58,9 @@ class IPOImplementationPipeline:
         attempts = 0
         while attempts < self.max_attempts:
             attempts += 1
-            path = self.developer.build_bot(spec)
+            path = self.developer.build_bot(
+                spec, context_builder=self.developer.context_builder
+            )
             if str(path.parent) not in sys.path:
                 sys.path.insert(0, str(path.parent))
             results = self.tester.run_unit_tests([spec.name])

--- a/tests/test_codex_db_helpers.py
+++ b/tests/test_codex_db_helpers.py
@@ -360,6 +360,7 @@ def test_bot_development_bot_uses_codex_samples(monkeypatch, tmp_path):
 
     prompt = bot._build_prompt(
         spec,
+        context_builder=builder,
         sample_limit=2,
         sample_sort_by="confidence",
         sample_with_vectors=True,

--- a/tests/test_context_builder.py
+++ b/tests/test_context_builder.py
@@ -260,7 +260,7 @@ def test_bot_development_bot_includes_context(monkeypatch, tmp_path):
     ctx = builder.build_context("alpha issue")
     bot = BotDevelopmentBot(repo_base=tmp_path, context_builder=builder)
     spec = BotSpec(name="demo", purpose="alpha issue")
-    prompt = bot._build_prompt(spec)
+    prompt = bot._build_prompt(spec, context_builder=builder)
     assert "\n\nContext:\n" in prompt
     assert ctx in prompt
 

--- a/tests/test_implementation_pipeline.py
+++ b/tests/test_implementation_pipeline.py
@@ -143,8 +143,8 @@ def test_prompt_contains_docstrings(tmp_path):
             super().__init__(repo_base=repo_base, context_builder=builder)
             self.prompts: list[str] = []
 
-        def build_bot(self, spec: bdb.BotSpec, model_id=None) -> Path:  # type: ignore[override]
-            prompt = self._build_prompt(spec)
+        def build_bot(self, spec: bdb.BotSpec, *, context_builder, model_id=None) -> Path:  # type: ignore[override]
+            prompt = self._build_prompt(spec, context_builder=context_builder)
             self.prompts.append(prompt)
             repo_dir = self.create_env(spec)
             file_path = repo_dir / f"{spec.name}.py"  # path-ignore
@@ -209,8 +209,8 @@ def test_prompt_includes_guideline_sections(tmp_path):
             super().__init__(repo_base=repo_base, context_builder=builder)
             self.prompt = ""
 
-        def build_bot(self, spec: bdb.BotSpec, model_id=None) -> Path:  # type: ignore[override]
-            self.prompt = self._build_prompt(spec)
+        def build_bot(self, spec: bdb.BotSpec, *, context_builder, model_id=None) -> Path:  # type: ignore[override]
+            self.prompt = self._build_prompt(spec, context_builder=context_builder)
             repo_dir = self.create_env(spec)
             file_path = repo_dir / f"{spec.name}.py"  # path-ignore
             file_path.write_text("pass")
@@ -357,7 +357,7 @@ def test_researcher_invoked_for_missing_info(tmp_path):
             self.opt.from_research = True
 
     class MiniDev(bdb.BotDevelopmentBot):
-        def build_bot(self, spec: bdb.BotSpec, model_id=None) -> Path:  # type: ignore[override]
+        def build_bot(self, spec: bdb.BotSpec, *, context_builder, model_id=None) -> Path:  # type: ignore[override]
             repo_dir = self.create_env(spec)
             file_path = repo_dir / f"{spec.name}.py"  # path-ignore
             file_path.write_text("pass")
@@ -446,11 +446,12 @@ def test_pipeline_uses_local_context_builder(tmp_path, monkeypatch):
             self,
             spec: bdb.BotSpec,
             *,
+            context_builder,
             model_id=None,
             **kwargs,
         ) -> Path:  # type: ignore[override]
-            self.used_builder = self.context_builder
-            prompt = self._build_prompt(spec)
+            self.used_builder = context_builder
+            prompt = self._build_prompt(spec, context_builder=context_builder)
             self.prompt = prompt
             repo_dir = self.create_env(spec)
             file_path = repo_dir / f"{spec.name}.py"  # path-ignore
@@ -534,7 +535,7 @@ def test_pipeline_openai_error_not_raised(tmp_path, monkeypatch, caplog):
 
 def test_pipeline_surfaces_build_errors(tmp_path, caplog):
     class FailingDev(bdb.BotDevelopmentBot):
-        def build_bot(self, spec: bdb.BotSpec, model_id=None) -> Path:  # type: ignore[override]
+        def build_bot(self, spec: bdb.BotSpec, *, context_builder, model_id=None) -> Path:  # type: ignore[override]
             raise RuntimeError("boom")
 
     builder = _ctx_builder()
@@ -576,7 +577,7 @@ def test_ipo_plan_fills_metadata_and_pipeline_runs(tmp_path):
             )
 
     class MiniDev(bdb.BotDevelopmentBot):
-        def build_bot(self, spec: bdb.BotSpec, model_id=None) -> Path:  # type: ignore[override]
+        def build_bot(self, spec: bdb.BotSpec, *, context_builder, model_id=None) -> Path:  # type: ignore[override]
             repo_dir = self.create_env(spec)
             file_path = repo_dir / f"{spec.name}.py"  # path-ignore
             file_path.write_text("pass")

--- a/tests/test_ipo_implementation_pipeline_context_builder.py
+++ b/tests/test_ipo_implementation_pipeline_context_builder.py
@@ -10,15 +10,16 @@ def test_context_builder_reused(tmp_path):
     builders: list[object] = []
 
     class StubContextBuilder:
-        pass
+        def __init__(self, *a, **k):
+            pass
 
     class StubDeveloper:
         def __init__(self, *a, context_builder=None, **k):
             self.context_builder = context_builder
             self.errors: list[str] = []
 
-        def build_bot(self, spec):
-            builders.append(self.context_builder)
+        def build_bot(self, spec, *, context_builder, model_id=None, **_):
+            builders.append(context_builder)
             return tmp_path / f"{spec.name}.py"
 
     @dataclass


### PR DESCRIPTION
## Summary
- Require `ContextBuilder` argument for `BotDevelopmentBot._build_prompt` and `build_bot`
- Pass shared `ContextBuilder` through bot creation and IPO implementation pipelines
- Add integration test ensuring prompt generation embeds vector context

## Testing
- `pytest tests/test_bot_development_bot.py::test_prompt_includes_vector_context tests/test_ipo_implementation_pipeline_context_builder.py::test_context_builder_reused -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc0dda9744832e986835b6d9e07cc1