### PR TITLE
Ensure ChatGPTEnhancementBot requires client context builder

### DIFF
--- a/chatgpt_enhancement_bot.py
+++ b/chatgpt_enhancement_bot.py
@@ -1036,6 +1036,8 @@ class ChatGPTEnhancementBot:
     ) -> None:
         if context_builder is None:
             raise ValueError("context_builder is required")
+        if client is not None and getattr(client, "context_builder", None) is None:
+            raise ValueError("client.context_builder is required")
         self.override_manager = override_manager
         self.client = client
         self.db = db or EnhancementDB(override_manager=override_manager)
@@ -1053,13 +1055,6 @@ class ChatGPTEnhancementBot:
                 self.client.gpt_memory = self.gpt_memory
             except Exception:
                 logger.debug("failed to attach gpt_memory to client", exc_info=True)
-        if self.client is not None and getattr(self.client, "context_builder", None) is None:
-            try:
-                self.client.context_builder = self.context_builder
-            except Exception:
-                logger.debug(
-                    "failed to attach context_builder to client", exc_info=True
-                )
 
     def _feasible(self, enh: Enhancement) -> bool:
         return len(enh.rationale.split()) < FEASIBLE_WORD_LIMIT


### PR DESCRIPTION
## Summary
- validate that ChatGPTEnhancementBot receives a ChatGPTClient already equipped with a ContextBuilder
- add regression test covering missing client context builder

## Testing
- `MENACE_DB_PATH=/tmp MENACE_SHARED_DB_PATH=/tmp MENACE_LIGHT_IMPORTS=1 PYTHONPATH=. pytest tests/test_chatgpt_enhancement_bot.py tests/test_research_aggregator_bot.py` *(fails: ImportError: cannot import name 'RAISE_ERRORS' from 'menace')*

------
https://chatgpt.com/codex/tasks/task_e_68be7f4d98b4832ebc679cf449055869