### PR TITLE
feat: support custom context builder

### DIFF
--- a/docs/monitoring_pipeline.md
+++ b/docs/monitoring_pipeline.md
@@ -53,12 +53,10 @@ Install `sentry-sdk` and create a `SentryClient` to capture exceptions from
 ```python
 from menace.sentry_client import SentryClient
 from menace.error_logger import ErrorLogger
-from vector_service import get_default_context_builder
+from vector_service import ContextBuilder
 
 sentry = SentryClient("https://public@o0.ingest.sentry.io/0")
-logger = ErrorLogger(
-    sentry=sentry, context_builder=get_default_context_builder()
-)
+logger = ErrorLogger(sentry=sentry, context_builder=ContextBuilder())
 ```
 
 ## Watchdog Runbooks

--- a/docs/roi_calculator.md
+++ b/docs/roi_calculator.md
@@ -126,9 +126,10 @@ tickets or feed the hints into a Codex prompt.
 
 ```python
 from menace_sandbox.error_logger import ErrorLogger
-from vector_service import get_default_context_builder
+from vector_service import ContextBuilder
 
-elog = ErrorLogger(context_builder=get_default_context_builder())
+builder = ContextBuilder()
+elog = ErrorLogger(context_builder=builder)
 elog.log_roi_cap(metrics, "scraper_bot")
 ```
 

--- a/tests/test_error_logger_builder_validation.py
+++ b/tests/test_error_logger_builder_validation.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import types
+
+os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
+
+import menace.error_logger as elog  # noqa: E402
+from menace.error_logger import ErrorLogger  # noqa: E402
+
+
+class DummyBuilder:
+    def __init__(self):
+        self.refresh_calls = 0
+
+    def refresh_db_weights(self):
+        self.refresh_calls += 1
+
+
+def test_refresh_called_before_generate_patch(monkeypatch, tmp_path):
+    builder = DummyBuilder()
+    db = types.SimpleNamespace(add_telemetry=lambda *a, **k: None)
+    logger = ErrorLogger(db=db, context_builder=builder)
+    initial_calls = builder.refresh_calls
+    called: list[bool] = []
+
+    def fake_generate_patch(module, *, context_builder):
+        assert context_builder is builder
+        assert builder.refresh_calls > initial_calls
+        called.append(True)
+        return 1
+
+    monkeypatch.setattr(elog, "generate_patch", fake_generate_patch)
+    monkeypatch.setattr(elog, "propose_fix", lambda metrics, profile: [("mod", "hint")])
+    monkeypatch.setattr(elog, "path_for_prompt", lambda module: module)
+    monkeypatch.setattr(elog, "cdh", None)
+
+    logger.log_fix_suggestions({}, {}, task_id="t", bot_id="b")
+    assert called


### PR DESCRIPTION
## Summary
- allow ErrorLogger to take an optional ContextBuilder
- refresh ContextBuilder before generating patches
- update docs and add tests for custom builder usage

## Testing
- ⚠️ `pytest tests/test_error_logger_update_trigger.py tests/test_error_logger_builder_validation.py` (vector_service import failed)
- ✅ `pytest tests/test_error_logger_builder_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdb5703244832e82220e05521b2ec3