### PR TITLE
refactor: drop default context builder

### DIFF
--- a/vector_service/__init__.py
+++ b/vector_service/__init__.py
@@ -8,6 +8,7 @@ from .patch_logger import PatchLogger
 from .cognition_layer import CognitionLayer
 from .embedding_backfill import EmbeddingBackfill
 from .vectorizer import SharedVectorService
+from .context_builder import ContextBuilder
 from .exceptions import (
     VectorServiceError,
     RateLimitError,
@@ -33,6 +34,7 @@ __all__ = [
     "CognitionLayer",
     "EmbeddingBackfill",
     "SharedVectorService",
+    "ContextBuilder",
     "EmbeddableDBMixin",
     "VectorServiceError",
     "RateLimitError",


### PR DESCRIPTION
## Summary
- expose ContextBuilder via `vector_service` package
- ensure no usage of deprecated `get_default_context_builder`

## Testing
- `python scripts/check_context_builder_usage.py`


------
https://chatgpt.com/codex/tasks/task_e_68bddae1a4f8832e8598c6ee3635b945