### PR TITLE
feat: integrate context builder into ChatGPT client

### DIFF
--- a/tests/test_chatgpt_client_context_builder.py
+++ b/tests/test_chatgpt_client_context_builder.py
@@ -1,0 +1,60 @@
+import types
+import sys
+import types
+
+sys.modules.setdefault(
+    "menace_sandbox.database_manager",
+    types.SimpleNamespace(DB_PATH="db", search_models=lambda *a, **k: []),
+)
+sys.modules.setdefault(
+    "menace_sandbox.database_management_bot",
+    types.SimpleNamespace(DatabaseManagementBot=object),
+)
+sys.modules.setdefault(
+    "menace_sandbox.shared_gpt_memory", types.SimpleNamespace(GPT_MEMORY_MANAGER=None)
+)
+sys.modules.setdefault(
+    "menace_sandbox.memory_logging", types.SimpleNamespace(log_with_tags=lambda *a, **k: None)
+)
+sys.modules.setdefault(
+    "menace_sandbox.memory_aware_gpt_client",
+    types.SimpleNamespace(ask_with_memory=lambda *a, **k: {}),
+)
+sys.modules.setdefault(
+    "menace_sandbox.local_knowledge_module",
+    types.SimpleNamespace(LocalKnowledgeModule=lambda *a, **k: types.SimpleNamespace(memory=None)),
+)
+sys.modules.setdefault(
+    "menace_sandbox.knowledge_retriever",
+    types.SimpleNamespace(
+        get_feedback=lambda *a, **k: [],
+        get_improvement_paths=lambda *a, **k: [],
+        get_error_fixes=lambda *a, **k: [],
+    ),
+)
+sys.modules.setdefault(
+    "governed_retrieval",
+    types.SimpleNamespace(govern_retrieval=lambda *a, **k: None, redact=lambda x: x),
+)
+
+import menace_sandbox.chatgpt_idea_bot as cib
+
+class DummyBuilder:
+    def __init__(self):
+        self.calls = []
+    def refresh_db_weights(self):
+        self.refreshed = True
+    def build(self, query, **_):
+        self.calls.append(query)
+        return "vector:" + query
+
+
+def test_builder_context_included():
+    builder = DummyBuilder()
+    client = cib.ChatGPTClient(context_builder=builder)
+    msgs = client.build_prompt_with_memory(["alpha", "beta"], "hi")
+    assert builder.calls == ["alpha beta"]
+    assert msgs[0]["role"] == "system"
+    assert "vector:alpha beta" in msgs[0]["content"]
+    assert msgs[-1]["role"] == "user"
+    assert msgs[-1]["content"] == "hi"

--- a/tests/test_chatgpt_idea_bot.py
+++ b/tests/test_chatgpt_idea_bot.py
@@ -3,12 +3,20 @@ pytest.skip("optional dependencies not installed", allow_module_level=True)
 import json
 from types import SimpleNamespace
 
-import menace.chatgpt_idea_bot as cib
+import menace_sandbox.chatgpt_idea_bot as cib
 
 
 def test_build_prompt():
-    client = cib.ChatGPTClient("key")
-    msg = cib.build_prompt(client, ["ai", "fintech"], prior="e-commerce")
+    class DummyBuilder:
+        def refresh_db_weights(self):
+            pass
+
+        def build(self, query, **_):
+            return ""
+
+    builder = DummyBuilder()
+    client = cib.ChatGPTClient("key", context_builder=builder)
+    msg = cib.build_prompt(client, builder, ["ai", "fintech"], prior="e-commerce")
     assert "e-commerce" in msg[-1]["content"]
     assert "ai, fintech" in msg[-1]["content"]
 


### PR DESCRIPTION
## Summary
- add optional `context_builder` field to `ChatGPTClient` with validation and refresh
- allow `build_prompt_with_memory` and `build_prompt` to inject vector context
- cover builder interaction with unit test

## Testing
- `pytest tests/test_chatgpt_client_context_builder.py::test_builder_context_included -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcd705bee0832eb690dab2c034e5c9