### PR TITLE
Refresh context builder in MarketManipulationBot

### DIFF
--- a/market_manipulation_bot.py
+++ b/market_manipulation_bot.py
@@ -27,11 +27,12 @@ class MarketManipulationBot:
         context_builder: ContextBuilder,
     ) -> None:
         self.intel_bot = intel_bot or CompetitiveIntelligenceBot()
+        context_builder.refresh_db_weights()
         self.context_builder = context_builder
         self.saturation_bot = (
             saturation_bot
             if saturation_bot is not None
-            else NicheSaturationBot(context_builder=context_builder)
+            else NicheSaturationBot(context_builder=self.context_builder)
         )
         self.checker = checker or ComplianceChecker()
         self.role = role


### PR DESCRIPTION
## Summary
- require and refresh ContextBuilder in MarketManipulationBot
- pass refreshed builder to NicheSaturationBot and orchestrator
- defer ContextBuilder imports in menace_master to avoid heavy init

## Testing
- `pytest tests/test_market_manipulation.py tests/test_market_manipulation_bot.py tests/test_menace_master.py::test_init_unused_bot_logs_failure tests/test_menace_master.py::test_main_run_cycles -q`


------
https://chatgpt.com/codex/tasks/task_e_68be41e30fd0832e90935db2dd915ed4