### PR TITLE
Refactor watchdogs to require explicit context builders

### DIFF
--- a/tests/test_advanced_error_management.py
+++ b/tests/test_advanced_error_management.py
@@ -4,6 +4,7 @@ import subprocess  # noqa: E402
 import os  # noqa: E402
 import menace.advanced_error_management as aem  # noqa: E402
 import menace.watchdog as wd  # noqa: E402
+from vector_service.context_builder_utils import get_default_context_builder  # noqa: E402
 import menace.error_bot as eb  # noqa: E402
 import menace.resource_allocation_optimizer as rao  # noqa: E402
 import menace.data_bot as db  # noqa: E402
@@ -85,7 +86,7 @@ def test_compile_dossier_generates_playbook(tmp_path, monkeypatch):
         return str(path)
 
     monkeypatch.setattr(aem.PlaybookGenerator, "generate", fake_generate)
-    builder = wd.get_default_context_builder()
+    builder = get_default_context_builder()
     watch = wd.Watchdog(err_db, roi_db, metrics_db, context_builder=builder)
     dossier, attachments = watch.compile_dossier()
     assert any(str(tmp_path / "pb.json") == a for a in attachments)
@@ -115,7 +116,7 @@ def test_watchdog_notifications_include_playbook(tmp_path, monkeypatch):
 
     notifier = wd.Notifier()
     notifier.notify = fake_notify
-    builder = wd.get_default_context_builder()
+    builder = get_default_context_builder()
     watch = wd.Watchdog(
         err_db, roi_db, metrics_db, notifier=notifier, context_builder=builder
     )

--- a/tests/test_chaos_monitoring_service.py
+++ b/tests/test_chaos_monitoring_service.py
@@ -3,6 +3,7 @@ import sys
 import types
 import tempfile
 from pathlib import Path
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 TMP = Path(tempfile.mkdtemp())
@@ -75,3 +76,8 @@ def test_error_logged(caplog):
     caplog.set_level("ERROR")
     _run_once(svc)
     assert "auto rollback failed" in caplog.text
+
+
+def test_builder_required_when_scheduler_missing():
+    with pytest.raises(ValueError):
+        mod.ChaosMonitoringService()

--- a/tests/test_chaos_scheduler.py
+++ b/tests/test_chaos_scheduler.py
@@ -7,6 +7,7 @@ from menace.chaos_scheduler import ChaosScheduler  # noqa: E402
 from menace.chaos_tester import ChaosTester  # noqa: E402
 import menace.watchdog as wd  # noqa: E402
 import menace.error_bot as eb  # noqa: E402
+from vector_service.context_builder_utils import get_default_context_builder  # noqa: E402
 import menace.resource_allocation_optimizer as rao  # noqa: E402
 import menace.data_bot as db  # noqa: E402
 
@@ -39,7 +40,7 @@ def test_scheduler_records_fault(monkeypatch, tmp_path):
     proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(1)"])
     bot = DummyBot(proc)
     err_db, roi_db, metrics_db = _setup_dbs(tmp_path)
-    builder = wd.get_default_context_builder()
+    builder = get_default_context_builder()
     watch = wd.Watchdog(err_db, roi_db, metrics_db, context_builder=builder)
     sched = ChaosScheduler(processes=[proc], bots=[bot], interval=0, watchdog=watch)
 

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -6,6 +6,7 @@ import menace.resource_allocation_optimizer as rao  # noqa: E402
 import menace.data_bot as db  # noqa: E402
 from menace.unified_event_bus import UnifiedEventBus  # noqa: E402
 from menace.error_logger import TelemetryEvent  # noqa: E402
+from vector_service.context_builder_utils import get_default_context_builder  # noqa: E402
 from datetime import datetime, timedelta  # noqa: E402
 
 
@@ -35,7 +36,7 @@ def test_watchdog_triggers(tmp_path, monkeypatch):
 
     notifier = wd.Notifier()
     notifier.notify = fake_notify
-    builder = wd.get_default_context_builder()
+    builder = get_default_context_builder()
     watch = wd.Watchdog(
         err_db, roi_db, metrics_db, notifier=notifier, context_builder=builder
     )
@@ -57,7 +58,7 @@ def test_watchdog_no_trigger(tmp_path):
         called.append(msg)
 
     notifier.notify = fake_notify
-    builder = wd.get_default_context_builder()
+    builder = get_default_context_builder()
     watch = wd.Watchdog(
         err_db, roi_db, metrics_db, notifier=notifier, context_builder=builder
     )
@@ -82,7 +83,7 @@ def test_watchdog_heals_lost_heartbeat(tmp_path, monkeypatch):
         "SelfHealingOrchestrator",
         lambda g, backend=None: DummyHealer(),
     )
-    builder = wd.get_default_context_builder()
+    builder = get_default_context_builder()
     watch = wd.Watchdog(
         err_db, roi_db, metrics_db, registry=registry, context_builder=builder
     )
@@ -167,7 +168,7 @@ def test_watchdog_runs_debugger(tmp_path, monkeypatch):
     bus = UnifiedEventBus()
 
     monkeypatch.setattr(wd, "AutomatedDebugger", DummyDebugger)
-    builder = wd.get_default_context_builder()
+    builder = get_default_context_builder()
     watch = wd.Watchdog(
         err_db,
         roi_db,
@@ -192,7 +193,7 @@ def test_restart_logging(tmp_path, monkeypatch):
 
     monkeypatch.setattr(wd, "SelfHealingOrchestrator", lambda g, backend=None: DummyHealer())
     log = tmp_path / "r.log"
-    builder = wd.get_default_context_builder()
+    builder = get_default_context_builder()
     watch = wd.Watchdog(
         err_db,
         roi_db,
@@ -228,7 +229,7 @@ def test_failover_restart(tmp_path, monkeypatch):
 
     monkeypatch.setattr(wd.subprocess, "Popen", fake_popen)
     log = tmp_path / "r.log"
-    builder = wd.get_default_context_builder()
+    builder = get_default_context_builder()
     watch = wd.Watchdog(
         err_db,
         roi_db,

--- a/tests/test_workflow_validation.py
+++ b/tests/test_workflow_validation.py
@@ -1,6 +1,7 @@
 import pytest
 pytest.skip("optional dependencies not installed", allow_module_level=True)
 import menace.watchdog as wd  # noqa: E402
+from vector_service.context_builder_utils import get_default_context_builder  # noqa: E402
 import menace.error_bot as eb  # noqa: E402
 import menace.resource_allocation_optimizer as rao  # noqa: E402
 import menace.data_bot as db  # noqa: E402
@@ -17,7 +18,7 @@ def _setup_dbs(tmp_path):
 
 def test_replay_updates_confidence(tmp_path):
     err_db, roi_db, metrics_db = _setup_dbs(tmp_path)
-    builder = wd.get_default_context_builder()
+    builder = get_default_context_builder()
     watch = wd.Watchdog(err_db, roi_db, metrics_db, context_builder=builder)
     orch = MenaceOrchestrator(context_builder=builder)
     watch.record_fault("fail", workflow="wf1")

--- a/watchdog.py
+++ b/watchdog.py
@@ -84,20 +84,14 @@ except Exception:  # pragma: no cover - gracefully degrade in tests
 from .retry_utils import retry
 
 try:  # pragma: no cover - optional dependency
-    from vector_service import ContextBuilder, get_default_context_builder
+    from vector_service import ContextBuilder
 except Exception:  # pragma: no cover - fallback when helper missing
     try:
         from vector_service.context_builder import ContextBuilder  # type: ignore
-
-        def get_default_context_builder(**kwargs):  # type: ignore
-            return ContextBuilder(**kwargs)
     except Exception:  # pragma: no cover - last resort
         class ContextBuilder:  # type: ignore[override]
             def refresh_db_weights(self) -> None:  # pragma: no cover - stub
                 pass
-
-        def get_default_context_builder(**kwargs):  # type: ignore
-            return ContextBuilder()
 
 if TYPE_CHECKING:
     from .replay_engine import ReplayValidator


### PR DESCRIPTION
## Summary
- drop fallback `get_default_context_builder` usage in watchdogs and Stripe watchdog
- plumb `ContextBuilder` through chaos monitoring service and related paths
- test builder injection and absence of implicit defaults

## Testing
- `PYTHONPATH=.. pytest test_auto_escalation_manager.py test_advanced_error_management.py test_workflow_validation.py test_chaos_scheduler.py test_chaos_monitoring_service.py -q`
- `PYTHONPATH=.. pytest test_watchdog.py -q` (skipped: optional dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68bd83655c34832ebd5fc8677decb39d