### PR TITLE
Ensure context builder is provided for patch generation

### DIFF
--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -6395,6 +6395,18 @@ class SelfImprovementEngine:
                             gen_kwargs["strategy"] = PromptStrategy(strat_name)
                         except Exception:
                             pass
+                    builder = getattr(
+                        self.self_coding_engine, "context_builder", None
+                    )
+                    if builder is not None:
+                        try:
+                            builder.refresh_db_weights()
+                        except Exception:
+                            self.logger.exception(
+                                "failed to initialise ContextBuilder"
+                            )
+                            raise
+                        gen_kwargs["context_builder"] = builder
                     task_id = self._patch_generator(
                         mod, self.self_coding_engine, **gen_kwargs
                     )

--- a/tests/test_relevancy_radar_engine_integration.py
+++ b/tests/test_relevancy_radar_engine_integration.py
@@ -11,6 +11,9 @@ class DummyLogger:
     def info(self, *a, **k):
         pass
 
+    def warning(self, *a, **k):
+        pass
+
     def exception(self, *a, **k):
         pass
 
@@ -22,28 +25,43 @@ def test_replace_flag_triggers_refactor_and_event(monkeypatch):
 
         def process_flags(self, flags):
             self.flags = flags
+            return flags
 
     stub = types.SimpleNamespace(ModuleRetirementService=DummyMRS)
     monkeypatch.setitem(sys.modules, "module_retirement_service", stub)
+    ss_mod = sys.modules.setdefault("sandbox_settings", types.SimpleNamespace())
+    ss_mod.DEFAULT_SEVERITY_SCORE_MAP = {}
+    sys.modules["menace.sandbox_settings"] = ss_mod
+    log_mod = sys.modules.setdefault("menace.logging_utils", types.ModuleType("menace.logging_utils"))
+    log_mod.get_logger = lambda *a, **k: DummyLogger()
+    log_mod.setup_logging = lambda *a, **k: None
+    log_mod.log_record = lambda **kw: kw
+    log_stub = types.ModuleType("menace_sandbox.logging_utils")
+    log_stub.get_logger = lambda *a, **k: DummyLogger()
+    log_stub.setup_logging = lambda *a, **k: None
+    log_stub.log_record = lambda **kw: kw
+    sys.modules["menace_sandbox.logging_utils"] = log_stub
 
     sie = _load_engine()
     engine = sie.SelfImprovementEngine.__new__(sie.SelfImprovementEngine)
     engine.logger = DummyLogger()
-    engine.self_coding_engine = object()
+    builder = types.SimpleNamespace(refresh_db_weights=lambda: None)
+    engine.self_coding_engine = types.SimpleNamespace(context_builder=builder)
     bus = mock.Mock()
     engine.event_bus = bus
 
     calls = []
 
     def fake_generate_patch(mod, sce, **kwargs):
-        calls.append((mod, sce))
+        calls.append((mod, sce, kwargs.get("context_builder")))
         return 123
 
     monkeypatch.setattr(sie, "generate_patch", fake_generate_patch)
+    engine._patch_generator = sie.generate_patch
 
     engine._handle_relevancy_flags({"foo": "replace", "bar": "retain"})
 
-    assert calls == [("foo", engine.self_coding_engine)]
+    assert calls == [("foo", engine.self_coding_engine, builder)]
     bus.publish.assert_any_call(
         "relevancy:replace", {"module": "foo", "task_id": 123}
     )

--- a/tests/test_self_improvement_cycle_integration.py
+++ b/tests/test_self_improvement_cycle_integration.py
@@ -13,7 +13,7 @@ ROOT = Path(__file__).resolve().parent.parent
 def _load_meta_planning():
     src = (ROOT / "self_improvement" / "meta_planning.py").read_text()  # path-ignore
     tree = ast.parse(src)
-    wanted = {"_get_entropy_threshold", "_should_encode", "self_improvement_cycle"}
+    wanted = {"_get_entropy_threshold", "_should_encode", "self_improvement_cycle", "_evaluate_cycle"}
     nodes = [
         n
         for n in tree.body
@@ -98,7 +98,7 @@ def test_self_improvement_cycle_runs_with_patch_and_orphans(tmp_path):
             import quick_fix_engine
             from sandbox_runner.orphan_integration import integrate_orphans
 
-            quick_fix_engine.generate_patch("repo")
+            quick_fix_engine.generate_patch("repo", context_builder=object())
             integrate_orphans(tmp_path)
             return [
                 {"chain": ["wf"], "roi_gain": 1.0, "failures": 0, "entropy": 0.0}


### PR DESCRIPTION
## Summary
- require an explicit ContextBuilder when generating quick fixes
- wire context builders through self-improvement and preemptive patch calls
- add tests for builder refresh and context forwarding

## Testing
- `SKIP=check-static-paths,check-dynamic-paths PYTHONPATH=. pre-commit run --files quick_fix_engine.py self_improvement/engine.py tests/integration/test_high_risk_preemptive_patch.py tests/test_quick_fix_engine.py tests/test_relevancy_radar_engine_integration.py tests/test_self_improvement_cycle_integration.py`
- `pytest tests/test_quick_fix_engine.py::test_generate_patch_uses_context_builder -q`

------
https://chatgpt.com/codex/tasks/task_e_68bcd23c137c832e83f89d573ea87e1b