### PR TITLE
Drop unused ContextBuilder in telemetry feedback

### DIFF
--- a/debug_loop_service.py
+++ b/debug_loop_service.py
@@ -38,7 +38,7 @@ class DebugLoopService:
             engine = SelfCodingEngine(
                 CodeDB(), MenaceMemoryManager(), context_builder=builder
             )
-            feedback = TelemetryFeedback(logger, engine, context_builder=builder)
+            feedback = TelemetryFeedback(logger, engine)
         self.feedback = feedback
         self.logger = logging.getLogger(self.__class__.__name__)
         self.failure_count = 0

--- a/stripe_watchdog.py
+++ b/stripe_watchdog.py
@@ -1832,9 +1832,7 @@ def main(argv: Optional[List[str]] = None) -> None:
                 logger.exception("failed to initialise SelfCodingEngine")
         if TelemetryFeedback and ErrorLogger and engine is not None:
             try:
-                telemetry = TelemetryFeedback(
-                    ErrorLogger(), engine, context_builder=builder
-                )
+                telemetry = TelemetryFeedback(ErrorLogger(), engine)
             except Exception:  # pragma: no cover - best effort
                 logger.exception("failed to initialise telemetry feedback")
 

--- a/telemetry_feedback.py
+++ b/telemetry_feedback.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import threading
 import time
-from typing import Optional, List, Tuple, Any
+from typing import Optional, List, Tuple
 
 from .dynamic_path_router import resolve_path
 
@@ -22,22 +22,34 @@ from .knowledge_graph import KnowledgeGraph
 
 
 class TelemetryFeedback:
-    """Monitor telemetry and trigger self-coding patches."""
+    """Monitor telemetry and trigger self-coding patches.
+
+    The class deliberately avoids any direct dependency on
+    :class:`~vector_service.context_builder.ContextBuilder`.  All prompt
+    construction responsibilities lie with the supplied
+    :class:`SelfCodingEngine`.
+    """
 
     def __init__(
         self,
         logger: ErrorLogger,
         engine: SelfCodingEngine,
         *,
-        context_builder: Any | None = None,
         threshold: int = 3,
         interval: int = 60,
         graph: KnowledgeGraph | None = None,
         router: DBRouter | None = None,
     ) -> None:
+        """Initialise the feedback loop.
+
+        ``TelemetryFeedback`` itself remains agnostic about
+        :class:`~vector_service.context_builder.ContextBuilder` usage; any
+        prompt construction is delegated to the provided
+        :class:`SelfCodingEngine`.  The engine should therefore be configured
+        with an appropriate builder.
+        """
         self.logger = logger
         self.engine = engine
-        self.context_builder = context_builder
         self.threshold = threshold
         self.interval = interval
         self.graph = graph

--- a/tests/test_debug_loop_service.py
+++ b/tests/test_debug_loop_service.py
@@ -13,6 +13,7 @@ pkg.__path__ = [str(TMP), str(ROOT)]
 sys.modules["menace"] = pkg
 sys.modules.pop("vector_service", None)
 vs_pkg = types.ModuleType("vector_service")
+vs_pkg.ContextBuilder = type("ContextBuilder", (), {"__init__": lambda self, *a, **k: None})
 sys.modules["vector_service"] = vs_pkg
 sys.modules["vector_service.context_builder_utils"] = types.SimpleNamespace(
     get_default_context_builder=lambda **_: types.SimpleNamespace(
@@ -22,7 +23,7 @@ sys.modules["vector_service.context_builder_utils"] = types.SimpleNamespace(
 
 # write stub modules to temporary package path
 (TMP / "telemetry_feedback.py").write_text(  # path-ignore
-    """class TelemetryFeedback:\n    def __init__(self, logger=None, engine=None, context_builder=None):\n        self.interval=0\n        self.started=False\n        self.stopped=False\n    def start(self):\n        self.started=True\n    def stop(self):\n        self.stopped=True\n"""
+    """class TelemetryFeedback:\n    def __init__(self, logger=None, engine=None):\n        self.interval=0\n        self.started=False\n        self.stopped=False\n    def start(self):\n        self.started=True\n    def stop(self):\n        self.stopped=True\n"""
 )
 (TMP / "error_logger.py").write_text(  # path-ignore
     "class ErrorLogger:\n    def __init__(self, **kwargs):\n        pass\n"

--- a/tests/test_telemetry_feedback.py
+++ b/tests/test_telemetry_feedback.py
@@ -91,7 +91,7 @@ def test_feedback_triggers_patch(tmp_path, monkeypatch, scope, src):
             source_menace_id=src,
         )
     monkeypatch.setattr(tf, "resolve_path", lambda _p: mod.resolve())
-    fb = tf.TelemetryFeedback(logger, engine, context_builder=object(), threshold=3)
+    fb = tf.TelemetryFeedback(logger, engine, threshold=3)
     fb._run_cycle(scope=scope)
     assert engine.calls and engine.calls[0][0] == mod.resolve()
 
@@ -110,6 +110,6 @@ def test_feedback_threshold(tmp_path, monkeypatch):
                 module_counts={"bot": 1},
             )
         )
-    fb = tf.TelemetryFeedback(logger, engine, context_builder=object(), threshold=3)
+    fb = tf.TelemetryFeedback(logger, engine, threshold=3)
     fb._run_cycle()
     assert not engine.calls


### PR DESCRIPTION
## Summary
- Remove unused `context_builder` argument from `TelemetryFeedback`
- Clarify that `SelfCodingEngine` handles context building
- Align debug loop, watchdog and tests with the new interface

## Testing
- `pytest tests/test_telemetry_feedback.py tests/test_debug_loop_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68bd1700bbb0832e9c6739020f8e717c