### PR TITLE
Require explicit context builder for prompts

### DIFF
--- a/docs/prompt_evolution_memory.md
+++ b/docs/prompt_evolution_memory.md
@@ -76,8 +76,8 @@ optimizer = PromptOptimizer(
     roi_weight=1.2           # emphasise ROI in ranking
 )
 
-engine = PromptEngine(retriever=my_retriever, optimizer=optimizer)
-engine.build_prompt("add caching")
+engine = PromptEngine(context_builder=ContextBuilder(), retriever=my_retriever, optimizer=optimizer)
+engine.build_prompt("add caching", context_builder=engine.context_builder)
 ```
 
 `PromptEngine` applies the optimizer's suggestions when formatting future

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -115,6 +115,7 @@ chunks = get_chunk_summaries(Path("bots/example.py"), 800)
 prompt = engine.build_prompt(
     "refactor helper",
     summaries=[c["summary"] for c in chunks],
+    context_builder=engine.context_builder,
 )
 ```
 

--- a/prompt_engine.py
+++ b/prompt_engine.py
@@ -744,12 +744,12 @@ class PromptEngine:
         tone: str | None = None,
         strategy: str | None = None,
         target_region: TargetRegion | None = None,
-        context_builder: ContextBuilder | None = None,
+        context_builder: ContextBuilder,
     ) -> Prompt:
         """Return a :class:`Prompt` for *task* using retrieved patch examples.
 
-        ``context_builder`` overrides :attr:`self.context_builder` for a single
-        invocation.
+        ``context_builder`` supplies token counting and ROI helpers for the
+        invocation and must be provided explicitly.
 
         ``context`` and ``retrieval_context`` allow callers to prepend
         additional information such as the snippet body, repository layout or
@@ -767,7 +767,9 @@ class PromptEngine:
         static fallback template is returned.
         """
 
-        builder = context_builder or self.context_builder
+        if context_builder is None:
+            raise ValueError("context_builder is required")
+        builder = context_builder
 
         def _count(text: str) -> int:
             counter = getattr(builder, "_count_tokens", None)

--- a/tests/test_build_prompt_summaries.py
+++ b/tests/test_build_prompt_summaries.py
@@ -17,8 +17,11 @@ def test_build_prompt_includes_summaries():
         retriever=DummyRetriever(records),
         patch_retriever=DummyRetriever(records),
         confidence_threshold=-1.0,
+        context_builder=object(),
     )
-    prompt = engine.build_prompt("do things", summaries=["sumA", "sumB"])
+    prompt = engine.build_prompt(
+        "do things", summaries=["sumA", "sumB"], context_builder=engine.context_builder
+    )
     text = str(prompt)
     assert "sumA" in text and "sumB" in text
 
@@ -29,8 +32,9 @@ def test_build_prompt_skips_summaries_when_absent():
         retriever=DummyRetriever(records),
         patch_retriever=DummyRetriever(records),
         confidence_threshold=-1.0,
+        context_builder=object(),
     )
-    prompt = engine.build_prompt("do things")
+    prompt = engine.build_prompt("do things", context_builder=engine.context_builder)
     text = str(prompt)
     assert "irrelevant" in text
     assert "sumA" not in text and "sumB" not in text

--- a/tests/test_chunk_workflow.py
+++ b/tests/test_chunk_workflow.py
@@ -127,6 +127,7 @@ def test_prompt_from_summaries_under_limit(tmp_path, monkeypatch):
         confidence_threshold=-1.0,
         token_threshold=50,
         chunk_token_threshold=20,
+        context_builder=object(),
     )
 
     if pc._count_tokens(code) > engine.token_threshold:
@@ -137,7 +138,9 @@ def test_prompt_from_summaries_under_limit(tmp_path, monkeypatch):
     else:
         context = code
 
-    prompt = engine.build_prompt("do something", context=context)
+    prompt = engine.build_prompt(
+        "do something", context=context, context_builder=engine.context_builder
+    )
     assert "sumA" in prompt.user and "sumB" in prompt.user
     assert "x = 0" not in prompt.user
     assert pc._count_tokens(prompt.user) <= engine.token_threshold

--- a/tests/test_payment_notice.py
+++ b/tests/test_payment_notice.py
@@ -215,7 +215,7 @@ def test_prompt_engine_build_prompt_contains_notice():
     from prompt_engine import PromptEngine
 
     engine = PromptEngine(retriever=None, context_builder=vector_service.ContextBuilder())
-    prompt = engine.build_prompt("task")
+    prompt = engine.build_prompt("task", context_builder=engine.context_builder)
     assert prompt.system.startswith(PAYMENT_ROUTER_NOTICE)
 
 

--- a/tests/test_prompt_engine_chunk_summaries.py
+++ b/tests/test_prompt_engine_chunk_summaries.py
@@ -48,9 +48,12 @@ def test_prompt_engine_auto_summarises_when_limit_exceeded(monkeypatch):
         token_threshold=50,
         chunk_token_threshold=20,
         llm=object(),
+        context_builder=object(),
     )
 
-    prompt = engine.build_prompt("do something", context=code)
+    prompt = engine.build_prompt(
+        "do something", context=code, context_builder=engine.context_builder
+    )
     assert calls == ["chunkA", "chunkB"]
     assert "sum:chunkA" in prompt and "sum:chunkB" in prompt
     assert "x = 0" not in prompt

--- a/tests/test_prompt_engine_llm_client_integration.py
+++ b/tests/test_prompt_engine_llm_client_integration.py
@@ -33,9 +33,10 @@ def test_prompt_engine_to_llm_client_flow():
         patch_retriever=SimpleRetriever(),
         top_n=1,
         confidence_threshold=0,
+        context_builder=object(),
     )
 
-    prompt = engine.build_prompt("do things")
+    prompt = engine.build_prompt("do things", context_builder=engine.context_builder)
     client = CapturingClient()
     result = client.generate(prompt)
 

--- a/tests/test_prompt_engine_optimizer_integration.py
+++ b/tests/test_prompt_engine_optimizer_integration.py
@@ -61,8 +61,13 @@ def test_optimizer_ranking_and_influence(tmp_path: Path, monkeypatch) -> None:
     )
     monkeypatch.setattr(pe_mod, "audit_log_event", lambda *a, **k: None)
 
-    engine = PromptEngine(retriever=DummyRetriever(), optimizer=opt, confidence_threshold=0.0)
-    prompt = engine.build_prompt("task")
+    engine = PromptEngine(
+        retriever=DummyRetriever(),
+        optimizer=opt,
+        confidence_threshold=0.0,
+        context_builder=object(),
+    )
+    prompt = engine.build_prompt("task", context_builder=engine.context_builder)
     assert engine.tone == "cheerful"
     assert "h1" in engine.last_metadata.get("structured_sections", [])
     assert isinstance(prompt, Prompt)

--- a/unit_tests/test_prompt_evolution_memory.py
+++ b/unit_tests/test_prompt_evolution_memory.py
@@ -112,8 +112,13 @@ def test_optimizer_ranking_influences_prompt_engine(tmp_path: Path, monkeypatch)
     monkeypatch.setattr(pe, "compress_snippets", lambda m: m)
     monkeypatch.setattr(pe, "audit_log_event", lambda *a, **k: None)
 
-    engine = PromptEngine(retriever=DummyRetriever(), optimizer=opt, confidence_threshold=0.0)
-    engine.build_prompt("task")
+    engine = PromptEngine(
+        retriever=DummyRetriever(),
+        optimizer=opt,
+        confidence_threshold=0.0,
+        context_builder=object(),
+    )
+    engine.build_prompt("task", context_builder=engine.context_builder)
 
     assert engine.tone == "cheerful"
     assert "h1" in engine.last_metadata.get("structured_sections", [])


### PR DESCRIPTION
## Summary
- require `context_builder` for `PromptEngine.build_prompt` and remove fallback
- update docs and tests to pass a builder explicitly

## Testing
- `pytest tests/test_prompt_engine.py tests/test_prompt_engine_llm_client_integration.py tests/test_prompt_engine_fallback.py tests/test_chunk_workflow.py tests/test_prompt_engine_chunk_summaries.py tests/test_prompt_engine_optimizer_integration.py tests/test_build_prompt_summaries.py tests/test_payment_notice.py unit_tests/test_prompt_engine.py unit_tests/test_prompt_evolution_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_68bd898e1b10832e9c1d448f014f9395