### PR TITLE
Inject ContextBuilder into ChatGPTPredictionBot

### DIFF
--- a/chatgpt_prediction_bot.py
+++ b/chatgpt_prediction_bot.py
@@ -677,6 +677,7 @@ class ChatGPTPredictionBot:
         threshold: float | None = None,
         client: ChatGPTClient | None = None,
         gpt_memory: GPTMemoryInterface | None = GPT_MEMORY_MANAGER,
+        context_builder: ContextBuilder | None = None,
         **model_kwargs,
     ) -> None:
         """Load a trained model or fall back to the internal pipeline.
@@ -695,12 +696,10 @@ class ChatGPTPredictionBot:
                 except Exception:
                     logger.debug("failed to attach gpt_memory to client", exc_info=True)
             self.client = client
-        elif gpt_memory is not None:
+        elif gpt_memory is not None and context_builder is not None:
             try:
-                builder = ContextBuilder()
-                builder.refresh_db_weights()
                 self.client = ChatGPTClient(
-                    gpt_memory=gpt_memory, context_builder=builder
+                    gpt_memory=gpt_memory, context_builder=context_builder
                 )
             except Exception:  # pragma: no cover - optional dependency
                 logger.debug("failed to initialize ChatGPTClient", exc_info=True)

--- a/menace_master.py
+++ b/menace_master.py
@@ -385,7 +385,7 @@ def _init_unused_bots() -> None:
         _wrap(BotDevelopmentBot, context_builder=builder),
         BotTestingBot,
         _wrap(ChatGPTEnhancementBot, client),
-        _wrap(ChatGPTPredictionBot, client),
+        _wrap(ChatGPTPredictionBot, client=client, context_builder=builder),
         _wrap(ChatGPTResearchBot, client),
         CompetitiveIntelligenceBot,
         _wrap(

--- a/tests/test_chatgpt_prediction_bot_warning.py
+++ b/tests/test_chatgpt_prediction_bot_warning.py
@@ -3,6 +3,28 @@ import sys
 import types
 
 import pytest
+from pathlib import Path
+
+pkg = types.ModuleType("menace")
+pkg.__path__ = [str(Path(__file__).resolve().parents[1])]
+pkg.RAISE_ERRORS = False
+sys.modules["menace"] = pkg
+
+vector_service_pkg = types.ModuleType("vector_service")
+vector_service_pkg.__path__ = []
+vector_service_pkg.SharedVectorService = object
+vector_service_pkg.CognitionLayer = object
+class _StubContextBuilder:
+    def refresh_db_weights(self):
+        pass
+ctx_mod = types.ModuleType("vector_service.context_builder")
+ctx_mod.ContextBuilder = _StubContextBuilder
+sys.modules["vector_service"] = vector_service_pkg
+sys.modules["vector_service.context_builder"] = ctx_mod
+sys.modules["menace.shared_gpt_memory"] = types.SimpleNamespace(GPT_MEMORY_MANAGER=None)
+
+
+DummyBuilder = _StubContextBuilder
 
 
 def test_warning_on_missing_sklearn(monkeypatch, caplog, tmp_path):
@@ -10,8 +32,14 @@ def test_warning_on_missing_sklearn(monkeypatch, caplog, tmp_path):
     # stub out optional dependencies before import
     monkeypatch.setitem(sys.modules, "sklearn", types.ModuleType("sklearn"))
     monkeypatch.setitem(sys.modules, "joblib", types.ModuleType("joblib"))
+    monkeypatch.setitem(sys.modules, "menace", pkg)
+    monkeypatch.setitem(sys.modules, "vector_service", vector_service_pkg)
+    monkeypatch.setitem(sys.modules, "vector_service.context_builder", ctx_mod)
+    monkeypatch.setitem(
+        sys.modules, "menace.shared_gpt_memory", types.SimpleNamespace(GPT_MEMORY_MANAGER=None)
+    )
     cpb = importlib.import_module("menace.chatgpt_prediction_bot")
-    bot = cpb.ChatGPTPredictionBot(tmp_path / "none.joblib")
+    bot = cpb.ChatGPTPredictionBot(tmp_path / "none.joblib", context_builder=DummyBuilder())
     assert "scikit-learn" in caplog.text
     assert not cpb._SKLEARN_AVAILABLE
     assert isinstance(bot.pipeline, cpb.Pipeline)
@@ -24,10 +52,16 @@ def test_warning_on_missing_sklearn(monkeypatch, caplog, tmp_path):
 def test_fallback_prediction_stable(monkeypatch, tmp_path):
     monkeypatch.setitem(sys.modules, "sklearn", types.ModuleType("sklearn"))
     monkeypatch.setitem(sys.modules, "joblib", types.ModuleType("joblib"))
+    monkeypatch.setitem(sys.modules, "menace", pkg)
+    monkeypatch.setitem(sys.modules, "vector_service", vector_service_pkg)
+    monkeypatch.setitem(sys.modules, "vector_service.context_builder", ctx_mod)
+    monkeypatch.setitem(
+        sys.modules, "menace.shared_gpt_memory", types.SimpleNamespace(GPT_MEMORY_MANAGER=None)
+    )
     cpb = importlib.import_module("menace.chatgpt_prediction_bot")
 
     bot = cpb.ChatGPTPredictionBot(
-        tmp_path / "none.joblib", l2=0.1, iters=5, val_steps=1
+        tmp_path / "none.joblib", l2=0.1, iters=5, val_steps=1, context_builder=DummyBuilder()
     )
     idea = cpb.IdeaFeatures(
         market_type="tech",


### PR DESCRIPTION
## Summary
- allow ChatGPTPredictionBot to receive a ContextBuilder and use it when creating ChatGPTClient
- wire ContextBuilder through Menace master setup
- adjust prediction bot tests with explicit builder stubs

## Testing
- `MENACE_LIGHT_IMPORTS=1 pytest tests/test_chatgpt_prediction_bot.py tests/test_chatgpt_prediction_bot_warning.py tests/test_chatgpt_prediction_bot_memory.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd8eac28bc832eb5793d19f1f20f00