### PR TITLE
Ensure ContextBuilder shared across bots

### DIFF
--- a/launch_menace_bots.py
+++ b/launch_menace_bots.py
@@ -171,6 +171,7 @@ def debug_and_deploy(repo: Path, *, jobs: int = 1, override_veto: bool = False) 
 
         SelfDebuggerSandbox = _SelfDebuggerSandbox
     sandbox = SelfDebuggerSandbox(_TelemProxy(error_db), engine)
+    sandbox.context_builder = builder
     try:
         deployer = DeploymentBot(
             code_db=code_db,

--- a/sandbox_runner.py
+++ b/sandbox_runner.py
@@ -973,6 +973,7 @@ def _sandbox_init(preset: Dict[str, Any], args: argparse.Namespace) -> SandboxCo
         policy=policy,
         state_getter=improver._policy_state,
     )
+    sandbox.context_builder = context_builder
     sandbox.error_logger = error_logger
     sandbox.error_forecaster = forecaster
     sandbox.quick_fix_engine = quick_fix_engine

--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -7151,6 +7151,7 @@ def run_repo_section_simulations(
                     object(),
                     SelfCodingEngine(CodeDB(), MenaceMemoryManager(), context_builder=builder),
                 )
+                debugger.context_builder = builder
                 try:
                     for sec_name, lines in sec_map.items():
                         code_str = "\n".join(lines)
@@ -8314,6 +8315,7 @@ def run_workflow_simulations(
                     object(),
                     SelfCodingEngine(CodeDB(), MenaceMemoryManager(), context_builder=builder),
                 )
+                debugger.context_builder = builder
                 mod_name = _module_from_step(step)
                 for preset in all_presets:
                     scenario = preset.get("SCENARIO_NAME", "")


### PR DESCRIPTION
## Summary
- attach the shared ContextBuilder to SelfDebuggerSandbox in launch_menace_bots
- propagate the ContextBuilder to SelfDebuggerSandbox within sandbox runner and environment simulations

## Testing
- `SKIP=check-static-paths,forbid-raw-stripe-usage PYTHONPATH=. pre-commit run --files launch_menace_bots.py sandbox_runner.py sandbox_runner/environment.py`

------
https://chatgpt.com/codex/tasks/task_e_68bc3479cff8832ea3502c68672c59da