### PR TITLE
Ensure consistent ContextBuilder usage in tests

### DIFF
--- a/tests/test_orphan_inclusion_after_patch.py
+++ b/tests/test_orphan_inclusion_after_patch.py
@@ -5,6 +5,9 @@ from pathlib import Path
 
 
 class SelfCodingEngine:
+    def __init__(self, context_builder=None):
+        self.context_builder = context_builder
+
     def patch_file(self, path: Path, description: str) -> None:  # pragma: no cover - stub
         raise NotImplementedError
 
@@ -50,7 +53,8 @@ def test_orphan_inclusion_after_patch(monkeypatch, tmp_path):
     oi_mod.integrate_orphans = integrate_orphans
     monkeypatch.setitem(sys.modules, "sandbox_runner.orphan_integration", oi_mod)
 
-    engine = SelfCodingEngine()
+    builder = object()
+    engine = SelfCodingEngine(builder)
 
     def fake_patch_file(path: Path, description: str) -> None:
         path.write_text("import orphan\n")

--- a/tests/test_patch_orphan_integration.py
+++ b/tests/test_patch_orphan_integration.py
@@ -6,6 +6,9 @@ from types import SimpleNamespace
 
 
 class SelfCodingEngine:
+    def __init__(self, context_builder=None):
+        self.context_builder = context_builder
+
     def patch_file(self, path: Path, description: str) -> None:
         raise NotImplementedError
 
@@ -79,7 +82,8 @@ def test_patch_orphan_integration(monkeypatch, tmp_path):
     oi_mod.integrate_orphans = integrate_orphans
     monkeypatch.setitem(sys.modules, "sandbox_runner.orphan_integration", oi_mod)
 
-    engine = SelfCodingEngine()
+    builder = object()
+    engine = SelfCodingEngine(builder)
 
     def fake_patch_file(path: Path, description: str) -> None:
         path.write_text("import new_mod\n")

--- a/tests/test_post_synthesis_orphan_inclusion.py
+++ b/tests/test_post_synthesis_orphan_inclusion.py
@@ -5,6 +5,9 @@ from pathlib import Path
 
 
 class SelfCodingEngine:
+    def __init__(self, context_builder=None):
+        self.context_builder = context_builder
+
     def patch_file(self, path: Path, description: str) -> None:  # pragma: no cover - stub
         raise NotImplementedError
 
@@ -92,7 +95,8 @@ def test_post_synthesis_orphan_inclusion(monkeypatch, tmp_path):
     oi_mod.integrate_orphans = integrate_orphans
     monkeypatch.setitem(sys.modules, "sandbox_runner.orphan_integration", oi_mod)
 
-    engine = SelfCodingEngine()
+    builder = object()
+    engine = SelfCodingEngine(builder)
 
     def fake_patch_file(path: Path, description: str) -> None:
         path.write_text("import helper\n")

--- a/unit_tests/test_self_coding_engine.py
+++ b/unit_tests/test_self_coding_engine.py
@@ -32,7 +32,8 @@ sys.modules.setdefault(
     "db_router", types.SimpleNamespace(GLOBAL_ROUTER=None, DBRouter=object, init_db_router=lambda *a, **k: None)
 )
 sys.modules.setdefault(
-    "vector_service", types.SimpleNamespace(CognitionLayer=object, SharedVectorService=object)
+    "vector_service",
+    types.SimpleNamespace(CognitionLayer=object, SharedVectorService=object, ContextBuilder=object),
 )
 sys.modules.setdefault(
     "menace.trend_predictor", types.SimpleNamespace(TrendPredictor=object)
@@ -54,6 +55,9 @@ sys.modules.setdefault(
 )
 sys.modules.setdefault(
     "rate_limit", types.SimpleNamespace(estimate_tokens=lambda *a, **k: 0)
+)
+sys.modules.setdefault(
+    "menace.rate_limit", types.SimpleNamespace(estimate_tokens=lambda *a, **k: 0)
 )
 sys.modules.setdefault(
     "menace.llm_router", types.SimpleNamespace(client_from_settings=lambda *a, **k: None)
@@ -299,11 +303,13 @@ def test_context_builder_shared(monkeypatch):
             return types.SimpleNamespace(text="ok")
 
     client = DummyClient()
+    builder = DummyBuilder()
     engine = sce.SelfCodingEngine(
         code_db,
         object(),
         llm_client=client,
         gpt_memory=gpt_mem,
+        context_builder=builder,
     )
 
     builder = engine.context_builder


### PR DESCRIPTION
## Summary
- update orphan integration tests to create a ContextBuilder before SelfCodingEngine instantiation
- align unit test with explicit ContextBuilder usage and stubs

## Testing
- `pytest tests/test_orphan_inclusion_after_patch.py -q`
- `pytest tests/test_patch_orphan_integration.py -q`
- `pytest tests/test_post_synthesis_orphan_inclusion.py -q`
- ⚠️ `pytest unit_tests/test_self_coding_engine.py -k test_context_builder_shared -q` (failed: heavy dependency import)


------
https://chatgpt.com/codex/tasks/task_e_68bc2e1fd550832ea41ffd90aeb9b8db