### PR TITLE
Require context builder for ChatGPTPredictionBot and include local context

### DIFF
--- a/tests/test_chatgpt_prediction_bot.py
+++ b/tests/test_chatgpt_prediction_bot.py
@@ -28,6 +28,7 @@ class _StubContextBuilder:
 
 ctx_mod = types.ModuleType("vector_service.context_builder")
 ctx_mod.ContextBuilder = _StubContextBuilder
+ctx_mod.FallbackResult = type("FallbackResult", (), {})
 sys.modules["vector_service"] = vector_service_pkg
 sys.modules["vector_service.context_builder"] = ctx_mod
 sys.modules["menace.shared_gpt_memory"] = types.SimpleNamespace(GPT_MEMORY_MANAGER=None)
@@ -66,7 +67,7 @@ def build_model(path: Path) -> None:
 def test_prediction(tmp_path):
     model_path = tmp_path / "model.joblib"
     build_model(model_path)
-    bot = cpb.ChatGPTPredictionBot(model_path)
+    bot = cpb.ChatGPTPredictionBot(model_path, context_builder=_StubContextBuilder())
     idea = cpb.IdeaFeatures(
         market_type="finance",
         monetization_model="subscription",
@@ -83,7 +84,7 @@ def test_prediction(tmp_path):
 def test_batch_prediction(tmp_path):
     model_path = tmp_path / "model.joblib"
     build_model(model_path)
-    bot = cpb.ChatGPTPredictionBot(model_path)
+    bot = cpb.ChatGPTPredictionBot(model_path, context_builder=_StubContextBuilder())
     ideas = [
         cpb.IdeaFeatures(
             market_type="tech",

--- a/tests/test_chatgpt_prediction_bot_warning.py
+++ b/tests/test_chatgpt_prediction_bot_warning.py
@@ -21,6 +21,7 @@ class _StubContextBuilder:
 
 ctx_mod = types.ModuleType("vector_service.context_builder")
 ctx_mod.ContextBuilder = _StubContextBuilder
+ctx_mod.FallbackResult = type("FallbackResult", (), {})
 sys.modules["vector_service"] = vector_service_pkg
 sys.modules["vector_service.context_builder"] = ctx_mod
 sys.modules["menace.shared_gpt_memory"] = types.SimpleNamespace(GPT_MEMORY_MANAGER=None)
@@ -38,7 +39,9 @@ def test_warning_on_missing_sklearn(monkeypatch, caplog, tmp_path):
         sys.modules, "menace.shared_gpt_memory", types.SimpleNamespace(GPT_MEMORY_MANAGER=None)
     )
     cpb = importlib.import_module("menace.chatgpt_prediction_bot")
-    bot = cpb.ChatGPTPredictionBot(tmp_path / "none.joblib")
+    bot = cpb.ChatGPTPredictionBot(
+        tmp_path / "none.joblib", context_builder=_StubContextBuilder()
+    )
     assert "scikit-learn" in caplog.text
     assert not cpb._SKLEARN_AVAILABLE
     assert isinstance(bot.pipeline, cpb.Pipeline)
@@ -60,7 +63,8 @@ def test_fallback_prediction_stable(monkeypatch, tmp_path):
     cpb = importlib.import_module("menace.chatgpt_prediction_bot")
 
     bot = cpb.ChatGPTPredictionBot(
-        tmp_path / "none.joblib", l2=0.1, iters=5, val_steps=1
+        tmp_path / "none.joblib", l2=0.1, iters=5, val_steps=1,
+        context_builder=_StubContextBuilder()
     )
     idea = cpb.IdeaFeatures(
         market_type="tech",


### PR DESCRIPTION
## Summary
- enforce `ContextBuilder` requirement in `ChatGPTPredictionBot` and refresh database weights
- attach builders to provided clients and prepend compressed local context in prediction prompts
- update tests for mandatory builders and context handling

## Testing
- `pytest tests/test_chatgpt_prediction_bot.py tests/test_chatgpt_prediction_bot_memory.py tests/test_chatgpt_prediction_bot_warning.py -q`
- `pre-commit run --files chatgpt_prediction_bot.py tests/test_chatgpt_prediction_bot.py tests/test_chatgpt_prediction_bot_memory.py tests/test_chatgpt_prediction_bot_warning.py` *(fails: No module named 'dynamic_path_router')*


------
https://chatgpt.com/codex/tasks/task_e_68be32d930ec832eb7c61b69be1599e4