### PR TITLE
Require ContextBuilder for QueryBot initialization

### DIFF
--- a/docs/context_builder.md
+++ b/docs/context_builder.md
@@ -100,8 +100,8 @@ summariser also operates offline, so even without the optional memory manager
 ## Integration
 
 `SelfCodingEngine`, `QuickFixEngine`, `BotDevelopmentBot`, `PromptEngine`,
-`AutomatedReviewer` and `Watchdog` expect a `ContextBuilder` to be supplied via
-constructor or method arguments.  Instantiate the builder with the standard
+`AutomatedReviewer`, `Watchdog` and `QueryBot` expect a `ContextBuilder` to be
+supplied via constructor or method arguments.  Instantiate the builder with the standard
 databases and pass it through explicitly:
 
 ```python


### PR DESCRIPTION
## Summary
- make ContextBuilder a required argument for QueryBot and propagate it to ChatGPTClient
- refresh database weights on initialization and append compressed vector context to prompts
- document QueryBot's ContextBuilder requirement and adjust tests

## Testing
- `pre-commit run --files query_bot.py docs/context_builder.md tests/test_query_bot.py` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*
- `pytest tests/test_query_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68be2da79588832ebcfc2b2d8f7ef864