### PR TITLE
refactor: require explicit context builder

### DIFF
--- a/launch_menace_bots.py
+++ b/launch_menace_bots.py
@@ -99,7 +99,7 @@ def _infer_schedule(doc: str) -> str:
 def debug_and_deploy(
     repo: Path,
     *,
-    context_builder: ContextBuilder | None = None,
+    context_builder: ContextBuilder,
     jobs: int = 1,
     override_veto: bool = False,
 ) -> None:
@@ -110,10 +110,9 @@ def debug_and_deploy(
     repo:
         Repository root containing bots to validate and deploy.
     context_builder:
-        Optional :class:`~vector_service.context_builder.ContextBuilder` used
-        for semantic context generation.  When ``None`` a new builder is
-        instantiated using the local database paths.  Its weights are refreshed
-        before building the coding engine.
+        Preconfigured :class:`~vector_service.context_builder.ContextBuilder`
+        used for semantic context generation. Its weights are refreshed before
+        building the coding engine.
     jobs:
         Number of parallel jobs for the test runner.
     override_veto:
@@ -125,8 +124,6 @@ def debug_and_deploy(
     except TypeError:
         code_db = CodeDB()
     memory_mgr = MenaceMemoryManager()
-    if context_builder is None:
-        context_builder = ContextBuilder()
     context_builder.refresh_db_weights()
     engine = SelfCodingEngine(
         code_db, memory_mgr, context_builder=context_builder
@@ -297,6 +294,7 @@ def main() -> None:
     args = parser.parse_args()
     debug_and_deploy(
         Path(args.repo),
+        context_builder=ContextBuilder(),
         jobs=args.jobs,
         override_veto=args.override_veto,
     )

--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -15,13 +15,7 @@ import json
 import os
 import sys
 import yaml
-try:
-    from vector_service.context_builder_utils import get_default_context_builder
-except ImportError:  # pragma: no cover - fallback when helper missing
-    from vector_service.context_builder import ContextBuilder  # type: ignore
-
-    def get_default_context_builder(**kwargs):  # type: ignore
-        return ContextBuilder(**kwargs)
+from vector_service.context_builder import ContextBuilder
 
 if os.getenv("SANDBOX_CENTRAL_LOGGING") == "1":
     from logging_utils import setup_logging
@@ -591,9 +585,10 @@ _INPUT_HISTORY_DB: InputHistoryDB | None = None
 
 # Shared error logger and category counters for sandbox runs
 KNOWLEDGE_GRAPH = KnowledgeGraph()
+CONTEXT_BUILDER = ContextBuilder()
 ERROR_LOGGER = ErrorLogger(
     knowledge_graph=KNOWLEDGE_GRAPH,
-    context_builder=get_default_context_builder(),
+    context_builder=CONTEXT_BUILDER,
 )
 ERROR_CATEGORY_COUNTS: Counter[str] = Counter()
 
@@ -7148,7 +7143,7 @@ def run_repo_section_simulations(
             for module, sec_map in sections.items():
                 tmp_dir = tempfile.mkdtemp(prefix="section_")
                 shutil.copytree(repo_path, tmp_dir, dirs_exist_ok=True)
-                builder = get_default_context_builder()
+                builder = ContextBuilder()
                 builder.refresh_db_weights()
                 debugger = SelfDebuggerSandbox(
                     object(),
@@ -8314,7 +8309,7 @@ def run_workflow_simulations(
         for wf in workflows:
             for step in wf.workflow:
                 snippet = _wf_snippet([step])
-                builder = get_default_context_builder()
+                builder = ContextBuilder()
                 builder.refresh_db_weights()
                 debugger = SelfDebuggerSandbox(
                     object(),


### PR DESCRIPTION
## Summary
- use ContextBuilder directly instead of get_default_context_builder in sandbox environment
- require explicit ContextBuilder for debug_and_deploy helper

## Testing
- `pre-commit run --files sandbox_runner/environment.py launch_menace_bots.py` *(fails: No module named 'dynamic_path_router')*
- `pytest tests/test_launch_menace_bots.py` *(fails: cannot import name 'CodeDB')*
- `pytest tests/test_self_debugger_sandbox.py -k baseline_config_from_env` *(fails: cannot import name 'ROITracker')*


------
https://chatgpt.com/codex/tasks/task_e_68bda8d852e8832ea634b2224ecf155e