### PR TITLE
Require explicit context builder for SelfDebuggerSandbox

### DIFF
--- a/launch_menace_bots.py
+++ b/launch_menace_bots.py
@@ -198,8 +198,9 @@ def debug_and_deploy(
                     pass
 
         SelfDebuggerSandbox = _SelfDebuggerSandbox
-    sandbox = SelfDebuggerSandbox(_TelemProxy(error_db), engine)
-    sandbox.context_builder = context_builder
+    sandbox = SelfDebuggerSandbox(
+        _TelemProxy(error_db), engine, context_builder=context_builder
+    )
     try:
         deployer = DeploymentBot(
             code_db=code_db,

--- a/sandbox_runner.py
+++ b/sandbox_runner.py
@@ -980,10 +980,10 @@ def _sandbox_init(
     sandbox = SelfDebuggerSandbox(
         _TelemProxy(telem_db),
         engine,
+        context_builder=context_builder,
         policy=policy,
         state_getter=improver._policy_state,
     )
-    sandbox.context_builder = context_builder
     sandbox.error_logger = error_logger
     sandbox.error_forecaster = forecaster
     sandbox.quick_fix_engine = quick_fix_engine

--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -7152,9 +7152,11 @@ def run_repo_section_simulations(
                 builder.refresh_db_weights()
                 debugger = SelfDebuggerSandbox(
                     object(),
-                    SelfCodingEngine(CodeDB(), MenaceMemoryManager(), context_builder=builder),
+                    SelfCodingEngine(
+                        CodeDB(), MenaceMemoryManager(), context_builder=builder
+                    ),
+                    context_builder=builder,
                 )
-                debugger.context_builder = builder
                 try:
                     for sec_name, lines in sec_map.items():
                         code_str = "\n".join(lines)
@@ -8316,9 +8318,11 @@ def run_workflow_simulations(
                 builder.refresh_db_weights()
                 debugger = SelfDebuggerSandbox(
                     object(),
-                    SelfCodingEngine(CodeDB(), MenaceMemoryManager(), context_builder=builder),
+                    SelfCodingEngine(
+                        CodeDB(), MenaceMemoryManager(), context_builder=builder
+                    ),
+                    context_builder=builder,
                 )
-                debugger.context_builder = builder
                 mod_name = _module_from_step(step)
                 for preset in all_presets:
                     scenario = preset.get("SCENARIO_NAME", "")

--- a/tests/integration/test_full_cycle_failure_recovery.py
+++ b/tests/integration/test_full_cycle_failure_recovery.py
@@ -6,7 +6,7 @@ import types
 import pytest
 
 from tests.test_self_test_service import mod as sts
-from tests.test_self_debugger_sandbox import sds, DummyTelem, DummyTrail
+from tests.test_self_debugger_sandbox import sds, DummyTelem, DummyTrail, DummyBuilder
 from tests.test_self_debugger_patch_flow import FlowEngine
 
 
@@ -79,7 +79,9 @@ def test_full_cycle_failure_and_recovery(monkeypatch, tmp_path, caplog):
     # ---- SelfDebuggerSandbox: failing subprocess then recovery ----
     engine = FlowEngine()
     trail = DummyTrail()
-    dbg = sds.SelfDebuggerSandbox(DummyTelem(), engine, audit_trail=trail)
+    dbg = sds.SelfDebuggerSandbox(
+        DummyTelem(), engine, context_builder=DummyBuilder(), audit_trail=trail
+    )
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(dbg, "_generate_tests", lambda logs: ["def test_ok():\n    assert True\n"])

--- a/tests/test_alignment_warnings.py
+++ b/tests/test_alignment_warnings.py
@@ -1,4 +1,5 @@
 from menace import quick_fix_engine, self_debugger_sandbox, human_alignment_agent, violation_logger
+from tests.test_self_debugger_sandbox import DummyBuilder
 from pathlib import Path
 
 
@@ -64,7 +65,10 @@ def test_self_debugger_preemptive_patch_logs_warning(tmp_path, monkeypatch):
             return [str(src)]
 
     sandbox = self_debugger_sandbox.SelfDebuggerSandbox(
-        object(), object(), error_predictor=Predictor()
+        object(),
+        object(),
+        context_builder=DummyBuilder(),
+        error_predictor=Predictor(),
     )
     sandbox.preemptive_fix_high_risk_modules(limit=1)
     assert logs, "expected alignment warning logged"

--- a/tests/test_context_feedback_logging.py
+++ b/tests/test_context_feedback_logging.py
@@ -154,7 +154,6 @@ _spec = importlib.util.spec_from_file_location('menace.self_debugger_sandbox', P
 sds = importlib.util.module_from_spec(_spec)
 assert _spec.loader is not None
 _spec.loader.exec_module(sds)
-sds.CONTEXT_BUILDER = _CB()
 
 
 class DummyTelem:
@@ -177,8 +176,9 @@ def test_context_feedback_logs_malformed_metadata(monkeypatch, caplog):
             pass
 
     monkeypatch.setattr(sds, 'ContextBuilder', DummyBuilder)
-    sds.CONTEXT_BUILDER = DummyBuilder()
-    dbg = sds.SelfDebuggerSandbox(DummyTelem(), DummyEngine())
+    dbg = sds.SelfDebuggerSandbox(
+        DummyTelem(), DummyEngine(), context_builder=DummyBuilder()
+    )
     report = types.SimpleNamespace(trace='x')
 
     with caplog.at_level(logging.ERROR, logger='AutomatedDebugger'):

--- a/tests/test_patch_score_backend.py
+++ b/tests/test_patch_score_backend.py
@@ -1,7 +1,13 @@
 import types
 import types
 import logging
-from tests.test_self_debugger_sandbox import DummyTelem, DummyEngine, DummyTrail
+from tests.test_self_debugger_sandbox import (
+    sds,
+    DummyTelem,
+    DummyEngine,
+    DummyTrail,
+    DummyBuilder,
+)
 import patch_score_backend as psb
 
 
@@ -301,7 +307,9 @@ def test_sandbox_backend_retries(monkeypatch, tmp_path):
     import time as _time
     monkeypatch.setattr(_time, "sleep", lambda *_: None)
 
-    dbg = sds.SelfDebuggerSandbox(DummyTelem(), DummyEngine(), audit_trail=DummyTrail())
+    dbg = sds.SelfDebuggerSandbox(
+        DummyTelem(), DummyEngine(), context_builder=DummyBuilder(), audit_trail=DummyTrail()
+    )
     dbg._log_patch("d", "ok")
     rows = dbg.recent_scores(1)
 
@@ -324,7 +332,9 @@ def test_sandbox_backend_unreachable_warns(monkeypatch, caplog, tmp_path):
     import time as _time
     monkeypatch.setattr(_time, "sleep", lambda *_: None)
 
-    dbg = sds.SelfDebuggerSandbox(DummyTelem(), DummyEngine(), audit_trail=DummyTrail())
+    dbg = sds.SelfDebuggerSandbox(
+        DummyTelem(), DummyEngine(), context_builder=DummyBuilder(), audit_trail=DummyTrail()
+    )
     caplog.set_level(logging.WARNING)
     dbg._log_patch("d", "ok")
     rows = dbg.recent_scores(1)

--- a/tests/test_post_round_orphan_scan_invocations.py
+++ b/tests/test_post_round_orphan_scan_invocations.py
@@ -153,7 +153,12 @@ sandbox_stub.__path__ = [str(Path(__file__).resolve().parents[1] / "sandbox_runn
 sandbox_stub.post_round_orphan_scan = lambda *a, **k: ([], True, True)
 sys.modules.setdefault("sandbox_runner", sandbox_stub)
 
-from tests.test_self_debugger_sandbox import sds, DummyTelem, DummyEngine  # noqa: E402
+from tests.test_self_debugger_sandbox import (
+    sds,
+    DummyTelem,
+    DummyEngine,
+    DummyBuilder,
+)  # noqa: E402
 
 
 def test_preemptive_fix_triggers_scan_once_success(monkeypatch, tmp_path):
@@ -174,7 +179,10 @@ def test_preemptive_fix_triggers_scan_once_success(monkeypatch, tmp_path):
         predict_high_risk_modules=lambda top_n=5: ["mod.py"]  # path-ignore
     )
     sandbox = sds.SelfDebuggerSandbox(
-        DummyTelem(), DummyEngine(), error_predictor=predictor
+        DummyTelem(),
+        DummyEngine(),
+        context_builder=DummyBuilder(),
+        error_predictor=predictor,
     )
 
     sandbox.preemptive_fix_high_risk_modules(limit=1)
@@ -199,7 +207,10 @@ def test_preemptive_fix_scan_failure_handled(monkeypatch, tmp_path):
         predict_high_risk_modules=lambda top_n=5: ["mod.py"]  # path-ignore
     )
     sandbox = sds.SelfDebuggerSandbox(
-        DummyTelem(), DummyEngine(), error_predictor=predictor
+        DummyTelem(),
+        DummyEngine(),
+        context_builder=DummyBuilder(),
+        error_predictor=predictor,
     )
 
     sandbox.preemptive_fix_high_risk_modules(limit=1)

--- a/tests/test_self_debugger_scoring.py
+++ b/tests/test_self_debugger_scoring.py
@@ -2,7 +2,7 @@ import types
 import logging
 import threading
 import contextlib
-from tests.test_self_debugger_sandbox import sds, DummyTelem, DummyEngine
+from tests.test_self_debugger_sandbox import sds, DummyTelem, DummyEngine, DummyBuilder
 
 
 def test_z_score_prefers_better_patch(tmp_path):
@@ -49,6 +49,7 @@ def test_z_score_prefers_better_patch(tmp_path):
     dbg = sds.SelfDebuggerSandbox(
         DummyTelem(),
         DummyEngine(),
+        context_builder=DummyBuilder(),
         score_weights=(1.0, 1.0, 1.0, 1.0, 0.0, 0.0),
         weight_update_interval=0.0,
     )
@@ -63,7 +64,12 @@ def test_z_score_prefers_better_patch(tmp_path):
 
 
 def test_complexity_penalizes_score():
-    dbg = sds.SelfDebuggerSandbox(DummyTelem(), DummyEngine(), score_weights=(1.0, 1.0, 1.0, 1.0, 0.0, 0.0))
+    dbg = sds.SelfDebuggerSandbox(
+        DummyTelem(),
+        DummyEngine(),
+        context_builder=DummyBuilder(),
+        score_weights=(1.0, 1.0, 1.0, 1.0, 0.0, 0.0),
+    )
     dbg._update_score_weights = lambda *a, **k: None
     dbg._metric_stats = {
         "coverage": (0.1, 0.05),
@@ -82,6 +88,7 @@ def test_complexity_penalizes_score():
 
 def test_entropy_penalizes_score():
     dbg = sds.SelfDebuggerSandbox.__new__(sds.SelfDebuggerSandbox)
+    dbg.context_builder = DummyBuilder()
     dbg.score_weights = (1.0, 1.0, 1.0, 1.0, 0.0, 0.0)
     dbg._baseline_tracker = types.SimpleNamespace(
         update=lambda s: (0.0, 0.0), stats=lambda: (0.0, 0.0)

--- a/tests/test_self_improvement_integration.py
+++ b/tests/test_self_improvement_integration.py
@@ -88,6 +88,7 @@ from tests.test_self_debugger_sandbox import (
     DummyTelem,
     DummyEngine,
     DummyTrail,
+    DummyBuilder,
 )
 from tests.test_self_debugger_patch_flow import FlowEngine
 from tests.test_self_improvement_logging import _load_engine
@@ -170,7 +171,9 @@ def test_self_improvement_integration(monkeypatch, tmp_path):
     # SelfDebuggerSandbox with dummy engine
     engine = FlowEngine()
     trail = DummyTrail()
-    dbg = sds.SelfDebuggerSandbox(DummyTelem(), engine, audit_trail=trail)
+    dbg = sds.SelfDebuggerSandbox(
+        DummyTelem(), engine, context_builder=DummyBuilder(), audit_trail=trail
+    )
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(dbg, "_generate_tests", lambda logs: ["def test_ok():\n    pass\n"])
     monkeypatch.setattr(sds.subprocess, "run", lambda *a, **k: None)


### PR DESCRIPTION
## Summary
- remove global `CONTEXT_BUILDER` and default fallback
- require explicit `ContextBuilder` in `SelfDebuggerSandbox` and refresh weights
- update sandbox callers and tests to pass builder explicitly
- add tests ensuring no global builder and injected builder is used

## Testing
- `pytest tests/test_self_debugger_sandbox.py -k 'builder_injected_and_refreshed or no_global_builder' tests/test_context_feedback_logging.py::test_context_feedback_logs_malformed_metadata -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd809b973c832eada3ba5f051c9a5c