### PR TITLE
Explicit context builder requirement

### DIFF
--- a/docs/vector_service.md
+++ b/docs/vector_service.md
@@ -113,8 +113,9 @@ applied.
 
 ```python
 from vector_service import CognitionLayer
+from vector_service.context_builder import ContextBuilder
 
-layer = CognitionLayer()
+layer = CognitionLayer(context_builder=ContextBuilder())
 ctx, sid = layer.query("What is ROI?")
 # ... apply patch ...
 layer.record_patch_outcome(sid, True)

--- a/tests/test_cognition_layer_risk_events.py
+++ b/tests/test_cognition_layer_risk_events.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 
 from vector_service.cognition_layer import CognitionLayer
@@ -41,8 +43,34 @@ def test_risk_scores_reduce_weights_and_emit_events(tmp_path, monkeypatch):
     retriever = DummyRetriever(hits)
     vec_db = VectorMetricsDB(tmp_path / "vec.db")
     bus = DummyBus()
+
+    class DummyBuilder:
+        def __init__(self, retriever):
+            self.retriever = retriever
+
+        def build_context(self, query, top_k=5, session_id="", **kwargs):
+            hits = self.retriever.search(query, top_k=top_k, session_id=session_id)
+            vectors = [(h["origin_db"], h["record_id"], h["score"]) for h in hits]
+            meta = {f"{h['origin_db']}:{h['record_id']}": h for h in hits}
+            stats = {"tokens": 0, "wall_time_ms": 0.0, "prompt_tokens": 0}
+            return "", session_id or "sid", vectors, meta, stats
+
+        def refresh_db_weights(self, *args, **kwargs):
+            pass
+
+    builder = DummyBuilder(retriever)
+    patch_logger = SimpleNamespace(
+        track_contributors=lambda *a, **k: {},
+        roi_tracker=None,
+        event_bus=bus,
+    )
     layer = CognitionLayer(
-        retriever=retriever, vector_metrics=vec_db, event_bus=bus, roi_tracker=None
+        retriever=retriever,
+        context_builder=builder,
+        patch_logger=patch_logger,
+        vector_metrics=vec_db,
+        event_bus=bus,
+        roi_tracker=None,
     )
 
     _ctx, sid = layer.query("q", top_k=2)

--- a/tests/test_retriever_reliability_refresh.py
+++ b/tests/test_retriever_reliability_refresh.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import universal_retriever as ur_mod
 from vector_service.cognition_layer import CognitionLayer
 from vector_service.retriever import Retriever
@@ -26,7 +28,15 @@ def test_reliability_reload_calls_universal_retriever(monkeypatch):
         code_db=object(),
     )
 
-    layer = CognitionLayer(retriever=Retriever(retriever=ur))
+    builder = SimpleNamespace()
+    patch_logger = SimpleNamespace(roi_tracker=None, event_bus=None)
+    layer = CognitionLayer(
+        context_builder=builder,
+        retriever=Retriever(retriever=ur),
+        patch_logger=patch_logger,
+        vector_metrics=None,
+        roi_tracker=None,
+    )
 
     layer.reload_reliability_scores()
 

--- a/tests/test_vector_metrics_weight_clamping.py
+++ b/tests/test_vector_metrics_weight_clamping.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 
 from vector_service.cognition_layer import CognitionLayer
@@ -6,7 +8,8 @@ from vector_metrics_db import VectorMetricsDB
 
 def test_weights_stay_within_bounds_after_feedback(tmp_path):
     vec_db = VectorMetricsDB(tmp_path / "vm.db")
-    layer = CognitionLayer(vector_metrics=vec_db)
+    builder = SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
+    layer = CognitionLayer(context_builder=builder, vector_metrics=vec_db)
     vectors = [("db1", "v1", 0.0), ("db2", "v2", 0.0)]
 
     for _ in range(5):

--- a/vector_service/README.md
+++ b/vector_service/README.md
@@ -18,10 +18,12 @@ top hits. `cognition_layer.py` orchestrates this flow:
 
 ```python
 from roi_tracker import ROITracker  # optional
+from vector_service.context_builder import ContextBuilder
 from vector_service.cognition_layer import CognitionLayer
 
 tracker = ROITracker()
-layer = CognitionLayer(roi_tracker=tracker)
+builder = ContextBuilder()
+layer = CognitionLayer(context_builder=builder, roi_tracker=tracker)
 
 ctx, session_id = layer.query("How can I fix latency?")
 # ...apply patch based on ctx...
@@ -85,10 +87,11 @@ retrieval ranker:
 
 ```python
 from vector_service.cognition_layer import CognitionLayer
+from vector_service.context_builder import ContextBuilder
 from vector_service.embedding_backfill import schedule_backfill
 import asyncio
 
-layer = CognitionLayer()
+layer = CognitionLayer(context_builder=ContextBuilder())
 ctx, sid = layer.query("Improve throughput?")
 layer.record_patch_outcome(sid, True)
 # contributors gain weight in the ranker


### PR DESCRIPTION
## Summary
- ensure CognitionLayer test helpers explicitly supply a ContextBuilder
- document the required ContextBuilder when instantiating CognitionLayer

## Testing
- `PYTHONPATH=$PWD pre-commit run --files tests/test_vector_metrics_weight_clamping.py tests/test_retriever_reliability_refresh.py tests/test_cognition_layer_risk_propagation.py tests/test_cognition_layer_risk_events.py vector_service/README.md docs/vector_service.md`
- `PYTHONPATH=$PWD python scripts/check_context_builder_usage.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdd5b02590832eb831d97748835346