### PR TITLE
Require explicit ContextBuilder in CognitionLayer

### DIFF
--- a/action_planner.py
+++ b/action_planner.py
@@ -182,7 +182,9 @@ class ActionPlanner:
         self.priority_weights: Dict[str, float] = {}
         if cognition_layer is None:
             try:
-                cognition_layer = CognitionLayer(context_builder=context_builder)
+                cognition_layer = CognitionLayer(
+                    context_builder=context_builder, roi_tracker=self.roi_tracker
+                )
             except Exception:  # pragma: no cover - optional dependency
                 cognition_layer = None
         self.cognition_layer = cognition_layer

--- a/tests/test_context_builder_roi_risk.py
+++ b/tests/test_context_builder_roi_risk.py
@@ -66,7 +66,10 @@ def test_risk_scores_penalize_and_propagate(tmp_path):
     ]
     retriever = DummyRetriever(hits)
     vec_db = VectorMetricsDB(tmp_path / "vec.db")
-    layer = CognitionLayer(retriever=retriever, vector_metrics=vec_db)
+    builder = ContextBuilder(retriever=retriever)
+    layer = CognitionLayer(
+        retriever=retriever, vector_metrics=vec_db, context_builder=builder
+    )
     ctx, sid = layer.query("q", top_k=1)
     parsed = json.loads(ctx)
     assert parsed["bots"][0]["roi"] == 1.0


### PR DESCRIPTION
## Summary
- require an explicit `ContextBuilder` for `CognitionLayer`
- attach ROI tracker and dependencies to provided builder without creating defaults
- update ActionPlanner and tests to supply a builder

## Testing
- `pytest tests/test_context_builder_roi_risk.py tests/test_cognition_layer_ranking_weights.py tests/test_cognition_layer_metrics.py -q` *(fails: FileNotFoundError: No such file or directory: '')*

------
https://chatgpt.com/codex/tasks/task_e_68bdd8c44c1c832eb0c36671c1115e2b