### PR TITLE
Clarify ContextBuilder injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,11 +259,11 @@ message if installation fails.
   ranking with ROI feedback – is available in
   [docs/vectorized_cognition.md](docs/vectorized_cognition.md).
 - Compact, offline context assembly via `ContextBuilder` which summarises error,
-  bot, workflow and code records for code-generation modules. Prompt‑constructing
-  bots must be supplied a builder configured for the standard local databases,
-  e.g. `ContextBuilder(bot_db="bots.db", code_db="code.db", error_db="errors.db",
-  workflow_db="workflows.db")` or the `get_default_context_builder()` helper, and
-  passed to `SelfCodingEngine` or `QuickFixEngine`
+  bot, workflow and code records for code‑generation modules. Prompt‑constructing
+  bots must receive a builder via constructor or method arguments, configured for
+  the standard local databases, e.g. `builder = ContextBuilder("bots.db",
+  "code.db", "errors.db", "workflows.db")`, then passed to `SelfCodingEngine`,
+  `QuickFixEngine`, `Watchdog` or `AutomatedReviewer`
   ([docs/context_builder.md](docs/context_builder.md))
 - Optional RabbitMQ integration via `UnifiedEventBus(rabbitmq_host=...)`
 - Schema migrations managed through Alembic
@@ -2115,10 +2115,12 @@ from menace.workflow_evolution_bot import WorkflowEvolutionBot
 from menace.trending_scraper import TrendingScraper
 from vector_service import ContextBuilder
 
+# supply an explicit builder for downstream modules
+builder = ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
 creator = BotCreationBot(
     workflow_bot=WorkflowEvolutionBot(),
     trending_scraper=TrendingScraper(),
-    context_builder=ContextBuilder(),
+    context_builder=builder,
 )
 # tasks is a list of PlanningTask objects
 creator.create_bots(tasks)

--- a/docs/chaos_testing.md
+++ b/docs/chaos_testing.md
@@ -4,9 +4,10 @@
 
 ```python
 from menace.chaos_scheduler import ChaosScheduler
-from menace.watchdog import Watchdog, get_default_context_builder
+from menace.watchdog import Watchdog
+from vector_service import ContextBuilder
 
-builder = get_default_context_builder()
+builder = ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
 scheduler = ChaosScheduler(
     processes=[proc],
     bots=[bot],
@@ -16,7 +17,7 @@ scheduler = ChaosScheduler(
 )
 scheduler.start()
 ```
-
+`Watchdog` receives the builder via the `context_builder` argument.
 When a fault is injected the scheduler calls `Watchdog.record_fault()` which logs the event and checks if the provided bot recovered via `ChaosTester.validate_recovery()`. Fault history is stored in-memory and included when operators gather diagnostics.
 
 Failed workflows can also be replayed once issues are resolved. Pass the `workflow` name to

--- a/docs/context_builder.md
+++ b/docs/context_builder.md
@@ -16,8 +16,12 @@ block that fits within strict token budgets.
 ## Configuration
 
 ```python
-from menace.context_builder import ContextBuilder
+from vector_service import ContextBuilder
 
+# explicit construction for the standard local databases
+builder = ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
+
+# configuration with optional tuning
 builder = ContextBuilder(
     error_db="errors.db",
     bot_db="bots.db",
@@ -95,19 +99,16 @@ summariser also operates offline, so even without the optional memory manager
 
 ## Integration
 
-`SelfCodingEngine`, `QuickFixEngine` and `BotDevelopmentBot` instantiate
-`ContextBuilder` automatically when available to enrich their prompts with
-historical context. `AutomatedReviewer` now requires an explicit
-`ContextBuilder` instance to provide similar context during reviews. All
-prompt‑constructing bots must supply a builder configured for the standard
-local databases:
+`SelfCodingEngine`, `QuickFixEngine`, `BotDevelopmentBot`, `PromptEngine`,
+`AutomatedReviewer` and `Watchdog` expect a `ContextBuilder` to be supplied via
+constructor or method arguments.  Instantiate the builder with the standard
+databases and pass it through explicitly:
 
 ```python
-from vector_service.context_builder_utils import get_default_context_builder
+from vector_service import ContextBuilder
 
-builder = get_default_context_builder()
-# equivalent to:
-# ContextBuilder(bot_db="bots.db", code_db="code.db", error_db="errors.db", workflow_db="workflows.db")
+builder = ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
+# e.g. engine = SelfCodingEngine(..., context_builder=builder)
 ```
 
 ## Static enforcement
@@ -138,10 +139,10 @@ through explicitly:
 
 ```python
 from menace_sandbox.chatgpt_idea_bot import build_prompt
-from vector_service.context_builder_utils import get_default_context_builder
+from vector_service import ContextBuilder
 
 def my_prompt(client):
-    builder = get_default_context_builder()
+    builder = ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
     # static check fails if ``context_builder`` is omitted
     return build_prompt(client, context_builder=builder, tags=["ai", "fintech"])
 ```

--- a/docs/monitoring_pipeline.md
+++ b/docs/monitoring_pipeline.md
@@ -67,20 +67,17 @@ writes the runbook to `/tmp/watchdog_runbook_<epoch>.json` and the path is attac
 to the alert. The unique runbook ID returned by the protocol is logged for traceability.
 
 ```python
-from menace.watchdog import (
-    Watchdog,
-    Notifier,
-    get_default_context_builder,
-)
+from menace.watchdog import Watchdog, Notifier
+from vector_service import ContextBuilder
 
 notifier = Notifier(slack_webhook="https://hooks.slack.com/services/TOKEN")
-builder = get_default_context_builder()
+builder = ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
 watchdog = Watchdog(
     err_db, roi_db, metrics_db, notifier=notifier, context_builder=builder
 )
 watchdog.check()
 ```
-
+`Watchdog` requires a `ContextBuilder` supplied via the `context_builder` argument.
 The `Watchdog` logs the generated runbook ID whenever an escalation occurs so
 operators can easily cross-reference alerts with archived runbooks.
 

--- a/docs/prompt_engine.md
+++ b/docs/prompt_engine.md
@@ -8,9 +8,9 @@ formats them into reusable snippets.
 
 ```python
 from prompt_engine import PromptEngine
-from vector_service.context_builder_utils import get_default_context_builder
+from vector_service import ContextBuilder
 
-builder = get_default_context_builder()
+builder = ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
 prompt = PromptEngine.construct_prompt(
     "Fix the failing parser",
     retry_trace="Traceback: ValueError",
@@ -20,9 +20,9 @@ prompt = PromptEngine.construct_prompt(
 print(prompt)
 ```
 
-All prompt‑constructing bots should use this helper or instantiate
-`ContextBuilder(bot_db="bots.db", code_db="code.db", error_db="errors.db",
-workflow_db="workflows.db")` directly so prompts include vector context.
+All prompt‑constructing bots (e.g., `SelfCodingEngine`, `QuickFixEngine`) must
+provide a `ContextBuilder` via the `context_builder` argument so prompts include
+vector context.
 
 A successful lookup yields a prompt such as:
 


### PR DESCRIPTION
## Summary
- Document explicit ContextBuilder construction for standard databases
- Require bots to accept a ContextBuilder via constructor or method arguments
- Remove recommendations to use get_default_context_builder and update examples

## Testing
- `PYTHONPATH=. pre-commit run --files README.md docs/chaos_testing.md docs/context_builder.md docs/monitoring_pipeline.md docs/prompt_engine.md`

------
https://chatgpt.com/codex/tasks/task_e_68bd5fb5ae98832e998bdfc00e2dbe45