### PR TITLE
Run ContextBuilder check in retrain workflow

### DIFF
--- a/.github/workflows/retrain_vector_ranker.yml
+++ b/.github/workflows/retrain_vector_ranker.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   retrain:
     runs-on: ubuntu-latest
+    env:
+      MENACE_SAFE: "1"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -15,5 +17,7 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: bash ./setup_env.sh
+      - name: Enforce ContextBuilder usage
+        run: python scripts/check_context_builder_usage.py
       - name: Retrain ranker
         run: python analytics/retrain_vector_ranker.py --vector-db vector_metrics.db --patch-db metrics.db

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,8 +82,10 @@ defaults or silent fallbacks. Tests should assert that these components fail
 fast when the builder is omitted.
 
 Run `python scripts/check_context_builder_usage.py` before committing to verify
-all relevant calls include a `context_builder` argument. Continuous integration
-runs this script and fails the build if any violations are found.
+all relevant calls include a `context_builder` argument. The command exits with
+non-zero status on violations, so add it to your local workflow to catch issues
+early. Continuous integration runs this script and fails the build if any
+violations are found.
 
 ## Stripe integration
 


### PR DESCRIPTION
## Summary
- run ContextBuilder usage check during ranker retrain workflow
- document that the ContextBuilder check exits non-zero on violations

## Testing
- `python scripts/check_context_builder_usage.py`
- `pre-commit run --files .github/workflows/retrain_vector_ranker.yml CONTRIBUTING.md` *(fails: static path 'snippet.py' not wrapped and ModuleNotFoundError: No module named 'dynamic_path_router')*


------
https://chatgpt.com/codex/tasks/task_e_68bd22071a80832eb6ddf13fdcea0ca6