### PR TITLE
Require explicit builder for MarketManipulationBot

### DIFF
--- a/market_manipulation_bot.py
+++ b/market_manipulation_bot.py
@@ -27,8 +27,8 @@ class MarketManipulationBot:
         context_builder: ContextBuilder,
     ) -> None:
         self.intel_bot = intel_bot or CompetitiveIntelligenceBot()
-        context_builder.refresh_db_weights()
         self.context_builder = context_builder
+        self.context_builder.refresh_db_weights()
         self.saturation_bot = (
             saturation_bot
             if saturation_bot is not None

--- a/tests/test_market_manipulation_builder.py
+++ b/tests/test_market_manipulation_builder.py
@@ -1,0 +1,41 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("menace")
+pkg.__path__ = [str(ROOT)]
+sys.modules["menace"] = pkg
+
+# Minimal stubs for dependencies used during import
+ci_mod = types.ModuleType("competitive_intelligence_bot")
+ci_mod.CompetitiveIntelligenceBot = type("CompetitiveIntelligenceBot", (), {})
+sys.modules["menace.competitive_intelligence_bot"] = ci_mod
+
+ns_mod = types.ModuleType("niche_saturation_bot")
+ns_mod.NicheSaturationBot = type("NicheSaturationBot", (), {})
+ns_mod.NicheCandidate = type("NicheCandidate", (), {})
+sys.modules["menace.niche_saturation_bot"] = ns_mod
+sys.modules["niche_saturation_bot"] = ns_mod
+setattr(pkg, "niche_saturation_bot", ns_mod)
+
+cc_mod = types.ModuleType("compliance_checker")
+cc_mod.ComplianceChecker = type("ComplianceChecker", (), {})
+sys.modules["menace.compliance_checker"] = cc_mod
+
+ctx_mod = types.ModuleType("vector_service.context_builder")
+class _ContextBuilder:
+    def refresh_db_weights(self):
+        pass
+ctx_mod.ContextBuilder = _ContextBuilder
+sys.modules["vector_service.context_builder"] = ctx_mod
+
+mm = importlib.import_module("menace.market_manipulation_bot")
+
+
+def test_missing_builder_raises():
+    with pytest.raises(TypeError):
+        mm.MarketManipulationBot()


### PR DESCRIPTION
## Summary
- Require MarketManipulationBot to receive a ContextBuilder and refresh it on init
- Add unit test verifying MarketManipulationBot raises when builder not provided

## Testing
- `pytest tests/test_market_manipulation_bot.py tests/test_market_manipulation.py -q`
- `pytest tests/test_market_manipulation_builder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be5b5e71c8832e99c5517eaad777b3