### PR TITLE
Integrate context builder into IPO planning

### DIFF
--- a/ipo_implementation_pipeline.py
+++ b/ipo_implementation_pipeline.py
@@ -46,7 +46,7 @@ class IPOImplementationPipeline:
         context_builder: ContextBuilder,
         max_attempts: int = 3,
     ) -> None:
-        self.ipo = ipo or IPOBot()
+        self.ipo = ipo or IPOBot(context_builder=context_builder)
         self.developer = developer or BotDevelopmentBot(
             context_builder=context_builder
         )

--- a/tests/test_ipo_bot.py
+++ b/tests/test_ipo_bot.py
@@ -1,11 +1,10 @@
 import pytest
-from pathlib import Path
-
-from db_router import GLOBAL_ROUTER, init_db_router
-import menace.ipo_bot as ipb
-
 
 pytest.skip("optional dependencies not installed", allow_module_level=True)
+
+from pathlib import Path  # noqa: E402
+from db_router import GLOBAL_ROUTER, init_db_router  # noqa: E402
+import menace.ipo_bot as ipb  # noqa: E402
 
 
 BLUEPRINT = "BotA collects data using BotB. BotC processes results after BotB."

--- a/tests/test_ipo_implementation_pipeline.py
+++ b/tests/test_ipo_implementation_pipeline.py
@@ -1,23 +1,29 @@
 import pytest
-pytest.skip("optional dependencies not installed", allow_module_level=True)
-from pathlib import Path
 
-from db_router import GLOBAL_ROUTER, init_db_router
-import menace.ipo_implementation_pipeline as ipp
-import menace.ipo_bot as ipb
-import menace.bot_development_bot as bdb
-import menace.bot_testing_bot as btb
-import menace.scalability_assessment_bot as sab
-import menace.deployment_bot as dep
+pytest.skip("optional dependencies not installed", allow_module_level=True)
+
+from pathlib import Path  # noqa: E402
+from db_router import GLOBAL_ROUTER, init_db_router  # noqa: E402
+import menace.ipo_implementation_pipeline as ipp  # noqa: E402
+import menace.ipo_bot as ipb  # noqa: E402
+import menace.bot_development_bot as bdb  # noqa: E402
+import menace.bot_testing_bot as btb  # noqa: E402
+import menace.scalability_assessment_bot as sab  # noqa: E402
+import menace.deployment_bot as dep  # noqa: E402
 
 
 def _make_db(path: Path) -> Path:
     init_db_router(
-        "ipo_pipeline_test", local_db_path=str(path.parent / "local.db"), shared_db_path=str(path)
+        "ipo_pipeline_test",
+        local_db_path=str(path.parent / "local.db"),
+        shared_db_path=str(path),
     )
     conn = GLOBAL_ROUTER.get_connection("bots")
     conn.execute(
-        "CREATE TABLE IF NOT EXISTS bots (id INTEGER PRIMARY KEY, name TEXT, keywords TEXT, reuse INTEGER)"
+        (
+            "CREATE TABLE IF NOT EXISTS bots ("
+            "id INTEGER PRIMARY KEY, name TEXT, keywords TEXT, reuse INTEGER)"
+        )
     )
     conn.commit()
     return path
@@ -29,8 +35,10 @@ def _ctx_builder():
 
 def test_full_pipeline(tmp_path: Path):
     db_path = _make_db(tmp_path / "models.db")
-    ipo = ipb.IPOBot(db_path=str(db_path), enhancements_db=tmp_path / "enh.db")
     builder = _ctx_builder()
+    ipo = ipb.IPOBot(
+        db_path=str(db_path), enhancements_db=tmp_path / "enh.db", context_builder=builder
+    )
     developer = bdb.BotDevelopmentBot(
         repo_base=tmp_path / "repos", context_builder=builder
     )

--- a/tests/test_ipo_implementation_pipeline_context_builder.py
+++ b/tests/test_ipo_implementation_pipeline_context_builder.py
@@ -34,6 +34,9 @@ def test_context_builder_reused(tmp_path):
     vs.ErrorResult = Exception
     vs.EmbeddableDBMixin = object
     sys.modules["vector_service"] = vs
+    vs_cb = types.ModuleType("vector_service.context_builder")
+    vs_cb.ContextBuilder = StubContextBuilder
+    sys.modules["vector_service.context_builder"] = vs_cb
 
     bd = types.ModuleType("menace.bot_development_bot")
     bd.BotDevelopmentBot = StubDeveloper
@@ -50,6 +53,7 @@ def test_context_builder_reused(tmp_path):
 
     dep = types.ModuleType("menace.deployment_bot")
     dep.DeploymentBot = object
+
     class DeploymentSpec:
         def __init__(self, name, resources, env):
             self.name = name


### PR DESCRIPTION
## Summary
- Extend `IPOBot.generate_plan` to harvest contextual snippets using `ContextBuilder`, compress them, and embed before ranking candidates.
- Ensure IPO implementation pipeline provides a `ContextBuilder` to `IPOBot`.
- Adjust tests to supply and stub `ContextBuilder` dependencies.

## Testing
- `pre-commit run --files ipo_bot.py ipo_implementation_pipeline.py tests/test_ipo_implementation_pipeline.py tests/test_ipo_bot.py tests/test_ipo_implementation_pipeline_context_builder.py`
- `pytest tests/test_ipo_bot.py tests/test_ipo_implementation_pipeline.py tests/test_ipo_implementation_pipeline_context_builder.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68be3bb75490832ea031042acc16faee