### PR TITLE
chore: enforce ContextBuilder usage in CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,8 @@ non-zero status on violations, so add it to your local workflow to catch issues
 early. Continuous integration runs this script and fails the build when it
 detects missing or implicit `ContextBuilder` usage.
 
+The `mypy` Makefile target runs this check automatically.
+
 ## Stripe integration
 
 To centralize billing logic and API configuration, the `stripe` Python package

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 .PHONY: mypy synergy-graph install-self-improvement-deps
 mypy:
-        mypy --config mypy.ini self_* sandbox_runner
-        python scripts/check_governed_embeddings.py
-        python scripts/check_governed_retrieval.py
+	mypy --config mypy.ini self_* sandbox_runner
+	python scripts/check_governed_embeddings.py
+	python scripts/check_governed_retrieval.py
+	python scripts/check_context_builder_usage.py
 
 synergy-graph:
         python module_synergy_grapher.py --build


### PR DESCRIPTION
## Summary
- run `check_context_builder_usage` in the mypy Makefile target
- note the ContextBuilder enforcement in contributing guide

## Testing
- `python scripts/check_context_builder_usage.py`

------
https://chatgpt.com/codex/tasks/task_e_68be0cc69bc0832e9296f292a6f02237