### PR TITLE
Wire ContextBuilder through AutomatedDebugger usage

### DIFF
--- a/auto_escalation_manager.py
+++ b/auto_escalation_manager.py
@@ -47,7 +47,7 @@ class AutoEscalationManager:
             engine = SelfCodingEngine(
                 CodeDB(), gpt_mem, event_bus=event_bus, context_builder=builder
             )
-            debugger = AutomatedDebugger(ErrorDB(), engine)
+            debugger = AutomatedDebugger(ErrorDB(), engine, context_builder=builder)
         self.debugger = debugger
         self.rollback_mgr = rollback_mgr
         self.event_bus = event_bus

--- a/automated_debugger.py
+++ b/automated_debugger.py
@@ -8,7 +8,7 @@ import re
 import subprocess
 import tempfile
 import traceback
-from typing import Iterable
+from typing import Any, Iterable
 
 from .self_coding_engine import SelfCodingEngine
 from .retry_utils import retry
@@ -22,9 +22,15 @@ _FRAME_RE = re.compile(r"File \"([^\"]+)\", line (\d+), in ([^\n]+)")
 class AutomatedDebugger:
     """Analyse telemetry logs and trigger self-coding fixes."""
 
-    def __init__(self, telemetry_db: object, engine: SelfCodingEngine) -> None:
+    def __init__(
+        self,
+        telemetry_db: object,
+        engine: SelfCodingEngine,
+        context_builder: Any | None = None,
+    ) -> None:
         self.telemetry_db = telemetry_db
         self.engine = engine
+        self.context_builder = context_builder
         self.logger = logging.getLogger("AutomatedDebugger")
         self._tracker = PatchAttemptTracker()
 

--- a/tests/test_automated_debugger.py
+++ b/tests/test_automated_debugger.py
@@ -46,7 +46,7 @@ class DummyEngine:
 
 
 class DummyTelem:
-    def __init__(self, log: str):
+    def __init__(self, log: str = ""):
         self.log = log
 
     def recent_errors(self, limit: int = 5):

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -135,7 +135,7 @@ def test_watchdog_runs_debugger(tmp_path, monkeypatch):
     called = []
 
     class DummyDebugger:
-        def __init__(self, db, eng):
+        def __init__(self, db, eng, **kwargs):
             pass
 
         def analyse_and_fix(self):

--- a/watchdog.py
+++ b/watchdog.py
@@ -432,7 +432,9 @@ class Watchdog:
             engine = SelfCodingEngine(
                 CodeDB(), MenaceMemoryManager(), context_builder=builder
             )
-            dbg = AutomatedDebugger(_Proxy(self.error_db), engine)
+            dbg = AutomatedDebugger(
+                _Proxy(self.error_db), engine, context_builder=builder
+            )
             dbg.analyse_and_fix()
             if self.event_bus:
                 try:


### PR DESCRIPTION
## Summary
- allow AutomatedDebugger to accept an optional ContextBuilder
- create a ContextBuilder in watchdog before SelfCodingEngine and pass it through to AutomatedDebugger
- forward ContextBuilder in AutoEscalationManager and adjust related tests

## Testing
- `pytest tests/test_watchdog.py -q`
- `pytest tests/test_automated_debugger.py -q`
- `pytest tests/test_auto_escalation_manager.py -q` *(fails: ImportError: cannot import name 'RAISE_ERRORS')*


------
https://chatgpt.com/codex/tasks/task_e_68bc2ad0c924832e845f6c0236afd137