### PR TITLE
chore: enforce context builder in pre-commit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,7 @@ jobs:
         run: pip install pre-commit
       - name: Enforce ContextBuilder usage
         run: pre-commit run check-context-builder-usage --all-files
+        # Fails the build if any prompt-generating call lacks a context_builder.
 
   tests:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ repos:
         language: system
         pass_filenames: false
         files: '\.py$'
+      # Ensure functions that generate prompts always supply a context_builder.
       - id: check-context-builder-usage
         name: Enforce ContextBuilder usage
         entry: python scripts/check_context_builder_usage.py


### PR DESCRIPTION
## Summary
- comment on pre-commit config for context builder enforcement
- document context builder check in CI workflow

## Testing
- `PYTHONPATH=. pre-commit run forbid-stripe-keys --files .pre-commit-config.yaml .github/workflows/tests.yml`
- `PYTHONPATH=. pre-commit run check-context-builder-usage --all-files` *(fails: getattr context_builder default None disallowed or missing context_builder)*

------
https://chatgpt.com/codex/tasks/task_e_68be9178a4ac832ea9290cf520b9b9f8