### PR TITLE
Require explicit ContextBuilder for ActionPlanner

### DIFF
--- a/action_planner.py
+++ b/action_planner.py
@@ -119,6 +119,7 @@ class ActionPlanner:
         self,
         pathway_db: PathwayDB,
         roi_db: ROIDB,
+        context_builder: ContextBuilder,
         *,
         alpha: float = 0.5,
         epsilon: float = 0.1,
@@ -138,6 +139,7 @@ class ActionPlanner:
     ) -> None:
         self.pathway_db = pathway_db
         self.roi_db = roi_db
+        self.context_builder = context_builder
         self.model = _RLModel(alpha, epsilon=epsilon, path=model_path)
         self.state_length = max(1, int(state_length))
         self.reward_fn = reward_fn
@@ -180,8 +182,7 @@ class ActionPlanner:
         self.priority_weights: Dict[str, float] = {}
         if cognition_layer is None:
             try:
-                builder = ContextBuilder()
-                cognition_layer = CognitionLayer(context_builder=builder)
+                cognition_layer = CognitionLayer(context_builder=context_builder)
             except Exception:  # pragma: no cover - optional dependency
                 cognition_layer = None
         self.cognition_layer = cognition_layer

--- a/docs/roi_tracker.md
+++ b/docs/roi_tracker.md
@@ -267,8 +267,9 @@ from the growth classification:
 from menace_sandbox.action_planner import ActionPlanner
 from menace_sandbox.neuroplasticity import PathwayDB
 from menace_sandbox.resource_allocation_optimizer import ROIDB
+from vector_service.context_builder import ContextBuilder
 
-planner = ActionPlanner(PathwayDB(), ROIDB(),
+planner = ActionPlanner(PathwayDB(), ROIDB(), ContextBuilder(),
                         feature_fn=lambda action: [0.1, 0.2])
 planner.update_priorities({"launch_campaign": 1.0, "cleanup": 0.8})
 print(planner.get_priority_queue())  # highest ROI and growth first


### PR DESCRIPTION
## Summary
- inject a required `ContextBuilder` into `ActionPlanner` and wire it to `CognitionLayer`
- update ROI tracker documentation example to supply the `ContextBuilder`

## Testing
- `python scripts/check_context_builder_usage.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdd09c92d8832eaffcfafa55e1946b