### PR TITLE
refactor: inject context builder into experiment manager

### DIFF
--- a/docs/experiment_manager.md
+++ b/docs/experiment_manager.md
@@ -9,8 +9,10 @@ p-value is below the configured threshold.
 Example:
 ```python
 from menace.experiment_manager import ExperimentManager
+from vector_service.context_builder import ContextBuilder
 
-manager = ExperimentManager(data_bot, capital_bot)
+builder = ContextBuilder()
+manager = ExperimentManager(data_bot, capital_bot, context_builder=builder)
 results = await manager.run_experiments(["bot_v1", "bot_v2"], energy=2)
 best = manager.best_variant(results)
 

--- a/variant_cli.py
+++ b/variant_cli.py
@@ -6,6 +6,8 @@ import argparse
 import json
 from typing import Any, Dict
 
+from vector_service.context_builder import ContextBuilder
+
 from .experiment_manager import ExperimentManager
 from .variant_manager import VariantManager
 from .mutation_lineage import MutationLineage
@@ -23,7 +25,13 @@ def main() -> None:  # pragma: no cover - CLI glue
     # Clone the branch explicitly so operators can see the new patch id
     new_patch = lineage.clone_branch_for_ab_test(args.patch_id, args.variant)
 
-    exp_mgr = ExperimentManager(DataBot(), CapitalManagementBot(), lineage=lineage)
+    builder = ContextBuilder()
+    exp_mgr = ExperimentManager(
+        DataBot(),
+        CapitalManagementBot(),
+        context_builder=builder,
+        lineage=lineage,
+    )
     vm = VariantManager(exp_mgr)
     event_id, results = vm.ab_test_branch(args.patch_id, args.variant)
     comparisons = exp_mgr.compare_variants(results)


### PR DESCRIPTION
## Summary
- allow ExperimentManager to accept an optional ContextBuilder and require it when no pipeline is supplied
- update variant CLI and documentation to pass in a ContextBuilder

## Testing
- `pytest tests/test_experiment_manager.py -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '')*

------
https://chatgpt.com/codex/tasks/task_e_68bdf86370bc832ebc22bea5369a0fa6