### PR TITLE
Require explicit context builder for ErrorBot

### DIFF
--- a/bot_creation_bot.py
+++ b/bot_creation_bot.py
@@ -100,7 +100,7 @@ class BotCreationBot(AdminBotBase):
         )
         self.tester = tester or BotTestingBot()
         self.deployer = deployer or DeploymentBot()
-        self.error_bot = error_bot or ErrorBot()
+        self.error_bot = error_bot or ErrorBot(context_builder=self.context_builder)
         self.scaler = scaler or ScalabilityAssessmentBot()
         self.config = config or CreationConfig()
         self.prediction_manager = prediction_manager

--- a/communication_maintenance_bot.py
+++ b/communication_maintenance_bot.py
@@ -311,7 +311,7 @@ if os.getenv("MENACE_LIGHT_IMPORTS"):
 
 
     class ErrorBot:
-        def __init__(self, db: ErrorDB) -> None:
+        def __init__(self, db: ErrorDB, context_builder=None) -> None:
             self.db = db
             self.logger = logging.getLogger("CommMaintenanceBot.ErrorBot")
 
@@ -1063,6 +1063,7 @@ class CommunicationMaintenanceBot(AdminBotBase):
         *,
         event_bus: Optional[UnifiedEventBus] = None,
         memory_mgr: MenaceMemoryManager | None = None,
+        context_builder: "ContextBuilder" | None = None,
         logger: logging.Logger | None = None,
         webhook_urls: Optional[Iterable[str] | str] = None,
         msg_retry_attempts: Optional[int] = None,
@@ -1094,7 +1095,10 @@ class CommunicationMaintenanceBot(AdminBotBase):
                     self.db = SQLiteMaintenanceDB()
             else:
                 self.db = SQLiteMaintenanceDB()
-        self.error_bot = error_bot or ErrorBot(ErrorDB(self.config.error_db_path))
+        self.context_builder = context_builder
+        self.error_bot = error_bot or ErrorBot(
+            ErrorDB(self.config.error_db_path), context_builder=self.context_builder
+        )
         repo_path = Path(repo_path or os.getenv("MAINTENANCE_REPO_PATH", "."))
         broker = broker or os.getenv("CELERY_BROKER_URL")
         if Celery and not broker and MENACE_MODE.lower() == "production":

--- a/diagnostic_manager.py
+++ b/diagnostic_manager.py
@@ -81,12 +81,26 @@ class DiagnosticManager:
         self,
         metrics_db: MetricsDB | None = None,
         error_bot: ErrorBot | None = None,
+        *,
+        context_builder: "ContextBuilder" | None = None,
         ledger: DecisionLedger | None = None,
         queue: CoordinationManager | None = None,
         log: ResolutionDB | None = None,
     ) -> None:
         self.metrics = metrics_db or MetricsDB()
-        self.error_bot = error_bot or ErrorBot(ErrorDB(), self.metrics)
+        self.context_builder = context_builder
+        if error_bot is None:
+            if self.context_builder is None:
+                from vector_service.context_builder import ContextBuilder
+
+                self.context_builder = ContextBuilder()
+            self.error_bot = ErrorBot(
+                ErrorDB(),
+                self.metrics,
+                context_builder=self.context_builder,
+            )
+        else:
+            self.error_bot = error_bot
         self.ledger = ledger or DecisionLedger()
         self.queue = queue or CoordinationManager()
         self.log = log or ResolutionDB()

--- a/docs/active_learning.md
+++ b/docs/active_learning.md
@@ -15,9 +15,10 @@ from menace.unified_event_bus import UnifiedEventBus
 from menace.error_bot import ErrorBot
 from menace.curriculum_builder import CurriculumBuilder
 from menace.self_learning_coordinator import SelfLearningCoordinator
+from vector_service.context_builder import ContextBuilder
 
 bus = UnifiedEventBus()
-err_bot = ErrorBot()
+err_bot = ErrorBot(context_builder=ContextBuilder())
 builder = CurriculumBuilder(err_bot, bus, threshold=5)
 coord = SelfLearningCoordinator(bus, curriculum_builder=builder)
 coord.start()

--- a/error_bot.py
+++ b/error_bot.py
@@ -919,7 +919,7 @@ class ErrorBot(AdminBotBase):
         event_bus: Optional[EventBus] = None,
         memory_mgr: MenaceMemoryManager | None = None,
         graph: KnowledgeGraph | None = None,
-        context_builder: ContextBuilder | None = None,
+        context_builder: ContextBuilder,
         forecaster: ErrorForecaster | None = None,
         self_coding_engine: "SelfCodingEngine" | None = None,
         improvement_engine: "SelfImprovementEngine" | None = None,
@@ -928,9 +928,12 @@ class ErrorBot(AdminBotBase):
         self.name = "ErrorBot"
         self.db = db or ErrorDB()
         self.graph = graph
-        builder = context_builder or ContextBuilder()
+        self.context_builder = context_builder
+        self.context_builder.refresh_db_weights()
         self.error_logger = ErrorLogger(
-            self.db, knowledge_graph=self.graph, context_builder=builder
+            self.db,
+            knowledge_graph=self.graph,
+            context_builder=self.context_builder,
         )
         self.data_bot = data_bot
         if metrics_db:

--- a/menace_gui.py
+++ b/menace_gui.py
@@ -53,7 +53,7 @@ class MenaceGUI(tk.Tk):
         else:
             logging.warning("OPENAI_API_KEY not set. ChatGPT features disabled.")
             self.conv_bot = None
-        self.error_bot = ErrorBot()
+        self.error_bot = ErrorBot(context_builder=self.context_builder)
         self._setup_widgets()
 
     # ------------------------------------------------------------------

--- a/menace_master.py
+++ b/menace_master.py
@@ -454,7 +454,7 @@ def run_once(models: Iterable[str]) -> None:
         try:  # best effort ErrorBot logging
             from menace.error_bot import ErrorBot  # type: ignore
 
-            err_bot = ErrorBot()  # type: ignore[call-arg]
+            err_bot = ErrorBot(context_builder=ContextBuilder())  # type: ignore[call-arg]
             if hasattr(err_bot, "handle_error"):
                 err_bot.handle_error(str(exc))
         except Exception:

--- a/sandbox_runner.py
+++ b/sandbox_runner.py
@@ -886,6 +886,7 @@ def _sandbox_init(
         telem_db,
         metrics_db,
         graph=graph,
+        context_builder=context_builder,
         forecaster=forecaster,
         improvement_engine=improver,
     )

--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -562,7 +562,7 @@ class SelfImprovementEngine:
             context_builder=builder,
         )
         self.action_planner = action_planner
-        err_bot = ErrorBot(ErrorDB(), MetricsDB())
+        err_bot = ErrorBot(ErrorDB(), MetricsDB(), context_builder=builder)
         self.error_bot = err_bot
         self.diagnostics = diagnostics or DiagnosticManager(MetricsDB(), err_bot)
         self._alignment_agent: AlignmentReviewAgent | None = None

--- a/self_model_bootstrap.py
+++ b/self_model_bootstrap.py
@@ -16,6 +16,7 @@ from menace.deployment_bot import DeploymentBot
 from menace.error_bot import ErrorBot
 from menace.data_bot import DataBot, MetricsDB
 from menace.capital_management_bot import CapitalManagementBot
+from vector_service.context_builder import ContextBuilder
 from menace.database_manager import add_model, update_model, DB_PATH
 
 
@@ -30,7 +31,7 @@ def bootstrap() -> int:
     deployer = DeploymentBot()
     capital_bot = CapitalManagementBot()
     data_bot = DataBot(MetricsDB(), capital_bot=capital_bot)
-    err_bot = ErrorBot(data_bot=data_bot)
+    err_bot = ErrorBot(data_bot=data_bot, context_builder=ContextBuilder())
 
     bot_files = sorted(resolve_dir(".").glob("*_bot.py"))
     bot_names = [p.stem for p in bot_files]

--- a/tests/test_bot_creation_bot.py
+++ b/tests/test_bot_creation_bot.py
@@ -197,7 +197,7 @@ def test_create_bots_logs_errors(tmp_path):
         developer=developer,
         tester=tester,
         deployer=deployer,
-        error_bot=eb.ErrorBot(err_db),
+        error_bot=eb.ErrorBot(err_db, context_builder=developer.context_builder),
         context_builder=developer.context_builder,
     )
     developer.errors.append("integration fail")
@@ -286,7 +286,7 @@ def test_code_db_updates_on_creation(tmp_path):
         developer=developer,
         tester=tester,
         deployer=deployer,
-        error_bot=eb.ErrorBot(err_db),
+        error_bot=eb.ErrorBot(err_db, context_builder=developer.context_builder),
         context_builder=developer.context_builder,
     )
 
@@ -451,7 +451,7 @@ def test_higher_order_contrarian_new_links(tmp_path):
         developer=developer,
         tester=tester,
         deployer=deployer,
-        error_bot=eb.ErrorBot(err_db),
+        error_bot=eb.ErrorBot(err_db, context_builder=developer.context_builder),
         context_builder=developer.context_builder,
     )
 
@@ -580,7 +580,10 @@ def test_enhancement_link_error_logged(tmp_path, caplog):
         developer=developer,
         tester=tester,
         deployer=deployer,
-        error_bot=eb.ErrorBot(eb.ErrorDB(tmp_path / "err.db")),
+        error_bot=eb.ErrorBot(
+            eb.ErrorDB(tmp_path / "err.db"),
+            context_builder=developer.context_builder,
+        ),
         context_builder=developer.context_builder,
     )
 

--- a/tests/test_communication_maintenance_bot.py
+++ b/tests/test_communication_maintenance_bot.py
@@ -1,6 +1,11 @@
 import os
 import sys
 import types
+
+
+class DummyBuilder:
+    def refresh_db_weights(self):
+        pass
 import logging
 from datetime import datetime
 import pytest
@@ -87,7 +92,7 @@ def test_hotfix_logs(monkeypatch, tmp_path):
 
     mdb = cmb.MaintenanceDB(tmp_path / "m.db")
     edb = cmb.ErrorDB(tmp_path / "e.db")
-    ebot = cmb.ErrorBot(edb)
+    ebot = cmb.ErrorBot(edb, context_builder=DummyBuilder())
     router = types.SimpleNamespace(terms=[])
     router.query_all = lambda term: router.terms.append(term) or {}
     bot = cmb.CommunicationMaintenanceBot(mdb, ebot, repo_path, db_router=router)

--- a/tests/test_database_steward_bot.py
+++ b/tests/test_database_steward_bot.py
@@ -9,6 +9,11 @@ import menace.error_bot as eb
 from sqlalchemy import Column, Integer, String, Table
 
 
+class DummyBuilder:
+    def refresh_db_weights(self):
+        pass
+
+
 def test_version_and_lock(tmp_path: Path):
     repo = tmp_path / "repo"
     bot = dsb.DatabaseStewardBot(sql_url=f"sqlite:///{tmp_path / 'db.sqlite'}", repo_path=repo)
@@ -36,7 +41,7 @@ def test_error_bot_fix(tmp_path: Path):
     admin = tmp_path / "admin.py"  # path-ignore
     admin.write_text("print('x')\n")
     err = eb.ErrorDB(tmp_path / "e.db")
-    ebot = eb.ErrorBot(err)
+    ebot = eb.ErrorBot(err, context_builder=DummyBuilder())
     bot = dsb.DatabaseStewardBot(
         sql_url=f"sqlite:///{tmp_path / 'db.sqlite'}",
         error_bot=ebot,

--- a/tests/test_diagnostic_manager.py
+++ b/tests/test_diagnostic_manager.py
@@ -6,6 +6,7 @@ import pandas as pd
 import menace.diagnostic_manager as dm
 import menace.data_bot as db
 import menace.error_bot as eb
+import types
 
 
 def make_metrics(tmp_path):
@@ -19,7 +20,8 @@ def test_diagnose(tmp_path):
     mdb = make_metrics(tmp_path)
     e = eb.ErrorDB(tmp_path / "e.db")
     e.log_discrepancy("d")
-    manager = dm.DiagnosticManager(mdb, eb.ErrorBot(e, mdb))
+    builder = types.SimpleNamespace(refresh_db_weights=lambda: None)
+    manager = dm.DiagnosticManager(mdb, eb.ErrorBot(e, mdb, context_builder=builder))
     issues = manager.diagnose()
     assert "high_response_time" in issues
     assert "error_rate" in issues
@@ -29,7 +31,12 @@ def test_diagnose(tmp_path):
 def test_resolve_and_log(tmp_path, monkeypatch):
     mdb = make_metrics(tmp_path)
     e = eb.ErrorDB(tmp_path / "e.db")
-    manager = dm.DiagnosticManager(mdb, eb.ErrorBot(e, mdb), log=dm.ResolutionDB(tmp_path / "r.db"))
+    builder = types.SimpleNamespace(refresh_db_weights=lambda: None)
+    manager = dm.DiagnosticManager(
+        mdb,
+        eb.ErrorBot(e, mdb, context_builder=builder),
+        log=dm.ResolutionDB(tmp_path / "r.db"),
+    )
     monkeypatch.setattr(dm.DynamicResourceAllocator, "allocate", lambda self, bots: [(b, True) for b in bots])
     manager.resolve_issue("high_response_time")
     rows = manager.log.fetch()

--- a/tests/test_error_bot_logging.py
+++ b/tests/test_error_bot_logging.py
@@ -40,10 +40,20 @@ class BadMem:
         raise RuntimeError("fail")
 
 
+class DummyBuilder:
+    def refresh_db_weights(self):
+        pass
+
+
 def test_error_bot_logs_failures(tmp_path, caplog):
     caplog.set_level(logging.ERROR)
     bus = BadBus()
-    bot = ErrorBot(ErrorDB(tmp_path / "e.db", event_bus=bus), event_bus=bus, memory_mgr=BadMem())
+    bot = ErrorBot(
+        ErrorDB(tmp_path / "e.db", event_bus=bus),
+        event_bus=bus,
+        memory_mgr=BadMem(),
+        context_builder=DummyBuilder(),
+    )
     bot.db._publish("t", {})
     text = caplog.text
     assert "event bus subscription failed" in text

--- a/tests/test_event_integration.py
+++ b/tests/test_event_integration.py
@@ -11,6 +11,11 @@ from menace.unified_event_bus import UnifiedEventBus  # noqa: E402
 from menace.menace_memory_manager import MenaceMemoryManager, MemoryEntry  # noqa: E402
 
 
+class DummyBuilder:
+    def refresh_db_weights(self):
+        pass
+
+
 def test_error_bot_event_subscription(tmp_path):
     bus = UnifiedEventBus()
     try:
@@ -19,7 +24,7 @@ def test_error_bot_event_subscription(tmp_path):
         pytest.skip("error bot unavailable")
     err_db = eb.ErrorDB(tmp_path / "e.db", event_bus=bus)
     metrics = db.MetricsDB(tmp_path / "m.db")
-    bot = eb.ErrorBot(err_db, metrics, event_bus=bus)
+    bot = eb.ErrorBot(err_db, metrics, event_bus=bus, context_builder=DummyBuilder())
     bus.publish("errors:new", {"message": "boom"})
     assert bot.last_error_event
 

--- a/tests/test_improvement_engine_registry.py
+++ b/tests/test_improvement_engine_registry.py
@@ -52,7 +52,8 @@ def _make_engine(tmp_path, name: str, monkeypatch):
     mdb = db.MetricsDB(tmp_path / f"{name}.m.db")
     edb = eb.ErrorDB(tmp_path / f"{name}.e.db")
     info = rab.InfoDB(tmp_path / f"{name}.i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    builder = types.SimpleNamespace(refresh_db_weights=lambda: None)
+    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb, context_builder=builder))
     pipe = StubPipeline()
     monkeypatch.setattr(sie, "bootstrap", lambda: 0)
     engine = sie.SelfImprovementEngine(

--- a/tests/test_logging_updates.py
+++ b/tests/test_logging_updates.py
@@ -13,7 +13,7 @@ def _stub_deps():
         mod.Template = type("T", (), {"render": lambda self, *a, **k: ""})
         sys.modules["jinja2"] = mod
     for name in ["yaml", "numpy", "matplotlib", "matplotlib.pyplot", "cryptography", "cryptography.hazmat", "cryptography.hazmat.primitives", "cryptography.hazmat.primitives.asymmetric"]:  # path-ignore  # noqa: E501
-        sys.modules.setdefault(name, types.ModuleType(name))
+    sys.modules.setdefault(name, types.ModuleType(name))
     sys.modules.pop('menace.database_steward_bot', None)
     sys.modules.pop('menace.capital_management_bot', None)
     sa = types.ModuleType("sqlalchemy")
@@ -65,7 +65,10 @@ def test_database_steward_safe_mode_logs(tmp_path, caplog):
         def is_safe_mode(self, module):
             return True
 
-    err_bot = eb.ErrorBot(eb.ErrorDB(tmp_path / "e.db"))  # noqa: F821
+    err_bot = eb.ErrorBot(
+        eb.ErrorDB(tmp_path / "e.db"),
+        context_builder=types.SimpleNamespace(refresh_db_weights=lambda: None),
+    )  # noqa: F821
     err_bot.db = DummyErrDB()
 
     class Conv:

--- a/tests/test_patch_score_backend.py
+++ b/tests/test_patch_score_backend.py
@@ -173,7 +173,10 @@ def test_engine_uses_backend(monkeypatch, tmp_path):
     mdb = sie_tests.db.MetricsDB(tmp_path / "m.db")
     edb = sie_tests.eb.ErrorDB(tmp_path / "e.db")
     info = sie_tests.rab.InfoDB(tmp_path / "i.db")
-    diag = sie_tests.dm.DiagnosticManager(mdb, sie_tests.eb.ErrorBot(edb, mdb))
+    builder = types.SimpleNamespace(refresh_db_weights=lambda: None)
+    diag = sie_tests.dm.DiagnosticManager(
+        mdb, sie_tests.eb.ErrorBot(edb, mdb, context_builder=builder)
+    )
 
     class StubPipeline:
         def run(self, model: str, energy: int = 1):

--- a/tests/test_safe_mode.py
+++ b/tests/test_safe_mode.py
@@ -17,8 +17,14 @@ def test_bot_safe_mode(tmp_path):
         def build(self, query, **_):
             return ""
 
-    conv = cmb.ConversationManagerBot(cib.ChatGPTClient("key", context_builder=DummyBuilder()))
-    bot = eb.ErrorBot(err_db, conversation_bot=conv, metrics_db=db.MetricsDB(tmp_path / "m.db"))
+    builder = DummyBuilder()
+    conv = cmb.ConversationManagerBot(cib.ChatGPTClient("key", context_builder=builder))
+    bot = eb.ErrorBot(
+        err_db,
+        conversation_bot=conv,
+        metrics_db=db.MetricsDB(tmp_path / "m.db"),
+        context_builder=builder,
+    )
     steward = dsb.DatabaseStewardBot(
         sql_url=f"sqlite:///{tmp_path / 'db.sqlite'}",
         error_bot=bot,

--- a/tests/test_self_improvement_engine.py
+++ b/tests/test_self_improvement_engine.py
@@ -430,11 +430,16 @@ import menace.evolution_history_db as eh
 import menace.self_improvement_policy as sip
 
 
+def _diag(edb, mdb):
+    builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
+    return dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb, context_builder=builder))
+
+
 def test_run_cycle(tmp_path, monkeypatch):
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
     builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
     agg = rab.ResearchAggregatorBot(["menace"], info_db=info, context_builder=builder)
     class StubPipeline:
@@ -457,7 +462,7 @@ def test_run_cycle_triggers_workflow_evolution(tmp_path, monkeypatch):
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
 
     class StubPipeline:
         def run(self, model: str, energy: int = 1):
@@ -555,7 +560,7 @@ def test_schedule_baseline_deviation(tmp_path, monkeypatch):
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
 
     class StubPipeline:
         def run(self, model: str, energy: int = 1):
@@ -615,7 +620,7 @@ def test_schedule_deviation_autoruns(tmp_path, monkeypatch):
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
 
     class StubPipeline:
         def run(self, model: str, energy: int = 1):
@@ -661,7 +666,7 @@ def test_policy_state_with_patch_metrics(tmp_path):
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
     hist = eh.EvolutionHistoryDB(tmp_path / "h.db")
     patch_db = cd.PatchHistoryDB(tmp_path / "p.db")
 
@@ -717,7 +722,7 @@ def test_pre_roi_energy_scaling(tmp_path, monkeypatch):
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
 
     class StubPipeline:
         def __init__(self) -> None:
@@ -770,7 +775,7 @@ def test_policy_state_includes_synergy(tmp_path):
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
 
     class StubPipeline:
         def run(self, model: str, energy: int = 1):
@@ -802,7 +807,7 @@ def test_engine_policy_persistence(tmp_path, monkeypatch):
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
 
     class StubPipeline:
         def run(self, model: str, energy: int = 1):
@@ -855,7 +860,7 @@ def test_synergy_energy_scaling(tmp_path, monkeypatch):
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
 
     class StubPipeline:
         def __init__(self) -> None:
@@ -900,7 +905,7 @@ def test_synergy_energy_cap(tmp_path, monkeypatch):
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
 
     class StubPipeline:
         def __init__(self) -> None:
@@ -933,7 +938,7 @@ def test_policy_update_receives_synergy_deltas(tmp_path, monkeypatch):
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
 
     class StubPipeline:
         def run(self, model: str, energy: int = 1):
@@ -985,7 +990,7 @@ def test_roi_history_group_ids(tmp_path, monkeypatch):
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
 
     class StubPipeline:
         def run(self, model: str, energy: int = 1):
@@ -1101,7 +1106,7 @@ def test_module_map_refresh_updates_roi_groups(tmp_path, monkeypatch):
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
 
     class StubPipeline:
         def run(self, model: str, energy: int = 1):
@@ -1169,7 +1174,7 @@ def test_init_refresh_called_for_unknown_patches(tmp_path, monkeypatch):
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
     class StubPipeline:
         def run(self, model: str, energy: int = 1):
             return mp.AutomationResult(package=None, roi=prb.ROIResult(0.0, 0.0, 0.0, 0.0, 0.0))
@@ -1226,7 +1231,7 @@ def test_init_discovers_module_groups(tmp_path, monkeypatch):
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
 
     class StubPipeline:
         def run(self, model: str, energy: int = 1):
@@ -1372,7 +1377,7 @@ def test_deployment_governor_promote_marks_workflow_ready(
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
 
     class StubPipeline:
         def run(self, model: str, energy: int = 1):
@@ -1405,7 +1410,7 @@ def test_deployment_governor_pilot_enqueues_borderline(
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
 
     class StubPipeline:
         def run(self, model: str, energy: int = 1):
@@ -1492,7 +1497,7 @@ def test_deployment_gate_promotes(tmp_path, monkeypatch):
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
     engine = sie.SelfImprovementEngine(
         interval=0,
         pipeline=_StubPipeline(),
@@ -1524,7 +1529,7 @@ def test_deployment_gate_borderline(tmp_path, monkeypatch):
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
     bucket = _Bucket()
     engine = sie.SelfImprovementEngine(
         interval=0,
@@ -1550,7 +1555,7 @@ def test_deployment_gate_pilot(tmp_path, monkeypatch):
     mdb = db.MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db")
     info = rab.InfoDB(tmp_path / "i.db")
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb))
+    diag = _diag(edb, mdb)
     engine = sie.SelfImprovementEngine(
         interval=0,
         pipeline=_StubPipeline(),

--- a/tests/test_self_learning_coordinator.py
+++ b/tests/test_self_learning_coordinator.py
@@ -297,7 +297,7 @@ def test_telemetry_summary_updates_training(tmp_path):
                 )
 
     class DummyErrorBot:
-        def __init__(self, db, metrics):
+        def __init__(self, db, metrics, context_builder=None):
             self.db = db
             self.metrics = metrics
 
@@ -317,7 +317,7 @@ def test_telemetry_summary_updates_training(tmp_path):
     engine = DummyEngine()
     mdb = MetricsDB(tmp_path / "m.db")
     edb = eb.ErrorDB(tmp_path / "e.db", event_bus=bus)
-    err_bot = eb.ErrorBot(edb, mdb)
+    err_bot = eb.ErrorBot(edb, mdb, context_builder=None)
     import os
     os.environ["SELF_LEARNING_SUMMARY_INTERVAL"] = "1"
     coord = SelfLearningCoordinator(


### PR DESCRIPTION
## Summary
- Require explicit context builder injection in ErrorBot and refresh DB weights on the provided builder
- Pass shared context builder to ErrorLogger and propagate through dependent components
- Update diagnostic and improvement utilities and tests to supply the builder

## Testing
- `pytest tests/test_error_bot.py::test_handle_known tests/test_error_bot.py::test_handle_unknown tests/test_error_bot_logging.py::test_error_bot_logs_failures tests/test_diagnostic_manager.py::test_diagnose -q` *(fails: vector_service import failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bde6a52b54832e819efb5fec91b2a2