### PR TITLE
Require explicit ContextBuilder for QueryBot

### DIFF
--- a/query_bot.py
+++ b/query_bot.py
@@ -172,6 +172,12 @@ class QueryBot:
             )
         self.client = client
         self.context_builder = context_builder
+        try:
+            self.client.context_builder = context_builder
+        except Exception:
+            logger.debug(
+                "failed to attach context_builder to client", exc_info=True
+            )
         self.context_builder.refresh_db_weights()
         self.fetcher = fetcher or DataFetcher()
         self.store = store or ContextStore()

--- a/tests/test_query_bot.py
+++ b/tests/test_query_bot.py
@@ -41,3 +41,8 @@ def test_process(monkeypatch):
     assert result.text == "ok"
     assert "get foo" in bot.history("cid")
     assert "x" in captured["prompt"]
+
+
+def test_requires_context_builder():
+    with pytest.raises(TypeError):
+        qb.QueryBot()


### PR DESCRIPTION
## Summary
- Require callers to provide a `ContextBuilder` when constructing `QueryBot`
- Always attach the supplied builder to `ChatGPTClient`
- Add unit test verifying `QueryBot` fails to initialize without a builder

## Testing
- `pytest tests/test_query_bot.py -q` *(fails: optional dependencies not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68be4eecff4c832e96b5f31c72b3e0e2