### PR TITLE
feat: support custom context builder in prompt engine

### DIFF
--- a/resource_allocation_bot.py
+++ b/resource_allocation_bot.py
@@ -321,7 +321,9 @@ class ResourceAllocationBot:
         except Exception:
             pass
         engine = PromptEngine(context_builder=self.context_builder, llm=llm)
-        prompt = engine.build_prompt(f"Improve {bot}", context=context)  # nocb
+        prompt = engine.build_prompt(
+            f"Improve {bot}", context=context, context_builder=self.context_builder
+        )
         if engine.llm is None:
             return "upgrade"
         try:


### PR DESCRIPTION
## Summary
- allow overriding `PromptEngine` context builder per-call
- ensure all build_prompt invocations explicitly pass a context builder

## Testing
- `python scripts/check_context_builder_usage.py`
- `pytest tests/test_prompt_engine.py tests/test_build_prompt_summaries.py unit_tests/test_prompt_engine.py -q` *(fails: PromptEngine.__init__ missing context_builder & PromptMemoryTrainer missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1bcb5f60832e975ae3be9a752ddf