### PR TITLE
Compress EnhancementBot context snippets

### DIFF
--- a/enhancement_bot.py
+++ b/enhancement_bot.py
@@ -25,6 +25,7 @@ from .chatgpt_enhancement_bot import (
     Enhancement,
 )
 from .micro_models.diff_summarizer import summarize_diff
+from snippet_compressor import compress_snippets
 
 from billing.prompt_notice import prepend_payment_notice
 from llm_interface import LLMClient, Prompt
@@ -135,7 +136,8 @@ class EnhancementBot:
         if confidence > 0.0:
             try:  # pragma: no cover - builder failures are non fatal
                 top_k = max(1, int(5 * confidence))
-                context = self.context_builder.build(hint, top_k=top_k)
+                retrieved = self.context_builder.build(hint, top_k=top_k)
+                context = compress_snippets({"snippet": retrieved}).get("snippet", "")
             except Exception:
                 context = ""
 

--- a/tests/test_enhancement_bot.py
+++ b/tests/test_enhancement_bot.py
@@ -21,6 +21,22 @@ code_db_stub = types.SimpleNamespace(CodeDB=object)
 sys.modules.setdefault("menace_sandbox.code_database", code_db_stub)
 sys.modules.setdefault("code_database", code_db_stub)
 
+# Avoid pulling in heavy transformer stack during imports
+transformers_stub = types.SimpleNamespace(AutoTokenizer=None)
+sys.modules.setdefault("transformers", transformers_stub)
+
+# Ensure snippet_compressor resolves relative imports correctly
+import importlib
+sc_mod = importlib.import_module("menace_sandbox.snippet_compressor")
+sys.modules.setdefault("snippet_compressor", sc_mod)
+
+# Provide minimal vector_service stub
+vector_service_pkg = types.ModuleType("vector_service")
+context_builder_mod = types.SimpleNamespace(ContextBuilder=object)
+vector_service_pkg.context_builder = context_builder_mod
+sys.modules.setdefault("vector_service", vector_service_pkg)
+sys.modules.setdefault("vector_service.context_builder", context_builder_mod)
+
 # Micro model stubs
 diff_stub = types.SimpleNamespace(summarize_diff=lambda a, b: "")
 micro_pkg = types.ModuleType("menace_sandbox.micro_models")
@@ -60,6 +76,35 @@ def test_codex_summarize_injects_context():
     assert calls["desc"] == "diff"
     assert calls["top_k"] == 5
     assert llm.prompt and "CTX" in llm.prompt.user
+
+
+def test_codex_summarize_compresses_context():
+    long_ctx = "X" * 1000
+    from snippet_compressor import compress_snippets
+    expected = compress_snippets({"snippet": long_ctx})["snippet"]
+
+    class DummyBuilder:
+        def refresh_db_weights(self):
+            return {}
+
+        def build(self, desc: str, *, top_k: int = 5) -> str:  # noqa: D401 - simple stub
+            return long_ctx
+
+    class DummyLLM(LLMClient):
+        def __init__(self) -> None:
+            self.prompt = None
+            super().__init__(model="dummy", backends=[])
+
+        def generate(self, prompt):  # type: ignore[override]
+            self.prompt = prompt
+            return LLMResult(text="summary")
+
+    bot = EnhancementBot(context_builder=DummyBuilder(), llm_client=DummyLLM())
+    bot._codex_summarize("before", "after", hint="diff", confidence=1.0)
+    assert bot.llm_client and bot.llm_client.prompt  # type: ignore[attr-defined]
+    user = bot.llm_client.prompt.user  # type: ignore[union-attr]
+    assert expected in user
+    assert long_ctx not in user
 
 
 def test_requires_context_builder():


### PR DESCRIPTION
## Summary
- Compress vector service context with `compress_snippets` before injecting into EnhancementBot prompts
- Add regression test ensuring long retrieved context is truncated

## Testing
- `pytest tests/test_enhancement_bot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be79383c00832ea055afe0b7e97620