### PR TITLE
feat: use contextual prompt engine for resource suggestions

### DIFF
--- a/contrarian_model_bot.py
+++ b/contrarian_model_bot.py
@@ -18,6 +18,7 @@ from .prediction_manager_bot import PredictionManager
 from .data_bot import DataBot
 from .strategy_prediction_bot import StrategyPredictionBot, CompetitorFeatures
 from .resource_allocation_bot import ResourceAllocationBot
+from vector_service import ContextBuilder
 from .resource_prediction_bot import ResourceMetrics
 from .task_handoff_bot import WorkflowDB as HandoffWorkflowDB, WorkflowRecord
 from .contrarian_db import ContrarianDB, ContrarianRecord
@@ -151,7 +152,9 @@ class ContrarianModelBot:
         self.prediction_manager = prediction_manager
         self.data_bot = data_bot
         self.strategy_bot = strategy_bot or StrategyPredictionBot()
-        self.allocator = allocator or ResourceAllocationBot()
+        self.allocator = allocator or ResourceAllocationBot(
+            context_builder=ContextBuilder()
+        )
         self.contrarian_db = contrarian_db or ContrarianDB()
         self.capital_manager = capital_manager
         self.model_ids = model_ids or []

--- a/dynamic_resource_allocator_bot.py
+++ b/dynamic_resource_allocator_bot.py
@@ -17,6 +17,7 @@ from .resource_allocation_bot import ResourceAllocationBot, AllocationDB
 from .neuroplasticity import PathwayDB
 from .advanced_error_management import PredictiveResourceAllocator
 from .resource_allocation_optimizer import ResourceAllocationOptimizer
+from vector_service import ContextBuilder
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
@@ -99,7 +100,9 @@ class DynamicResourceAllocator:
         self.metrics_db = metrics_db or MetricsDB()
         self.prediction_bot = prediction_bot or ResourcePredictionBot()
         self.ledger = ledger or DecisionLedger()
-        self.alloc_bot = alloc_bot or ResourceAllocationBot(AllocationDB())
+        self.alloc_bot = alloc_bot or ResourceAllocationBot(
+            AllocationDB(), context_builder=ContextBuilder()
+        )
         self.pathway_db = pathway_db
         self.scaler = predictive_allocator or PredictiveResourceAllocator(self.metrics_db)
         self.orchestrator = orchestrator

--- a/menace_gui.py
+++ b/menace_gui.py
@@ -9,7 +9,6 @@ from typing import List
 from pathlib import Path
 
 from .conversation_manager_bot import ConversationManagerBot, ChatGPTClient
-from vector_service.context_builder import ContextBuilder
 from .env_config import OPENAI_API_KEY
 from .menace_memory_manager import MenaceMemoryManager
 from .report_generation_bot import ReportGenerationBot
@@ -18,6 +17,7 @@ from .bot_database import BotDB
 from .resources_bot import ROIHistoryDB
 from .resource_prediction_bot import ResourcePredictionBot, ResourceMetrics
 from .resource_allocation_bot import ResourceAllocationBot, AllocationDB
+from vector_service import ContextBuilder
 from .scope_utils import Scope, build_scope_clause, apply_scope
 try:  # shared GPT memory instance
     from .shared_gpt_memory import GPT_MEMORY_MANAGER
@@ -183,7 +183,9 @@ class MenaceGUI(tk.Tk):
             bot_db = BotDB()
             roi_db = ROIHistoryDB()
             pred_bot = ResourcePredictionBot()
-            alloc_bot = ResourceAllocationBot(AllocationDB())
+            alloc_bot = ResourceAllocationBot(
+                AllocationDB(), context_builder=ContextBuilder()
+            )
 
             records = bot_db.fetch_all()
             metrics: dict[str, ResourceMetrics] = {}

--- a/niche_saturation_bot.py
+++ b/niche_saturation_bot.py
@@ -27,6 +27,7 @@ from .resource_allocation_bot import ResourceAllocationBot
 from .resource_prediction_bot import ResourceMetrics
 from .prediction_manager_bot import PredictionManager
 from .strategy_prediction_bot import StrategyPredictionBot
+from vector_service import ContextBuilder
 
 
 @dataclass
@@ -94,7 +95,9 @@ class NicheSaturationBot:
         strategy_bot: "StrategyPredictionBot" | None = None,
     ) -> None:
         self.db = db or NicheDB()
-        self.alloc_bot = alloc_bot or ResourceAllocationBot()
+        self.alloc_bot = alloc_bot or ResourceAllocationBot(
+            context_builder=ContextBuilder()
+        )
         self.prediction_manager = prediction_manager
         self.assigned_prediction_bots = []
         if self.prediction_manager:

--- a/resources_bot.py
+++ b/resources_bot.py
@@ -22,6 +22,7 @@ from vector_service import EmbeddableDBMixin
 from resource_vectorizer import ResourceVectorizer
 from .resource_allocation_bot import ResourceAllocationBot, AllocationDB
 from .resource_prediction_bot import ResourceMetrics
+from vector_service import ContextBuilder
 from .prediction_manager_bot import PredictionManager
 from .strategy_prediction_bot import StrategyPredictionBot
 
@@ -110,7 +111,9 @@ class ResourcesBot:
         strategy_bot: "StrategyPredictionBot" | None = None,
     ) -> None:
         self.db = db or ROIHistoryDB()
-        self.alloc_bot = alloc_bot or ResourceAllocationBot(AllocationDB())
+        self.alloc_bot = alloc_bot or ResourceAllocationBot(
+            AllocationDB(), context_builder=ContextBuilder()
+        )
         self.strategy_bot = strategy_bot
         self.prediction_manager = prediction_manager
         self.assigned_prediction_bots = []

--- a/tests/test_dynamic_resource_allocator_bot.py
+++ b/tests/test_dynamic_resource_allocator_bot.py
@@ -6,6 +6,11 @@ import menace.resource_prediction_bot as rpb
 import menace.neuroplasticity as neu
 
 
+class _DummyBuilder:
+    def build(self, *_: object, **__: object) -> str:
+        return "ctx"
+
+
 def test_allocate_and_log(tmp_path, monkeypatch):
     monkeypatch.setattr(db, "psutil", None)
     monkeypatch.setattr(db, "Gauge", None)
@@ -16,7 +21,9 @@ def test_allocate_and_log(tmp_path, monkeypatch):
         mdb,
         rpb.ResourcePredictionBot(rpb.TemplateDB(tmp_path / "t.csv")),
         drab.DecisionLedger(tmp_path / "d.db"),
-        drab.ResourceAllocationBot(drab.AllocationDB(tmp_path / "a.db")),
+        drab.ResourceAllocationBot(
+            drab.AllocationDB(tmp_path / "a.db"), context_builder=_DummyBuilder()
+        ),
     )
     actions = allocator.allocate(["bot1"])
     rows = allocator.ledger.fetch()
@@ -58,7 +65,9 @@ def test_myelinated_priority(tmp_path, monkeypatch):
         mdb,
         rpb.ResourcePredictionBot(rpb.TemplateDB(tmp_path / "t.csv")),
         drab.DecisionLedger(tmp_path / "d.db"),
-        drab.ResourceAllocationBot(drab.AllocationDB(tmp_path / "a.db")),
+        drab.ResourceAllocationBot(
+            drab.AllocationDB(tmp_path / "a.db"), context_builder=_DummyBuilder()
+        ),
         pdb,
     )
     actions = allocator.allocate(["bot1", "bot2"])

--- a/tests/test_logging_exceptions.py
+++ b/tests/test_logging_exceptions.py
@@ -37,6 +37,11 @@ class _KG:
 kg_mod.KnowledgeGraph = _KG
 sys.modules["menace.knowledge_graph"] = kg_mod
 
+dpr_mod = types.ModuleType("dynamic_path_router")
+dpr_mod.get_project_root = lambda *a, **k: Path(".")
+dpr_mod.get_project_roots = lambda *a, **k: [Path(".")]
+sys.modules.setdefault("dynamic_path_router", dpr_mod)
+
 from menace.evaluation_history_db import EvaluationHistoryDB
 import db_router
 
@@ -68,6 +73,11 @@ class ResourceAllocationBot:
 alloc_mod.ResourceAllocationBot = ResourceAllocationBot
 sys.modules["menace.resource_allocation_bot"] = alloc_mod
 
+
+class _DummyBuilder:
+    def build(self, *_: object, **__: object) -> str:
+        return "ctx"
+
 import menace.niche_saturation_bot as ns
 from menace.menace_memory_manager import MenaceMemoryManager
 
@@ -77,7 +87,7 @@ def test_saturate_logs_strategy_error(tmp_path, caplog):
         def receive_niche_info(self, info):
             raise RuntimeError("boom")
 
-    alloc = ResourceAllocationBot()
+    alloc = ResourceAllocationBot(context_builder=_DummyBuilder())
     bot = ns.NicheSaturationBot(
         db=ns.NicheDB(tmp_path / "n.db"), alloc_bot=alloc, strategy_bot=BadStrategy()
     )

--- a/tests/test_niche_saturation_bot.py
+++ b/tests/test_niche_saturation_bot.py
@@ -5,10 +5,17 @@ import menace.resource_allocation_bot as rab
 import menace.resource_prediction_bot as rpb
 
 
+class _DummyBuilder:
+    def build(self, *_: object, **__: object) -> str:
+        return "ctx"
+
+
 def test_saturate_logs(tmp_path):
     db = nsb.NicheDB(tmp_path / "niche.db")
     alloc_db = rab.AllocationDB(tmp_path / "alloc.db")
-    alloc_bot = rab.ResourceAllocationBot(alloc_db, rpb.TemplateDB(tmp_path / "t.csv"))
+    alloc_bot = rab.ResourceAllocationBot(
+        alloc_db, rpb.TemplateDB(tmp_path / "t.csv"), context_builder=_DummyBuilder()
+    )
     bot = nsb.NicheSaturationBot(db, alloc_bot)
     cand = nsb.NicheCandidate(name="ai-tools", demand=5.0, competition=1.0, trend=1.0)
     actions = bot.saturate([cand])

--- a/tests/test_resource_allocation_bot.py
+++ b/tests/test_resource_allocation_bot.py
@@ -4,9 +4,16 @@ import menace.resource_allocation_bot as rab
 import menace.resource_prediction_bot as rpb
 
 
+class _DummyBuilder:
+    def build(self, *_: object, **__: object) -> str:
+        return "ctx"
+
+
 def test_allocate_and_history(tmp_path):
     db = rab.AllocationDB(tmp_path / "a.db")
-    bot = rab.ResourceAllocationBot(db, rpb.TemplateDB(tmp_path / "t.csv"))
+    bot = rab.ResourceAllocationBot(
+        db, rpb.TemplateDB(tmp_path / "t.csv"), context_builder=_DummyBuilder()
+    )
     metrics = {
         "x": rpb.ResourceMetrics(cpu=1.0, memory=50.0, disk=1.0, time=1.0),
         "y": rpb.ResourceMetrics(cpu=10.0, memory=90.0, disk=5.0, time=2.0),
@@ -19,7 +26,7 @@ def test_allocate_and_history(tmp_path):
 
 
 def test_genetic_step():
-    bot = rab.ResourceAllocationBot(rab.AllocationDB(":memory:"))
+    bot = rab.ResourceAllocationBot(rab.AllocationDB(":memory:"), context_builder=_DummyBuilder())
     strategies = [{"name": "a", "roi": 0.1}, {"name": "b", "roi": 0.5}]
     best = bot.genetic_step(strategies)
     assert best["name"] == "b"
@@ -45,7 +52,12 @@ class StubManager:
 def test_allocate_with_prediction(tmp_path):
     manager = StubManager(DummyPred())
     db = rab.AllocationDB(tmp_path / "a.db")
-    bot = rab.ResourceAllocationBot(db, rpb.TemplateDB(tmp_path / "t.csv"), prediction_manager=manager)
+    bot = rab.ResourceAllocationBot(
+        db,
+        rpb.TemplateDB(tmp_path / "t.csv"),
+        prediction_manager=manager,
+        context_builder=_DummyBuilder(),
+    )
     metrics = {"x": rpb.ResourceMetrics(cpu=1.0, memory=1.0, disk=1.0, time=1.0)}
     scores = bot.evaluate(metrics)
     assert manager.registry["p"].bot.called

--- a/tests/test_resources_bot.py
+++ b/tests/test_resources_bot.py
@@ -5,10 +5,16 @@ import menace.resource_allocation_bot as rab
 import menace.resources_bot as resb
 
 
+class _DummyBuilder:
+    def build(self, *_: object, **__: object) -> str:
+        return "ctx"
+
 def test_redistribute_records(tmp_path):
     db = resb.ROIHistoryDB(tmp_path / "roi.db")
     alloc_db = rab.AllocationDB(tmp_path / "a.db")
-    alloc_bot = rab.ResourceAllocationBot(alloc_db, rpb.TemplateDB(tmp_path / "t.csv"))
+    alloc_bot = rab.ResourceAllocationBot(
+        alloc_db, rpb.TemplateDB(tmp_path / "t.csv"), context_builder=_DummyBuilder()
+    )
     bot = resb.ResourcesBot(db, alloc_bot)
     metrics = {
         "b1": rpb.ResourceMetrics(cpu=1.0, memory=50.0, disk=1.0, time=1.0),
@@ -50,7 +56,9 @@ def test_strategy_and_persistence(tmp_path):
     strategy = DummyStrategy()
     db = resb.ROIHistoryDB(tmp_path / "r.db")
     alloc_db = rab.AllocationDB(tmp_path / "a.db")
-    alloc_bot = rab.ResourceAllocationBot(alloc_db, rpb.TemplateDB(tmp_path / "t.csv"))
+    alloc_bot = rab.ResourceAllocationBot(
+        alloc_db, rpb.TemplateDB(tmp_path / "t.csv"), context_builder=_DummyBuilder()
+    )
     bot = resb.ResourcesBot(db, alloc_bot, prediction_manager=manager, strategy_bot=strategy)
     metrics = {"b": rpb.ResourceMetrics(cpu=1.0, memory=1.0, disk=1.0, time=1.0)}
     bot.redistribute(metrics)


### PR DESCRIPTION
## Summary
- inject ContextBuilder into ResourceAllocationBot and use PromptEngine with local LLM for suggestions
- ensure callers pass ContextBuilder when constructing ResourceAllocationBot
- provide dummy builders in tests for new dependency

## Testing
- `pytest unit_tests/test_llm_router.py -q`
- `pytest tests/test_logging_exceptions.py::test_saturate_logs_strategy_error -q` *(fails: ImportError: cannot import name 'get_project_root')*

------
https://chatgpt.com/codex/tasks/task_e_68bd030fc370832e8e1aa34640495097