### PR TITLE
chore: enforce context builder dependency

### DIFF
--- a/chaos_monitoring_service.py
+++ b/chaos_monitoring_service.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-"""Run chaos experiments and automatically rollback failing bots."""
+"""Run chaos experiments and automatically rollback failing bots.
+
+The service relies on :class:`vector_service.ContextBuilder` for contextual
+analysis.  Importing this module without ``vector_service`` installed will
+raise an :class:`ImportError` with guidance for the integrator.
+"""
 
 import logging
 import threading
@@ -13,14 +18,13 @@ from .resource_allocation_optimizer import ROIDB
 from .data_bot import MetricsDB
 from .advanced_error_management import AutomatedRollbackManager
 
-try:  # pragma: no cover - optional dependency
+try:
     from vector_service import ContextBuilder
-except Exception:  # pragma: no cover - fallback when helper missing
-    try:
-        from vector_service.context_builder import ContextBuilder  # type: ignore
-    except Exception:  # pragma: no cover - last resort
-        class ContextBuilder:  # type: ignore[override]
-            pass
+except Exception as exc:  # pragma: no cover - fail fast when dependency missing
+    raise ImportError(
+        "chaos_monitoring_service requires vector_service.ContextBuilder; install"
+        " the vector_service package to enable context retrieval"
+    ) from exc
 
 
 class ChaosMonitoringService:

--- a/enhancement_bot.py
+++ b/enhancement_bot.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+"""Automatically validate and merge Codex refactors.
+
+The enhancement workflow depends on :class:`vector_service.ContextBuilder` for
+supplementary code context.  If the ``vector_service`` package is unavailable an
+informative :class:`ImportError` is raised at import time.
+"""
+
 import hashlib
 import subprocess
 import time
@@ -21,10 +28,15 @@ from .micro_models.diff_summarizer import summarize_diff
 
 from billing.prompt_notice import prepend_payment_notice
 from llm_interface import LLMClient, Prompt
-try:  # pragma: no cover - optional service layer
+
+try:
     from vector_service import ContextBuilder
-except Exception:  # pragma: no cover - degrade gracefully
-    ContextBuilder = None  # type: ignore
+except Exception as exc:  # pragma: no cover - fail fast when dependency missing
+    raise ImportError(
+        "enhancement_bot requires vector_service.ContextBuilder; install the"
+        " vector_service package to enable context retrieval"
+    ) from exc
+
 try:  # pragma: no cover - allow flat imports
     from .dynamic_path_router import resolve_path
 except Exception:  # pragma: no cover - fallback for flat layout

--- a/tests/test_context_builder_import_error.py
+++ b/tests/test_context_builder_import_error.py
@@ -1,0 +1,24 @@
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "menace.auto_escalation_manager",
+        "menace.watchdog",
+        "menace.chaos_monitoring_service",
+        "menace.enhancement_bot",
+        "menace.self_coding_engine",
+    ],
+)
+def test_modules_require_vector_service(module_name, monkeypatch):
+    """Modules should fail fast when ``vector_service`` is unavailable."""
+
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    monkeypatch.delitem(sys.modules, "vector_service", raising=False)
+
+    with pytest.raises(ImportError):
+        importlib.import_module(module_name)

--- a/watchdog.py
+++ b/watchdog.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+"""System health watchdog.
+
+This module depends on :class:`vector_service.ContextBuilder` for gathering
+diagnostic context.  Importing this module without the ``vector_service``
+package installed results in an :class:`ImportError` to make the dependency
+explicit.
+"""
+
 import json
 import logging
 import os
@@ -83,15 +91,13 @@ except Exception:  # pragma: no cover - gracefully degrade in tests
     UnifiedEventBus = None  # type: ignore
 from .retry_utils import retry
 
-try:  # pragma: no cover - optional dependency
+try:
     from vector_service import ContextBuilder
-except Exception:  # pragma: no cover - fallback when helper missing
-    try:
-        from vector_service.context_builder import ContextBuilder  # type: ignore
-    except Exception:  # pragma: no cover - last resort
-        class ContextBuilder:  # type: ignore[override]
-            def refresh_db_weights(self) -> None:  # pragma: no cover - stub
-                pass
+except Exception as exc:  # pragma: no cover - fail fast when dependency missing
+    raise ImportError(
+        "watchdog requires vector_service.ContextBuilder; install the"
+        " vector_service package to enable context retrieval"
+    ) from exc
 
 if TYPE_CHECKING:
     from .replay_engine import ReplayValidator


### PR DESCRIPTION
## Summary
- remove fallback ContextBuilder stubs and fail fast when vector_service missing
- document ContextBuilder requirement in module docstrings
- add tests ensuring modules error without vector_service

## Testing
- `pre-commit run --files auto_escalation_manager.py watchdog.py chaos_monitoring_service.py enhancement_bot.py self_coding_engine.py tests/test_context_builder_import_error.py` *(fails: check-static-paths, forbid-raw-stripe-usage)*
- `pytest tests/test_context_builder_import_error.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd93509f90832e9a0fa5a1c5bb8d4c