### PR TITLE
refactor: simplify context builder helper

### DIFF
--- a/tests/test_context_builder_utils.py
+++ b/tests/test_context_builder_utils.py
@@ -1,0 +1,77 @@
+import sys
+import types
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Provide lightweight stubs for heavy dependencies so the real modules can be
+# imported without initialising databases or accessing configuration files.
+# ---------------------------------------------------------------------------
+ROOT = Path(__file__).resolve().parents[1]
+sys.modules.setdefault(
+    "retrieval_cache", types.SimpleNamespace(RetrievalCache=type("RetrievalCache", (), {}))
+)
+sys.modules.setdefault(
+    "vector_service.retriever",
+    types.SimpleNamespace(
+        Retriever=type("Retriever", (), {"__init__": lambda self, *a, **k: None}),
+        PatchRetriever=type(
+            "PatchRetriever", (), {"__init__": lambda self, *a, **k: None}
+        ),
+        FallbackResult=type("FallbackResult", (), {}),
+    ),
+)
+sys.modules.setdefault("vector_service.patch_logger", types.SimpleNamespace(_VECTOR_RISK=0))
+sys.modules.setdefault("vector_metrics_db", types.SimpleNamespace(VectorMetricsDB=None))
+sys.modules.setdefault(
+    "compliance.license_fingerprint", types.SimpleNamespace(DENYLIST={})
+)
+
+
+class ContextBuilderConfig:
+    def __init__(self):
+        self.ranking_weight = 1.0
+        self.roi_weight = 1.0
+        self.recency_weight = 1.0
+        self.safety_weight = 1.0
+        self.max_tokens = 1000
+        self.regret_penalty = 0.0
+        self.alignment_penalty = 0.0
+        self.alert_penalty = 0.0
+        self.risk_penalty = 1.0
+        self.roi_tag_penalties = {}
+        self.enhancement_weight = 1.0
+        self.max_alignment_severity = 1.0
+        self.max_alerts = 5
+        self.license_denylist = set()
+        self.precise_token_count = False
+        self.max_diff_lines = 200
+        self.similarity_metric = "cosine"
+
+
+sys.modules.setdefault("config", types.SimpleNamespace(ContextBuilderConfig=ContextBuilderConfig))
+
+# Create a lightweight package so submodules can be imported without executing
+# the actual ``vector_service`` package ``__init__``.
+pkg = types.ModuleType("vector_service")
+pkg.__path__ = [str(ROOT / "vector_service")]
+sys.modules.setdefault("vector_service", pkg)
+
+from vector_service.context_builder_utils import get_default_context_builder
+from vector_service.context_builder import ContextBuilder
+
+
+def test_get_default_context_builder_returns_builder():
+    dummy_retriever = types.SimpleNamespace()
+    builder = get_default_context_builder(
+        retriever=dummy_retriever, precise_token_count=False
+    )
+    assert isinstance(builder, ContextBuilder)
+    builder.refresh_db_weights({})
+
+
+def test_kwargs_forwarded_to_context_builder():
+    dummy_retriever = types.SimpleNamespace()
+    builder = get_default_context_builder(
+        retriever=dummy_retriever, max_tokens=1, precise_token_count=False
+    )
+    assert builder.max_tokens == 1

--- a/vector_service/context_builder_utils.py
+++ b/vector_service/context_builder_utils.py
@@ -1,4 +1,11 @@
-"""Utilities for constructing ContextBuilder instances with default databases."""
+"""Utilities for constructing :class:`~vector_service.context_builder.ContextBuilder`.
+
+The real :class:`ContextBuilder` already provides sensible defaults for all of
+its parameters.  This module simply exposes a tiny convenience wrapper that
+forwards any keyword arguments to the constructor.  Callers can therefore rely
+on the defaults defined by :class:`ContextBuilder` and
+``ContextBuilderConfig`` or override them by passing ``**kwargs``.
+"""
 
 from __future__ import annotations
 
@@ -8,11 +15,21 @@ from .context_builder import ContextBuilder
 
 
 def get_default_context_builder(**kwargs: Any) -> ContextBuilder:
-    """Return a :class:`ContextBuilder` preconfigured with default databases."""
-    return ContextBuilder(
-        bot_db="bots.db",
-        code_db="code.db",
-        error_db="errors.db",
-        workflow_db="workflows.db",
-        **kwargs,
-    )
+    """Return a ready-to-use :class:`ContextBuilder`.
+
+    Parameters
+    ----------
+    **kwargs:
+        Additional keyword arguments forwarded directly to
+        :class:`ContextBuilder`.  Common options include ``retriever``,
+        ``max_tokens`` and other tuning parameters.  Unspecified arguments fall
+        back to the defaults provided by :class:`ContextBuilder` and
+        ``ContextBuilderConfig``.
+
+    Returns
+    -------
+    ContextBuilder
+        An instance configured with the standard defaults.
+    """
+
+    return ContextBuilder(**kwargs)


### PR DESCRIPTION
## Summary
- streamline `get_default_context_builder` by removing obsolete DB arguments
- forward kwargs directly to `ContextBuilder` and document defaults
- add unit tests verifying the helper returns a usable builder

## Testing
- `pytest tests/test_context_builder_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd3a7cca54832eb76e62b9c68dfb17