### PR TITLE
Document ContextBuilder requirement for quick fix patch generation

### DIFF
--- a/quick_fix_engine.py
+++ b/quick_fix_engine.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-"""Automatically propose fixes for recurring errors."""
+"""Automatically propose fixes for recurring errors.
+
+The public :func:`generate_patch` helper expects callers to provide a
+pre-configured :class:`vector_service.ContextBuilder`. The builder should
+have its database weights refreshed before use to ensure accurate context
+retrieval.
+"""
 
 __version__ = "1.0.0"
 

--- a/self_improvement/patch_generation.py
+++ b/self_improvement/patch_generation.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-"""Patch generation utilities for the self-improvement engine."""
+"""Patch generation utilities for the self-improvement engine.
+
+This module provides a thin wrapper around :mod:`quick_fix_engine`'s patch
+generation.  Callers must supply a ready-to-use
+``vector_service.ContextBuilder`` instance when invoking
+``generate_patch``.
+"""
 
 import logging
 
@@ -53,7 +59,8 @@ def generate_patch(
             exc_info=exc,
         )
         raise RuntimeError(
-            "quick_fix_engine is required for patch generation. Install it via `pip install quick_fix_engine`."
+            "quick_fix_engine is required for patch generation. "
+            "Install it via `pip install quick_fix_engine`."
         ) from exc
     try:
         patch_id = _call_with_retries(


### PR DESCRIPTION
## Summary
- clarify in `quick_fix_engine` that callers must supply a preconfigured `ContextBuilder`
- document `ContextBuilder` requirement in self-improvement patch generation wrapper

## Testing
- `pre-commit run --files quick_fix_engine.py self_improvement/patch_generation.py` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*
- `pytest tests/test_quick_fix_engine.py::test_generate_patch_blocks_risky -q`
- `pytest tests/self_improvement/test_patch_generation_wrapper.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcf35e7520832ebbaffa8e7f22fe8d