### PR TITLE
feat: inject context builder into research bot

### DIFF
--- a/menace_master.py
+++ b/menace_master.py
@@ -386,7 +386,7 @@ def _init_unused_bots() -> None:
         BotTestingBot,
         _wrap(ChatGPTEnhancementBot, client, context_builder=builder),
         _wrap(ChatGPTPredictionBot, client=client, context_builder=builder),
-        _wrap(ChatGPTResearchBot, client),
+        _wrap(ChatGPTResearchBot, builder, client),
         CompetitiveIntelligenceBot,
         _wrap(
             ContrarianModelBot,

--- a/tests/test_chatgpt_research_bot.py
+++ b/tests/test_chatgpt_research_bot.py
@@ -18,8 +18,8 @@ def test_process(monkeypatch):
 
         def build(self, query, **_):
             return ""
-
-    client = cib.ChatGPTClient("key", context_builder=DummyBuilder())
+    builder = DummyBuilder()
+    client = cib.ChatGPTClient("key", context_builder=builder)
     responses = [
         {"choices": [{"message": {"content": "Answer one."}}]},
         {"choices": [{"message": {"content": "Answer two."}}]},
@@ -40,7 +40,7 @@ def test_process(monkeypatch):
         sent["summary"] = summary
 
     monkeypatch.setattr(crb, "send_to_aggregator", fake_send)
-    bot = crb.ChatGPTResearchBot(client)
+    bot = crb.ChatGPTResearchBot(builder, client)
     result = bot.process("Question", depth=2, ratio=0.5)
     assert len(result.conversation) == 2
     assert sent["conv"] == result.conversation

--- a/tests/test_research_aggregator_bot.py
+++ b/tests/test_research_aggregator_bot.py
@@ -88,7 +88,7 @@ def test_chatgpt_integration(monkeypatch):
         return {"choices": [{"message": {"content": "Some info"}}]}
 
     monkeypatch.setattr(client, "ask", fake_ask)
-    chat_bot = crb.ChatGPTResearchBot(client)
+    chat_bot = crb.ChatGPTResearchBot(builder, client)
 
     text_bot = rab.TextResearchBot()
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- allow ChatGPTResearchBot to accept a ContextBuilder and create its own ChatGPTClient when one isn't provided
- include vector context when calling ask_with_memory
- update bot instantiation sites to pass ContextBuilder explicitly

## Testing
- `python -m py_compile chatgpt_research_bot.py menace_master.py tests/test_chatgpt_research_bot.py tests/test_research_aggregator_bot.py`
- `pytest tests/test_chatgpt_research_bot.py tests/test_research_aggregator_bot.py tests/test_cross_query.py tests/test_dbrouter_semantic_search.py tests/test_infodb_vector_search.py tests/test_infodb_fts.py tests/test_infodb_crossref.py tests/test_research_fallback_bot.py tests/test_auto_link.py tests/test_menace_master.py tests/test_dependency_watchdog_events.py -q` *(fails: RuntimeError: vector_service import failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf0b8442c832e87fbcf052e72f8b8