### PR TITLE
Handle session based context in AutomatedReviewer

### DIFF
--- a/auto_escalation_manager.py
+++ b/auto_escalation_manager.py
@@ -127,7 +127,12 @@ class AutoEscalationManager:
         self.logger = logging.getLogger(self.__class__.__name__)
 
     # ------------------------------------------------------------------
-    def handle(self, message: str, attachments: Iterable[str] | None = None) -> None:
+    def handle(
+        self,
+        message: str,
+        attachments: Iterable[str] | None = None,
+        session_id: str | None = None,
+    ) -> None:
         """Attempt automated recovery actions."""
         try:
             self.debugger.analyse_and_fix()

--- a/tests/test_automated_reviewer_context_builder_invocation.py
+++ b/tests/test_automated_reviewer_context_builder_invocation.py
@@ -9,7 +9,7 @@ class RecordingBuilder:
 
     def build(self, payload, **_):  # pragma: no cover - simple stub
         self.calls.append(payload)
-        return "ctx"
+        return {"snippet": "ctx"}
 
     def refresh_db_weights(self):
         pass
@@ -23,9 +23,11 @@ class DummyCognitionLayer:
 class RecordingEscalator:
     def __init__(self) -> None:
         self.attachments = None
+        self.session_id = None
 
-    def handle(self, *_a, attachments=None, **_k):
+    def handle(self, *_a, attachments=None, session_id=None, **_k):
         self.attachments = attachments
+        self.session_id = session_id
 
 
 sys.modules["vector_service"] = types.SimpleNamespace(
@@ -47,3 +49,4 @@ def test_reviewer_uses_context_builder():
 
     assert builder.calls, "context_builder.build was not invoked"
     assert esc.attachments and "ctx" in esc.attachments[0]
+    assert esc.session_id


### PR DESCRIPTION
## Summary
- Generate a session id for critical review handling and pass it through the context builder and escalation manager
- Ignore vector service FallbackResult/ErrorResult outputs and compress retrieved context snippets
- Allow AutoEscalationManager.handle to accept an optional session_id

## Testing
- `pytest tests/test_automated_reviewer.py::test_escalation_on_critical tests/test_automated_reviewer.py::test_vector_service_metrics_and_fallback tests/test_automated_reviewer_context_builder_invocation.py::test_reviewer_uses_context_builder -q`
- `pytest tests/test_auto_escalation_manager.py::test_notifier_uses_auto_handler tests/test_auto_escalation_manager.py::test_notifier_default_handler -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde02e3d58832e9e7e2789b81aaca0