### PR TITLE
Require context builder for NicheSaturationBot

### DIFF
--- a/menace_master.py
+++ b/menace_master.py
@@ -403,7 +403,6 @@ def _init_unused_bots() -> None:
         MirrorBot,
         _wrap(
             NicheSaturationBot,
-            alloc_bot=ResourceAllocationBot(context_builder=builder),
             context_builder=builder,
         ),
         _wrap(MarketManipulationBot, context_builder=builder),

--- a/niche_saturation_bot.py
+++ b/niche_saturation_bot.py
@@ -108,11 +108,8 @@ class NicheSaturationBot:
 
         self.context_builder = context_builder
         self.db = db or NicheDB()
-        if alloc_bot is None:
-            self.alloc_bot = ResourceAllocationBot(context_builder=self.context_builder)
-        else:
-            self.alloc_bot = alloc_bot
-            self.alloc_bot.context_builder = self.context_builder
+        self.alloc_bot = alloc_bot or ResourceAllocationBot(context_builder=self.context_builder)
+        self.alloc_bot.context_builder = self.context_builder
         self.prediction_manager = prediction_manager
         self.assigned_prediction_bots = []
         if self.prediction_manager:

--- a/tests/test_niche_saturation_requires_builder.py
+++ b/tests/test_niche_saturation_requires_builder.py
@@ -1,0 +1,78 @@
+import types
+import sys
+from pathlib import Path
+import pytest
+
+# Create a lightweight menace package to avoid heavy imports
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("menace")
+pkg.__path__ = [str(ROOT)]
+sys.modules["menace"] = pkg
+
+# stub dependencies before importing module
+stub_ctx = types.ModuleType("vector_service.context_builder")
+class ContextBuilder:
+    def refresh_db_weights(self):
+        pass
+    def build(self, *a, **k):
+        return ""
+stub_ctx.ContextBuilder = ContextBuilder
+sys.modules["vector_service.context_builder"] = stub_ctx
+
+rab_mod = types.ModuleType("menace.resource_allocation_bot")
+class ResourceAllocationBot:
+    def __init__(self, *a, **k):
+        self.context_builder = k.get("context_builder")
+    def allocate(self, *a, **k):
+        return []
+rab_mod.ResourceAllocationBot = ResourceAllocationBot
+sys.modules["menace.resource_allocation_bot"] = rab_mod
+setattr(pkg, "resource_allocation_bot", rab_mod)
+
+rpb_mod = types.ModuleType("menace.resource_prediction_bot")
+class ResourceMetrics:
+    def __init__(self, cpu=0.0, memory=0.0, disk=0.0, time=0.0):
+        self.cpu = cpu
+        self.memory = memory
+        self.disk = disk
+        self.time = time
+rpb_mod.ResourceMetrics = ResourceMetrics
+sys.modules["menace.resource_prediction_bot"] = rpb_mod
+setattr(pkg, "resource_prediction_bot", rpb_mod)
+
+pmb_mod = types.ModuleType("menace.prediction_manager_bot")
+class PredictionManager:
+    def __init__(self, *a, **k):
+        self.registry = {}
+    def assign_prediction_bots(self, *_):
+        return []
+pmb_mod.PredictionManager = PredictionManager
+sys.modules["menace.prediction_manager_bot"] = pmb_mod
+setattr(pkg, "prediction_manager_bot", pmb_mod)
+
+spb_mod = types.ModuleType("menace.strategy_prediction_bot")
+class StrategyPredictionBot:
+    pass
+spb_mod.StrategyPredictionBot = StrategyPredictionBot
+sys.modules["menace.strategy_prediction_bot"] = spb_mod
+setattr(pkg, "strategy_prediction_bot", spb_mod)
+
+import menace.niche_saturation_bot as nsb
+
+
+class DummyAllocBot:
+    def __init__(self):
+        self.context_builder = object()
+    def allocate(self, *_):
+        return []
+
+
+class DummyDB:
+    def add(self, *_):
+        pass
+
+
+def test_requires_context_builder():
+    alloc = DummyAllocBot()
+    with pytest.raises(TypeError):
+        nsb.NicheSaturationBot(db=DummyDB(), alloc_bot=alloc, context_builder=None)


### PR DESCRIPTION
## Summary
- enforce ContextBuilder requirement in NicheSaturationBot and always propagate it to the resource allocator
- update Menace master bot initialization to pass ContextBuilder when creating NicheSaturationBot
- add regression test ensuring NicheSaturationBot raises if context builder is missing

## Testing
- `pytest tests/test_niche_saturation_requires_builder.py tests/test_niche_saturation_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68be52096a50832e820499dd196326d8