### PR TITLE
Refine context builder usage in service supervisor

### DIFF
--- a/service_supervisor.py
+++ b/service_supervisor.py
@@ -60,12 +60,19 @@ from .menace_memory_manager import MenaceMemoryManager  # noqa: E402
 from .model_automation_pipeline import ModelAutomationPipeline  # noqa: E402
 from .quick_fix_engine import QuickFixEngine  # noqa: E402
 try:  # noqa: E402 - optional helper for default ContextBuilder
-    from vector_service import ContextBuilder, get_default_context_builder
+    from vector_service import ContextBuilder
 except ImportError:  # pragma: no cover - fallback when helper missing
     from vector_service import ContextBuilder  # type: ignore
 
-    def get_default_context_builder(**kwargs):  # type: ignore
-        return ContextBuilder(**kwargs)
+
+def get_default_context_builder(**kwargs):  # type: ignore
+    return ContextBuilder(
+        bot_db="bots.db",
+        code_db="code.db",
+        error_db="errors.db",
+        workflow_db="workflows.db",
+        **kwargs,
+    )
 
 try:  # optional dependency
     import psutil  # type: ignore


### PR DESCRIPTION
## Summary
- Inline a default context builder pointing at bots.db, code.db, errors.db and workflows.db
- Ensure supervisor constructor uses the new factory and refreshes DB weights
- Pass this builder into SelfCodingEngine and QuickFixEngine

## Testing
- `pytest tests/test_service_installer.py tests/test_supervisor_watchdog.py tests/test_cluster_supervisor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd27c9dd48832ea9d8cf85509efb48