### PR TITLE
Require explicit context builder in model automation pipeline

### DIFF
--- a/contrarian_model_bot.py
+++ b/contrarian_model_bot.py
@@ -148,18 +148,20 @@ class ContrarianModelBot:
         self.innovations_db = innovations_db or InnovationsDB()
         self.info_db = info_db or InfoDB()
         self.enh_db = enhancements_db or EnhancementDB()
-        self.aggregator = aggregator or ResearchAggregatorBot([], info_db=self.info_db, enhancements_db=self.enh_db)
+        builder = ContextBuilder(
+            bot_db="bots.db",
+            code_db="code.db",
+            error_db="errors.db",
+            workflow_db="workflows.db",
+        )
+        builder.refresh_db_weights()
+        self.aggregator = aggregator or ResearchAggregatorBot(
+            [], info_db=self.info_db, enhancements_db=self.enh_db, context_builder=builder
+        )
         self.prediction_manager = prediction_manager
         self.data_bot = data_bot
         self.strategy_bot = strategy_bot or StrategyPredictionBot()
         if allocator is None:
-            builder = ContextBuilder(
-                bot_db="bots.db",
-                code_db="code.db",
-                error_db="errors.db",
-                workflow_db="workflows.db",
-            )
-            builder.refresh_db_weights()
             allocator = ResourceAllocationBot(context_builder=builder)
         self.allocator = allocator
         self.contrarian_db = contrarian_db or ContrarianDB()

--- a/docs/implementation_pipeline.md
+++ b/docs/implementation_pipeline.md
@@ -93,8 +93,9 @@ If the key is absent the fallback is skipped entirely.
 
 ```python
 from menace.research_aggregator_bot import ResearchAggregatorBot
+from vector_service import ContextBuilder
 
-researcher = ResearchAggregatorBot(["security", "optimisation"])
+researcher = ResearchAggregatorBot(["security", "optimisation"], context_builder=ContextBuilder())
 ```
 Start the helper FastAPI app in `stage3_service.py` to collect these findings.
 Set ``STAGE3_URL`` to the endpoint (for the default port use

--- a/docs/sandbox_self_improvement.md
+++ b/docs/sandbox_self_improvement.md
@@ -48,9 +48,10 @@ PY
 ```python
 from self_improvement.api import SelfImprovementEngine
 from model_automation_pipeline import ModelAutomationPipeline
+from vector_service import ContextBuilder
 
 engine = SelfImprovementEngine(bot_name="alpha",
-                               pipeline=ModelAutomationPipeline())
+                               pipeline=ModelAutomationPipeline(context_builder=ContextBuilder()))
 engine.run_cycle()
 ```
 

--- a/docs/self_improvement_engine.md
+++ b/docs/self_improvement_engine.md
@@ -7,10 +7,11 @@ import os
 from dynamic_path_router import resolve_path
 from menace.self_improvement.api import SelfImprovementEngine, ImprovementEngineRegistry
 from menace.model_automation_pipeline import ModelAutomationPipeline
+from vector_service import ContextBuilder
 
 engine = SelfImprovementEngine(
     bot_name="alpha",
-    pipeline=ModelAutomationPipeline(),
+    pipeline=ModelAutomationPipeline(context_builder=ContextBuilder()),
     state_path=resolve_path(f"{os.getenv('SANDBOX_DATA_DIR', 'sandbox_data')}/alpha_state.json"),
 )
 registry = ImprovementEngineRegistry()
@@ -558,9 +559,14 @@ Provide it with a `CapitalManagementBot`, a `DataBot` and a factory function
 that returns a new `SelfImprovementEngine` for a given name:
 
 ```python
+from vector_service import ContextBuilder
+
+
 def factory(name: str) -> SelfImprovementEngine:
-    return SelfImprovementEngine(bot_name=name,
-                                 pipeline=ModelAutomationPipeline())
+    return SelfImprovementEngine(
+        bot_name=name,
+        pipeline=ModelAutomationPipeline(context_builder=ContextBuilder()),
+    )
 
 registry = ImprovementEngineRegistry()
 registry.register_engine("alpha", factory("alpha"))

--- a/experiment_manager.py
+++ b/experiment_manager.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 from .model_automation_pipeline import ModelAutomationPipeline, AutomationResult
+from vector_service import ContextBuilder
 from .data_bot import DataBot
 from .capital_management_bot import CapitalManagementBot
 from .prediction_manager_bot import PredictionManager
@@ -45,7 +46,19 @@ class ExperimentManager:
     ) -> None:
         self.data_bot = data_bot
         self.capital_bot = capital_bot
-        self.pipeline = pipeline or ModelAutomationPipeline()
+        if pipeline is None:
+            builder = ContextBuilder()
+            try:
+                builder.refresh_db_weights()
+            except Exception:
+                pass
+            self.pipeline = ModelAutomationPipeline(
+                data_bot=self.data_bot,
+                capital_manager=self.capital_bot,
+                context_builder=builder,
+            )
+        else:
+            self.pipeline = pipeline
         self.prediction_manager = prediction_manager
         self.experiment_db = experiment_db or ExperimentHistoryDB()
         self.p_threshold = p_threshold

--- a/menace_orchestrator.py
+++ b/menace_orchestrator.py
@@ -225,8 +225,11 @@ class MenaceOrchestrator:
             )
         db_router.GLOBAL_ROUTER = router
         self.router = router
+        builder = get_default_context_builder()
         self.pipeline = ModelAutomationPipeline(
-            pathway_db=pathway_db, myelination_threshold=myelination_threshold
+            pathway_db=pathway_db,
+            myelination_threshold=myelination_threshold,
+            context_builder=builder,
         )
         self.pathway_db = pathway_db
         self.myelination_threshold = myelination_threshold

--- a/sandbox_runner.py
+++ b/sandbox_runner.py
@@ -955,7 +955,7 @@ def _sandbox_init(
     from menace.model_automation_pipeline import ModelAutomationPipeline
 
     quick_manager = SelfCodingManager(
-        engine, ModelAutomationPipeline(), bot_name="menace"
+        engine, ModelAutomationPipeline(context_builder=context_builder), bot_name="menace"
     )
     quick_fix_engine = QuickFixEngine(
         telem_db, quick_manager, graph=graph, context_builder=context_builder

--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -371,6 +371,7 @@ from ..model_automation_pipeline import (
     ModelAutomationPipeline,
     AutomationResult,
 )
+from vector_service import ContextBuilder
 from ..diagnostic_manager import DiagnosticManager
 from ..error_bot import ErrorBot, ErrorDB
 from ..data_bot import MetricsDB, DataBot
@@ -547,9 +548,18 @@ class SelfImprovementEngine:
         self.interval = interval
         self.bot_name = bot_name
         self.info_db = info_db or InfoDB()
-        self.aggregator = ResearchAggregatorBot([bot_name], info_db=self.info_db)
+        builder = ContextBuilder()
+        try:
+            builder.refresh_db_weights()
+        except Exception:
+            pass
+        self.aggregator = ResearchAggregatorBot(
+            [bot_name], info_db=self.info_db, context_builder=builder
+        )
         self.pipeline = pipeline or ModelAutomationPipeline(
-            aggregator=self.aggregator, action_planner=action_planner
+            aggregator=self.aggregator,
+            action_planner=action_planner,
+            context_builder=builder,
         )
         self.action_planner = action_planner
         err_bot = ErrorBot(ErrorDB(), MetricsDB())

--- a/tests/test_experiment_manager.py
+++ b/tests/test_experiment_manager.py
@@ -1,6 +1,26 @@
+import os
 import types
 import sys
 import asyncio
+from pathlib import Path
+
+os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
+
+vs = types.ModuleType("vector_service")
+class DummyBuilder:
+    def __init__(self, *a, **k):
+        pass
+    def refresh_db_weights(self):
+        pass
+vs.ContextBuilder = DummyBuilder
+vs.CognitionLayer = object
+sys.modules["vector_service"] = vs
+
+menace_pkg = types.ModuleType("menace")
+menace_pkg.__path__ = [str(Path(__file__).resolve().parent.parent)]
+menace_pkg.RAISE_ERRORS = False
+sys.modules["menace"] = menace_pkg
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 dummy_mods = {
     'menace.model_automation_pipeline': types.SimpleNamespace(ModelAutomationPipeline=object, AutomationResult=object),

--- a/tests/test_logging_updates.py
+++ b/tests/test_logging_updates.py
@@ -118,8 +118,8 @@ def test_pipeline_prime_logging(caplog):
         from menace.research_aggregator_bot import ResearchAggregatorBot
     except Exception:
         pytest.skip("pipeline import failed")
-    agg = ResearchAggregatorBot([])
     builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
+    agg = ResearchAggregatorBot([], context_builder=builder)
     pipeline = mapl.ModelAutomationPipeline(aggregator=agg, context_builder=builder)
 
     class BadBot:

--- a/tests/test_model_allocation_weight.py
+++ b/tests/test_model_allocation_weight.py
@@ -1,5 +1,26 @@
+import os
 import pytest
+os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
 pytest.importorskip("networkx")
+import types
+import sys
+from pathlib import Path
+
+vs = types.ModuleType("vector_service")
+class DummyBuilder:
+    def __init__(self, *a, **k):
+        pass
+    def refresh_db_weights(self):
+        pass
+vs.ContextBuilder = DummyBuilder
+vs.CognitionLayer = object
+sys.modules["vector_service"] = vs
+
+menace_pkg = types.ModuleType("menace")
+menace_pkg.__path__ = [str(Path(__file__).resolve().parent.parent)]
+menace_pkg.RAISE_ERRORS = False
+sys.modules["menace"] = menace_pkg
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 import menace.model_automation_pipeline as mapl  # noqa: E402
 import menace.research_aggregator_bot as rab  # noqa: E402
@@ -35,7 +56,9 @@ def _setup_pipeline(pathway):
     builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
     return mapl.ModelAutomationPipeline(
         aggregator=agg,
-        synthesis_bot=isb.InformationSynthesisBot(db_url="sqlite:///:memory:"),
+        synthesis_bot=isb.InformationSynthesisBot(
+            db_url="sqlite:///:memory:", aggregator=agg
+        ),
         validator=tvb.TaskValidationBot(["model"]),
         planner=bpb.BotPlanningBot(),
         hierarchy=mapl.HierarchyAssessmentBot(),

--- a/tests/test_model_automation_pipeline.py
+++ b/tests/test_model_automation_pipeline.py
@@ -34,7 +34,9 @@ def test_pipeline_runs(tmp_path):
     builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
     pipeline = mapl.ModelAutomationPipeline(
         aggregator=agg,
-        synthesis_bot=isb.InformationSynthesisBot(db_url="sqlite:///:memory:"),
+        synthesis_bot=isb.InformationSynthesisBot(
+            db_url="sqlite:///:memory:", aggregator=agg
+        ),
         validator=tvb.TaskValidationBot(["model"]),
         planner=bpb.BotPlanningBot(),
         hierarchy=mapl.HierarchyAssessmentBot(),
@@ -58,7 +60,9 @@ def test_reuse_granular(monkeypatch, tmp_path):
     builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
     pipeline = mapl.ModelAutomationPipeline(
         aggregator=agg,
-        synthesis_bot=isb.InformationSynthesisBot(db_url="sqlite:///:memory:"),
+        synthesis_bot=isb.InformationSynthesisBot(
+            db_url="sqlite:///:memory:", aggregator=agg
+        ),
         validator=tvb.TaskValidationBot(["model"]),
         planner=bpb.BotPlanningBot(),
         hierarchy=mapl.HierarchyAssessmentBot(),

--- a/tests/test_model_automation_pipeline_memory.py
+++ b/tests/test_model_automation_pipeline_memory.py
@@ -1,5 +1,26 @@
+import os
 import pytest
+os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
 pytest.importorskip("networkx")
+import types
+import sys
+from pathlib import Path
+
+vs = types.ModuleType("vector_service")
+class DummyBuilder:
+    def __init__(self, *a, **k):
+        pass
+    def refresh_db_weights(self):
+        pass
+vs.ContextBuilder = DummyBuilder
+vs.CognitionLayer = object
+sys.modules["vector_service"] = vs
+
+menace_pkg = types.ModuleType("menace")
+menace_pkg.__path__ = [str(Path(__file__).resolve().parent.parent)]
+menace_pkg.RAISE_ERRORS = False
+sys.modules["menace"] = menace_pkg
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 import menace.model_automation_pipeline as mapl  # noqa: E402
 import menace.research_aggregator_bot as rab  # noqa: E402
 import menace.task_handoff_bot as thb  # noqa: E402
@@ -35,7 +56,9 @@ def test_memory_search_called(monkeypatch, tmp_path):
     builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
     pipeline = mapl.ModelAutomationPipeline(
         aggregator=agg,
-        synthesis_bot=isb.InformationSynthesisBot(db_url="sqlite:///:memory:"),
+        synthesis_bot=isb.InformationSynthesisBot(
+            db_url="sqlite:///:memory:", aggregator=agg
+        ),
         validator=tvb.TaskValidationBot(["model"]),
         planner=bpb.BotPlanningBot(),
         hierarchy=mapl.HierarchyAssessmentBot(),

--- a/tests/test_pipeline_graph_save.py
+++ b/tests/test_pipeline_graph_save.py
@@ -1,6 +1,27 @@
+import os
 import pytest
 
+os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
 pytest.importorskip("networkx")
+import types
+import sys
+from pathlib import Path
+
+vs = types.ModuleType("vector_service")
+class DummyBuilder:
+    def __init__(self, *a, **k):
+        pass
+    def refresh_db_weights(self):
+        pass
+vs.ContextBuilder = DummyBuilder
+vs.CognitionLayer = object
+sys.modules["vector_service"] = vs
+
+menace_pkg = types.ModuleType("menace")
+menace_pkg.__path__ = [str(Path(__file__).resolve().parent.parent)]
+menace_pkg.RAISE_ERRORS = False
+sys.modules["menace"] = menace_pkg
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 import menace.model_automation_pipeline as mapl  # noqa: E402
 import menace.research_aggregator_bot as rab  # noqa: E402
@@ -27,7 +48,9 @@ def test_pipeline_calls_save(monkeypatch, tmp_path):
     builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
     pipeline = mapl.ModelAutomationPipeline(
         aggregator=agg,
-        synthesis_bot=isb.InformationSynthesisBot(db_url="sqlite:///:memory:"),
+        synthesis_bot=isb.InformationSynthesisBot(
+            db_url="sqlite:///:memory:", aggregator=agg
+        ),
         validator=tvb.TaskValidationBot(["model"]),
         planner=bpb.BotPlanningBot(),
         hierarchy=mapl.HierarchyAssessmentBot(),

--- a/tests/test_self_coding_manager_thresholds.py
+++ b/tests/test_self_coding_manager_thresholds.py
@@ -1,8 +1,27 @@
+import os
 import pytest
 import sys
 import types
 import subprocess
 import tempfile
+from pathlib import Path
+os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
+
+vs = types.ModuleType("vector_service")
+class DummyBuilder:
+    def __init__(self, *a, **k):
+        pass
+    def refresh_db_weights(self):
+        pass
+vs.ContextBuilder = DummyBuilder
+vs.CognitionLayer = object
+sys.modules["vector_service"] = vs
+
+menace_pkg = types.ModuleType("menace")
+menace_pkg.__path__ = [str(Path(__file__).resolve().parent.parent)]
+menace_pkg.RAISE_ERRORS = False
+sys.modules["menace"] = menace_pkg
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 import shutil
 from pathlib import Path
 
@@ -83,7 +102,8 @@ def test_dynamic_confidence_threshold_blocks_merge(monkeypatch, tmp_path):
     mdb = db.MetricsDB(tmp_path / "m.db")
     data_bot = db.DataBot(mdb, evolution_db=hist)
     engine = DummyEngine()
-    pipeline = mapl.ModelAutomationPipeline()
+    builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
+    pipeline = mapl.ModelAutomationPipeline(context_builder=builder)
     mgr = scm.SelfCodingManager(engine, pipeline, bot_name="bot", data_bot=data_bot)
     mgr.baseline_tracker.update(confidence=0.9)
 

--- a/tests/test_self_improvement_engine.py
+++ b/tests/test_self_improvement_engine.py
@@ -4,6 +4,27 @@ import sys
 import pytest
 import asyncio
 
+os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
+import types
+
+from pathlib import Path
+
+vs = types.ModuleType("vector_service")
+class DummyBuilder:
+    def __init__(self, *a, **k):
+        pass
+    def refresh_db_weights(self):
+        pass
+vs.ContextBuilder = DummyBuilder
+vs.CognitionLayer = object
+sys.modules["vector_service"] = vs
+
+menace_pkg = types.ModuleType("menace")
+menace_pkg.__path__ = [str(Path(__file__).resolve().parent.parent)]
+menace_pkg.RAISE_ERRORS = False
+sys.modules["menace"] = menace_pkg
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
 import json
 from pathlib import Path
 import types
@@ -414,7 +435,8 @@ def test_run_cycle(tmp_path, monkeypatch):
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
     diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
-    agg = rab.ResearchAggregatorBot(["menace"], info_db=info)
+    builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
+    agg = rab.ResearchAggregatorBot(["menace"], info_db=info, context_builder=builder)
     class StubPipeline:
         def run(self, model: str, energy: int = 1):
             return mp.AutomationResult(

--- a/unit_tests/test_self_coding_manager_failed_tags.py
+++ b/unit_tests/test_self_coding_manager_failed_tags.py
@@ -29,6 +29,7 @@ sys.modules.setdefault("vector_service", vec_mod)
 # Minimal menace package to avoid executing heavy __init__
 menace_pkg = types.ModuleType("menace")
 menace_pkg.__path__ = [str(Path(__file__).resolve().parent.parent)]
+menace_pkg.RAISE_ERRORS = False
 sys.modules.setdefault("menace", menace_pkg)
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
@@ -42,6 +43,9 @@ class AutomationResult:
     def __init__(self, roi=None):
         self.roi = roi
 class ModelAutomationPipeline:
+    def __init__(self, *a, **k):
+        pass
+
     def run(self, *a, **k):
         return AutomationResult()
 mapl_mod.AutomationResult = AutomationResult
@@ -120,7 +124,8 @@ def test_failed_tags_recorded(monkeypatch, tmp_path):
             return 1, False, 0.0
 
     engine = Engine()
-    pipeline = ModelAutomationPipeline()
+    builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
+    pipeline = ModelAutomationPipeline(context_builder=builder)
     mgr = scm.SelfCodingManager(engine, pipeline)
 
     # ensure clone path exists and file copied during git clone


### PR DESCRIPTION
## Summary
- require a ContextBuilder when constructing ModelAutomationPipeline and wire it through sub-bots
- pass ContextBuilder from callers like MenaceOrchestrator, ExperimentManager, sandbox runner, and self-improvement engine
- update docs, tests, and related utilities for the new requirement

## Testing
- `pytest tests/test_model_automation_pipeline.py tests/test_model_automation_pipeline_memory.py tests/test_planning_trust_weight.py tests/test_model_allocation_weight.py tests/test_logging_updates.py tests/test_self_coding_manager_thresholds.py unit_tests/test_self_coding_manager_failed_tags.py tests/test_pipeline_graph_save.py tests/test_self_improvement_engine.py tests/test_experiment_manager.py` *(fails: vector_service import failed)*
- `pytest tests/test_logging_updates.py` *(fails: vector_service import failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd63f5fcc4832eb47b6a12fe69504f