### PR TITLE
Require explicit context builder for IPOBot

### DIFF
--- a/docs/implementation_pipeline.md
+++ b/docs/implementation_pipeline.md
@@ -110,8 +110,14 @@ uvicorn stage3_service:app
 
 ```python
 from menace.ipo_bot import IPOBot
+from vector_service.context_builder import ContextBuilder
 
-ipo = IPOBot(db_path="models.db", enhancements_db="enhancements.db")
+builder = ContextBuilder()
+ipo = IPOBot(
+    db_path="models.db",
+    enhancements_db="enhancements.db",
+    context_builder=builder,
+)
 
 pipeline = ImplementationPipeline(researcher=researcher, ipo=ipo)
 ```

--- a/menace_master.py
+++ b/menace_master.py
@@ -364,8 +364,8 @@ def _init_unused_bots() -> None:
             def refresh_db_weights(self):
                 pass
 
-            def build(self, query: str, **_: object) -> str:
-                return ""
+            def build_context(self, *args: object, **kwargs: object) -> list[object]:
+                return []
 
         builder = _DummyBuilder()
 
@@ -398,7 +398,7 @@ def _init_unused_bots() -> None:
         ErrorBot,
         GAPredictionBot,
         GeneticAlgorithmBot,
-        IPOBot,
+        _wrap(IPOBot, context_builder=builder),
         _wrap(ImplementationOptimiserBot, context_builder=builder),
         MirrorBot,
         _wrap(

--- a/tests/test_ipo_bot_builder_required.py
+++ b/tests/test_ipo_bot_builder_required.py
@@ -1,0 +1,26 @@
+import importlib
+import sys
+import types
+import pytest
+
+
+def test_ipobot_requires_builder():
+    vs = types.ModuleType("vector_service")
+    cb_mod = types.ModuleType("vector_service.context_builder")
+
+    class DummyBuilder:
+        def refresh_db_weights(self):
+            pass
+
+        def build_context(self, *args, **kwargs):
+            return []
+
+    cb_mod.ContextBuilder = DummyBuilder
+    vs.context_builder = cb_mod
+    sys.modules.setdefault("vector_service", vs)
+    sys.modules.setdefault("vector_service.context_builder", cb_mod)
+
+    ipb = importlib.import_module("menace.ipo_bot")
+
+    with pytest.raises(TypeError):
+        ipb.IPOBot()


### PR DESCRIPTION
## Summary
- require a `ContextBuilder` when constructing `IPOBot`
- refresh builder weights and validate type during IPOBot init
- ensure orchestrator provides a builder and update docs accordingly
- add unit test covering missing builder scenario

## Testing
- `pytest tests/test_ipo_bot_builder_required.py tests/test_menace_master.py::test_init_unused_bot_logs_failure tests/test_ipo_implementation_pipeline_context_builder.py::test_context_builder_reused -q`

------
https://chatgpt.com/codex/tasks/task_e_68be54d9296c832ea70e4383f3dc1b2c