### PR TITLE
Ensure ChatGPTResearchBot client provides context builder

### DIFF
--- a/chatgpt_research_bot.py
+++ b/chatgpt_research_bot.py
@@ -612,8 +612,11 @@ class ChatGPTResearchBot:
             client = ChatGPTClient(
                 context_builder=context_builder, gpt_memory=gpt_memory
             )
-        if not isinstance(client, ChatGPTClient):
-            raise TypeError("client must be ChatGPTClient")
+        else:
+            if not isinstance(client, ChatGPTClient):
+                raise TypeError("client must be ChatGPTClient")
+            if getattr(client, "context_builder", None) is None:
+                raise ValueError("client.context_builder must not be None")
         self.client = client
         self.send_callback = send_callback
         if db_steward is not None and not isinstance(db_steward, DBRouter):
@@ -627,13 +630,6 @@ class ChatGPTResearchBot:
                 self.client.gpt_memory = self.gpt_memory
             except Exception:
                 logger.debug("failed to attach gpt_memory to client", exc_info=True)
-        if getattr(self.client, "context_builder", None) is None:
-            try:
-                self.client.context_builder = self.context_builder
-            except Exception:
-                logger.debug(
-                    "failed to attach context_builder to client", exc_info=True
-                )
 
     def _truncate_history(self, text: str) -> str:
         limit = self.settings.conversation_token_limit

--- a/tests/test_chatgpt_research_bot.py
+++ b/tests/test_chatgpt_research_bot.py
@@ -19,7 +19,7 @@ def test_process(monkeypatch):
         def build(self, query, **_):
             return ""
     builder = DummyBuilder()
-    client = cib.ChatGPTClient("key", context_builder=builder)
+    client = cib.ChatGPTClient(api_key="key", context_builder=builder)
     responses = [
         {"choices": [{"message": {"content": "Answer one."}}]},
         {"choices": [{"message": {"content": "Answer two."}}]},

--- a/tests/test_research_aggregator_bot.py
+++ b/tests/test_research_aggregator_bot.py
@@ -82,7 +82,7 @@ def test_interactive_loop(monkeypatch, tmp_path):
 
 def test_chatgpt_integration(monkeypatch):
     builder = _builder()
-    client = cib.ChatGPTClient("key", context_builder=builder)
+    client = cib.ChatGPTClient(api_key="key", context_builder=builder)
 
     def fake_ask(messages):
         return {"choices": [{"message": {"content": "Some info"}}]}


### PR DESCRIPTION
## Summary
- validate that a provided ChatGPTClient already includes a context_builder
- drop fallback that injected context_builder into ChatGPTClient
- update tests to construct ChatGPTClient with explicit context_builder

## Testing
- `pytest tests/test_chatgpt_research_bot.py tests/test_research_aggregator_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68be7d275968832e931d7af2feafb3cd