### PR TITLE
refactor refund anomaly detector to require context builder

### DIFF
--- a/tests/test_refund_anomaly_detector.py
+++ b/tests/test_refund_anomaly_detector.py
@@ -78,7 +78,10 @@ def test_detects_unlogged_and_unauthorized(tmp_path, monkeypatch):
     logged: list[dict] = []
     monkeypatch.setattr(rad.billing_logger, "log_event", lambda **kw: logged.append(kw))
 
-    anomalies = rad.detect_anomalies(hours=1, whitelist_path=whitelist, db_path=db_path)
+    builder = SimpleNamespace(refresh_db_weights=lambda: None)
+    anomalies = rad.detect_anomalies(
+        hours=1, whitelist_path=whitelist, db_path=db_path, context_builder=builder
+    )
 
     assert {a["reason"] for a in anomalies} == {"unlogged", "unauthorized"}
     assert {a["id"] for a in anomalies} == {"evt_unlogged", "evt_unauth"}


### PR DESCRIPTION
## Summary
- remove default context builder usage from refund anomaly detector
- require a caller-supplied ContextBuilder and refresh weights
- adjust tests to supply dummy builders and simulate config updates

## Testing
- `python -m pytest tests/test_refund_anomaly_detector.py tests/test_refund_anomaly_detector_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdab070328832eacbec2adfae33417