### PR TITLE
require explicit context builder for cognition layer

### DIFF
--- a/docs/vectorized_cognition.md
+++ b/docs/vectorized_cognition.md
@@ -17,15 +17,20 @@ vectorizers → EmbeddingBackfill/EmbeddingScheduler → Retriever/ContextBuilde
 ## Building Context and Logging Feedback
 
 ```python
+from vector_service.context_builder import ContextBuilder
 from cognition_layer import build_cognitive_context, log_feedback
 
+builder = ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
+
 # Build a context for a natural‑language request
-context, session_id = build_cognitive_context("optimise cache eviction", top_k=5)
+context, session_id = build_cognitive_context(
+    "optimise cache eviction", top_k=5, context_builder=builder
+)
 
 # ...apply patch based on the context...
 
 # Record whether the change succeeded
-log_feedback(session_id, True, patch_id="cache-fix-42")
+log_feedback(session_id, True, patch_id="cache-fix-42", context_builder=builder)
 ```
 
 `build_cognitive_context` wraps `vector_service.cognition_layer.CognitionLayer.query` to return a JSON context blob and session id. `log_feedback` forwards patch outcomes so ROI histories and ranking weights can update.

--- a/tests/test_cognition_layer_pipeline.py
+++ b/tests/test_cognition_layer_pipeline.py
@@ -73,11 +73,13 @@ def test_cognition_layer_pipeline_feedback_updates_weights_and_roi():
         roi_tracker=tracker,
     )
 
-    cl_module._layer = layer
+    setattr(builder, "_cognition_layer", layer)
     cl_module._roi_tracker = tracker
 
-    _ctx, sid = cl_module.build_cognitive_context("example query", top_k=1)
-    cl_module.log_feedback(sid, True)
+    _ctx, sid = cl_module.build_cognitive_context(
+        "example query", top_k=1, context_builder=builder
+    )
+    cl_module.log_feedback(sid, True, context_builder=builder)
 
     weights = metrics.get_db_weights()
     assert weights.get("db1", 0.0) > 0.0


### PR DESCRIPTION
## Summary
- drop module-level context builder and layer from cognition_layer
- require ContextBuilder to be passed to cognition layer helpers
- update docs and tests to pass builders explicitly

## Testing
- `python scripts/check_context_builder_usage.py`
- `pytest tests/test_cognition_layer.py tests/test_cognition_layer_pipeline.py tests/integration/test_build_cognitive_context_feedback.py` *(fails: FileNotFoundError: 'workflow_roi_history.json' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde920c454832eb1bc6d466458dc9b