### PR TITLE
Require context builder for ChatGPTPredictionBot

### DIFF
--- a/tests/test_chatgpt_prediction_bot.py
+++ b/tests/test_chatgpt_prediction_bot.py
@@ -113,3 +113,8 @@ def test_evaluate_enhancement():
     ev = bot.evaluate_enhancement("Improve", "Adds more features and efficiency")
     assert -1.0 <= ev.value <= 1.0
     assert ev.description and ev.reason
+
+
+def test_init_without_builder_errors():
+    with pytest.raises(TypeError):
+        cpb.ChatGPTPredictionBot(context_builder=None)

--- a/tests/test_chatgpt_prediction_bot_memory.py
+++ b/tests/test_chatgpt_prediction_bot_memory.py
@@ -85,5 +85,5 @@ def test_memory_without_builder_errors(monkeypatch):
     mem = FakeMemory()
     monkeypatch.setattr(cpb, "joblib", None)
     monkeypatch.setattr(cpb, "sentiment_score", lambda text: 0.0)
-    with pytest.raises(AttributeError):
+    with pytest.raises(TypeError):
         cpb.ChatGPTPredictionBot(gpt_memory=mem, context_builder=None)


### PR DESCRIPTION
## Summary
- enforce presence of a ContextBuilder in `ChatGPTPredictionBot`
- always wire ContextBuilder into provided `gpt_memory` and `client`
- cover missing builder scenarios with new unit tests

## Testing
- `pytest tests/test_chatgpt_prediction_bot.py tests/test_chatgpt_prediction_bot_memory.py tests/test_chatgpt_prediction_bot_warning.py`

------
https://chatgpt.com/codex/tasks/task_e_68be58e4d094832eb6e37ebba7911c9a