### PR TITLE
Require ContextBuilder for DebugLoopService

### DIFF
--- a/debug_loop_service.py
+++ b/debug_loop_service.py
@@ -29,28 +29,27 @@ class DebugLoopService:
         feedback: TelemetryFeedback | None = None,
         *,
         graph: KnowledgeGraph | None = None,
-        context_builder: ContextBuilder | None = None,
+        context_builder: ContextBuilder,
     ) -> None:
         """Create service.
 
         Parameters
         ----------
         context_builder:
-            Optional :class:`~vector_service.ContextBuilder` used when creating
+            Preconfigured :class:`~vector_service.ContextBuilder` used when creating
             telemetry and self-coding components.
         """
         self.graph = graph or KnowledgeGraph()
         if feedback is None:
-            builder = context_builder or ContextBuilder()
             try:
-                builder.refresh_db_weights()
+                context_builder.refresh_db_weights()
             except Exception:
                 pass
             logger = ErrorLogger(
-                knowledge_graph=self.graph, context_builder=builder
+                knowledge_graph=self.graph, context_builder=context_builder
             )
             engine = SelfCodingEngine(
-                CodeDB(), MenaceMemoryManager(), context_builder=builder
+                CodeDB(), MenaceMemoryManager(), context_builder=context_builder
             )
             feedback = TelemetryFeedback(logger, engine)
         self.feedback = feedback

--- a/service_supervisor.py
+++ b/service_supervisor.py
@@ -207,7 +207,7 @@ def _debug_worker() -> None:
     """Continuously run telemetry-driven debugging."""
     from .debug_loop_service import DebugLoopService
     logger = logging.getLogger("debug_worker")
-    service = DebugLoopService()
+    service = DebugLoopService(context_builder=ContextBuilder())
     stop = Event()
     interval = float(os.getenv("DEBUG_INTERVAL", "300"))
     service.run_continuous(interval=interval, stop_event=stop)

--- a/tests/test_debug_loop_service.py
+++ b/tests/test_debug_loop_service.py
@@ -52,7 +52,7 @@ spec.loader.exec_module(mod)
 def test_collect_crash_traces(tmp_path):
     log = tmp_path / "err.log"
     log.write_text("Traceback\nboom", encoding="utf-8")
-    svc = mod.DebugLoopService()
+    svc = mod.DebugLoopService(context_builder=vs_pkg.ContextBuilder())
     svc.collect_crash_traces(str(tmp_path))
     assert svc.graph.traces and svc.graph.traces[0][0] == "err"
 
@@ -60,14 +60,14 @@ def test_collect_crash_traces(tmp_path):
 def test_collect_crash_traces_ignores(tmp_path):
     log = tmp_path / "info.log"
     log.write_text("no error", encoding="utf-8")
-    svc = mod.DebugLoopService()
+    svc = mod.DebugLoopService(context_builder=vs_pkg.ContextBuilder())
     svc.collect_crash_traces(str(tmp_path))
     assert not svc.graph.traces
 
 
 def test_run_continuous_logs_errors(monkeypatch, caplog):
     stop = threading.Event()
-    svc = mod.DebugLoopService()
+    svc = mod.DebugLoopService(context_builder=vs_pkg.ContextBuilder())
 
     def fail_collect(path):
         stop.set()


### PR DESCRIPTION
## Summary
- Require a ContextBuilder when constructing DebugLoopService
- Use supplied builder to initialize ErrorLogger and SelfCodingEngine
- Pass ContextBuilder during DebugLoopService setup in service supervisor and tests

## Testing
- `pytest tests/test_debug_loop_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdfe02be78832e885236bd256517dd