### PR TITLE
Use explicit generate_patch call and remove default context builder

### DIFF
--- a/menace_cli.py
+++ b/menace_cli.py
@@ -157,16 +157,15 @@ def handle_patch(args: argparse.Namespace) -> int:
     except Exception as exc:
         print(f"ContextBuilder initialisation failed: {exc}", file=sys.stderr)
         return 1
-    patch_args = {
-        "context_builder": builder,
-        "engine": None,
-        "description": args.desc,
-        "patch_logger": patch_logger,
-        "context": ctx,
-    }
-    if args.effort_estimate is not None:
-        patch_args["effort_estimate"] = args.effort_estimate
-    patch_id = quick_fix_engine.generate_patch(args.module, **patch_args)
+    patch_id = quick_fix_engine.generate_patch(
+        args.module,
+        context_builder=builder,
+        engine=None,
+        description=args.desc,
+        patch_logger=patch_logger,
+        context=ctx,
+        effort_estimate=args.effort_estimate,
+    )
     if not patch_id:
         return 1
     record = db.get(patch_id)

--- a/vector_service/__init__.py
+++ b/vector_service/__init__.py
@@ -5,7 +5,6 @@ This package provides the canonical vector retrieval service.
 
 from .retriever import Retriever, FallbackResult
 from .context_builder import ContextBuilder
-from .context_builder_utils import get_default_context_builder
 from .patch_logger import PatchLogger
 from .cognition_layer import CognitionLayer
 from .embedding_backfill import EmbeddingBackfill
@@ -32,7 +31,6 @@ __all__ = [
     "Retriever",
     "FallbackResult",
     "ContextBuilder",
-    "get_default_context_builder",
     "PatchLogger",
     "CognitionLayer",
     "EmbeddingBackfill",

--- a/vector_service/cognition_layer.py
+++ b/vector_service/cognition_layer.py
@@ -38,7 +38,6 @@ from dynamic_path_router import resolve_path
 
 from .retriever import Retriever, PatchRetriever
 from .context_builder import ContextBuilder
-from .context_builder_utils import get_default_context_builder
 from .patch_logger import PatchLogger
 from vector_metrics_db import VectorMetricsDB
 from .decorators import log_and_measure
@@ -99,7 +98,7 @@ class CognitionLayer:
         if context_builder is not None:
             self.context_builder = context_builder
         else:
-            self.context_builder = get_default_context_builder(
+            self.context_builder = ContextBuilder(
                 retriever=self.retriever,
                 patch_retriever=self.patch_retriever,
                 ranking_model=ranking_model,


### PR DESCRIPTION
## Summary
- Replace patch CLI helper to call `quick_fix_engine.generate_patch` with explicit keyword arguments
- Eliminate `get_default_context_builder` usage in `vector_service`, instantiating `ContextBuilder` directly and removing re-export

## Testing
- `python scripts/check_context_builder_usage.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdbe17ec68832eb46e51cf5d6b18e3