### PR TITLE
Ensure refund anomaly detector optional imports are properly nested

### DIFF
--- a/billing/refund_anomaly_detector.py
+++ b/billing/refund_anomaly_detector.py
@@ -28,6 +28,7 @@ try:  # Optional dependency – self-coding engine
     from code_database import CodeDB  # type: ignore
     from menace_memory_manager import MenaceMemoryManager  # type: ignore
     try:
+        # Prefer the default context builder helper when available.
         from vector_service.context_builder_utils import get_default_context_builder
     except ImportError:  # pragma: no cover - fallback when helper missing
         from vector_service.context_builder import ContextBuilder  # type: ignore

--- a/unit_tests/test_refund_anomaly_detector_import.py
+++ b/unit_tests/test_refund_anomaly_detector_import.py
@@ -1,0 +1,14 @@
+import pathlib
+import sys
+import types
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+
+def test_import_module() -> None:
+    stub = types.ModuleType("menace_sanity_layer")
+    stub.record_billing_event = lambda *a, **k: None
+    stub.record_payment_anomaly = lambda *a, **k: None
+    sys.modules["menace_sanity_layer"] = stub
+
+    import billing.refund_anomaly_detector  # noqa: F401


### PR DESCRIPTION
## Summary
- Clarify optional self-coding-engine imports and ensure they are indented within the try block
- Add a stub-based unit test to verify `billing.refund_anomaly_detector` imports without syntax errors

## Testing
- `python -m py_compile billing/refund_anomaly_detector.py`
- `pytest unit_tests/test_refund_anomaly_detector_import.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcec6fac0c832ebf185a97b94586f4