### PR TITLE
Allow QueryBot to use shared context builder

### DIFF
--- a/model_automation_pipeline.py
+++ b/model_automation_pipeline.py
@@ -22,7 +22,7 @@ try:
     from marshmallow import ValidationError as MMValidationError  # type: ignore
     ValidationError = MMValidationError
 except Exception:  # pragma: no cover - optional dependency
-    from .simple_validation import (
+    from .simple_validation import (  # noqa: F401
         SimpleSchema as Schema,
         fields,
         ValidationError,
@@ -196,12 +196,7 @@ class ModelAutomationPipeline:
         self.monitor_bot = monitor_bot or OperationalMonitoringBot()
         self.db_bot = db_bot or CentralDatabaseBot(db_router=self.db_router)
         self.sentiment_bot = sentiment_bot or SentimentBot()
-        self.query_bot = query_bot or QueryBot()
-        if getattr(self.query_bot, "client", None):
-            try:
-                self.query_bot.client.context_builder = self.context_builder
-            except Exception:
-                pass
+        self.query_bot = query_bot or QueryBot(context_builder=self.context_builder)
         self.memory_bot = memory_bot or MemoryBot()
         self.comms_test_bot = comms_test_bot or CommunicationTestingBot()
         self.discrepancy_bot = discrepancy_bot or DiscrepancyDetectionBot()

--- a/tests/test_query_bot.py
+++ b/tests/test_query_bot.py
@@ -24,7 +24,7 @@ def test_process(monkeypatch):
     client = cib.ChatGPTClient("k", context_builder=builder)
     monkeypatch.setattr(client, "ask", lambda msgs: {"choices": [{"message": {"content": "ok"}}]})
     fetcher = qb.DataFetcher({"foo": {"val": 1}})
-    bot = qb.QueryBot(client, fetcher=fetcher)
+    bot = qb.QueryBot(client, fetcher=fetcher, context_builder=builder)
     result = bot.process("get foo", "cid")
     assert result.data == {"foo": {"val": 1}}
     assert result.text == "ok"


### PR DESCRIPTION
## Summary
- allow `QueryBot` to accept an optional `context_builder`
- require a `context_builder` when no client is provided and build `ChatGPTClient` with it
- wire `ModelAutomationPipeline` and tests to pass a shared builder

## Testing
- `pre-commit run --files query_bot.py model_automation_pipeline.py tests/test_query_bot.py`
- `pytest tests/test_query_bot.py tests/test_model_automation_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdfa0d6210832e91d04ed7db40f392