### PR TITLE
Require context builder for ImplementationOptimiserBot

### DIFF
--- a/implementation_optimiser_bot.py
+++ b/implementation_optimiser_bot.py
@@ -36,14 +36,18 @@ class ImplementationOptimiserBot:
         self,
         engine: SelfCodingEngine | None = None,
         *,
-        context_builder: ContextBuilder | None = None,
+        context_builder: ContextBuilder,
     ) -> None:
+        if context_builder is None:
+            raise ValueError("context_builder is required")
         self.history: List[TaskPackage] = []
         self.engine = engine
         self.context_builder = context_builder
-        if self.engine is not None and context_builder is not None:
+        if self.engine is not None:
             try:
                 self.engine.context_builder = context_builder  # type: ignore[attr-defined]
+                if hasattr(self.engine.context_builder, "refresh_db_weights"):
+                    self.engine.context_builder.refresh_db_weights()  # type: ignore[attr-defined]
             except Exception:
                 pass
 

--- a/tests/test_fill_missing.py
+++ b/tests/test_fill_missing.py
@@ -2,13 +2,16 @@ import pytest
 
 pytest.importorskip("requests")
 
-import types
-import sys
+import types  # noqa: E402
+import sys  # noqa: E402
 sys.modules.setdefault("cryptography", types.ModuleType("cryptography"))
 sys.modules.setdefault("cryptography.hazmat", types.ModuleType("hazmat"))
 sys.modules.setdefault("cryptography.hazmat.primitives", types.ModuleType("primitives"))
 sys.modules.setdefault("cryptography.hazmat.primitives.asymmetric", types.ModuleType("asymmetric"))
-sys.modules.setdefault("cryptography.hazmat.primitives.asymmetric.ed25519", types.ModuleType("ed25519"))
+sys.modules.setdefault(
+    "cryptography.hazmat.primitives.asymmetric.ed25519",
+    types.ModuleType("ed25519"),
+)  # noqa: E501
 ed = sys.modules["cryptography.hazmat.primitives.asymmetric.ed25519"]
 ed.Ed25519PrivateKey = types.SimpleNamespace(generate=lambda: object())
 ed.Ed25519PublicKey = object
@@ -24,8 +27,8 @@ sys.modules.setdefault("jinja2", jinja_mod)
 sys.modules.setdefault("yaml", types.ModuleType("yaml"))
 sys.modules.setdefault("numpy", types.ModuleType("numpy"))
 
-import menace.task_handoff_bot as thb
-import menace.implementation_optimiser_bot as iob
+import menace.task_handoff_bot as thb  # noqa: E402
+import menace.implementation_optimiser_bot as iob  # noqa: E402
 
 
 def _package(name="t", deps=None, *, meta=None):
@@ -44,7 +47,8 @@ def _package(name="t", deps=None, *, meta=None):
 
 
 def test_fill_missing_provides_default():
-    bot = iob.ImplementationOptimiserBot()
+    builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
+    bot = iob.ImplementationOptimiserBot(context_builder=builder)
     pkg = bot.fill_missing(_package(deps=["other"]))
     code = pkg.tasks[0].code
     assert "import other" in code
@@ -58,7 +62,8 @@ class DummyEngine:
 
 
 def test_fill_missing_uses_engine():
-    bot = iob.ImplementationOptimiserBot(engine=DummyEngine())
+    builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
+    bot = iob.ImplementationOptimiserBot(engine=DummyEngine(), context_builder=builder)
     pkg = bot.fill_missing(_package())
     code = pkg.tasks[0].code
     assert code.startswith("def helper():")
@@ -66,7 +71,8 @@ def test_fill_missing_uses_engine():
 
 
 def test_fill_missing_shell_language():
-    bot = iob.ImplementationOptimiserBot()
+    builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
+    bot = iob.ImplementationOptimiserBot(context_builder=builder)
     meta = {"language": "bash"}
     pkg = bot.fill_missing(_package(name="sh", deps=["echo hi"], meta=meta))
     code = pkg.tasks[0].code

--- a/tests/test_implementation_optimiser_bot.py
+++ b/tests/test_implementation_optimiser_bot.py
@@ -1,7 +1,8 @@
 import pytest
 pytest.skip("optional dependencies not installed", allow_module_level=True)
-import menace.task_handoff_bot as thb
-import menace.implementation_optimiser_bot as iob
+import menace.task_handoff_bot as thb  # noqa: E402
+import menace.implementation_optimiser_bot as iob  # noqa: E402
+import types  # noqa: E402
 
 
 def test_process_records_package():
@@ -15,7 +16,8 @@ def test_process_records_package():
             metadata={},
         )
     ])
-    bot = iob.ImplementationOptimiserBot()
+    builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
+    bot = iob.ImplementationOptimiserBot(context_builder=builder)
     advice = bot.process(pkg)
     assert bot.history and bot.history[0] is pkg
     assert advice[0].name == "t"

--- a/tests/test_implementation_pipeline.py
+++ b/tests/test_implementation_pipeline.py
@@ -101,7 +101,7 @@ def _fake_subprocess(monkeypatch):
 def test_pipeline_runs(tmp_path):
     builder = _ctx_builder()
     handoff = thb.TaskHandoffBot()
-    optimiser = iob.ImplementationOptimiserBot()
+    optimiser = iob.ImplementationOptimiserBot(context_builder=builder)
     developer = bdb.BotDevelopmentBot(repo_base=tmp_path, context_builder=builder)
     pipeline = ip.ImplementationPipeline(
         builder,
@@ -173,7 +173,7 @@ def run():
     desc, docs = _extract(code)
     builder = _ctx_builder()
     handoff = thb.TaskHandoffBot()
-    optimiser = iob.ImplementationOptimiserBot()
+    optimiser = iob.ImplementationOptimiserBot(context_builder=builder)
     developer = CaptureDevBot(repo_base=tmp_path, builder=builder)
     pipeline = ip.ImplementationPipeline(
         builder,
@@ -268,7 +268,7 @@ def test_retry_handoff_and_plan_generation(tmp_path):
 
     builder = _ctx_builder()
     handoff = DummyHandoff()
-    optimiser = iob.ImplementationOptimiserBot()
+    optimiser = iob.ImplementationOptimiserBot(context_builder=builder)
     developer = bdb.BotDevelopmentBot(repo_base=tmp_path, context_builder=builder)
     ipo = DummyIPO()
     pipeline = ip.ImplementationPipeline(
@@ -299,7 +299,7 @@ def test_handoff_fails_after_two_network_errors(tmp_path):
 
     builder = _ctx_builder()
     handoff = FailingHandoff()
-    optimiser = iob.ImplementationOptimiserBot()
+    optimiser = iob.ImplementationOptimiserBot(context_builder=builder)
     developer = bdb.BotDevelopmentBot(repo_base=tmp_path, context_builder=builder)
     pipeline = ip.ImplementationPipeline(
         builder,

--- a/tests/test_missing_context_builder.py
+++ b/tests/test_missing_context_builder.py
@@ -4,12 +4,14 @@ from pathlib import Path
 import pytest
 
 # Provide lightweight stubs for the vector_service module used by the targets
+
 class DummyContextBuilder:
     def refresh_db_weights(self):
         pass
 
     def build(self, *a, **k):  # pragma: no cover - simple stub
         return ""
+
 
 vector_service_stub = types.SimpleNamespace(
     ContextBuilder=DummyContextBuilder,
@@ -24,17 +26,30 @@ vector_service_stub = types.SimpleNamespace(
 sys.modules.setdefault("vector_service", vector_service_stub)
 
 # Stub modules imported by quick_fix_engine to avoid heavy dependencies
-sys.modules.setdefault("menace_sandbox.error_bot", types.SimpleNamespace(ErrorDB=object))
-sys.modules.setdefault("menace_sandbox.self_coding_manager", types.SimpleNamespace(SelfCodingManager=object))
-sys.modules.setdefault("menace_sandbox.knowledge_graph", types.SimpleNamespace(KnowledgeGraph=object))
-sys.modules.setdefault("menace_sandbox.patch_provenance", types.SimpleNamespace(PatchLogger=object))
+sys.modules.setdefault(
+    "menace_sandbox.error_bot",
+    types.SimpleNamespace(ErrorDB=object),
+)  # noqa: E501
+sys.modules.setdefault(
+    "menace_sandbox.self_coding_manager",
+    types.SimpleNamespace(SelfCodingManager=object),
+)  # noqa: E501
+sys.modules.setdefault(
+    "menace_sandbox.knowledge_graph",
+    types.SimpleNamespace(KnowledgeGraph=object),
+)  # noqa: E501
+sys.modules.setdefault(
+    "menace_sandbox.patch_provenance",
+    types.SimpleNamespace(PatchLogger=object),
+)  # noqa: E501
 
 # Ensure package imports work when tests executed directly
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-from menace_sandbox.bot_development_bot import BotDevelopmentBot
-from menace_sandbox.quick_fix_engine import QuickFixEngine
-from menace_sandbox.automated_reviewer import AutomatedReviewer
+from menace_sandbox.bot_development_bot import BotDevelopmentBot  # noqa: E402
+from menace_sandbox.quick_fix_engine import QuickFixEngine  # noqa: E402
+from menace_sandbox.automated_reviewer import AutomatedReviewer  # noqa: E402
+from menace_sandbox.implementation_optimiser_bot import ImplementationOptimiserBot  # noqa: E402
 
 
 def test_bot_development_bot_requires_context_builder(tmp_path):
@@ -58,3 +73,8 @@ def test_automated_reviewer_requires_context_builder():
             bot_db=bot_db,
             escalation_manager=escalation_manager,
         )
+
+
+def test_implementation_optimiser_bot_requires_context_builder():
+    with pytest.raises(ValueError):
+        ImplementationOptimiserBot(context_builder=None)  # type: ignore[arg-type]

--- a/tests/test_model_allocation_weight.py
+++ b/tests/test_model_allocation_weight.py
@@ -1,21 +1,25 @@
 import pytest
 pytest.importorskip("networkx")
 
-import menace.model_automation_pipeline as mapl
-import menace.research_aggregator_bot as rab
-import menace.task_handoff_bot as thb
-import menace.information_synthesis_bot as isb
-import menace.task_validation_bot as tvb
-import menace.bot_planning_bot as bpb
-import menace.pre_execution_roi_bot as prb
-import menace.implementation_optimiser_bot as iob
-import menace.resource_prediction_bot as rpb
+import menace.model_automation_pipeline as mapl  # noqa: E402
+import menace.research_aggregator_bot as rab  # noqa: E402
+import menace.task_handoff_bot as thb  # noqa: E402
+import menace.information_synthesis_bot as isb  # noqa: E402
+import menace.task_validation_bot as tvb  # noqa: E402
+import menace.bot_planning_bot as bpb  # noqa: E402
+import menace.pre_execution_roi_bot as prb  # noqa: E402
+import menace.implementation_optimiser_bot as iob  # noqa: E402
+import menace.resource_prediction_bot as rpb  # noqa: E402
+import types  # noqa: E402
+
 
 class DummyAggregator:
     def __init__(self):
         self.info_db = rab.InfoDB(":memory:")
+
     def process(self, topic: str, energy: int = 1):
         return []
+
 
 class HighPathway:
     def similar_actions(self, action: str, limit: int = 1):
@@ -25,8 +29,10 @@ class LowPathway:
     def similar_actions(self, action: str, limit: int = 1):
         return [("x", 0.0)]
 
+
 def _setup_pipeline(pathway):
     agg = DummyAggregator()
+    builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
     return mapl.ModelAutomationPipeline(
         aggregator=agg,
         synthesis_bot=isb.InformationSynthesisBot(db_url="sqlite:///:memory:"),
@@ -36,19 +42,30 @@ def _setup_pipeline(pathway):
         predictor=rpb.ResourcePredictionBot(),
         roi_bot=prb.PreExecutionROIBot(prb.ROIHistoryDB(":memory:")),
         handoff=thb.TaskHandoffBot(),
-        optimiser=iob.ImplementationOptimiserBot(),
+        optimiser=iob.ImplementationOptimiserBot(context_builder=builder),
         workflow_db=thb.WorkflowDB(":memory:"),
         pathway_db=pathway,
         myelination_threshold=1.0,
+        context_builder=builder,
     )
+
 
 def _stub_pipeline(pipeline, monkeypatch, capture):
     monkeypatch.setattr(pipeline, "_gather_research", lambda model, energy: [])
     monkeypatch.setattr(pipeline, "_items_to_tasks", lambda items: [])
     monkeypatch.setattr(pipeline, "_plan_bots", lambda tasks: [])
     monkeypatch.setattr(pipeline, "_predict_resources", lambda plans: {})
-    monkeypatch.setattr(pipeline, "_roi", lambda model, tasks: prb.ROIResult(1.0,0,0,1.0,0))
-    monkeypatch.setattr(pipeline.roi_bot, "handoff_to_implementation", lambda b,opt,title: thb.TaskPackage(tasks=[]))
+    monkeypatch.setattr(
+        pipeline,
+        "_roi",
+        lambda model, tasks: prb.ROIResult(1.0, 0, 0, 1.0, 0),
+    )
+    monkeypatch.setattr(
+        pipeline.roi_bot,
+        "handoff_to_implementation",
+        lambda b, opt, title: thb.TaskPackage(tasks=[]),
+    )
+
     def fake_allocate(bots, *, weight=1.0):
         capture["weight"] = weight
         return [(b, True) for b in bots]
@@ -56,7 +73,9 @@ def _stub_pipeline(pipeline, monkeypatch, capture):
     monkeypatch.setattr(
         pipeline,
         "_run_support_bots",
-        lambda model, *, energy=1.0, weight=1.0: pipeline.allocator.allocate([model], weight=weight),
+        lambda model, *, energy=1.0, weight=1.0: pipeline.allocator.allocate(
+            [model], weight=weight
+        ),
     )
     monkeypatch.setattr(pipeline, "_prime_bots", lambda: capture.setdefault("primed", True))
 
@@ -66,6 +85,7 @@ def test_allocation_weight_boost(monkeypatch):
     _stub_pipeline(pipe, monkeypatch, capture)
     pipe.run("m")
     assert capture.get("weight", 1.0) > 1.0
+
 
 def test_allocation_weight_normal(monkeypatch):
     capture = {}

--- a/tests/test_model_automation_pipeline.py
+++ b/tests/test_model_automation_pipeline.py
@@ -1,23 +1,37 @@
 import pytest
 pytest.skip("optional dependencies not installed", allow_module_level=True)
-import menace.model_automation_pipeline as mapl
-import menace.research_aggregator_bot as rab
-import menace.task_handoff_bot as thb
-import menace.information_synthesis_bot as isb
-import menace.task_validation_bot as tvb
-import menace.bot_planning_bot as bpb
-import menace.pre_execution_roi_bot as prb
-import menace.implementation_optimiser_bot as iob
-import menace.resource_prediction_bot as rpb
+import menace.model_automation_pipeline as mapl  # noqa: E402
+import menace.research_aggregator_bot as rab  # noqa: E402
+import menace.task_handoff_bot as thb  # noqa: E402
+import menace.information_synthesis_bot as isb  # noqa: E402
+import menace.task_validation_bot as tvb  # noqa: E402
+import menace.bot_planning_bot as bpb  # noqa: E402
+import menace.pre_execution_roi_bot as prb  # noqa: E402
+import menace.implementation_optimiser_bot as iob  # noqa: E402
+import menace.resource_prediction_bot as rpb  # noqa: E402
+import types  # noqa: E402
+
 
 class DummyAggregator:
     def __init__(self):
         self.info_db = rab.InfoDB(":memory:")
+
     def process(self, topic: str, energy: int = 1):
-        return [rab.ResearchItem(topic=topic, content="data", timestamp=0.0, title=topic, tags=["workflow"], category="workflow")]
+        return [
+            rab.ResearchItem(
+                topic=topic,
+                content="data",
+                timestamp=0.0,
+                title=topic,
+                tags=["workflow"],
+                category="workflow",
+            )
+        ]
+
 
 def test_pipeline_runs(tmp_path):
     agg = DummyAggregator()
+    builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
     pipeline = mapl.ModelAutomationPipeline(
         aggregator=agg,
         synthesis_bot=isb.InformationSynthesisBot(db_url="sqlite:///:memory:"),
@@ -27,9 +41,10 @@ def test_pipeline_runs(tmp_path):
         predictor=rpb.ResourcePredictionBot(),
         roi_bot=prb.PreExecutionROIBot(prb.ROIHistoryDB(tmp_path / "hist.csv")),
         handoff=thb.TaskHandoffBot(api_url="http://localhost"),
-        optimiser=iob.ImplementationOptimiserBot(),
+        optimiser=iob.ImplementationOptimiserBot(context_builder=builder),
         workflow_db=thb.WorkflowDB(tmp_path / "wf.db"),
         funds=100.0,
+        context_builder=builder,
     )
     result = pipeline.run("model")
     assert result.package is not None
@@ -40,6 +55,7 @@ def test_reuse_granular(monkeypatch, tmp_path):
     agg = DummyAggregator()
     wf_db = thb.WorkflowDB(tmp_path / "wf.db")
     wf_db.add(thb.WorkflowRecord(workflow=["step1", "step2"], title="model", description="model"))
+    builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
     pipeline = mapl.ModelAutomationPipeline(
         aggregator=agg,
         synthesis_bot=isb.InformationSynthesisBot(db_url="sqlite:///:memory:"),
@@ -49,12 +65,19 @@ def test_reuse_granular(monkeypatch, tmp_path):
         predictor=rpb.ResourcePredictionBot(),
         roi_bot=prb.PreExecutionROIBot(prb.ROIHistoryDB(tmp_path / "hist.csv")),
         handoff=thb.TaskHandoffBot(),
-        optimiser=iob.ImplementationOptimiserBot(),
+        optimiser=iob.ImplementationOptimiserBot(context_builder=builder),
         workflow_db=wf_db,
         funds=0.0,
+        context_builder=builder,
     )
 
-    monkeypatch.setattr(pipeline, "_items_to_tasks", lambda items: [isb.SynthesisTask(description="base", urgency=1, complexity=1, category="analysis")])
+    monkeypatch.setattr(
+        pipeline,
+        "_items_to_tasks",
+        lambda items: [
+            isb.SynthesisTask(description="base", urgency=1, complexity=1, category="analysis")
+        ],
+    )
     captured = {}
 
     def capture(tasks):
@@ -64,8 +87,16 @@ def test_reuse_granular(monkeypatch, tmp_path):
     monkeypatch.setattr(pipeline, "_validate_tasks", capture)
     monkeypatch.setattr(pipeline, "_plan_bots", lambda tasks: [])
     monkeypatch.setattr(pipeline, "_predict_resources", lambda plans: {})
-    monkeypatch.setattr(pipeline, "_roi", lambda model, tasks: prb.ROIResult(1.0, 0.0, 0.0, 1.0, 0.0))
-    monkeypatch.setattr(pipeline.roi_bot, "handoff_to_implementation", lambda build_tasks, opt, title: thb.TaskPackage(tasks=[]))
+    monkeypatch.setattr(
+        pipeline,
+        "_roi",
+        lambda model, tasks: prb.ROIResult(1.0, 0.0, 0.0, 1.0, 0.0),
+    )
+    monkeypatch.setattr(
+        pipeline.roi_bot,
+        "handoff_to_implementation",
+        lambda build_tasks, opt, title: thb.TaskPackage(tasks=[]),
+    )
     monkeypatch.setattr(
         pipeline, "_run_support_bots", lambda model, *, energy=1.0, weight=1.0: None
     )

--- a/tests/test_model_automation_pipeline_memory.py
+++ b/tests/test_model_automation_pipeline_memory.py
@@ -1,32 +1,38 @@
 import pytest
 pytest.importorskip("networkx")
-import menace.model_automation_pipeline as mapl
-import menace.research_aggregator_bot as rab
-import menace.task_handoff_bot as thb
-import menace.information_synthesis_bot as isb
-import menace.task_validation_bot as tvb
-import menace.bot_planning_bot as bpb
-import menace.pre_execution_roi_bot as prb
-import menace.implementation_optimiser_bot as iob
-import menace.resource_prediction_bot as rpb
-import menace.memory_bot as mb
-from menace.menace_memory_manager import MenaceMemoryManager
-from menace.db_router import DBRouter
+import menace.model_automation_pipeline as mapl  # noqa: E402
+import menace.research_aggregator_bot as rab  # noqa: E402
+import menace.task_handoff_bot as thb  # noqa: E402
+import menace.information_synthesis_bot as isb  # noqa: E402
+import menace.task_validation_bot as tvb  # noqa: E402
+import menace.bot_planning_bot as bpb  # noqa: E402
+import menace.pre_execution_roi_bot as prb  # noqa: E402
+import menace.implementation_optimiser_bot as iob  # noqa: E402
+import menace.resource_prediction_bot as rpb  # noqa: E402
+import menace.memory_bot as mb  # noqa: E402
+from menace.menace_memory_manager import MenaceMemoryManager  # noqa: E402
+from menace.db_router import DBRouter  # noqa: E402
+import types  # noqa: E402
+
 
 class DummyAggregator:
     def __init__(self):
         self.info_db = rab.InfoDB(":memory:")
+
     def process(self, topic: str, energy: int = 1):
         return []
+
 
 class DummyPathway:
     def similar_actions(self, action: str, limit: int = 1):
         return [("a", 2.0)]
 
+
 def test_memory_search_called(monkeypatch, tmp_path):
     agg = DummyAggregator()
     mem_bot = mb.MemoryBot(mb.MemoryStorage(tmp_path / "m.json.gz"))
     db_router = DBRouter(memory_mgr=MenaceMemoryManager(tmp_path / "mem.db"))
+    builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
     pipeline = mapl.ModelAutomationPipeline(
         aggregator=agg,
         synthesis_bot=isb.InformationSynthesisBot(db_url="sqlite:///:memory:"),
@@ -36,25 +42,31 @@ def test_memory_search_called(monkeypatch, tmp_path):
         predictor=rpb.ResourcePredictionBot(),
         roi_bot=prb.PreExecutionROIBot(prb.ROIHistoryDB(tmp_path / "hist.csv")),
         handoff=thb.TaskHandoffBot(),
-        optimiser=iob.ImplementationOptimiserBot(),
+        optimiser=iob.ImplementationOptimiserBot(context_builder=builder),
         workflow_db=thb.WorkflowDB(tmp_path / "wf.db"),
         memory_bot=mem_bot,
         pathway_db=DummyPathway(),
         myelination_threshold=1.0,
         db_router=db_router,
+        context_builder=builder,
     )
     monkeypatch.setattr(pipeline, "_gather_research", lambda model, energy: [])
     monkeypatch.setattr(pipeline, "_items_to_tasks", lambda items: [])
     monkeypatch.setattr(pipeline, "_plan_bots", lambda tasks: [])
     monkeypatch.setattr(pipeline, "_predict_resources", lambda plans: {})
-    monkeypatch.setattr(pipeline, "_roi", lambda model, tasks: prb.ROIResult(1.0,0,0,1.0,0))
-    monkeypatch.setattr(pipeline.roi_bot, "handoff_to_implementation", lambda b,opt,title: thb.TaskPackage(tasks=[]))
+    monkeypatch.setattr(pipeline, "_roi", lambda model, tasks: prb.ROIResult(1.0, 0, 0, 1.0, 0))
+    monkeypatch.setattr(
+        pipeline.roi_bot,
+        "handoff_to_implementation",
+        lambda b, opt, title: thb.TaskPackage(tasks=[]),
+    )
     monkeypatch.setattr(
         pipeline,
         "_run_support_bots",
         lambda model, *, energy=1.0, weight=1.0: None,
     )
     called = {}
+
     def fake_search(term, limit=5):
         called['hit'] = True
         return []

--- a/tests/test_pre_execution_handoff.py
+++ b/tests/test_pre_execution_handoff.py
@@ -1,14 +1,24 @@
 import pytest
 pytest.skip("optional dependencies not installed", allow_module_level=True)
-import menace.pre_execution_roi_bot as prb
-import menace.implementation_optimiser_bot as iob
-import menace.task_handoff_bot as thb
+import menace.pre_execution_roi_bot as prb  # noqa: E402
+import menace.implementation_optimiser_bot as iob  # noqa: E402
+import menace.task_handoff_bot as thb  # noqa: E402
+import types  # noqa: E402
 
 
 def test_handoff_to_implementation(monkeypatch):
     bot = prb.PreExecutionROIBot()
-    optimiser = iob.ImplementationOptimiserBot()
-    tasks = [prb.BuildTask(name="a", complexity=1.0, frequency=1.0, expected_income=1.0, resources={})]
+    builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
+    optimiser = iob.ImplementationOptimiserBot(context_builder=builder)
+    tasks = [
+        prb.BuildTask(
+            name="a",
+            complexity=1.0,
+            frequency=1.0,
+            expected_income=1.0,
+            resources={},
+        )
+    ]
     package = thb.TaskPackage(tasks=[])
 
     def fake_compile(infos):


### PR DESCRIPTION
## Summary
- enforce mandatory ContextBuilder in ImplementationOptimiserBot
- pass builders through ModelAutomationPipeline and tests
- add negative test for missing context builder

## Testing
- `pre-commit run --files implementation_optimiser_bot.py model_automation_pipeline.py tests/test_fill_missing.py tests/test_model_allocation_weight.py tests/test_model_automation_pipeline_memory.py tests/test_model_automation_pipeline.py tests/test_planning_trust_weight.py tests/test_pipeline_graph_save.py tests/test_pre_execution_handoff.py tests/test_implementation_optimiser_bot.py tests/test_implementation_pipeline.py tests/test_missing_context_builder.py tests/test_logging_updates.py` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router'; flake8 errors)*
- `pytest tests/test_fill_missing.py::test_fill_missing_provides_default tests/test_missing_context_builder.py::test_implementation_optimiser_bot_requires_context_builder -q` *(fails: found no collectors)*

------
https://chatgpt.com/codex/tasks/task_e_68bced539e18832e9e904b1840a56852