### PR TITLE
Require context builder for enhancement bot

### DIFF
--- a/tests/test_payment_notice.py
+++ b/tests/test_payment_notice.py
@@ -198,9 +198,16 @@ def test_enhancement_bot_injects_notice():
             self.captured = prompt
             return LLMResult(text="")
 
+    class DummyBuilder:
+        def refresh_db_weights(self):
+            return {}
+
+        def build(self, query, **_):
+            return ""
+
     llm = DummyLLM()
-    bot = EnhancementBot(llm_client=llm)
-    bot._codex_summarize("a", "b")
+    bot = EnhancementBot(context_builder=DummyBuilder(), llm_client=llm)
+    bot._codex_summarize("a", "b", confidence=1.0)
     assert llm.captured and llm.captured.system.startswith(PAYMENT_ROUTER_NOTICE)
 
 


### PR DESCRIPTION
## Summary
- Make `ContextBuilder` mandatory for `EnhancementBot` and cache DB weights
- Use confidence to scale context retrieval in `_codex_summarize`
- Add tests for required builder and context injection

## Testing
- `pytest tests/test_enhancement_bot.py tests/test_payment_notice.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd46c46a74832e970b7219cafebd7e