### PR TITLE
Inject ContextBuilder dependency into BotCreationBot

### DIFF
--- a/README.md
+++ b/README.md
@@ -2113,10 +2113,12 @@ trending product names scraped from multiple sources:
 from menace.bot_creation_bot import BotCreationBot
 from menace.workflow_evolution_bot import WorkflowEvolutionBot
 from menace.trending_scraper import TrendingScraper
+from vector_service import ContextBuilder
 
 creator = BotCreationBot(
     workflow_bot=WorkflowEvolutionBot(),
     trending_scraper=TrendingScraper(),
+    context_builder=ContextBuilder(),
 )
 # tasks is a list of PlanningTask objects
 creator.create_bots(tasks)

--- a/discovery_scheduler.py
+++ b/discovery_scheduler.py
@@ -13,6 +13,7 @@ from .research_aggregator_bot import InfoDB, ResearchItem
 from .bot_creation_bot import BotCreationBot
 from .bot_planning_bot import PlanningTask
 from .normalize_scraped_data import load_items, normalize
+from vector_service import ContextBuilder
 
 
 class DiscoveryScheduler:
@@ -26,7 +27,10 @@ class DiscoveryScheduler:
         interval: int = 3600,
     ) -> None:
         self.scraper = scraper or TrendingScraper()
-        self.creation_bot = creation_bot or BotCreationBot()
+        self.context_builder = ContextBuilder()
+        self.creation_bot = creation_bot or BotCreationBot(
+            context_builder=self.context_builder
+        )
         self.interval = interval
         self.running = False
         self._thread: Optional[threading.Thread] = None

--- a/model_automation_pipeline.py
+++ b/model_automation_pipeline.py
@@ -190,7 +190,9 @@ class ModelAutomationPipeline:
         self.comms_test_bot = comms_test_bot or CommunicationTestingBot()
         self.discrepancy_bot = discrepancy_bot or DiscrepancyDetectionBot()
         self.finance_bot = finance_bot or FinanceRouterBot()
-        self.creation_bot = creation_bot or BotCreationBot()
+        self.creation_bot = creation_bot or BotCreationBot(
+            context_builder=self.context_builder
+        )
         self.meta_ga_bot = meta_ga_bot or MetaGeneticAlgorithmBot()
         self.offer_bot = offer_bot or OfferTestingBot()
         self.fallback_bot = fallback_bot or ResearchFallbackBot()

--- a/tests/test_bot_creation_bot.py
+++ b/tests/test_bot_creation_bot.py
@@ -44,7 +44,10 @@ def _ctx_builder():
 
 
 def test_needs_new_bot(tmp_path):
-    bot = bcb.BotCreationBot(metrics_db=_metrics(tmp_path))
+    bot = bcb.BotCreationBot(
+        metrics_db=_metrics(tmp_path),
+        context_builder=_ctx_builder(),
+    )
     assert bot.needs_new_bot()
 
 
@@ -67,7 +70,11 @@ class StubManager:
 
 def test_needs_new_bot_with_prediction(tmp_path):
     manager = StubManager(DummyPred())
-    bot = bcb.BotCreationBot(metrics_db=_metrics(tmp_path), prediction_manager=manager)
+    bot = bcb.BotCreationBot(
+        metrics_db=_metrics(tmp_path),
+        prediction_manager=manager,
+        context_builder=_ctx_builder(),
+    )
     assert bot.assigned_prediction_bots == ["p"]
     assert not bot.needs_new_bot()
     assert manager.registry["p"].bot.called
@@ -96,6 +103,7 @@ def test_create_bots(tmp_path):
         tester=tester,
         deployer=deployer,
         intent_clusterer=DummyClusterer(),
+        context_builder=developer.context_builder,
     )
     task = bp.PlanningTask(
         description="do", complexity=1, frequency=1, expected_time=0.1, actions=["run"]
@@ -158,6 +166,7 @@ def test_trending_scraper_receives_energy(tmp_path):
         deployer=deployer,
         trending_scraper=scraper,
         capital_bot=DummyCapital(),
+        context_builder=developer.context_builder,
     )
     task = bp.PlanningTask(
         description="do",
@@ -189,6 +198,7 @@ def test_create_bots_logs_errors(tmp_path):
         tester=tester,
         deployer=deployer,
         error_bot=eb.ErrorBot(err_db),
+        context_builder=developer.context_builder,
     )
     developer.errors.append("integration fail")
     task = bp.PlanningTask(
@@ -231,6 +241,7 @@ def test_create_bots_records_workflows(tmp_path):
         developer=developer,
         tester=tester,
         deployer=deployer,
+        context_builder=developer.context_builder,
     )
 
     dm.DB_PATH = tmp_path / "models.db"
@@ -276,6 +287,7 @@ def test_code_db_updates_on_creation(tmp_path):
         tester=tester,
         deployer=deployer,
         error_bot=eb.ErrorBot(err_db),
+        context_builder=developer.context_builder,
     )
 
     task = bp.PlanningTask(
@@ -342,6 +354,7 @@ def test_creation_updates_status_and_enh_links(tmp_path):
         developer=developer,
         tester=tester,
         deployer=deployer,
+        context_builder=developer.context_builder,
     )
 
     task = bp.PlanningTask(
@@ -387,6 +400,7 @@ def test_higher_order_contrarian_timestamp(tmp_path):
         developer=developer,
         tester=tester,
         deployer=deployer,
+        context_builder=developer.context_builder,
     )
 
     tasks = [
@@ -438,6 +452,7 @@ def test_higher_order_contrarian_new_links(tmp_path):
         tester=tester,
         deployer=deployer,
         error_bot=eb.ErrorBot(err_db),
+        context_builder=developer.context_builder,
     )
 
     tasks = [
@@ -485,6 +500,7 @@ def test_workflow_bot_links(tmp_path):
         developer=developer,
         tester=tester,
         deployer=deployer,
+        context_builder=developer.context_builder,
     )
 
     task = bp.PlanningTask(
@@ -519,6 +535,7 @@ def test_trending_order(tmp_path):
         tester=tester,
         deployer=deployer,
         trending_scraper=DummyScraper(),
+        context_builder=developer.context_builder,
     )
 
     tasks = [
@@ -564,6 +581,7 @@ def test_enhancement_link_error_logged(tmp_path, caplog):
         tester=tester,
         deployer=deployer,
         error_bot=eb.ErrorBot(eb.ErrorDB(tmp_path / "err.db")),
+        context_builder=developer.context_builder,
     )
 
     task = bp.PlanningTask(


### PR DESCRIPTION
## Summary
- inject ContextBuilder into BotCreationBot and propagate to development and cognition layers
- require callers to supply builder in pipelines, schedulers, docs and tests

## Testing
- `python scripts/check_context_builder_usage.py`
- `MENACE_ROOT=/workspace/menace_sandbox pytest tests/test_bot_creation_bot.py -q` *(fails: RuntimeError: vector_service import failed)*


------
https://chatgpt.com/codex/tasks/task_e_68bd52ffd5e4832eb3293c1a4d1d827f