### PR TITLE
Ensure ContextBuilder is explicitly provided to prompt engine

### DIFF
--- a/prompt_engine.py
+++ b/prompt_engine.py
@@ -300,6 +300,8 @@ class PromptEngine:
         return self.chunk_summary_cache_dir
 
     def __post_init__(self) -> None:  # pragma: no cover - lightweight setup
+        if self.context_builder is None:
+            raise ValueError("PromptEngine requires a ContextBuilder instance")
         try:
             self.template_path = resolve_path(self.template_path)
         except Exception:
@@ -1293,6 +1295,8 @@ class PromptEngine:
         strategy: str | None = None,
     ) -> Prompt:
         """Class method wrapper used by existing callers and tests."""
+        if context_builder is None:
+            raise ValueError("context_builder is required")
 
         return build_prompt(
             goal,
@@ -1338,6 +1342,8 @@ def build_prompt(
     strategy: str | None = None,
 ) -> Prompt:
     """Convenience helper to build a :class:`Prompt` without instantiating ``PromptEngine``."""
+    if context_builder is None:
+        raise ValueError("context_builder is required")
 
     engine = PromptEngine(
         retriever=retriever,


### PR DESCRIPTION
## Summary
- validate `PromptEngine` instantiation requires a `ContextBuilder`
- enforce `build_prompt` helpers raise `ValueError` when no builder is supplied

## Testing
- `python -m py_compile prompt_engine.py`
- ⚠️ `pytest tests/test_context_builder_static.py::test_flags_missing_context_builder -q` *(failed: heavy dependency import chain)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6d438fc4832e9eeeb657aa0f5b6d