### PR TITLE
feat: allow custom context builder in launch pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,9 @@ bucket is configured or run as a limited pilot.
 - Synergy-aware environment presets adapt CPU, memory, bandwidth and threat levels ([docs/environment_generator.md](docs/environment_generator.md))
 - Sandboxed self-debugging using `SelfDebuggerSandbox` (invoked by `launch_menace_bots.py` after the test run)
 - Comprehensive build pipeline in `launch_menace_bots.py` that plans,
-  develops, tests and scales bots before deployment
+  develops, tests and scales bots before deployment.  The CLI constructs a
+  default `ContextBuilder` and passes it to `debug_and_deploy` so callers can
+  supply custom builders if needed.
 - Automated implementation pipeline turning tasks into runnable bots ([docs/implementation_pipeline.md](docs/implementation_pipeline.md))
 - Models repository workflow with visual agents ([docs/models_repo_workflow.md](docs/models_repo_workflow.md))
 - Retirement of underperforming models by `ModelPerformanceMonitor`


### PR DESCRIPTION
## Summary
- accept a ContextBuilder in `debug_and_deploy` and refresh its weights
- pass ContextBuilder from CLI entry point and document the new argument
- update tests for the new parameter

## Testing
- `pytest tests/test_launch_menace_bots.py::test_debug_and_deploy_runs_sandbox -q` *(fails: ImportError: cannot import name 'CodeDB' from 'code_database')*

------
https://chatgpt.com/codex/tasks/task_e_68bd7a707fe0832eaec81fb9046f4b34