### PR TITLE
Pass ContextBuilder to SelfCodingEngine

### DIFF
--- a/docs/self_coding_engine.md
+++ b/docs/self_coding_engine.md
@@ -9,10 +9,14 @@ from dynamic_path_router import resolve_path
 from menace.self_coding_engine import SelfCodingEngine
 from menace.code_database import CodeDB
 from menace.menace_memory_manager import MenaceMemoryManager
+from vector_service.context_builder import ContextBuilder
 
+builder = ContextBuilder()
+builder.refresh_db_weights()
 engine = SelfCodingEngine(
     CodeDB(resolve_path('code.db')),
     MenaceMemoryManager(resolve_path('mem.db')),
+    context_builder=builder,
 )
 engine.apply_patch(resolve_path('utils.py'), 'normalize text')
 ```
@@ -45,11 +49,15 @@ recorded so future patches can reuse relevant context.
 
 ```python
 from gpt_memory import GPTMemoryManager
+from vector_service.context_builder import ContextBuilder
 
+builder = ContextBuilder()
+builder.refresh_db_weights()
 engine = SelfCodingEngine(
     CodeDB("code.db"),
     MenaceMemoryManager("mem.db"),
     gpt_memory=GPTMemoryManager("helpers.db"),
+    context_builder=builder,
 )
 engine.gpt_memory.log_interaction("write sort helper", "generated code", tags=["bugfix"])
 ```

--- a/tests/test_orphan_inclusion_after_patch.py
+++ b/tests/test_orphan_inclusion_after_patch.py
@@ -4,6 +4,10 @@ import types
 from pathlib import Path
 
 
+class ContextBuilder:
+    pass
+
+
 class SelfCodingEngine:
     def __init__(self, context_builder=None):
         self.context_builder = context_builder
@@ -53,7 +57,7 @@ def test_orphan_inclusion_after_patch(monkeypatch, tmp_path):
     oi_mod.integrate_orphans = integrate_orphans
     monkeypatch.setitem(sys.modules, "sandbox_runner.orphan_integration", oi_mod)
 
-    builder = object()
+    builder = ContextBuilder()
     engine = SelfCodingEngine(builder)
 
     def fake_patch_file(path: Path, description: str) -> None:

--- a/tests/test_patch_orphan_integration.py
+++ b/tests/test_patch_orphan_integration.py
@@ -5,6 +5,10 @@ from pathlib import Path
 from types import SimpleNamespace
 
 
+class ContextBuilder:
+    pass
+
+
 class SelfCodingEngine:
     def __init__(self, context_builder=None):
         self.context_builder = context_builder
@@ -82,7 +86,7 @@ def test_patch_orphan_integration(monkeypatch, tmp_path):
     oi_mod.integrate_orphans = integrate_orphans
     monkeypatch.setitem(sys.modules, "sandbox_runner.orphan_integration", oi_mod)
 
-    builder = object()
+    builder = ContextBuilder()
     engine = SelfCodingEngine(builder)
 
     def fake_patch_file(path: Path, description: str) -> None:

--- a/tests/test_post_synthesis_orphan_inclusion.py
+++ b/tests/test_post_synthesis_orphan_inclusion.py
@@ -1,7 +1,14 @@
 import json
 import sys
 import types
+import json
+import sys
+import types
 from pathlib import Path
+
+
+class ContextBuilder:
+    pass
 
 
 class SelfCodingEngine:
@@ -95,7 +102,7 @@ def test_post_synthesis_orphan_inclusion(monkeypatch, tmp_path):
     oi_mod.integrate_orphans = integrate_orphans
     monkeypatch.setitem(sys.modules, "sandbox_runner.orphan_integration", oi_mod)
 
-    builder = object()
+    builder = ContextBuilder()
     engine = SelfCodingEngine(builder)
 
     def fake_patch_file(path: Path, description: str) -> None:

--- a/tests/test_repo_root_overrides.py
+++ b/tests/test_repo_root_overrides.py
@@ -1,9 +1,15 @@
 import importlib
+import importlib
 import sys
 import types
 from pathlib import Path
 
 import pytest
+
+
+class ContextBuilder:
+    def build_context(self, *a, **k):
+        return {}
 
 
 def test_environment_respects_sandbox_repo_path(tmp_path, monkeypatch):
@@ -20,6 +26,7 @@ def test_environment_respects_sandbox_repo_path(tmp_path, monkeypatch):
     monkeypatch.setenv("SANDBOX_DATA_DIR", str(data_dir))
 
     import dynamic_path_router as dpr
+    dpr = importlib.reload(dpr)
     dpr.clear_cache()
 
     records = []
@@ -78,13 +85,14 @@ def test_self_coding_engine_respects_menace_root(tmp_path, monkeypatch):
     monkeypatch.setenv("SANDBOX_DATA_DIR", str(data))
 
     import dynamic_path_router as dpr
+    dpr = importlib.reload(dpr)
     dpr.clear_cache()
 
     sce = importlib.reload(importlib.import_module("self_coding_engine"))
 
     class Dummy: ...
 
-    eng = sce.SelfCodingEngine(Dummy(), Dummy(), context_builder=types.SimpleNamespace())
+    eng = sce.SelfCodingEngine(Dummy(), Dummy(), context_builder=ContextBuilder())
     eng.failure_similarity_tracker.update(similarity=0.5)
     eng._save_state()
 
@@ -102,6 +110,7 @@ def test_cli_resolves_paths_under_repo(monkeypatch, tmp_path):
     monkeypatch.setenv("SANDBOX_REPO_PATH", str(repo))
 
     import dynamic_path_router as dpr
+    dpr = importlib.reload(dpr)
     dpr.clear_cache()
 
     cli = importlib.reload(importlib.import_module("sandbox_runner.cli"))

--- a/unit_tests/test_self_coding_engine.py
+++ b/unit_tests/test_self_coding_engine.py
@@ -303,7 +303,7 @@ def test_context_builder_shared(monkeypatch):
             return types.SimpleNamespace(text="ok")
 
     client = DummyClient()
-    builder = DummyBuilder()
+    builder = sce.ContextBuilder()
     engine = sce.SelfCodingEngine(
         code_db,
         object(),


### PR DESCRIPTION
## Summary
- Ensure SelfCodingEngine examples include a ContextBuilder instance
- Provide lightweight ContextBuilder stubs in tests invoking SelfCodingEngine

## Testing
- `pytest tests/test_build_visual_agent_prompt.py` (fail: missing `prompt_chunk_token_threshold` in stubbed settings)


------
https://chatgpt.com/codex/tasks/task_e_68bc3aed68e0832eaa42168f7f6bc64c