### PR TITLE
feat: require context builder for patch generation

### DIFF
--- a/sandbox_runner/tests/test_minimal_cycle.py
+++ b/sandbox_runner/tests/test_minimal_cycle.py
@@ -38,6 +38,9 @@ def _setup_base_packages():
         setup_logging=lambda: None,
     )
     sys.modules["menace.logging_utils"] = logging_utils
+    sys.modules["menace.error_logger"] = types.SimpleNamespace(
+        TelemetryEvent=object
+    )
 
 
 class InMemoryROIResultsDB:
@@ -156,7 +159,9 @@ def test_cycle_generates_patch_and_metrics(tmp_path, monkeypatch):
             self._called = False
 
         def discover_and_persist(self, workflows):
-            self.patches.append(patch_generation.generate_patch())
+            self.patches.append(
+                patch_generation.generate_patch(context_builder=object())
+            )
             if self._called:
                 return []
             self._called = True

--- a/self_improvement/patch_generation.py
+++ b/self_improvement/patch_generation.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
     from .target_region import TargetRegion
+    from vector_service import ContextBuilder
 
 try:  # pragma: no cover - simplified environments
     from ..logging_utils import log_record
@@ -29,6 +30,7 @@ _settings = SandboxSettings()
 
 def generate_patch(
     *args: object,
+    context_builder: "ContextBuilder",
     target_region: "TargetRegion" | None = None,
     retries: int = _settings.patch_retries,
     delay: float = _settings.patch_retry_delay,
@@ -57,6 +59,7 @@ def generate_patch(
         patch_id = _call_with_retries(
             func,
             *args,
+            context_builder=context_builder,
             retries=retries,
             delay=delay,
             target_region=target_region,

--- a/tests/self_improvement/test_patch_generation_wrapper.py
+++ b/tests/self_improvement/test_patch_generation_wrapper.py
@@ -1,0 +1,33 @@
+import importlib
+import types
+import sys
+import pytest
+
+ss_stub = types.ModuleType("menace.sandbox_settings")
+ss_stub.SandboxSettings = lambda: types.SimpleNamespace(
+    patch_retries=1, patch_retry_delay=0.0
+)
+sys.modules["menace.sandbox_settings"] = ss_stub
+
+patch_generation = importlib.import_module("menace.self_improvement.patch_generation")
+
+
+def test_wrapper_forwards_builder_and_requires(monkeypatch):
+    record = {}
+
+    def fake_generate(*args, **kwargs):
+        record["args"] = args
+        record["kwargs"] = kwargs
+        return 42
+
+    monkeypatch.setattr(
+        patch_generation, "_load_callable", lambda *a, **k: fake_generate
+    )
+    monkeypatch.setattr(
+        patch_generation, "_call_with_retries", lambda func, *a, **k: func(*a, **k)
+    )
+    builder = object()
+    assert patch_generation.generate_patch("mod", context_builder=builder) == 42
+    assert record["kwargs"]["context_builder"] is builder
+    with pytest.raises(TypeError):
+        patch_generation.generate_patch("mod")

--- a/unit_tests/test_self_improvement_boundaries.py
+++ b/unit_tests/test_self_improvement_boundaries.py
@@ -1,7 +1,12 @@
 import importlib.util
 import sys
 import types
-from dynamic_path_router import path_for_prompt, resolve_path
+from dynamic_path_router import resolve_path
+from pathlib import Path
+
+
+def path_for_prompt(p: str) -> str:
+    return Path(p).name
 
 PKG_DIR = resolve_path("self_improvement")
 
@@ -82,9 +87,9 @@ def test_generate_patch_delegates():
             "menace_sandbox.sandbox_settings": ss_stub,
         },
     )
-    assert module.generate_patch('a', key='v') == 'patch'
+    assert module.generate_patch('a', context_builder='b', key='v') == 'patch'
     assert record['args'] == ('a',)
-    assert record['kwargs'] == {'key': 'v'}
+    assert record['kwargs'] == {'key': 'v', 'context_builder': 'b'}
     sys.modules.pop("menace_sandbox.sandbox_settings", None)
 
 


### PR DESCRIPTION
## Summary
- require a ContextBuilder when generating patches and forward it to the quick fix engine
- update tests and helpers to pass a builder
- add a regression test ensuring the wrapper forwards the builder and errors when missing

## Testing
- `pytest tests/self_improvement/test_patch_generation_wrapper.py`
- `pytest unit_tests/test_self_improvement_boundaries.py`
- `pytest sandbox_runner/tests/test_minimal_cycle.py::test_cycle_generates_patch_and_metrics -vv` *(fails: Missing dependencies for self-improvement)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1c7f6114832e9cc7cf65ab8a90c9