### PR TITLE
Require explicit context builder in sandbox runner

### DIFF
--- a/sandbox_runner/cycle.py
+++ b/sandbox_runner/cycle.py
@@ -1432,17 +1432,16 @@ def _sandbox_cycle_runner(
                     if insight:
                         prompt = f"{insight}\n\n{prompt}"
                     gpt_mem = getattr(ctx.gpt_client, "gpt_memory", None)
-                    builder = getattr(ctx, "context_builder", None)
-                    if builder is not None:
-                        cb_session = uuid.uuid4().hex
-                        try:
-                            mem_ctx = builder.build(memory_key, session_id=cb_session)
-                            if isinstance(mem_ctx, (FallbackResult, ErrorResult)):
-                                mem_ctx = ""
-                        except Exception:
+                    builder = ctx.context_builder
+                    cb_session = uuid.uuid4().hex
+                    try:
+                        mem_ctx = builder.build(memory_key, session_id=cb_session)
+                        if isinstance(mem_ctx, (FallbackResult, ErrorResult)):
                             mem_ctx = ""
-                        if mem_ctx:
-                            prompt += "\n\n### Memory\n" + mem_ctx
+                    except Exception:
+                        mem_ctx = ""
+                    if mem_ctx:
+                        prompt += "\n\n### Memory\n" + mem_ctx
                     lkm = getattr(__import__("sys").modules.get("sandbox_runner"), "LOCAL_KNOWLEDGE_MODULE", None)
                     history = ctx.conversations.get(memory_key, [])
                     history_text = "\n".join(
@@ -1702,17 +1701,16 @@ def _sandbox_cycle_runner(
                         if insight:
                             prompt = f"{insight}\n\n{prompt}"
                         gpt_mem = getattr(ctx.gpt_client, "gpt_memory", None)
-                        builder = getattr(ctx, "context_builder", None)
-                        if builder is not None:
-                            cb_session = uuid.uuid4().hex
-                            try:
-                                mem_ctx = builder.build("brainstorm", session_id=cb_session)
-                                if isinstance(mem_ctx, (FallbackResult, ErrorResult)):
-                                    mem_ctx = ""
-                            except Exception:
+                        builder = ctx.context_builder
+                        cb_session = uuid.uuid4().hex
+                        try:
+                            mem_ctx = builder.build("brainstorm", session_id=cb_session)
+                            if isinstance(mem_ctx, (FallbackResult, ErrorResult)):
                                 mem_ctx = ""
-                            if mem_ctx:
-                                prompt += "\n\n### Memory\n" + mem_ctx
+                        except Exception:
+                            mem_ctx = ""
+                        if mem_ctx:
+                            prompt += "\n\n### Memory\n" + mem_ctx
                         hist = ctx.conversations.get("brainstorm", [])
                         lkm = getattr(__import__("sys").modules.get("sandbox_runner"), "LOCAL_KNOWLEDGE_MODULE", None)
                         history_text = "\n".join(
@@ -1806,17 +1804,16 @@ def _sandbox_cycle_runner(
                     )
                     if insight:
                         prompt = f"{insight}\n\n{prompt}"
-                    builder = getattr(ctx, "context_builder", None)
-                    if builder is not None:
-                        cb_session = uuid.uuid4().hex
-                        try:
-                            mem_ctx = builder.build("brainstorm", session_id=cb_session)
-                            if isinstance(mem_ctx, (FallbackResult, ErrorResult)):
-                                mem_ctx = ""
-                        except Exception:
+                    builder = ctx.context_builder
+                    cb_session = uuid.uuid4().hex
+                    try:
+                        mem_ctx = builder.build("brainstorm", session_id=cb_session)
+                        if isinstance(mem_ctx, (FallbackResult, ErrorResult)):
                             mem_ctx = ""
-                        if mem_ctx:
-                            prompt += "\n\n### Memory\n" + mem_ctx
+                    except Exception:
+                        mem_ctx = ""
+                    if mem_ctx:
+                        prompt += "\n\n### Memory\n" + mem_ctx
                     hist = ctx.conversations.get("brainstorm", [])
                     lkm = getattr(__import__("sys").modules.get("sandbox_runner"), "LOCAL_KNOWLEDGE_MODULE", None)
                     history_text = "\n".join(


### PR DESCRIPTION
## Summary
- require explicit `context_builder` cleanup handling in sandbox runner
- use provided `context_builder` for brainstorming prompts
- drop fallback `getattr` checks for `context_builder`

## Testing
- `pytest sandbox_runner/tests/test_minimal_cycle.py -q` *(fails: Missing dependencies for self-improvement)*
- `pytest tests/test_sandbox_runner_metrics.py::test_build_section_prompt_metrics -q` *(error: 'workflow_roi_history.json' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be8433ebd8832eb590cccc624170d6