### PR TITLE
Accept shared ContextBuilder in ResourcesBot

### DIFF
--- a/menace_master.py
+++ b/menace_master.py
@@ -414,6 +414,7 @@ def _init_unused_bots() -> None:
         _wrap(
             ResourcesBot,
             alloc_bot=ResourceAllocationBot(context_builder=builder),
+            context_builder=builder,
         ),
         ScalabilityAssessmentBot,
         StrategyPredictionBot,

--- a/resources_bot.py
+++ b/resources_bot.py
@@ -107,12 +107,13 @@ class ResourcesBot:
         db: ROIHistoryDB | None = None,
         alloc_bot: ResourceAllocationBot | None = None,
         *,
+        context_builder: ContextBuilder,
         prediction_manager: "PredictionManager" | None = None,
         strategy_bot: "StrategyPredictionBot" | None = None,
     ) -> None:
         self.db = db or ROIHistoryDB()
         self.alloc_bot = alloc_bot or ResourceAllocationBot(
-            AllocationDB(), context_builder=ContextBuilder()
+            AllocationDB(), context_builder=context_builder
         )
         self.strategy_bot = strategy_bot
         self.prediction_manager = prediction_manager

--- a/tests/test_resources_bot.py
+++ b/tests/test_resources_bot.py
@@ -15,10 +15,11 @@ class _DummyBuilder:
 def test_redistribute_records(tmp_path):
     db = resb.ROIHistoryDB(tmp_path / "roi.db")
     alloc_db = rab.AllocationDB(tmp_path / "a.db")
+    builder = _DummyBuilder()
     alloc_bot = rab.ResourceAllocationBot(
-        alloc_db, rpb.TemplateDB(tmp_path / "t.csv"), context_builder=_DummyBuilder()
+        alloc_db, rpb.TemplateDB(tmp_path / "t.csv"), context_builder=builder
     )
-    bot = resb.ResourcesBot(db, alloc_bot)
+    bot = resb.ResourcesBot(db, alloc_bot, context_builder=builder)
     metrics = {
         "b1": rpb.ResourceMetrics(cpu=1.0, memory=50.0, disk=1.0, time=1.0),
         "b2": rpb.ResourceMetrics(cpu=5.0, memory=100.0, disk=2.0, time=2.0),
@@ -59,10 +60,17 @@ def test_strategy_and_persistence(tmp_path):
     strategy = DummyStrategy()
     db = resb.ROIHistoryDB(tmp_path / "r.db")
     alloc_db = rab.AllocationDB(tmp_path / "a.db")
+    builder = _DummyBuilder()
     alloc_bot = rab.ResourceAllocationBot(
-        alloc_db, rpb.TemplateDB(tmp_path / "t.csv"), context_builder=_DummyBuilder()
+        alloc_db, rpb.TemplateDB(tmp_path / "t.csv"), context_builder=builder
     )
-    bot = resb.ResourcesBot(db, alloc_bot, prediction_manager=manager, strategy_bot=strategy)
+    bot = resb.ResourcesBot(
+        db,
+        alloc_bot,
+        context_builder=builder,
+        prediction_manager=manager,
+        strategy_bot=strategy,
+    )
     metrics = {"b": rpb.ResourceMetrics(cpu=1.0, memory=1.0, disk=1.0, time=1.0)}
     bot.redistribute(metrics)
     hist = bot.current_allocations()


### PR DESCRIPTION
## Summary
- Allow ResourcesBot to receive a ContextBuilder and forward it to ResourceAllocationBot
- Update ResourcesBot call sites to share the ContextBuilder

## Testing
- `pytest tests/test_resources_bot.py -q`
- `pytest tests/test_menace_master.py -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '')*

------
https://chatgpt.com/codex/tasks/task_e_68bdf533fa7c832e8a77ec555532f2f8