### PR TITLE
Refactor context builder instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,9 +433,9 @@ bucket is configured or run as a limited pilot.
 - Synergy-aware environment presets adapt CPU, memory, bandwidth and threat levels ([docs/environment_generator.md](docs/environment_generator.md))
 - Sandboxed self-debugging using `SelfDebuggerSandbox` (invoked by `launch_menace_bots.py` after the test run)
 - Comprehensive build pipeline in `launch_menace_bots.py` that plans,
-  develops, tests and scales bots before deployment.  The CLI constructs a
-  default `ContextBuilder` and passes it to `debug_and_deploy` so callers can
-  supply custom builders if needed.
+  develops, tests and scales bots before deployment.  `debug_and_deploy`
+  creates a `ContextBuilder` with local database paths by default, but callers
+  may supply custom builders if needed.
 - Automated implementation pipeline turning tasks into runnable bots ([docs/implementation_pipeline.md](docs/implementation_pipeline.md))
 - Models repository workflow with visual agents ([docs/models_repo_workflow.md](docs/models_repo_workflow.md))
 - Retirement of underperforming models by `ModelPerformanceMonitor`


### PR DESCRIPTION
## Summary
- import `ContextBuilder` directly in launch helper
- instantiate `ContextBuilder` inside `debug_and_deploy` when none provided
- update README to reflect new context builder behaviour

## Testing
- `pre-commit run --files launch_menace_bots.py README.md` *(fails: static path reference and raw Stripe checks)*
- `PYTHONPATH=$PWD pytest tests/test_launch_menace_bots.py -k test_debug_and_deploy_runs_sandbox -q` *(fails: ImportError: cannot import name 'CodeDB' from 'code_database')*


------
https://chatgpt.com/codex/tasks/task_e_68bda743f38c832ebdaf65bd31169813