### PR TITLE
Ensure context builder DB availability

### DIFF
--- a/automated_reviewer.py
+++ b/automated_reviewer.py
@@ -43,6 +43,11 @@ class AutomatedReviewer:
             raise TypeError("context_builder must implement build()")
         self.context_builder = context_builder
         try:
+            self.context_builder.refresh_db_weights()
+        except Exception as exc:
+            self.logger.error("context builder refresh failed: %s", exc)
+            raise RuntimeError("context builder refresh failed") from exc
+        try:
             self.cognition_layer = CognitionLayer(context_builder=context_builder)
         except Exception:  # pragma: no cover - optional dependency failed
             self.logger.error("failed to initialise CognitionLayer", exc_info=True)

--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -334,6 +334,11 @@ class BotDevelopmentBot:
                 self.logger.error(msg)
             raise ValueError(msg)
         self.context_builder = context_builder
+        try:
+            self.context_builder.refresh_db_weights()
+        except Exception as exc:
+            self.logger.error("context builder refresh failed: %s", exc)
+            raise RuntimeError("context builder refresh failed") from exc
         # warn about missing optional dependencies
         for dep_name, mod in {
             "requests": requests,

--- a/implementation_optimiser_bot.py
+++ b/implementation_optimiser_bot.py
@@ -43,6 +43,11 @@ class ImplementationOptimiserBot:
         self.history: List[TaskPackage] = []
         self.engine = engine
         self.context_builder = context_builder
+        try:
+            self.context_builder.refresh_db_weights()
+        except Exception as exc:
+            logger.error("context builder refresh failed: %s", exc)
+            raise RuntimeError("context builder refresh failed") from exc
         if self.engine is not None:
             try:
                 self.engine.context_builder = context_builder  # type: ignore[attr-defined]

--- a/resource_allocation_bot.py
+++ b/resource_allocation_bot.py
@@ -101,6 +101,13 @@ class ResourceAllocationBot:
         self.db = db or AllocationDB()
         self.template_db = template_db or TemplateDB()
         self.context_builder = context_builder
+        try:
+            self.context_builder.refresh_db_weights()
+        except Exception as exc:
+            logging.getLogger("ResourceAllocationBot").error(
+                "context builder refresh failed: %s", exc
+            )
+            raise RuntimeError("context builder refresh failed") from exc
         self.data_bot = data_bot
         self.capital_bot = capital_bot
         self.prediction_manager = prediction_manager

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -476,6 +476,11 @@ class SelfCodingEngine:
                     extra={"context_builder": type(builder).__name__},
                 )
         self.context_builder = builder
+        try:
+            self.context_builder.refresh_db_weights()
+        except Exception as exc:
+            self.logger.error("context builder refresh failed: %s", exc)
+            raise RuntimeError("context builder refresh failed") from exc
         if patch_logger is not None and getattr(patch_logger, "roi_tracker", None) is None:
             try:
                 patch_logger.roi_tracker = tracker  # type: ignore[attr-defined]

--- a/tests/integration/test_chunked_patch_flow.py
+++ b/tests/integration/test_chunked_patch_flow.py
@@ -158,7 +158,10 @@ def _setup_engine(tmp_path, monkeypatch):
         llm_client=DummyLLM(),
         prompt_chunk_token_threshold=50,
         chunk_summary_cache_dir=tmp_path,
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
     engine.data_bot = None
     engine.trend_predictor = None

--- a/tests/integration/test_patch_escalation_metrics.py
+++ b/tests/integration/test_patch_escalation_metrics.py
@@ -47,7 +47,10 @@ def test_escalation_metrics(monkeypatch, tmp_path):
     engine = SelfCodingEngine(
         code_db=object(),
         memory_mgr=object(),
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
     engine.audit_trail = types.SimpleNamespace(record=lambda payload: None)
     engine._build_retry_context = lambda desc, rep: {}

--- a/tests/test_automated_reviewer_context_builder_invocation.py
+++ b/tests/test_automated_reviewer_context_builder_invocation.py
@@ -11,6 +11,9 @@ class RecordingBuilder:
         self.calls.append(payload)
         return "ctx"
 
+    def refresh_db_weights(self):
+        pass
+
 
 class DummyCognitionLayer:
     def __init__(self, *, context_builder=None, **__):

--- a/tests/test_automated_rollback.py
+++ b/tests/test_automated_rollback.py
@@ -93,7 +93,10 @@ def test_multi_node_auto_rollback(tmp_path, monkeypatch):
         bot_name="A",
         rollback_mgr=rb,
         delta_tracker=tracker_a,
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
     eng_b = sce.SelfCodingEngine(
         cd.CodeDB(tmp_path / "c.db"),
@@ -102,7 +105,10 @@ def test_multi_node_auto_rollback(tmp_path, monkeypatch):
         bot_name="B",
         rollback_mgr=rb,
         delta_tracker=tracker_b,
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
 
     for eng in (eng_a, eng_b):

--- a/tests/test_billing_prompt_injection.py
+++ b/tests/test_billing_prompt_injection.py
@@ -54,7 +54,8 @@ def test_billing_instructions_in_prompt(monkeypatch):
     engine.prompt_evolution_memory = None
     engine.roi_tracker = None
     engine.context_builder = types.SimpleNamespace(
-        build_context=lambda *a, **k: {}
+        build_context=lambda *a, **k: {},
+        refresh_db_weights=lambda *a, **k: None,
     )
     engine.prompt_tone = None
     engine._last_prompt_metadata = {}

--- a/tests/test_coordinated_rollback.py
+++ b/tests/test_coordinated_rollback.py
@@ -82,7 +82,10 @@ def test_coordinated_rollback(tmp_path, monkeypatch):
         bot_name="A",
         rollback_mgr=rb,
         delta_tracker=tracker_a,
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
     eng_b = sce.SelfCodingEngine(
         cd.CodeDB(tmp_path / "c.db"),
@@ -91,7 +94,10 @@ def test_coordinated_rollback(tmp_path, monkeypatch):
         bot_name="B",
         rollback_mgr=rb,
         delta_tracker=tracker_b,
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
 
     for eng in (eng_a, eng_b):

--- a/tests/test_dynamic_resource_allocator_bot.py
+++ b/tests/test_dynamic_resource_allocator_bot.py
@@ -10,6 +10,9 @@ class _DummyBuilder:
     def build(self, *_: object, **__: object) -> str:
         return "ctx"
 
+    def refresh_db_weights(self):
+        pass
+
 
 def test_allocate_and_log(tmp_path, monkeypatch):
     monkeypatch.setattr(db, "psutil", None)

--- a/tests/test_engine_access_control.py
+++ b/tests/test_engine_access_control.py
@@ -21,7 +21,10 @@ def test_apply_patch_denied_logs(tmp_path):
         bot_roles={"reader": "read"},
         audit_trail_path=str(tmp_path / "audit.log"),
         audit_privkey=priv_bytes,
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
 
     path = tmp_path / "file.py"  # path-ignore

--- a/tests/test_failure_fingerprint_logging.py
+++ b/tests/test_failure_fingerprint_logging.py
@@ -15,7 +15,10 @@ def _make_engine(tmp_path):
         code_db=object(),
         memory_mgr=object(),
         patch_db=None,
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
     eng._build_retry_context = lambda desc, rep: {}
     eng._run_ci = lambda path=None: None

--- a/tests/test_failure_fingerprint_retry.py
+++ b/tests/test_failure_fingerprint_retry.py
@@ -52,7 +52,10 @@ def _build_engine(monkeypatch, tmp_path, similar_return, skip: bool = False):
         memory_mgr=object(),
         patch_db=patch_db,
         skip_retry_on_similarity=skip,
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
     records: list[dict] = []
     engine.audit_trail = types.SimpleNamespace(record=lambda payload: records.append(payload))

--- a/tests/test_full_self_optimisation.py
+++ b/tests/test_full_self_optimisation.py
@@ -87,7 +87,10 @@ def test_full_self_optimisation(tmp_path, monkeypatch):
         mm.MenaceMemoryManager(tmp_path / "mem.db"),
         data_bot=data_bot,
         patch_db=patch_db,
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
     monkeypatch.setattr(engine, "_run_ci", lambda: True)
     monkeypatch.setattr(engine, "generate_helper", lambda d: "def auto_x():\n    pass\n")

--- a/tests/test_generate_helper_fallback.py
+++ b/tests/test_generate_helper_fallback.py
@@ -37,7 +37,10 @@ def _engine(tmp_path: Path) -> sce.SelfCodingEngine:
     return sce.SelfCodingEngine(
         cd.CodeDB(tmp_path / "c.db"),
         mm.MenaceMemoryManager(tmp_path / "m.db"),
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
 
 

--- a/tests/test_implementation_optimiser_bot.py
+++ b/tests/test_implementation_optimiser_bot.py
@@ -21,3 +21,12 @@ def test_process_records_package():
     advice = bot.process(pkg)
     assert bot.history and bot.history[0] is pkg
     assert advice[0].name == "t"
+
+
+def test_refresh_db_weights_failure():
+    class BadBuilder:
+        def refresh_db_weights(self):
+            raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        iob.ImplementationOptimiserBot(context_builder=BadBuilder())

--- a/tests/test_logging_exceptions.py
+++ b/tests/test_logging_exceptions.py
@@ -78,6 +78,9 @@ class _DummyBuilder:
     def build(self, *_: object, **__: object) -> str:
         return "ctx"
 
+    def refresh_db_weights(self):
+        pass
+
 import menace.niche_saturation_bot as ns
 from menace.menace_memory_manager import MenaceMemoryManager
 

--- a/tests/test_niche_saturation_bot.py
+++ b/tests/test_niche_saturation_bot.py
@@ -9,6 +9,9 @@ class _DummyBuilder:
     def build(self, *_: object, **__: object) -> str:
         return "ctx"
 
+    def refresh_db_weights(self):
+        pass
+
 
 def test_saturate_logs(tmp_path):
     db = nsb.NicheDB(tmp_path / "niche.db")

--- a/tests/test_patch_outcome_negatives.py
+++ b/tests/test_patch_outcome_negatives.py
@@ -184,7 +184,10 @@ def test_rollback_logs_negative_outcome(tmp_path, monkeypatch):
         mem,
         data_bot=data_bot,
         patch_db=patch_db,
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
     engine.formal_verifier = None
     monkeypatch.setattr(engine, "_run_ci", lambda *a, **k: True)
@@ -218,7 +221,10 @@ def test_failed_tests_log_negative_outcome(tmp_path, monkeypatch):
         mem,
         data_bot=data_bot,
         patch_db=patch_db,
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
     engine.formal_verifier = None
     monkeypatch.setattr(engine, "_run_ci", lambda *a, **k: False)

--- a/tests/test_patch_outcome_skipped.py
+++ b/tests/test_patch_outcome_skipped.py
@@ -46,7 +46,10 @@ def test_skipped_enhancement_logs_negative_outcome(tmp_path, monkeypatch):
         mem,
         data_bot=data_bot,
         patch_db=patch_db,
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
     engine.formal_verifier = None
     monkeypatch.setattr(engine, "_run_ci", lambda *a, **k: True)

--- a/tests/test_patch_retry_escalation.py
+++ b/tests/test_patch_retry_escalation.py
@@ -46,7 +46,10 @@ def test_region_escalation(monkeypatch, tmp_path):
     engine = SelfCodingEngine(
         code_db=object(),
         memory_mgr=object(),
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
     engine.audit_trail = types.SimpleNamespace(record=lambda payload: None)
     engine._build_retry_context = lambda desc, rep: {}

--- a/tests/test_prompt_logging_and_optimizer.py
+++ b/tests/test_prompt_logging_and_optimizer.py
@@ -30,7 +30,10 @@ def make_engine(tmp_path: Path):
         prompt_evolution_memory=logger,
         prompt_optimizer=optimizer,
         audit_trail_path=str(tmp_path / "audit.log"),
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
     return engine, success_log, failure_log, optimizer
 

--- a/tests/test_resource_allocation_bot.py
+++ b/tests/test_resource_allocation_bot.py
@@ -8,6 +8,9 @@ class _DummyBuilder:
     def build(self, *_: object, **__: object) -> str:
         return "ctx"
 
+    def refresh_db_weights(self):
+        pass
+
 
 def test_allocate_and_history(tmp_path):
     db = rab.AllocationDB(tmp_path / "a.db")
@@ -23,6 +26,15 @@ def test_allocate_and_history(tmp_path):
     assert len(hist) == 2
     assert actions[0][1] is True
     assert actions[1][1] is False
+
+
+def test_refresh_db_weights_failure(tmp_path):
+    class BadBuilder(_DummyBuilder):
+        def refresh_db_weights(self):
+            raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        rab.ResourceAllocationBot(rab.AllocationDB(tmp_path / "a.db"), context_builder=BadBuilder())
 
 
 def test_genetic_step():

--- a/tests/test_resources_bot.py
+++ b/tests/test_resources_bot.py
@@ -9,6 +9,9 @@ class _DummyBuilder:
     def build(self, *_: object, **__: object) -> str:
         return "ctx"
 
+    def refresh_db_weights(self):
+        pass
+
 def test_redistribute_records(tmp_path):
     db = resb.ROIHistoryDB(tmp_path / "roi.db")
     alloc_db = rab.AllocationDB(tmp_path / "a.db")

--- a/tests/test_self_coding_engine_chunking.py
+++ b/tests/test_self_coding_engine_chunking.py
@@ -38,7 +38,10 @@ _setmod("vector_service", vec_mod)
 _setmod("vector_service.retriever", types.ModuleType("vector_service.retriever"))
 _setmod("vector_service.decorators", types.ModuleType("vector_service.decorators"))
 
-builder = types.SimpleNamespace(build_context=lambda *a, **k: {})
+builder = types.SimpleNamespace(
+    build_context=lambda *a, **k: {},
+    refresh_db_weights=lambda *a, **k: None,
+)
 
 code_db_mod = types.ModuleType("code_database")
 code_db_mod.CodeDB = object

--- a/tests/test_self_coding_engine_logging.py
+++ b/tests/test_self_coding_engine_logging.py
@@ -121,7 +121,10 @@ def test_roi_tracker_logging(caplog):
         DummyMemory(),
         patch_logger=BadPatchLogger(),
         cognition_layer=BadCognitionLayer(),
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
     messages = [record.message for record in caplog.records]
     assert any("patch_logger" in m for m in messages)
@@ -135,7 +138,10 @@ def test_knowledge_service_logging(monkeypatch, caplog):
         DummyMemory(),
         knowledge_service=object(),
         llm_client=llm,
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
     monkeypatch.setattr(sce, "get_feedback", lambda *a, **k: [])
     monkeypatch.setattr(sce, "get_error_fixes", lambda *a, **k: [])
@@ -167,7 +173,10 @@ def test_tempfile_cleanup_logging(monkeypatch, caplog, tmp_path):
         object(),
         DummyMemory(),
         llm_client=llm,
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
 
     class Verifier:

--- a/tests/test_self_coding_engine_patch_logger.py
+++ b/tests/test_self_coding_engine_patch_logger.py
@@ -127,7 +127,10 @@ def test_track_contributors_records_roi():
         DummyDB(),
         DummyMem(),
         patch_logger=pl,
-        context_builder=types.SimpleNamespace(build_context=lambda *a, **k: {}),
+        context_builder=types.SimpleNamespace(
+            build_context=lambda *a, **k: {},
+            refresh_db_weights=lambda *a, **k: None,
+        ),
     )
     vectors = [("db1", "v1", 0.1), ("db2", "v2", 0.2)]
     engine._track_contributors(


### PR DESCRIPTION
## Summary
- refresh context builder database weights during bot initialization and raise descriptive errors on failure
- verify that bots reject invalid context builders lacking valid refresh implementations

## Testing
- `pytest tests/test_automated_reviewer.py::test_refresh_db_weights_failure -q` *(fails: ImportError: cannot import name 'EmbeddableDBMixin')*
- `pytest tests/test_implementation_optimiser_bot.py::test_refresh_db_weights_failure -q` *(fails: found no collectors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3e1aaf9c832e84999c5f0f10915b