### PR TITLE
Require context builder in diagnostic manager

### DIFF
--- a/diagnostic_manager.py
+++ b/diagnostic_manager.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import logging
-import sqlite3
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, TYPE_CHECKING
 
 from db_router import GLOBAL_ROUTER, LOCAL_TABLES, init_db_router
 
@@ -15,6 +14,9 @@ try:  # pragma: no cover - support package and flat layouts
     from .dynamic_path_router import resolve_path
 except Exception:  # pragma: no cover - fallback when executed directly
     from dynamic_path_router import resolve_path  # type: ignore
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from vector_service.context_builder import ContextBuilder
 
 try:
     import pandas as pd  # type: ignore
@@ -82,7 +84,7 @@ class DiagnosticManager:
         metrics_db: MetricsDB | None = None,
         error_bot: ErrorBot | None = None,
         *,
-        context_builder: "ContextBuilder" | None = None,
+        context_builder: "ContextBuilder",
         ledger: DecisionLedger | None = None,
         queue: CoordinationManager | None = None,
         log: ResolutionDB | None = None,
@@ -90,10 +92,6 @@ class DiagnosticManager:
         self.metrics = metrics_db or MetricsDB()
         self.context_builder = context_builder
         if error_bot is None:
-            if self.context_builder is None:
-                from vector_service.context_builder import ContextBuilder
-
-                self.context_builder = ContextBuilder()
             self.error_bot = ErrorBot(
                 ErrorDB(),
                 self.metrics,

--- a/model_automation_pipeline.py
+++ b/model_automation_pipeline.py
@@ -214,7 +214,9 @@ class ModelAutomationPipeline:
                 AllocationDB(), context_builder=self.context_builder
             )
         )
-        self.diagnostic_manager = diagnostic_manager or DiagnosticManager()
+        self.diagnostic_manager = diagnostic_manager or DiagnosticManager(
+            context_builder=self.context_builder
+        )
         self.idea_bank = idea_bank or KeywordBank()
         self.news_db = news_db or NewsDB()
         self.reinvestment_bot = reinvestment_bot or AutoReinvestmentBot()

--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -1080,7 +1080,7 @@ def _get_history_db() -> InputHistoryDB:
 
 if DiagnosticManager is not None:
     try:
-        _DIAGNOSTIC = DiagnosticManager()
+        _DIAGNOSTIC = DiagnosticManager(context_builder=ContextBuilder())
     except (OSError, RuntimeError) as exc:  # pragma: no cover - diagnostics optional
         logger.warning(
             "diagnostic manager unavailable",

--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -564,7 +564,9 @@ class SelfImprovementEngine:
         self.action_planner = action_planner
         err_bot = ErrorBot(ErrorDB(), MetricsDB(), context_builder=builder)
         self.error_bot = err_bot
-        self.diagnostics = diagnostics or DiagnosticManager(MetricsDB(), err_bot)
+        self.diagnostics = diagnostics or DiagnosticManager(
+            MetricsDB(), err_bot, context_builder=builder
+        )
         self._alignment_agent: AlignmentReviewAgent | None = None
         self.last_run = 0.0
         self.capital_bot = capital_bot

--- a/tests/test_improvement_engine_registry.py
+++ b/tests/test_improvement_engine_registry.py
@@ -53,7 +53,9 @@ def _make_engine(tmp_path, name: str, monkeypatch):
     edb = eb.ErrorDB(tmp_path / f"{name}.e.db")
     info = rab.InfoDB(tmp_path / f"{name}.i.db")
     builder = types.SimpleNamespace(refresh_db_weights=lambda: None)
-    diag = dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb, context_builder=builder))
+    diag = dm.DiagnosticManager(
+        mdb, eb.ErrorBot(edb, mdb, context_builder=builder), context_builder=builder
+    )
     pipe = StubPipeline()
     monkeypatch.setattr(sie, "bootstrap", lambda: 0)
     engine = sie.SelfImprovementEngine(

--- a/tests/test_patch_score_backend.py
+++ b/tests/test_patch_score_backend.py
@@ -1,5 +1,4 @@
 import types
-import types
 import logging
 from tests.test_self_debugger_sandbox import (
     sds,
@@ -175,7 +174,9 @@ def test_engine_uses_backend(monkeypatch, tmp_path):
     info = sie_tests.rab.InfoDB(tmp_path / "i.db")
     builder = types.SimpleNamespace(refresh_db_weights=lambda: None)
     diag = sie_tests.dm.DiagnosticManager(
-        mdb, sie_tests.eb.ErrorBot(edb, mdb, context_builder=builder)
+        mdb,
+        sie_tests.eb.ErrorBot(edb, mdb, context_builder=builder),
+        context_builder=builder,
     )
 
     class StubPipeline:

--- a/tests/test_self_improvement_engine.py
+++ b/tests/test_self_improvement_engine.py
@@ -432,7 +432,9 @@ import menace.self_improvement_policy as sip
 
 def _diag(edb, mdb):
     builder = types.SimpleNamespace(refresh_db_weights=lambda *a, **k: None)
-    return dm.DiagnosticManager(mdb, eb.ErrorBot(edb, mdb, context_builder=builder))
+    return dm.DiagnosticManager(
+        mdb, eb.ErrorBot(edb, mdb, context_builder=builder), context_builder=builder
+    )
 
 
 def test_run_cycle(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Make `DiagnosticManager` require a `ContextBuilder` and pass it to `ErrorBot`
- Update construction sites across the codebase to supply the builder

## Testing
- `pre-commit run --files diagnostic_manager.py sandbox_runner/environment.py self_improvement/engine.py model_automation_pipeline.py tests/test_improvement_engine_registry.py tests/test_patch_score_backend.py tests/test_diagnostic_manager.py` *(failed: Prevent static .py path references; Ensure dynamic paths use resolve_path; Prevent raw Stripe keys or endpoints)*
- `flake8 diagnostic_manager.py sandbox_runner/environment.py self_improvement/engine.py model_automation_pipeline.py tests/test_improvement_engine_registry.py tests/test_patch_score_backend.py tests/test_diagnostic_manager.py`
- `pytest tests/test_diagnostic_manager.py tests/test_improvement_engine_registry.py tests/test_patch_score_backend.py tests/test_self_improvement_engine.py` *(failed: missing modules like vector_service)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfbc56600832eb3a68550c47fa966