### PR TITLE
Remove unused context builder parameter from TaskHandoffBot

### DIFF
--- a/implementation_pipeline.py
+++ b/implementation_pipeline.py
@@ -70,14 +70,7 @@ class ImplementationPipeline:
             Planner used to generate IPO execution plans.
         """
         self.context_builder = context_builder
-        if handoff is not None:
-            try:
-                handoff.context_builder = context_builder  # type: ignore[attr-defined]
-            except Exception:
-                pass
-            self.handoff = handoff
-        else:
-            self.handoff = TaskHandoffBot(context_builder=context_builder)
+        self.handoff = handoff or TaskHandoffBot()
         if optimiser is not None:
             try:
                 optimiser.context_builder = context_builder  # type: ignore[attr-defined]
@@ -99,7 +92,9 @@ class ImplementationPipeline:
                 pass
             self.researcher = researcher
         elif isinstance(ResearchAggregatorBot, type) and ResearchAggregatorBot is not object:
-            self.researcher = ResearchAggregatorBot([], context_builder=context_builder)  # type: ignore
+            self.researcher = ResearchAggregatorBot(
+                [], context_builder=context_builder
+            )  # type: ignore
         else:
             self.researcher = None
         if ipo is not None:

--- a/task_handoff_bot.py
+++ b/task_handoff_bot.py
@@ -13,7 +13,7 @@ import logging
 import sqlite3
 from .unified_event_bus import UnifiedEventBus
 from .workflow_graph import WorkflowGraph
-from vector_service import EmbeddableDBMixin, ContextBuilder
+from vector_service import EmbeddableDBMixin
 from db_router import (
     DBRouter,
     GLOBAL_ROUTER,
@@ -541,10 +541,8 @@ class TaskHandoffBot:
         workflow_db: Optional[WorkflowDB] = None,
         *,
         event_bus: Optional[UnifiedEventBus] = None,
-        context_builder: ContextBuilder | None = None,
     ) -> None:
         self.api_url = api_url
-        self.context_builder = context_builder
         if zmq:
             self.context = zmq.Context.instance()
             self.socket = self.context.socket(zmq.PAIR)

--- a/tests/test_pipeline_context_builder_flow.py
+++ b/tests/test_pipeline_context_builder_flow.py
@@ -48,9 +48,6 @@ def test_builder_flows_through_pipeline(tmp_path, monkeypatch):
         tasks: list[TaskInfo]
 
     class StubHandoffBot:
-        def __init__(self, *, context_builder=None):
-            self.context_builder = context_builder
-
         def compile(self, tasks):
             return TaskPackage(list(tasks))
 
@@ -154,7 +151,11 @@ def test_builder_flows_through_pipeline(tmp_path, monkeypatch):
     monkeypatch.setattr(
         ip,
         "subprocess",
-        types.SimpleNamespace(run=lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="", stderr="")),
+        types.SimpleNamespace(
+            run=lambda *a, **k: types.SimpleNamespace(
+                returncode=0, stdout="", stderr=""
+            )
+        ),
     )
     ip.TaskInfo = TaskInfo
     ip.TaskPackage = TaskPackage
@@ -180,7 +181,6 @@ def test_builder_flows_through_pipeline(tmp_path, monkeypatch):
     pipeline.run([task])
 
     assert pipeline.context_builder is builder
-    assert pipeline.handoff.context_builder is builder
     assert pipeline.optimiser.context_builder is builder
     assert pipeline.developer.context_builder is builder
     assert pipeline.researcher.context_builder is builder


### PR DESCRIPTION
## Summary
- drop unused ContextBuilder dependency from `TaskHandoffBot`
- simplify `ImplementationPipeline` and test stubs to reflect new API

## Testing
- `pre-commit run --files task_handoff_bot.py implementation_pipeline.py tests/test_pipeline_context_builder_flow.py` *(fails: check-static-paths, forbid-raw-stripe-usage)*
- `pytest tests/test_pipeline_context_builder_flow.py`
- `pytest tests/test_task_handoff_bot.py tests/test_pipeline_context_builder_flow.py` *(fails: RuntimeError: vector_service import failed)*
- `pytest tests/test_implementation_pipeline.py::test_retry_handoff_and_plan_generation` *(fails: TypeError: object.__init__() takes exactly one argument)*

------
https://chatgpt.com/codex/tasks/task_e_68bd12ae8b94832e8376a296dc69a12c