### PR TITLE
Require ContextBuilder for SanityConsumer

### DIFF
--- a/tests/integration/test_sanity_consumer_flow.py
+++ b/tests/integration/test_sanity_consumer_flow.py
@@ -132,10 +132,15 @@ def test_watchdog_anomaly_reaches_consumer(monkeypatch, tmp_path):
     monkeypatch.setattr(sc, "SelfCodingEngine", DummyEngine)
 
     class DummyBuilder:
-        def refresh_db_weights(self):
-            pass
+        def __init__(self) -> None:
+            self.refreshed = False
 
-    consumer = sc.SanityConsumer(event_bus=bus, context_builder=DummyBuilder())
+        def refresh_db_weights(self):
+            self.refreshed = True
+
+    builder = DummyBuilder()
+    consumer = sc.SanityConsumer(event_bus=bus, context_builder=builder)
+    assert builder.refreshed
 
     # Emit anomaly
     record = {"type": "missing_charge", "id": "ch_1", "amount": 5}

--- a/tests/test_sanity_consumer_engine.py
+++ b/tests/test_sanity_consumer_engine.py
@@ -90,8 +90,11 @@ sys.modules["menace_memory_manager"] = mmm_module
 
 
 class _Builder:
+    def __init__(self):
+        self.refreshed = False
+
     def refresh_db_weights(self):
-        pass
+        self.refreshed = True
 
 import billing.sanity_consumer as sc  # noqa: E402
 from unified_event_bus import UnifiedEventBus  # noqa: E402
@@ -103,8 +106,12 @@ def test_injected_engine_used():
         pass
 
     engine = DummyEngine()
-    consumer = sc.SanityConsumer(event_bus=UnifiedEventBus(), engine=engine)
+    builder = _Builder()
+    consumer = sc.SanityConsumer(
+        event_bus=UnifiedEventBus(), engine=engine, context_builder=builder
+    )
     assert consumer._get_engine() is engine
+    assert builder.refreshed
 
 
 def test_engine_instantiates_dependencies(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Require a `ContextBuilder` when instantiating `SanityConsumer`
- Drop `None` checks and refresh DB weights during `SanityConsumer` initialization
- Update tests to provide builders and verify refresh

## Testing
- `pytest tests/test_sanity_consumer_engine.py -q`
- `pytest tests/integration/test_sanity_consumer_flow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde4178794832eb052c5fe992a9c53