### PR TITLE
Require explicit context builder and compress prompt context

### DIFF
--- a/resource_allocation_bot.py
+++ b/resource_allocation_bot.py
@@ -23,6 +23,7 @@ from .prediction_manager_bot import PredictionManager
 from .databases import MenaceDB
 from .contrarian_db import ContrarianDB
 from db_router import GLOBAL_ROUTER, init_db_router
+from snippet_compressor import compress_snippets
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from .resources_bot import ResourcesBot
@@ -328,8 +329,11 @@ class ResourceAllocationBot:
         except Exception:
             pass
         engine = PromptEngine(context_builder=self.context_builder, llm=llm)
+        retrieval_ctx = compress_snippets({"snippet": context}).get("snippet", context)
         prompt = engine.build_prompt(
-            f"Improve {bot}", context=context, context_builder=self.context_builder
+            f"Improve {bot}",
+            retrieval_context=retrieval_ctx,
+            context_builder=self.context_builder,
         )
         if engine.llm is None:
             return "upgrade"

--- a/tests/test_logging_exceptions.py
+++ b/tests/test_logging_exceptions.py
@@ -97,12 +97,13 @@ def test_saturate_logs_strategy_error(tmp_path, caplog):
         def receive_niche_info(self, info):
             raise RuntimeError("boom")
 
-    alloc = ResourceAllocationBot(context_builder=_DummyBuilder())
+    builder = _DummyBuilder()
+    alloc = ResourceAllocationBot(context_builder=builder)
     bot = ns.NicheSaturationBot(
         db=ns.NicheDB(tmp_path / "n.db"),
         alloc_bot=alloc,
         strategy_bot=BadStrategy(),
-        context_builder=_DummyBuilder(),
+        context_builder=builder,
     )
     caplog.set_level(logging.ERROR)
     bot.saturate([ns.NicheCandidate("x", 1.0, 0.0)])

--- a/tests/test_niche_saturation_bot.py
+++ b/tests/test_niche_saturation_bot.py
@@ -16,10 +16,11 @@ class _DummyBuilder:
 def test_saturate_logs(tmp_path):
     db = nsb.NicheDB(tmp_path / "niche.db")
     alloc_db = rab.AllocationDB(tmp_path / "alloc.db")
+    builder = _DummyBuilder()
     alloc_bot = rab.ResourceAllocationBot(
-        alloc_db, rpb.TemplateDB(tmp_path / "t.csv"), context_builder=_DummyBuilder()
+        alloc_db, rpb.TemplateDB(tmp_path / "t.csv"), context_builder=builder
     )
-    bot = nsb.NicheSaturationBot(db, alloc_bot, context_builder=_DummyBuilder())
+    bot = nsb.NicheSaturationBot(db, alloc_bot, context_builder=builder)
     cand = nsb.NicheCandidate(name="ai-tools", demand=5.0, competition=1.0, trend=1.0)
     actions = bot.saturate([cand])
     hist = db.history()


### PR DESCRIPTION
## Summary
- require explicit ContextBuilder when instantiating `NicheSaturationBot` and forward it to any provided `ResourceAllocationBot`
- compress retrieval snippets when suggesting improvements and embed them into prompt payloads
- update tests to supply a builder explicitly

## Testing
- `pytest tests/test_logging_exceptions.py::test_saturate_logs_strategy_error`
- `pytest tests/test_niche_saturation_bot.py tests/test_logging_exceptions.py` *(fails: TypeError in MenaceMemoryManager and ImportError for CodeDB)*

------
https://chatgpt.com/codex/tasks/task_e_68be2c341128832ebd1cd9ca400b422d