### PR TITLE
Add context builder injection for SanityConsumer

### DIFF
--- a/tests/integration/test_sanity_consumer_flow.py
+++ b/tests/integration/test_sanity_consumer_flow.py
@@ -131,7 +131,11 @@ def test_watchdog_anomaly_reaches_consumer(monkeypatch, tmp_path):
             self.updates.append(meta)
     monkeypatch.setattr(sc, "SelfCodingEngine", DummyEngine)
 
-    consumer = sc.SanityConsumer(event_bus=bus)
+    class DummyBuilder:
+        def refresh_db_weights(self):
+            pass
+
+    consumer = sc.SanityConsumer(event_bus=bus, context_builder=DummyBuilder())
 
     # Emit anomaly
     record = {"type": "missing_charge", "id": "ch_1", "amount": 5}


### PR DESCRIPTION
## Summary
- accept an optional `ContextBuilder` in `SanityConsumer` and refresh it before creating the engine
- drop internal `get_default_context_builder` usage
- adjust tests for explicit builder injection

## Testing
- `pytest tests/test_sanity_consumer_engine.py`
- `pytest tests/integration/test_sanity_consumer_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdaf001bd4832ea847e091d5ec9d76