### PR TITLE
refactor: accept context builder in IPO pipeline

### DIFF
--- a/ipo_implementation_pipeline.py
+++ b/ipo_implementation_pipeline.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Iterable, Optional
+from typing import List
 import json
 import sys
 import logging
@@ -12,13 +12,14 @@ try:
 except ImportError:  # pragma: no cover - fallback when helper missing
     from vector_service import ContextBuilder  # type: ignore
 
-logger = logging.getLogger(__name__)
 from .bot_development_bot import BotDevelopmentBot, BotSpec
 from .bot_testing_bot import BotTestingBot
 from .scalability_assessment_bot import ScalabilityAssessmentBot
 from .deployment_bot import DeploymentBot, DeploymentSpec
 from .task_handoff_bot import TaskHandoffBot, TaskInfo
 from .research_aggregator_bot import ResearchAggregatorBot
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -66,7 +67,7 @@ class IPOImplementationPipeline:
         while attempts < self.max_attempts:
             attempts += 1
             path = self.developer.build_bot(
-                spec, context_builder=self.developer.context_builder
+                spec, context_builder=self.context_builder
             )
             if str(path.parent) not in sys.path:
                 sys.path.insert(0, str(path.parent))


### PR DESCRIPTION
## Summary
- require a ContextBuilder when initializing `IPOImplementationPipeline`
- reuse the supplied builder instead of relying on a developer's default

## Testing
- `pre-commit run --files ipo_implementation_pipeline.py` *(fails: No module named 'dynamic_path_router')*
- `pytest tests/test_ipo_implementation_pipeline_context_builder.py::test_context_builder_reused -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdba6bcd18832e97908656690f7d1a