### PR TITLE
Require explicit context builder for chat completions

### DIFF
--- a/billing/openai_wrapper.py
+++ b/billing/openai_wrapper.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 
 This module exposes :func:`chat_completion_create` which mirrors
 ``openai.ChatCompletion.create`` but automatically prepends
-:data:`~stripe_policy.PAYMENT_ROUTER_NOTICE` to the ``messages`` list.
-It allows passing a custom ``openai_client`` for easy testing.
+:data:`~stripe_policy.PAYMENT_ROUTER_NOTICE` to the ``messages`` list and
+appends compressed retrieval context.  The wrapper requires a
+``ContextBuilder`` instance and will raise a descriptive error when one is
+not supplied.  A custom ``openai_client`` can be provided for easy testing.
 """
 
+import json
 from typing import Any, Dict, List, Optional
 
 from vector_service.context_builder import ContextBuilder
+from snippet_compressor import compress_snippets
 
 from resilience import retry_with_backoff
 from sandbox_settings import SandboxSettings
@@ -26,21 +30,29 @@ def chat_completion_create(
     messages: List[Dict[str, str]],
     *,
     openai_client: Optional[Any] = None,
-    context_builder: ContextBuilder | None = None,
+    context_builder: ContextBuilder,
     **kwargs: Any,
 ) -> Any:
     """Proxy ``openai.ChatCompletion.create`` with payment notice injection."""
 
+    if context_builder is None:
+        raise TypeError("context_builder is required for chat_completion_create")
+
     client = openai_client or openai
     if client is None:  # pragma: no cover - import guard
         raise RuntimeError("openai library not available")
+
     msgs = prepend_payment_notice(messages)
-    if context_builder is not None and messages:
-        ctx = context_builder.build(messages[-1]["content"])
-        if isinstance(ctx, dict):
-            msgs.append(ctx)
-        else:
-            msgs.append({"role": "system", "content": ctx})
+
+    # Build retrieval context from the latest user message and compress it
+    query = messages[-1]["content"] if messages else ""
+    ctx_res = context_builder.build(query)
+    ctx = ctx_res[0] if isinstance(ctx_res, tuple) else ctx_res
+    if isinstance(ctx, (dict, list)):
+        ctx = json.dumps(ctx, separators=(",", ":"))
+    ctx = compress_snippets({"snippet": ctx}).get("snippet", ctx)
+    msgs.append({"role": "system", "content": ctx})
+
     _settings = SandboxSettings()
     delays = list(getattr(_settings, "codex_retry_delays", [2, 5, 10]))
     return retry_with_backoff(


### PR DESCRIPTION
## Summary
- enforce required `ContextBuilder` in OpenAI wrapper and append compressed context to messages
- adjust tests and utilities to pass builder explicitly
- add regression tests for wrapper behavior and builder requirement

## Testing
- `python scripts/check_context_builder_usage.py` *(fails: multiple get_default_context_builder violations)*
- `pytest tests/test_payment_notice.py tests/test_context_builder_static.py neurosales/tests/test_external_integrations.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd67cc8b2c832e95421435c079af30