### PR TITLE
Require explicit ContextBuilder for CognitionLayer

### DIFF
--- a/action_planner.py
+++ b/action_planner.py
@@ -34,6 +34,7 @@ from .adaptive_roi_predictor import AdaptiveROIPredictor
 from .roi_tracker import ROITracker
 from sandbox_settings import SandboxSettings
 from vector_service import CognitionLayer
+from vector_service.context_builder import ContextBuilder
 from .governance import check_veto, load_rules
 
 logger = logging.getLogger(__name__)
@@ -179,7 +180,8 @@ class ActionPlanner:
         self.priority_weights: Dict[str, float] = {}
         if cognition_layer is None:
             try:
-                cognition_layer = CognitionLayer()
+                builder = ContextBuilder()
+                cognition_layer = CognitionLayer(context_builder=builder)
             except Exception:  # pragma: no cover - optional dependency
                 cognition_layer = None
         self.cognition_layer = cognition_layer

--- a/vector_service_api.py
+++ b/vector_service_api.py
@@ -28,6 +28,7 @@ from vector_service import (
     VectorServiceError,
     FallbackResult,
 )
+from vector_service.context_builder import ContextBuilder
 from vector_service.patch_logger import RoiTag
 try:  # pragma: no cover - optional dependency
     from roi_tracker import ROITracker
@@ -58,7 +59,8 @@ app = FastAPI()
 # expose stateless interfaces which makes them safe to reuse across requests.
 _retriever = Retriever()
 _roi_tracker = ROITracker()
-_cognition_layer = CognitionLayer(roi_tracker=_roi_tracker)
+_context_builder = ContextBuilder(retriever=_retriever)
+_cognition_layer = CognitionLayer(context_builder=_context_builder, roi_tracker=_roi_tracker)
 _patch_logger = PatchLogger(roi_tracker=_roi_tracker)
 _backfill = EmbeddingBackfill()
 _ranker_scheduler = start_scheduler_from_env([_cognition_layer])


### PR DESCRIPTION
## Summary
- make CognitionLayer constructor demand a ContextBuilder and error if missing
- adjust API and action planner to supply explicit context builders
- document ContextBuilder requirement and example usage

## Testing
- `python scripts/check_context_builder_usage.py`
- `pytest tests/test_cognition_layer.py` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '')*
- `pytest tests/test_vector_service_api.py -q` *(skipped)*
- `pytest tests/test_action_planner.py -q` *(fails: FileNotFoundError: 'workflow_roi_history.json' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc0c634d8832eb5c0d73b6a62a7c7