### PR TITLE
Configure context builder for contrarian allocation

### DIFF
--- a/contrarian_model_bot.py
+++ b/contrarian_model_bot.py
@@ -152,9 +152,16 @@ class ContrarianModelBot:
         self.prediction_manager = prediction_manager
         self.data_bot = data_bot
         self.strategy_bot = strategy_bot or StrategyPredictionBot()
-        self.allocator = allocator or ResourceAllocationBot(
-            context_builder=ContextBuilder()
-        )
+        if allocator is None:
+            builder = ContextBuilder(
+                bot_db="bots.db",
+                code_db="code.db",
+                error_db="errors.db",
+                workflow_db="workflows.db",
+            )
+            builder.refresh_db_weights()
+            allocator = ResourceAllocationBot(context_builder=builder)
+        self.allocator = allocator
         self.contrarian_db = contrarian_db or ContrarianDB()
         self.capital_manager = capital_manager
         self.model_ids = model_ids or []


### PR DESCRIPTION
## Summary
- Build ResourceAllocationBot with a ContextBuilder targeting bots, code, error, and workflow databases
- Refresh database weights before passing the builder to the allocator
- Note that ResourceAllocationBot propagates the ContextBuilder to its PromptEngine

## Testing
- `pytest tests/test_contrarian_model_bot.py -q` *(skipped: optional dependencies not installed)*
- `pytest tests/test_logging_exceptions.py -q` *(fails: ImportError: cannot import name 'get_project_root')*


------
https://chatgpt.com/codex/tasks/task_e_68bd2be17cf4832e84eb35874c4f61ce