### PR TITLE
feat: add context builder support for prompts

### DIFF
--- a/tests/test_chatgpt_client_context_builder.py
+++ b/tests/test_chatgpt_client_context_builder.py
@@ -1,6 +1,5 @@
 import types
 import sys
-import types
 
 sys.modules.setdefault(
     "menace_sandbox.database_manager",
@@ -37,13 +36,16 @@ sys.modules.setdefault(
     types.SimpleNamespace(govern_retrieval=lambda *a, **k: None, redact=lambda x: x),
 )
 
-import menace_sandbox.chatgpt_idea_bot as cib
+import menace_sandbox.chatgpt_idea_bot as cib  # noqa: E402
+
 
 class DummyBuilder:
     def __init__(self):
         self.calls = []
+
     def refresh_db_weights(self):
         self.refreshed = True
+
     def build(self, query, **_):
         self.calls.append(query)
         return "vector:" + query
@@ -53,8 +55,8 @@ def test_builder_context_included():
     builder = DummyBuilder()
     client = cib.ChatGPTClient(context_builder=builder)
     msgs = client.build_prompt_with_memory(["alpha", "beta"], "hi")
-    assert builder.calls == ["alpha beta hi"]
+    assert builder.calls == ["alpha beta"]
     assert msgs[0]["role"] == "system"
-    assert "vector:alpha beta hi" in msgs[0]["content"]
+    assert "vector:alpha beta" in msgs[0]["content"]
     assert msgs[-1]["role"] == "user"
     assert msgs[-1]["content"] == "hi"

--- a/tests/test_chatgpt_client_knowledge.py
+++ b/tests/test_chatgpt_client_knowledge.py
@@ -42,7 +42,15 @@ def test_ask_injects_context_and_logs(monkeypatch):
     cib.requests = type("R", (), {"Timeout": Exception, "RequestException": Exception})
 
     session = DummySession(record)
-    client = cib.ChatGPTClient(api_key="key", session=session)
+
+    class DummyBuilder:
+        def refresh_db_weights(self):
+            pass
+
+        def build(self, query, **_):
+            return ""
+
+    client = cib.ChatGPTClient(api_key="key", session=session, context_builder=DummyBuilder())
     knowledge = DummyKnowledge(record)
 
     resp = client.ask(

--- a/tests/test_chatgpt_client_memory.py
+++ b/tests/test_chatgpt_client_memory.py
@@ -8,7 +8,7 @@ sys.modules.setdefault(
     "menace.database_management_bot", types.SimpleNamespace(DatabaseManagementBot=object)
 )
 
-import menace.chatgpt_idea_bot as cib
+import menace.chatgpt_idea_bot as cib  # noqa: E402
 
 
 class FakeMemory:
@@ -24,7 +24,15 @@ class FakeMemory:
 
 def test_build_prompt_with_memory():
     mem = FakeMemory()
-    client = cib.ChatGPTClient(gpt_memory=mem)
+
+    class DummyBuilder:
+        def refresh_db_weights(self):
+            pass
+
+        def build(self, query, **_):
+            return ""
+
+    client = cib.ChatGPTClient(gpt_memory=mem, context_builder=DummyBuilder())
     msgs = client.build_prompt_with_memory(["ai"], "hello")
     assert msgs[0]["role"] == "system"
     assert "ctx:ai" in msgs[0]["content"]
@@ -34,7 +42,15 @@ def test_build_prompt_with_memory():
 
 def test_ask_logs_interaction(monkeypatch):
     mem = FakeMemory()
-    client = cib.ChatGPTClient(gpt_memory=mem)
+
+    class DummyBuilder:
+        def refresh_db_weights(self):
+            pass
+
+        def build(self, query, **_):
+            return ""
+
+    client = cib.ChatGPTClient(gpt_memory=mem, context_builder=DummyBuilder())
     client.session = None  # force offline response
     monkeypatch.setattr(
         client,
@@ -45,4 +61,3 @@ def test_ask_logs_interaction(monkeypatch):
     assert mem.logged[0][0] == "hi"
     assert mem.logged[0][1] == "resp"
     assert cib.INSIGHT in mem.logged[0][2]
-

--- a/tests/test_chatgpt_enhancement_bot.py
+++ b/tests/test_chatgpt_enhancement_bot.py
@@ -18,7 +18,15 @@ def test_propose(monkeypatch, tmp_path):
             {"message": {"content": json.dumps([{"idea": "New", "rationale": "More efficient"}])}}
         ]
     }
-    client = cib.ChatGPTClient("key")
+
+    class DummyBuilder:
+        def refresh_db_weights(self):
+            pass
+
+        def build(self, query, **_):
+            return ""
+
+    client = cib.ChatGPTClient("key", context_builder=DummyBuilder())
     monkeypatch.setattr(ceb, "ask_with_memory", lambda *a, **k: resp)
     router = ceb.init_db_router("enhprop", str(tmp_path / "local.db"), str(tmp_path / "shared.db"))
     db = ceb.EnhancementDB(tmp_path / "enh.db", router=router)

--- a/tests/test_chatgpt_idea_bot.py
+++ b/tests/test_chatgpt_idea_bot.py
@@ -1,9 +1,7 @@
 import pytest
 pytest.skip("optional dependencies not installed", allow_module_level=True)
-import json
-from types import SimpleNamespace
-
-import menace_sandbox.chatgpt_idea_bot as cib
+import json  # noqa: E402
+import menace_sandbox.chatgpt_idea_bot as cib  # noqa: E402
 
 
 def test_build_prompt():
@@ -43,7 +41,14 @@ def test_generate_and_filter(monkeypatch):
         ]
     }
 
-    client = cib.ChatGPTClient("key")
+    class DummyBuilder:
+        def refresh_db_weights(self):
+            pass
+
+        def build(self, query, **_):
+            return ""
+
+    client = cib.ChatGPTClient("key", context_builder=DummyBuilder())
     monkeypatch.setattr(client, "ask", lambda msgs, **kw: fake_resp)
     validator = cib.SocialValidator()
     monkeypatch.setattr(validator, "is_unique_online", lambda name: name == "Idea1")

--- a/tests/test_chatgpt_research_bot.py
+++ b/tests/test_chatgpt_research_bot.py
@@ -1,7 +1,7 @@
 import pytest
 pytest.skip("optional dependencies not installed", allow_module_level=True)
-import menace.chatgpt_research_bot as crb
-import menace.chatgpt_idea_bot as cib
+import menace.chatgpt_research_bot as crb  # noqa: E402
+import menace.chatgpt_idea_bot as cib  # noqa: E402
 
 
 def test_summarise_text():
@@ -12,7 +12,14 @@ def test_summarise_text():
 
 
 def test_process(monkeypatch):
-    client = cib.ChatGPTClient("key")
+    class DummyBuilder:
+        def refresh_db_weights(self):
+            pass
+
+        def build(self, query, **_):
+            return ""
+
+    client = cib.ChatGPTClient("key", context_builder=DummyBuilder())
     responses = [
         {"choices": [{"message": {"content": "Answer one."}}]},
         {"choices": [{"message": {"content": "Answer two."}}]},

--- a/tests/test_conversation_manager_bot.py
+++ b/tests/test_conversation_manager_bot.py
@@ -1,21 +1,30 @@
 import pytest
 pytest.skip("optional dependencies not installed", allow_module_level=True)
-import types
-from pathlib import Path
+from pathlib import Path  # noqa: E402
 
-import menace.report_generation_bot as rgb
-import menace.data_bot as db
+import menace.report_generation_bot as rgb  # noqa: E402
+import menace.data_bot as db  # noqa: E402
 
-import menace.conversation_manager_bot as cmb
-import menace.chatgpt_idea_bot as cib
+import menace.conversation_manager_bot as cmb  # noqa: E402
+import menace.chatgpt_idea_bot as cib  # noqa: E402
+
+
+class DummyBuilder:
+    def refresh_db_weights(self):
+        pass
+
+    def build(self, query, **_):
+        return ""
 
 
 def test_cache(monkeypatch):
-    client = cib.ChatGPTClient("key")
+    client = cib.ChatGPTClient("key", context_builder=DummyBuilder())
     calls = []
+
     def fake_ask(msgs):
         calls.append(1)
         return {"choices": [{"message": {"content": "reply"}}]}
+
     monkeypatch.setattr(client, "ask", fake_ask)
     bot = cmb.ConversationManagerBot(client)
     r1 = bot.ask("hello")
@@ -25,9 +34,15 @@ def test_cache(monkeypatch):
 
 
 def test_audio_flow(monkeypatch, tmp_path: Path):
-    client = cib.ChatGPTClient("key")
-    monkeypatch.setattr(client, "ask", lambda msgs: {"choices": [{"message": {"content": "answer"}}]})
-    bot = cmb.ConversationManagerBot(client, stage7_bots={"data": lambda q: "data"})
+    client = cib.ChatGPTClient("key", context_builder=DummyBuilder())
+    monkeypatch.setattr(
+        client,
+        "ask",
+        lambda msgs: {"choices": [{"message": {"content": "answer"}}]},
+    )
+    bot = cmb.ConversationManagerBot(
+        client, stage7_bots={"data": lambda q: "data"}
+    )
     monkeypatch.setattr(bot, "transcribe", lambda p: "what is up")
     monkeypatch.setattr(bot, "synthesize", lambda t, out_path=None: tmp_path / "out.mp3")
     result = bot.ask_audio(Path("foo.wav"), target_bot="data")
@@ -36,9 +51,19 @@ def test_audio_flow(monkeypatch, tmp_path: Path):
 
 
 def test_request_report(tmp_path: Path):
-    client = cib.ChatGPTClient("key")
+    client = cib.ChatGPTClient("key", context_builder=DummyBuilder())
     mdb = db.MetricsDB(tmp_path / "m.db")
-    mdb.add(db.MetricRecord(bot="b", cpu=1.0, memory=1.0, response_time=0.1, disk_io=1.0, net_io=1.0, errors=0))
+    mdb.add(
+        db.MetricRecord(
+            bot="b",
+            cpu=1.0,
+            memory=1.0,
+            response_time=0.1,
+            disk_io=1.0,
+            net_io=1.0,
+            errors=0,
+        )
+    )
     reporter = rgb.ReportGenerationBot(db=mdb, reports_dir=tmp_path)
     bot = cmb.ConversationManagerBot(client, report_bot=reporter)
     report = bot.request_report(start="1970-01-01", end="2100-01-01")

--- a/tests/test_error_bot.py
+++ b/tests/test_error_bot.py
@@ -315,7 +315,15 @@ def test_safe_mode_activation(tmp_path):
     from menace.conversation_manager_bot import ConversationManagerBot
 
     err_db = eb.ErrorDB(tmp_path / "e.db")
-    client = cib.ChatGPTClient("key")
+
+    class DummyBuilder:
+        def refresh_db_weights(self):
+            pass
+
+        def build(self, query, **_):
+            return ""
+
+    client = cib.ChatGPTClient("key", context_builder=DummyBuilder())
     conv = ConversationManagerBot(client)
     metrics = make_metrics(tmp_path)
     bot = eb.ErrorBot(err_db, metrics, conversation_bot=conv)

--- a/tests/test_newsreader_bot_monetise.py
+++ b/tests/test_newsreader_bot_monetise.py
@@ -9,8 +9,8 @@ sys.modules.setdefault(
     "menace.database_management_bot", types.SimpleNamespace(DatabaseManagementBot=object)
 )
 
-import menace.chatgpt_idea_bot as cib
-import menace.newsreader_bot as nrb
+import menace.chatgpt_idea_bot as cib  # noqa: E402
+import menace.newsreader_bot as nrb  # noqa: E402
 
 
 class FakeMemory:
@@ -23,7 +23,15 @@ class FakeMemory:
 
 def test_monetise_event_records_interaction(monkeypatch):
     mem = FakeMemory()
-    client = cib.ChatGPTClient(gpt_memory=mem)
+
+    class DummyBuilder:
+        def refresh_db_weights(self):
+            pass
+
+        def build(self, query, **_):
+            return ""
+
+    client = cib.ChatGPTClient(gpt_memory=mem, context_builder=DummyBuilder())
     client.session = None  # force offline mode
     monkeypatch.setattr(
         client,

--- a/tests/test_payment_notice.py
+++ b/tests/test_payment_notice.py
@@ -138,7 +138,14 @@ def test_chatgpt_client_injects_notice(monkeypatch):
             captured["messages"] = json["messages"]
             return DummyResponse()
 
-    client = ChatGPTClient(session=DummySession(), gpt_memory=None)
+    class DummyBuilder:
+        def refresh_db_weights(self):
+            pass
+
+        def build(self, query, **_):
+            return ""
+
+    client = ChatGPTClient(session=DummySession(), gpt_memory=None, context_builder=DummyBuilder())
     client.ask([{"role": "user", "content": "hi"}], use_memory=False, tags=[])
     assert captured["messages"][0]["content"].startswith(PAYMENT_ROUTER_NOTICE)
 

--- a/tests/test_safe_mode.py
+++ b/tests/test_safe_mode.py
@@ -1,18 +1,29 @@
 import pytest
 pytest.skip("optional dependencies not installed", allow_module_level=True)
-import pytest
-import menace.error_bot as eb
-import menace.database_steward_bot as dsb
-import menace.conversation_manager_bot as cmb
-import menace.chatgpt_idea_bot as cib
-import menace.data_bot as db
+import menace.error_bot as eb  # noqa: E402
+import menace.database_steward_bot as dsb  # noqa: E402
+import menace.conversation_manager_bot as cmb  # noqa: E402
+import menace.chatgpt_idea_bot as cib  # noqa: E402
+import menace.data_bot as db  # noqa: E402
 
 
 def test_bot_safe_mode(tmp_path):
     err_db = eb.ErrorDB(tmp_path / "e.db")
-    conv = cmb.ConversationManagerBot(cib.ChatGPTClient("key"))
+
+    class DummyBuilder:
+        def refresh_db_weights(self):
+            pass
+
+        def build(self, query, **_):
+            return ""
+
+    conv = cmb.ConversationManagerBot(cib.ChatGPTClient("key", context_builder=DummyBuilder()))
     bot = eb.ErrorBot(err_db, conversation_bot=conv, metrics_db=db.MetricsDB(tmp_path / "m.db"))
-    steward = dsb.DatabaseStewardBot(sql_url=f"sqlite:///{tmp_path / 'db.sqlite'}", error_bot=bot, conversation_bot=conv)
+    steward = dsb.DatabaseStewardBot(
+        sql_url=f"sqlite:///{tmp_path / 'db.sqlite'}",
+        error_bot=bot,
+        conversation_bot=conv,
+    )
     bot.record_runtime_error("boom", bot_ids=["DatabaseStewardBot"])
     with pytest.raises(RuntimeError):
         steward.deduplicate()


### PR DESCRIPTION
## Summary
- require a ContextBuilder when creating ChatGPTClient and wire it into prompt generation
- query ContextBuilder with tags and prior info, merging its context with memory results
- update tests and utilities to provide a ContextBuilder

## Testing
- `pre-commit run --files chatgpt_idea_bot.py menace_master.py tests/test_chatgpt_client_context_builder.py tests/test_chatgpt_client_gpt_memory.py tests/test_chatgpt_client_knowledge.py tests/test_chatgpt_client_memory.py tests/test_chatgpt_enhancement_bot.py tests/test_chatgpt_idea_bot.py tests/test_chatgpt_research_bot.py tests/test_conversation_manager_bot.py tests/test_error_bot.py tests/test_newsreader_bot_monetise.py tests/test_payment_notice.py tests/test_research_aggregator_bot.py tests/test_safe_mode.py` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*
- `pytest` *(fails: 34 errors, missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf49b448c832ebf2dd803ff6828e3