### PR TITLE
Pass context builder into service supervisor

### DIFF
--- a/cluster_supervisor.py
+++ b/cluster_supervisor.py
@@ -15,8 +15,14 @@ from .service_supervisor import ServiceSupervisor
 class ClusterServiceSupervisor(ServiceSupervisor):
     """Extend :class:`ServiceSupervisor` to manage remote supervisors."""
 
-    def __init__(self, hosts: Iterable[str] | None = None, check_interval: float = 5.0) -> None:
-        super().__init__(check_interval=check_interval)
+    def __init__(
+        self,
+        hosts: Iterable[str] | None = None,
+        check_interval: float = 5.0,
+        *,
+        context_builder: "ContextBuilder",
+    ) -> None:
+        super().__init__(check_interval=check_interval, context_builder=context_builder)
         env_hosts = os.getenv("CLUSTER_HOSTS", "").split(",")
         self.hosts = [h.strip() for h in (hosts or env_hosts) if h.strip()]
         failover = os.getenv("FAILOVER_HOSTS", "").split(",")


### PR DESCRIPTION
## Summary
- inject `ContextBuilder` into `ServiceSupervisor` and propagate to `ClusterServiceSupervisor`
- remove internal default context builder helper
- wire up default builder in `main`
- update cluster supervisor tests for new API

## Testing
- `pytest tests/test_cluster_supervisor.py -q`
- `pytest tests/test_supervisor_watchdog.py -q`
- `pytest tests/test_service_installer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd56e2abb8832ea2ff87f9f714ab32