### PR TITLE
Use module-level build_prompt with context builder

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -1273,9 +1273,8 @@ class SelfCodingEngine:
                 or metadata.get("prompt_id")
                 or metadata.get("prompt_strategy")
             )
-        build = self.prompt_engine.build_prompt
         try:
-            prompt_obj = build(
+            prompt_obj = build_prompt(
                 description,
                 context=context_block,
                 retrieval_context=retrieval_context,
@@ -1284,6 +1283,7 @@ class SelfCodingEngine:
                 summaries=summaries,
                 target_region=target_region,
                 strategy=strategy,
+                context_builder=self.context_builder,
             )
         except TypeError:
             if target_region is not None:
@@ -1299,12 +1299,13 @@ class SelfCodingEngine:
                     if context_block
                     else instr
                 )
-            prompt_obj = build(
+            prompt_obj = build_prompt(
                 description,
                 context=context_block,
                 retrieval_context=retrieval_context,
                 retry_trace=retry_trace,
                 summaries=summaries,
+                context_builder=self.context_builder,
             )
         except Exception as exc:
             self._last_retry_trace = str(exc)


### PR DESCRIPTION
## Summary
- switch helper prompt generation to module-level `build_prompt`
- ensure `context_builder` is provided in both prompt-building branches

## Testing
- `SKIP=check-static-paths,forbid-stripe-imports,forbid-raw-stripe-usage PYTHONPATH=. pre-commit run --files self_coding_engine.py`
- `python scripts/check_context_builder_usage.py`
- `pytest tests/test_self_coding_engine_chunking.py::test_build_prompt_*` *(fails: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd01b0077c832e91c2933e64ff0bf2