### PR TITLE
Wire ContextBuilder into vector_service_api

### DIFF
--- a/vector_service_api.py
+++ b/vector_service_api.py
@@ -59,8 +59,12 @@ app = FastAPI()
 # expose stateless interfaces which makes them safe to reuse across requests.
 _retriever = Retriever()
 _roi_tracker = ROITracker()
-_context_builder = ContextBuilder(retriever=_retriever)
-_cognition_layer = CognitionLayer(context_builder=_context_builder, roi_tracker=_roi_tracker)
+_builder = ContextBuilder()
+_builder.refresh_db_weights()
+_cognition_layer = CognitionLayer(
+    roi_tracker=_roi_tracker,
+    context_builder=_builder,
+)
 _patch_logger = PatchLogger(roi_tracker=_roi_tracker)
 _backfill = EmbeddingBackfill()
 _ranker_scheduler = start_scheduler_from_env([_cognition_layer])


### PR DESCRIPTION
## Summary
- initialise a reusable ContextBuilder and refresh its DB weights
- pass the builder into CognitionLayer during API startup
- adjust vector_service_api tests for the new builder-based setup

## Testing
- `python scripts/check_context_builder_usage.py`
- `pytest tests/test_vector_service_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdd3ce910c832e9941489716cf40e2