### PR TITLE
Require explicit context builder injection across sandbox utilities

### DIFF
--- a/composite_workflow_scorer.py
+++ b/composite_workflow_scorer.py
@@ -34,6 +34,7 @@ from .workflow_scorer_core import (
     compute_bottleneck_index,
     compute_patchability,
 )
+from vector_service.context_builder import ContextBuilder
 
 try:  # pragma: no cover - optional dependency
     from .code_database import PatchHistoryDB
@@ -349,11 +350,13 @@ class CompositeWorkflowScorer(ROIScorer):
         """Backwards compatible wrapper executing sandbox simulations."""
 
         start = time.perf_counter()
+        builder = ContextBuilder()
         tracker, details = sandbox_runner.environment.run_workflow_simulations(
             workflows_db=workflow_id,
             env_presets=env_presets,
             return_details=True,
             tracker=self.tracker,
+            context_builder=builder,
         )
         runtime = time.perf_counter() - start
 

--- a/docs/autonomous_sandbox.md
+++ b/docs/autonomous_sandbox.md
@@ -262,13 +262,17 @@ every module can be exercised under both intensities:
 
 ```python
 from environment_generator import generate_canonical_presets
+from vector_service.context_builder import ContextBuilder
 
 presets = generate_canonical_presets()
 # access individual levels
 low_latency = presets["high_latency_api"]["low"]
 high_latency = presets["high_latency_api"]["high"]
 # run all scenarios under both severities
-run_repo_section_simulations(repo_path, env_presets=presets)
+builder = ContextBuilder()
+run_repo_section_simulations(
+    repo_path, env_presets=presets, context_builder=builder
+)
 ```
 
 Set `SANDBOX_FAIL_ON_MISSING_SCENARIOS=1` to raise an error if any canonical

--- a/docs/sandbox_runner.md
+++ b/docs/sandbox_runner.md
@@ -360,10 +360,14 @@ levels for the same scenario:
 
 ```python
 from environment_generator import generate_canonical_presets
+from vector_service.context_builder import ContextBuilder
 from sandbox_runner import run_repo_section_simulations
 
 presets = generate_canonical_presets()
-tracker = run_repo_section_simulations("/repo", env_presets=presets)
+builder = ContextBuilder()
+tracker = run_repo_section_simulations(
+    "/repo", env_presets=presets, context_builder=builder
+)
 ```
 
 Run all canonical profiles with:
@@ -697,7 +701,7 @@ runner.run(task, timeout=2.0, memory_limit=50_000_000)
 
 ## Workflow Simulations
 
-`run_workflow_simulations(workflows_db, env_presets=None)` replays stored
+`run_workflow_simulations(workflows_db, env_presets=None, context_builder=builder)` replays stored
 workflow sequences under each environment preset. ROI deltas and metrics are
 aggregated per workflow ID. After iterating over individual workflows a single
 combined snippet containing all steps is executed. Metrics from this run are
@@ -716,7 +720,7 @@ The differences are stored under `synergy_roi` and `synergy_<metric>` entries in
 `roi_history.json`. The delta is also attributed to each involved module so
 `ROITracker.rankings()` reflects the overall cross‑module impact.
 
-`run_workflow_simulations()` performs the same comparison for entire workflows.
+`run_workflow_simulations(..., context_builder=builder)` performs the same comparison for entire workflows.
 Each workflow is executed on its own and then as part of a single combined
 snippet. `synergy_roi` and `synergy_<metric>` values capture how the result of
 the combined workflow run differs from the average metrics recorded during the

--- a/sandbox_runner.py
+++ b/sandbox_runner.py
@@ -1323,19 +1323,12 @@ def _sandbox_cleanup(ctx: SandboxContext) -> None:
 def _sandbox_main(
     preset: Dict[str, Any],
     args: argparse.Namespace,
-    context_builder: ContextBuilder | None = None,
+    context_builder: ContextBuilder,
 ) -> "ROITracker":
     from menace.roi_tracker import ROITracker
 
     global SANDBOX_ENV_PRESETS, _local_knowledge_refresh_counter
     logger.info("starting sandbox run", extra=log_record(preset=preset))
-    if context_builder is None:
-        context_builder = ContextBuilder(
-            bot_db="bots.db",
-            code_db="code.db",
-            error_db="errors.db",
-            workflow_db="workflows.db",
-        )
     try:
         context_builder.refresh_db_weights()
     except Exception:
@@ -1809,6 +1802,7 @@ def _sandbox_main(
                 module_algorithm=getattr(args, "module_algorithm", "greedy"),
                 module_threshold=float(getattr(args, "module_threshold", 0.1)),
                 module_semantic=getattr(args, "module_semantic", False),
+                context_builder=context_builder,
             )
         except Exception:
             logger.exception("workflow simulations failed")

--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -4545,6 +4545,7 @@ class SelfImprovementEngine:
                 env_presets=env_map,
                 return_details=True,
                 runner_config=self.runner_config,
+                context_builder=self.self_coding_engine.context_builder,
             )
             scenario_synergy = getattr(tracker_wf, "scenario_synergy", {})
             for runs in wf_details.values():
@@ -4594,7 +4595,7 @@ class SelfImprovementEngine:
             for m in modules:
                 try:
                     tracker_res, details = _sim(
-                        str(repo), modules=[m], return_details=True
+                        str(repo), modules=[m], return_details=True, context_builder=self.self_coding_engine.context_builder
                     )
                 except Exception:
                     continue


### PR DESCRIPTION
## Summary
- remove global context builder and default fallbacks
- require ContextBuilder parameter for sandbox runners and simulations
- inject builder from CLI and helper utilities and refresh documentation

## Testing
- `pre-commit run --files sandbox_runner/environment.py sandbox_runner.py sandbox_runner/cli.py scripts/full_autonomous_run.py self_improvement/engine.py composite_workflow_scorer.py docs/autonomous_sandbox.md docs/sandbox_runner.md` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*
- `pytest tests/test_self_debugger_sandbox.py::test_no_global_builder tests/test_self_debugger_sandbox.py::test_builder_injected_and_refreshed` *(fails: ImportError: cannot import name 'ROITracker')*

------
https://chatgpt.com/codex/tasks/task_e_68be05d36944832e888d9f293f3dde92