### PR TITLE
refactor: require explicit context builder

### DIFF
--- a/tests/test_chaos_monitoring_service.py
+++ b/tests/test_chaos_monitoring_service.py
@@ -3,7 +3,6 @@ import sys
 import types
 import tempfile
 from pathlib import Path
-import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 TMP = Path(tempfile.mkdtemp())
@@ -15,17 +14,43 @@ sys.modules["menace"] = pkg
 
 # stub modules
 (TMP / "chaos_scheduler.py").write_text(  # path-ignore
-    """class ChaosScheduler:\n    def __init__(self, watchdog=None):\n        self.watchdog=watchdog\n        self.interval=0\n        self.started=False\n    def start(self):\n        self.started=True\n"""
+    (
+        "class ChaosScheduler:\n"
+        "    def __init__(self, watchdog=None):\n"
+        "        self.watchdog=watchdog\n"
+        "        self.interval=0\n"
+        "        self.started=False\n"
+        "    def start(self):\n"
+        "        self.started=True\n"
+    )
 )
 (TMP / "watchdog.py").write_text(  # path-ignore
-    """class Watchdog:\n    def __init__(self, *a, **k):\n        self.synthetic_faults=[]\n"""
+    "class Watchdog:\n    def __init__(self, *a, **k):\n        self.synthetic_faults=[]\n"
 )
 (TMP / "error_bot.py").write_text("class ErrorDB: pass\n")  # path-ignore
 (TMP / "resource_allocation_optimizer.py").write_text("class ROIDB: pass\n")  # path-ignore
 (TMP / "data_bot.py").write_text("class MetricsDB: pass\n")  # path-ignore
 (TMP / "advanced_error_management.py").write_text(  # path-ignore
-    """class AutomatedRollbackManager:\n    def __init__(self, raise_error=False):\n        self.raise_error=raise_error\n        self.calls=[]\n    def auto_rollback(self, version, bots):\n        self.calls.append((version, bots))\n        if self.raise_error:\n            raise RuntimeError('boom')\n"""
+    (
+        "class AutomatedRollbackManager:\n"
+        "    def __init__(self, raise_error=False):\n"
+        "        self.raise_error=raise_error\n"
+        "        self.calls=[]\n"
+        "    def auto_rollback(self, version, bots):\n"
+        "        self.calls.append((version, bots))\n"
+        "        if self.raise_error:\n"
+        "            raise RuntimeError('boom')\n"
+    )
 )
+
+
+class DummyBuilder:
+    def __init__(self) -> None:
+        self.refreshed = False
+
+    def refresh_db_weights(self) -> None:
+        self.refreshed = True
+
 
 spec = importlib.util.spec_from_file_location(
     "menace.chaos_monitoring_service",
@@ -40,10 +65,12 @@ spec.loader.exec_module(mod)
 def _run_once(svc):
     class OnceEvent:
         def __init__(self):
-            self.count=0
+            self.count = 0
+
         def wait(self, interval):
-            self.count+=1
-            return self.count>1
+            self.count += 1
+            return self.count > 1
+
     svc._monitor(OnceEvent())
 
 
@@ -52,7 +79,9 @@ def test_auto_rollback_triggered():
     wd.synthetic_faults = [{"bot": "x"}]
     sched = mod.ChaosScheduler(wd)
     rb = mod.AutomatedRollbackManager()
-    svc = mod.ChaosMonitoringService(scheduler=sched, rollback_mgr=rb)
+    svc = mod.ChaosMonitoringService(
+        scheduler=sched, rollback_mgr=rb, context_builder=DummyBuilder()
+    )
     _run_once(svc)
     assert rb.calls == [("latest", ["x"])]
 
@@ -62,7 +91,9 @@ def test_no_action_when_recovered():
     wd.synthetic_faults = [{"bot": "x", "recovered": True}]
     sched = mod.ChaosScheduler(wd)
     rb = mod.AutomatedRollbackManager()
-    svc = mod.ChaosMonitoringService(scheduler=sched, rollback_mgr=rb)
+    svc = mod.ChaosMonitoringService(
+        scheduler=sched, rollback_mgr=rb, context_builder=DummyBuilder()
+    )
     _run_once(svc)
     assert rb.calls == []
 
@@ -72,12 +103,15 @@ def test_error_logged(caplog):
     wd.synthetic_faults = [{"bot": "x"}]
     sched = mod.ChaosScheduler(wd)
     rb = mod.AutomatedRollbackManager(raise_error=True)
-    svc = mod.ChaosMonitoringService(scheduler=sched, rollback_mgr=rb)
+    svc = mod.ChaosMonitoringService(
+        scheduler=sched, rollback_mgr=rb, context_builder=DummyBuilder()
+    )
     caplog.set_level("ERROR")
     _run_once(svc)
     assert "auto rollback failed" in caplog.text
 
 
-def test_builder_required_when_scheduler_missing():
-    with pytest.raises(ValueError):
-        mod.ChaosMonitoringService()
+def test_weights_refreshed_on_startup():
+    builder = DummyBuilder()
+    mod.ChaosMonitoringService(context_builder=builder)
+    assert builder.refreshed


### PR DESCRIPTION
## Summary
- inject required `ContextBuilder` into `ChaosMonitoringService`
- refresh DB weights on service startup
- update chaos monitoring tests to supply `ContextBuilder`

## Testing
- `pytest tests/test_chaos_monitoring_service.py`
- `pre-commit run --files chaos_monitoring_service.py tests/test_chaos_monitoring_service.py` *(fails: check-static-paths, forbid-raw-stripe-usage)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbb3f6b24832e9238ade749df1968