### PR TITLE
Centralize ContextBuilder defaults

### DIFF
--- a/auto_escalation_manager.py
+++ b/auto_escalation_manager.py
@@ -16,7 +16,13 @@ from .rollback_manager import RollbackManager
 from .error_bot import ErrorDB
 from .unified_event_bus import UnifiedEventBus
 from .local_knowledge_module import init_local_knowledge
-from vector_service.context_builder import ContextBuilder
+try:
+    from vector_service.context_builder_utils import get_default_context_builder
+except ImportError:  # pragma: no cover - fallback when helper missing
+    from vector_service.context_builder import ContextBuilder  # type: ignore
+
+    def get_default_context_builder(**kwargs):  # type: ignore
+        return ContextBuilder(**kwargs)
 
 
 class AutoEscalationManager:
@@ -36,9 +42,7 @@ class AutoEscalationManager:
             gpt_mem = init_local_knowledge(
                 os.getenv("GPT_MEMORY_DB", "gpt_memory.db")
             ).memory
-            builder = ContextBuilder(
-                bot_db="bots.db", code_db="code.db", error_db="errors.db", workflow_db="workflows.db"
-            )
+            builder = get_default_context_builder()
             builder.refresh_db_weights()
             engine = SelfCodingEngine(
                 CodeDB(), gpt_mem, event_bus=event_bus, context_builder=builder

--- a/billing/refund_anomaly_detector.py
+++ b/billing/refund_anomaly_detector.py
@@ -27,7 +27,13 @@ try:  # Optional dependency – self-coding engine
 from self_coding_engine import SelfCodingEngine  # type: ignore
 from code_database import CodeDB  # type: ignore
 from menace_memory_manager import MenaceMemoryManager  # type: ignore
-from vector_service.context_builder import ContextBuilder
+try:
+    from vector_service.context_builder_utils import get_default_context_builder
+except ImportError:  # pragma: no cover - fallback when helper missing
+    from vector_service.context_builder import ContextBuilder  # type: ignore
+
+    def get_default_context_builder(**kwargs):  # type: ignore
+        return ContextBuilder(**kwargs)
 except Exception:  # pragma: no cover - best effort
     SelfCodingEngine = None  # type: ignore
     CodeDB = None  # type: ignore
@@ -94,9 +100,7 @@ def detect_anomalies(
     engine = self_coding_engine
     if engine is None and SelfCodingEngine and CodeDB and MenaceMemoryManager:
         try:  # pragma: no cover - best effort
-            builder = ContextBuilder(
-                bot_db="bots.db", code_db="code.db", error_db="errors.db", workflow_db="workflows.db"
-            )
+            builder = get_default_context_builder()
             builder.refresh_db_weights()
             engine = SelfCodingEngine(
                 CodeDB(), MenaceMemoryManager(), context_builder=builder

--- a/billing/sanity_consumer.py
+++ b/billing/sanity_consumer.py
@@ -17,7 +17,13 @@ from typing import Any, Dict
 from unified_event_bus import UnifiedEventBus
 from sanity_feedback import SanityFeedback
 from self_coding_engine import SelfCodingEngine
-from vector_service.context_builder import ContextBuilder
+try:
+    from vector_service.context_builder_utils import get_default_context_builder
+except ImportError:  # pragma: no cover - fallback when helper missing
+    from vector_service.context_builder import ContextBuilder  # type: ignore
+
+    def get_default_context_builder(**kwargs):  # type: ignore
+        return ContextBuilder(**kwargs)
 import menace_sanity_layer
 from dynamic_path_router import resolve_path
 
@@ -73,9 +79,7 @@ class SanityConsumer:
                 except Exception:  # pragma: no cover - best effort
                     logger.exception("failed to initialise MenaceMemoryManager")
                     memory_mgr = object()
-            builder = ContextBuilder(
-                bot_db="bots.db", code_db="code.db", error_db="errors.db", workflow_db="workflows.db"
-            )
+            builder = get_default_context_builder()
             builder.refresh_db_weights()
             self._engine = SelfCodingEngine(code_db, memory_mgr, context_builder=builder)
             except Exception:  # pragma: no cover - best effort

--- a/bot_creation_bot.py
+++ b/bot_creation_bot.py
@@ -35,7 +35,13 @@ from .admin_bot_base import AdminBotBase
 from datetime import datetime
 from .database_manager import DB_PATH, update_model
 from vector_service.cognition_layer import CognitionLayer
-from vector_service import ContextBuilder
+try:
+    from vector_service import ContextBuilder, get_default_context_builder
+except ImportError:  # pragma: no cover - fallback when helper missing
+    from vector_service import ContextBuilder  # type: ignore
+
+    def get_default_context_builder(**kwargs):  # type: ignore
+        return ContextBuilder(**kwargs)
 from .roi_tracker import ROITracker
 from .menace_sanity_layer import fetch_recent_billing_issues
 try:  # pragma: no cover - allow flat imports
@@ -90,7 +96,7 @@ class BotCreationBot(AdminBotBase):
         super().__init__(db_router=db_router)
         self.metrics_db = metrics_db or MetricsDB()
         self.planner = planner or BotPlanningBot()
-        builder = ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
+        builder = get_default_context_builder()
         self.developer = developer or BotDevelopmentBot(
             context_builder=builder, db_steward=self.db_router
         )

--- a/cognition_layer.py
+++ b/cognition_layer.py
@@ -25,7 +25,13 @@ from __future__ import annotations
 
 from typing import Any, Tuple
 
-from vector_service.context_builder import ContextBuilder
+try:
+    from vector_service import ContextBuilder, get_default_context_builder
+except ImportError:  # pragma: no cover - fallback when helper missing
+    from vector_service import ContextBuilder  # type: ignore
+
+    def get_default_context_builder(**kwargs):  # type: ignore
+        return ContextBuilder(**kwargs)
 from vector_service.cognition_layer import CognitionLayer as _CognitionLayer
 from patch_safety import PatchSafety
 from roi_tracker import ROITracker
@@ -44,7 +50,9 @@ __all__ = [
 # through retrieval, ranking, patch safety and ROI tracking.
 _roi_tracker = ROITracker()
 _patch_safety = PatchSafety()
-_context_builder = ContextBuilder(roi_tracker=_roi_tracker, patch_safety=_patch_safety)
+_context_builder = get_default_context_builder(
+    roi_tracker=_roi_tracker, patch_safety=_patch_safety
+)
 _layer = _CognitionLayer(context_builder=_context_builder, roi_tracker=_roi_tracker)
 
 

--- a/debug_loop_service.py
+++ b/debug_loop_service.py
@@ -14,7 +14,13 @@ from .self_coding_engine import SelfCodingEngine
 from .code_database import CodeDB
 from .menace_memory_manager import MenaceMemoryManager
 from .knowledge_graph import KnowledgeGraph
-from vector_service.context_builder import ContextBuilder
+try:
+    from vector_service.context_builder_utils import get_default_context_builder
+except ImportError:  # pragma: no cover - fallback when helper missing
+    from vector_service.context_builder import ContextBuilder  # type: ignore
+
+    def get_default_context_builder(**kwargs):  # type: ignore
+        return ContextBuilder(**kwargs)
 
 
 class DebugLoopService:
@@ -26,9 +32,7 @@ class DebugLoopService:
         self.graph = graph or KnowledgeGraph()
         if feedback is None:
             logger = ErrorLogger(knowledge_graph=self.graph)
-            builder = ContextBuilder(
-                bot_db="bots.db", code_db="code.db", error_db="errors.db", workflow_db="workflows.db"
-            )
+            builder = get_default_context_builder()
             builder.refresh_db_weights()
             engine = SelfCodingEngine(
                 CodeDB(), MenaceMemoryManager(), context_builder=builder

--- a/error_logger.py
+++ b/error_logger.py
@@ -60,14 +60,17 @@ except Exception:  # pragma: no cover - package fallback
 
 try:  # pragma: no cover - optional dependency
     from .quick_fix_engine import generate_patch
-    from vector_service import ContextBuilder
+    from vector_service import ContextBuilder, get_default_context_builder
 except Exception:
     try:
         from quick_fix_engine import generate_patch  # type: ignore
-        from vector_service import ContextBuilder  # type: ignore
+        from vector_service import ContextBuilder, get_default_context_builder  # type: ignore
     except Exception:
         generate_patch = None  # type: ignore
         ContextBuilder = None  # type: ignore
+
+        def get_default_context_builder(**kwargs):  # type: ignore
+            return ContextBuilder(**kwargs) if ContextBuilder else None
 
 from governed_embeddings import governed_embed, get_embedder
 try:  # pragma: no cover - allow flat imports
@@ -746,13 +749,9 @@ class ErrorLogger:
                     )
                 else:
                     try:
-                        builder = ContextBuilder(
-                            bot_db="bots.db",
-                            code_db="code.db",
-                            error_db="errors.db",
-                            workflow_db="workflows.db",
-                        )
-                        builder.refresh_db_weights()
+                        builder = get_default_context_builder()
+                        if builder is not None:
+                            builder.refresh_db_weights()
                     except Exception as e:  # pragma: no cover - init issues
                         self.logger.error(
                             "ContextBuilder initialisation failed for %s: %s",

--- a/ipo_implementation_pipeline.py
+++ b/ipo_implementation_pipeline.py
@@ -7,7 +7,13 @@ import sys
 import logging
 
 from .ipo_bot import IPOBot, ExecutionPlan
-from vector_service import ContextBuilder
+try:
+    from vector_service import ContextBuilder, get_default_context_builder
+except ImportError:  # pragma: no cover - fallback when helper missing
+    from vector_service import ContextBuilder  # type: ignore
+
+    def get_default_context_builder(**kwargs):  # type: ignore
+        return ContextBuilder(**kwargs)
 
 logger = logging.getLogger(__name__)
 from .bot_development_bot import BotDevelopmentBot, BotSpec
@@ -41,7 +47,7 @@ class IPOImplementationPipeline:
         max_attempts: int = 3,
     ) -> None:
         self.ipo = ipo or IPOBot()
-        builder = ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
+        builder = get_default_context_builder()
         self.developer = developer or BotDevelopmentBot(context_builder=builder)
         self.tester = tester or BotTestingBot()
         self.scaler = scaler or ScalabilityAssessmentBot()

--- a/launch_menace_bots.py
+++ b/launch_menace_bots.py
@@ -36,7 +36,13 @@ SelfDebuggerSandbox = None  # type: ignore
 from menace.code_database import CodeDB  # noqa: E402
 from menace.menace_memory_manager import MenaceMemoryManager  # noqa: E402
 from menace.self_coding_engine import SelfCodingEngine  # noqa: E402
-from vector_service.context_builder import ContextBuilder  # noqa: E402
+try:
+    from vector_service.context_builder_utils import get_default_context_builder  # noqa: E402
+except ImportError:  # pragma: no cover - fallback when helper missing
+    from vector_service.context_builder import ContextBuilder  # type: ignore
+
+    def get_default_context_builder(**kwargs):  # type: ignore
+        return ContextBuilder(**kwargs)
 from menace.error_bot import ErrorDB  # noqa: E402
 from menace.error_logger import ErrorLogger  # noqa: E402
 from menace.knowledge_graph import KnowledgeGraph  # noqa: E402
@@ -103,9 +109,7 @@ def debug_and_deploy(repo: Path, *, jobs: int = 1, override_veto: bool = False) 
     except TypeError:
         code_db = CodeDB()
     memory_mgr = MenaceMemoryManager()
-    builder = ContextBuilder(
-        bot_db="bots.db", code_db="code.db", error_db="errors.db", workflow_db="workflows.db"
-    )
+    builder = get_default_context_builder()
     builder.refresh_db_weights()
     engine = SelfCodingEngine(code_db, memory_mgr, context_builder=builder)
     error_db = ErrorDB(router=GLOBAL_ROUTER)

--- a/menace_master.py
+++ b/menace_master.py
@@ -422,14 +422,18 @@ def deploy_patch(path: Path, description: str) -> None:
     rb = AutomatedRollbackManager()
     policy = PatchApprovalPolicy(rollback_mgr=rb)
     from menace.self_coding_engine import SelfCodingEngine
-    from vector_service.context_builder import ContextBuilder
     from menace.code_database import CodeDB
     from menace.menace_memory_manager import MenaceMemoryManager
     from menace.model_automation_pipeline import ModelAutomationPipeline
+    try:
+        from vector_service.context_builder_utils import get_default_context_builder
+    except ImportError:  # pragma: no cover - fallback
+        from vector_service.context_builder import ContextBuilder  # type: ignore
 
-    builder = ContextBuilder(
-        bot_db="bots.db", code_db="code.db", error_db="errors.db", workflow_db="workflows.db"
-    )
+        def get_default_context_builder(**kwargs):  # type: ignore
+            return ContextBuilder(**kwargs)
+
+    builder = get_default_context_builder()
     builder.refresh_db_weights()
     engine = SelfCodingEngine(CodeDB(), MenaceMemoryManager(), context_builder=builder)
     manager = SelfCodingManager(

--- a/sandbox_runner.py
+++ b/sandbox_runner.py
@@ -43,6 +43,11 @@ from log_tags import INSIGHT, IMPROVEMENT_PATH, FEEDBACK, ERROR_FIX
 from memory_aware_gpt_client import ask_with_memory
 from shared_knowledge_module import LOCAL_KNOWLEDGE_MODULE, LocalKnowledgeModule
 from vector_service import FallbackResult, ContextBuilder
+try:  # pragma: no cover - support missing helper during tests
+    from vector_service import get_default_context_builder
+except ImportError:  # pragma: no cover - fallback
+    def get_default_context_builder(**kwargs):  # type: ignore
+        return ContextBuilder(**kwargs)
 try:  # pragma: no cover - optional dependency
     from vector_service import ErrorResult  # type: ignore
 except Exception:  # pragma: no cover - fallback
@@ -936,12 +941,7 @@ def _sandbox_init(preset: Dict[str, Any], args: argparse.Namespace) -> SandboxCo
                 logger.info("using VisualAgentClientStub due to failure")
             except Exception:
                 va_client = None
-    context_builder = ContextBuilder(
-        bot_db="bots.db",
-        code_db="code.db",
-        error_db="errors.db",
-        workflow_db="workflows.db",
-    )
+    context_builder = get_default_context_builder()
     context_builder.refresh_db_weights()
     engine = SelfCodingEngine(
         CodeDB(),

--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -15,7 +15,13 @@ import json
 import os
 import sys
 import yaml
-from vector_service.context_builder import ContextBuilder
+try:
+    from vector_service.context_builder_utils import get_default_context_builder
+except ImportError:  # pragma: no cover - fallback when helper missing
+    from vector_service.context_builder import ContextBuilder  # type: ignore
+
+    def get_default_context_builder(**kwargs):  # type: ignore
+        return ContextBuilder(**kwargs)
 
 if os.getenv("SANDBOX_CENTRAL_LOGGING") == "1":
     from logging_utils import setup_logging
@@ -7139,9 +7145,7 @@ def run_repo_section_simulations(
             for module, sec_map in sections.items():
                 tmp_dir = tempfile.mkdtemp(prefix="section_")
                 shutil.copytree(repo_path, tmp_dir, dirs_exist_ok=True)
-                builder = ContextBuilder(
-                    bot_db="bots.db", code_db="code.db", error_db="errors.db", workflow_db="workflows.db"
-                )
+                builder = get_default_context_builder()
                 builder.refresh_db_weights()
                 debugger = SelfDebuggerSandbox(
                     object(),
@@ -8304,9 +8308,7 @@ def run_workflow_simulations(
         for wf in workflows:
             for step in wf.workflow:
                 snippet = _wf_snippet([step])
-                builder = ContextBuilder(
-                    bot_db="bots.db", code_db="code.db", error_db="errors.db", workflow_db="workflows.db"
-                )
+                builder = get_default_context_builder()
                 builder.refresh_db_weights()
                 debugger = SelfDebuggerSandbox(
                     object(),

--- a/service_supervisor.py
+++ b/service_supervisor.py
@@ -59,7 +59,13 @@ from .code_database import CodeDB  # noqa: E402
 from .menace_memory_manager import MenaceMemoryManager  # noqa: E402
 from .model_automation_pipeline import ModelAutomationPipeline  # noqa: E402
 from .quick_fix_engine import QuickFixEngine  # noqa: E402
-from vector_service import ContextBuilder  # noqa: E402
+try:  # noqa: E402 - optional helper for default ContextBuilder
+    from vector_service import ContextBuilder, get_default_context_builder
+except ImportError:  # pragma: no cover - fallback when helper missing
+    from vector_service import ContextBuilder  # type: ignore
+
+    def get_default_context_builder(**kwargs):  # type: ignore
+        return ContextBuilder(**kwargs)
 
 try:  # optional dependency
     import psutil  # type: ignore
@@ -366,12 +372,7 @@ class ServiceSupervisor:
             rollback_mgr=self.rollback_mgr, bot_name="menace"
         )
         self.auto_mgr = AutoEscalationManager()
-        self.context_builder = ContextBuilder(
-            bot_db="bots.db",
-            code_db="code.db",
-            error_db="errors.db",
-            workflow_db="workflows.db",
-        )
+        self.context_builder = get_default_context_builder()
         self.context_builder.refresh_db_weights()
         engine = SelfCodingEngine(
             CodeDB(), MenaceMemoryManager(), context_builder=self.context_builder

--- a/stripe_watchdog.py
+++ b/stripe_watchdog.py
@@ -162,7 +162,13 @@ except Exception:  # pragma: no cover - best effort
 
 try:  # Optional dependency – self-coding feedback
     from self_coding_engine import SelfCodingEngine  # type: ignore
-    from vector_service.context_builder import ContextBuilder
+    try:
+        from vector_service.context_builder_utils import get_default_context_builder
+    except ImportError:  # pragma: no cover - fallback
+        from vector_service.context_builder import ContextBuilder  # type: ignore
+
+        def get_default_context_builder(**kwargs):  # type: ignore
+            return ContextBuilder(**kwargs)
     from code_database import CodeDB  # type: ignore
     from menace_memory_manager import MenaceMemoryManager  # type: ignore
 except Exception:  # pragma: no cover - best effort
@@ -1816,9 +1822,7 @@ def main(argv: Optional[List[str]] = None) -> None:
     if SANITY_LAYER_FEEDBACK_ENABLED:
         if SelfCodingEngine and CodeDB and MenaceMemoryManager:
             try:
-                builder = ContextBuilder(
-                    bot_db="bots.db", code_db="code.db", error_db="errors.db", workflow_db="workflows.db"
-                )
+                builder = get_default_context_builder()
                 builder.refresh_db_weights()
                 engine = SelfCodingEngine(
                     CodeDB(), MenaceMemoryManager(), context_builder=builder

--- a/vector_service/__init__.py
+++ b/vector_service/__init__.py
@@ -5,6 +5,7 @@ This package provides the canonical vector retrieval service.
 
 from .retriever import Retriever, FallbackResult
 from .context_builder import ContextBuilder
+from .context_builder_utils import get_default_context_builder
 from .patch_logger import PatchLogger
 from .cognition_layer import CognitionLayer
 from .embedding_backfill import EmbeddingBackfill
@@ -31,6 +32,7 @@ __all__ = [
     "Retriever",
     "FallbackResult",
     "ContextBuilder",
+    "get_default_context_builder",
     "PatchLogger",
     "CognitionLayer",
     "EmbeddingBackfill",

--- a/vector_service/cognition_layer.py
+++ b/vector_service/cognition_layer.py
@@ -38,6 +38,7 @@ from dynamic_path_router import resolve_path
 
 from .retriever import Retriever, PatchRetriever
 from .context_builder import ContextBuilder
+from .context_builder_utils import get_default_context_builder
 from .patch_logger import PatchLogger
 from vector_metrics_db import VectorMetricsDB
 from .decorators import log_and_measure
@@ -95,13 +96,16 @@ class CognitionLayer:
             except Exception:  # pragma: no cover - best effort
                 db_weights = None
         self._db_weights: Dict[str, float] = dict(db_weights or {})
-        self.context_builder = context_builder or ContextBuilder(
-            retriever=self.retriever,
-            patch_retriever=self.patch_retriever,
-            ranking_model=ranking_model,
-            roi_tracker=self.roi_tracker,
-            db_weights=db_weights,
-        )
+        if context_builder is not None:
+            self.context_builder = context_builder
+        else:
+            self.context_builder = get_default_context_builder(
+                retriever=self.retriever,
+                patch_retriever=self.patch_retriever,
+                ranking_model=ranking_model,
+                roi_tracker=self.roi_tracker,
+                db_weights=db_weights,
+            )
         if (
             context_builder is not None
             and getattr(context_builder, "patch_retriever", None) is None

--- a/vector_service/context_builder_utils.py
+++ b/vector_service/context_builder_utils.py
@@ -1,0 +1,18 @@
+"""Utilities for constructing ContextBuilder instances with default databases."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .context_builder import ContextBuilder
+
+
+def get_default_context_builder(**kwargs: Any) -> ContextBuilder:
+    """Return a :class:`ContextBuilder` preconfigured with default databases."""
+    return ContextBuilder(
+        bot_db="bots.db",
+        code_db="code.db",
+        error_db="errors.db",
+        workflow_db="workflows.db",
+        **kwargs,
+    )

--- a/watchdog.py
+++ b/watchdog.py
@@ -417,13 +417,17 @@ class Watchdog:
         try:
             from .automated_debugger import AutomatedDebugger
             from .self_coding_engine import SelfCodingEngine
-            from vector_service.context_builder import ContextBuilder
             from .code_database import CodeDB
             from .menace_memory_manager import MenaceMemoryManager
+            try:
+                from vector_service.context_builder_utils import get_default_context_builder
+            except ImportError:  # pragma: no cover - fallback
+                from vector_service.context_builder import ContextBuilder  # type: ignore
 
-            builder = ContextBuilder(
-                bot_db="bots.db", code_db="code.db", error_db="errors.db", workflow_db="workflows.db"
-            )
+                def get_default_context_builder(**kwargs):  # type: ignore
+                    return ContextBuilder(**kwargs)
+
+            builder = get_default_context_builder()
             builder.refresh_db_weights()
             engine = SelfCodingEngine(
                 CodeDB(), MenaceMemoryManager(), context_builder=builder


### PR DESCRIPTION
## Summary
- add `get_default_context_builder` helper with default database paths
- use helper across services, pipelines and CLI

## Testing
- `pytest tests/test_menace_cli.py tests/test_bot_creation_bot.py tests/test_ipo_implementation_pipeline.py tests/test_scalability_pipeline.py tests/test_implementation_pipeline.py -q` *(fails: FileNotFoundError: 'menace_retrieval_cache_local.db' not found)*
- `pytest tests/test_menace_cli.py -q` *(fails: FileNotFoundError: 'menace_..._local.db' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc209fb3f4832e98dc6ce0e02c2ca1