### PR TITLE
Require context builder for error logging

### DIFF
--- a/tests/test_error_logger_builder_validation.py
+++ b/tests/test_error_logger_builder_validation.py
@@ -16,16 +16,15 @@ class DummyBuilder:
         self.refresh_calls += 1
 
 
-def test_refresh_called_before_generate_patch(monkeypatch, tmp_path):
+def test_refresh_called_during_init(monkeypatch, tmp_path):
     builder = DummyBuilder()
     db = types.SimpleNamespace(add_telemetry=lambda *a, **k: None)
     logger = ErrorLogger(db=db, context_builder=builder)
-    initial_calls = builder.refresh_calls
     called: list[bool] = []
 
     def fake_generate_patch(module, *, context_builder):
         assert context_builder is builder
-        assert builder.refresh_calls > initial_calls
+        assert builder.refresh_calls == 1
         called.append(True)
         return 1
 

--- a/tests/test_error_logger_fix_suggestions.py
+++ b/tests/test_error_logger_fix_suggestions.py
@@ -1,6 +1,22 @@
 import json
-import menace.error_bot as eb
+import pytest
+import sqlite3
 import menace.error_logger as elog
+
+
+class DummyDB:
+    def __init__(self, path):
+        self.conn = sqlite3.connect(path)
+        self.conn.execute(
+            "CREATE TABLE telemetry (id INTEGER PRIMARY KEY, fix_suggestions TEXT, bottlenecks TEXT)"
+        )
+
+    def add_telemetry(self, event):
+        self.conn.execute(
+            "INSERT INTO telemetry (fix_suggestions, bottlenecks) VALUES (?, ?)",
+            (json.dumps(event.fix_suggestions), json.dumps(event.bottlenecks)),
+        )
+        self.conn.commit()
 
 
 class DummyBuilder:
@@ -11,7 +27,7 @@ class DummyBuilder:
 def test_log_fix_suggestions_emits_events_and_triggers_patch_and_codex(
     tmp_path, monkeypatch, caplog
 ):
-    db = eb.ErrorDB(tmp_path / "e.db")
+    db = DummyDB(tmp_path / "e.db")
     logger = elog.ErrorLogger(db, context_builder=DummyBuilder())
     patch_calls = []
 
@@ -25,6 +41,7 @@ def test_log_fix_suggestions_emits_events_and_triggers_patch_and_codex(
         "propose_fix",
         lambda m, p: [("mod1", "hint1"), ("", "generic hint")],
     )
+    monkeypatch.setattr(elog, "path_for_prompt", lambda module: module)
     caplog.set_level("INFO", logger=elog.__name__)
 
     events = logger.log_fix_suggestions({"a": 0.1}, {}, task_id="t1", bot_id="b1")
@@ -42,21 +59,7 @@ def test_log_fix_suggestions_emits_events_and_triggers_patch_and_codex(
     assert [json.loads(r[1]) for r in rows] == [["mod1"], []]
 
 
-def test_log_fix_suggestions_without_builder_does_not_patch(
-    tmp_path, monkeypatch
-):
-    db = eb.ErrorDB(tmp_path / "e.db")
-    logger = elog.ErrorLogger(db, context_builder=None)
-    patch_calls = []
-
-    def fake_patch(module, *a, **k):
-        patch_calls.append(module)
-        return 1
-
-    monkeypatch.setattr(elog, "generate_patch", fake_patch, raising=False)
-    monkeypatch.setattr(
-        elog, "propose_fix", lambda m, p: [("mod1", "hint1")]
-    )
-
-    logger.log_fix_suggestions({"a": 0.1}, {}, task_id="t1", bot_id="b1")
-    assert patch_calls == []
+def test_log_fix_suggestions_requires_builder(tmp_path):
+    db = DummyDB(tmp_path / "e.db")
+    with pytest.raises(TypeError):
+        elog.ErrorLogger(db, context_builder=None)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- require a ContextBuilder when creating `ErrorLogger` and refresh weights during initialization
- simplify patch generation in `ErrorLogger.log_fix_suggestions` by assuming the builder is always present
- update tests to exercise new builder requirement

## Testing
- `pytest tests/test_error_logger_builder_validation.py tests/test_error_logger_fix_suggestions.py -q`
- `pytest tests/test_error_logger_update_trigger.py -q` *(fails: RuntimeError: vector_service import failed)*

------
https://chatgpt.com/codex/tasks/task_e_68be01b5cfc8832eb9a1bb15b1a16e6a