### PR TITLE
feat: integrate context builder into enhancement bot

### DIFF
--- a/menace_master.py
+++ b/menace_master.py
@@ -384,7 +384,7 @@ def _init_unused_bots() -> None:
     bot_classes = [
         _wrap(BotDevelopmentBot, context_builder=builder),
         BotTestingBot,
-        _wrap(ChatGPTEnhancementBot, client),
+        _wrap(ChatGPTEnhancementBot, client, context_builder=builder),
         _wrap(ChatGPTPredictionBot, client=client, context_builder=builder),
         _wrap(ChatGPTResearchBot, client),
         CompetitiveIntelligenceBot,

--- a/tests/test_chatgpt_enhancement_bot.py
+++ b/tests/test_chatgpt_enhancement_bot.py
@@ -25,13 +25,13 @@ def test_propose(monkeypatch, tmp_path):
 
         def build(self, query, **_):
             return ""
-
-    client = cib.ChatGPTClient("key", context_builder=DummyBuilder())
+    builder = DummyBuilder()
+    client = cib.ChatGPTClient("key", context_builder=builder)
     monkeypatch.setattr(ceb, "ask_with_memory", lambda *a, **k: resp)
     router = ceb.init_db_router("enhprop", str(tmp_path / "local.db"), str(tmp_path / "shared.db"))
     db = ceb.EnhancementDB(tmp_path / "enh.db", router=router)
     db.add_embedding = lambda *a, **k: None
-    bot = ceb.ChatGPTEnhancementBot(client, db=db)
+    bot = ceb.ChatGPTEnhancementBot(client, db=db, context_builder=builder)
     monkeypatch.setattr(bot, "_feasible", lambda e: True)
     results = bot.propose("Improve", num_ideas=1, context="ctx")
     assert results and results[0].context == "ctx"

--- a/tests/test_research_aggregator_bot.py
+++ b/tests/test_research_aggregator_bot.py
@@ -7,7 +7,7 @@ import menace.chatgpt_idea_bot as cib  # noqa: E402
 import menace.chatgpt_enhancement_bot as ceb  # noqa: E402
 import menace.chatgpt_prediction_bot as cpb  # noqa: E402
 import sqlite3  # noqa: E402
-import types
+import types  # noqa: E402
 
 
 def _builder():
@@ -108,7 +108,11 @@ def test_chatgpt_integration(monkeypatch):
 
 
 def test_enhancement_prediction(monkeypatch, tmp_path):
-    enh_bot = ceb.ChatGPTEnhancementBot(None, db=ceb.EnhancementDB(tmp_path / "e.db"))
+    enh_bot = ceb.ChatGPTEnhancementBot(
+        None,
+        db=ceb.EnhancementDB(tmp_path / "e.db"),
+        context_builder=_builder(),
+    )
     monkeypatch.setattr(
         enh_bot,
         "propose",
@@ -136,7 +140,7 @@ def test_enhancement_prediction(monkeypatch, tmp_path):
 
 def test_enhancement_links(monkeypatch, tmp_path):
     enh_db = ceb.EnhancementDB(tmp_path / "e.db")
-    enh_bot = ceb.ChatGPTEnhancementBot(None, db=enh_db)
+    enh_bot = ceb.ChatGPTEnhancementBot(None, db=enh_db, context_builder=_builder())
     monkeypatch.setattr(
         enh_bot,
         "propose",
@@ -192,7 +196,7 @@ def test_infodb_summary_and_depth(tmp_path):
 
 def test_enhancement_generates_followup_research(monkeypatch, tmp_path):
     enh_db = ceb.EnhancementDB(tmp_path / "e.db")
-    enh_bot = ceb.ChatGPTEnhancementBot(None, db=enh_db)
+    enh_bot = ceb.ChatGPTEnhancementBot(None, db=enh_db, context_builder=_builder())
     monkeypatch.setattr(
         enh_bot,
         "propose",


### PR DESCRIPTION
## Summary
- require `ContextBuilder` in `ChatGPTEnhancementBot` and use it to build compressed vector context before prompting
- ensure service runners pass a `ContextBuilder` when creating the enhancement bot
- update tests for new constructor

## Testing
- `pre-commit run --files chatgpt_enhancement_bot.py menace_master.py tests/test_chatgpt_enhancement_bot.py tests/test_research_aggregator_bot.py` *(failed: check-static-paths hook could not run due to missing project dependencies)*
- `PYTHONPATH=. pytest tests/test_chatgpt_enhancement_bot.py tests/test_research_aggregator_bot.py -q` *(failed: ImportError: cannot import name 'RAISE_ERRORS' from 'menace')*


------
https://chatgpt.com/codex/tasks/task_e_68bdeeb0e7d0832ea45f2cf97bf446a2