### PR TITLE
Require external context builder for AutoEscalationManager

### DIFF
--- a/automated_reviewer.py
+++ b/automated_reviewer.py
@@ -34,7 +34,7 @@ class AutomatedReviewer:
         if escalation_manager is None:
             from .auto_escalation_manager import AutoEscalationManager
 
-            escalation_manager = AutoEscalationManager()
+            escalation_manager = AutoEscalationManager(context_builder=context_builder)
         self.escalation_manager = escalation_manager
         self.logger = logging.getLogger(self.__class__.__name__)
         if context_builder is None:

--- a/service_supervisor.py
+++ b/service_supervisor.py
@@ -378,9 +378,9 @@ class ServiceSupervisor:
         self.approval_policy = PatchApprovalPolicy(
             rollback_mgr=self.rollback_mgr, bot_name="menace"
         )
-        self.auto_mgr = AutoEscalationManager()
         self.context_builder = get_default_context_builder()
         self.context_builder.refresh_db_weights()
+        self.auto_mgr = AutoEscalationManager(context_builder=self.context_builder)
         engine = SelfCodingEngine(
             CodeDB(), MenaceMemoryManager(), context_builder=self.context_builder
         )


### PR DESCRIPTION
## Summary
- accept a ContextBuilder in `AutoEscalationManager` and reuse it for the debugger
- pass an explicit builder when instantiating `AutoEscalationManager`
- make watchdog and tests resilient by providing fallbacks for optional dependencies

## Testing
- `pytest tests/test_auto_escalation_manager.py::test_notifier_uses_auto_handler tests/test_auto_escalation_manager.py::test_notifier_default_handler tests/test_auto_escalation_manager.py::test_publish_retry_and_log -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd4ea15640832e9053a5e14209ba5f