### PR TITLE
Ensure ResearchAggregatorBot uses ContextBuilder

### DIFF
--- a/model_automation_pipeline.py
+++ b/model_automation_pipeline.py
@@ -155,7 +155,10 @@ class ModelAutomationPipeline:
         )
         self.workflow_db = workflow_db or WorkflowDB(event_bus=event_bus)
         self.synthesis_bot = synthesis_bot or InformationSynthesisBot(
-            aggregator=self.aggregator, workflow_db=self.workflow_db, event_bus=event_bus
+            aggregator=self.aggregator,
+            workflow_db=self.workflow_db,
+            event_bus=event_bus,
+            context_builder=self.context_builder,
         )
         self.validator = validator or TaskValidationBot([])
         self.planner = planner or BotPlanningBot()

--- a/research_aggregator_bot.py
+++ b/research_aggregator_bot.py
@@ -759,7 +759,8 @@ class ResearchAggregatorBot:
         *,
         context_builder: ContextBuilder,
     ) -> None:
-        if context_builder is None:
+        builder = context_builder
+        if builder is None:
             raise ValueError("ContextBuilder is required")
         self.requirements = list(requirements)
         self.memory = memory or ResearchMemory()
@@ -779,12 +780,12 @@ class ResearchAggregatorBot:
         self.sources_queried: List[str] = []
         self.cache_ttl = cache_ttl
         self.cache: dict[str, tuple[float, List[ResearchItem]]] = {}
-        self.context_builder = context_builder
         try:
-            self.context_builder.refresh_db_weights()
+            builder.refresh_db_weights()
         except Exception:
             logger.exception("Failed to initialise ContextBuilder")
             raise
+        self.context_builder = builder
 
     # ------------------------------------------------------------------
     def _increment_enh_count(self, model_id: int) -> None:


### PR DESCRIPTION
## Summary
- Require ContextBuilder when constructing ResearchAggregatorBot and refresh database weights up front
- Thread ContextBuilder through InformationSynthesisBot and ModelAutomationPipeline
- Update tests to supply stub ContextBuilder instances

## Testing
- `pytest tests/test_research_aggregator_bot.py -q`
- `pytest tests/test_research_aggregator_bot.py tests/test_information_synthesis_bot.py tests/test_model_automation_pipeline.py -q` *(fails: vector_service import failed)*


------
https://chatgpt.com/codex/tasks/task_e_68bd6b76f8cc832eb5d05e416ef65b9c