### PR TITLE
Require explicit ContextBuilder for DynamicResourceAllocator

### DIFF
--- a/diagnostic_manager.py
+++ b/diagnostic_manager.py
@@ -148,7 +148,7 @@ class DiagnosticManager:
         success = False
         if issue == "high_response_time":
             bots = {row[0] for row in self.metrics.fetch(5).itertuples(index=False)}
-            DynamicResourceAllocator(self.metrics).allocate(bots)
+            DynamicResourceAllocator(self.metrics, context_builder=self.context_builder).allocate(bots)
             action = "reallocate_resources"
             success = True
         elif issue == "error_rate":

--- a/menace_master.py
+++ b/menace_master.py
@@ -424,6 +424,7 @@ def _init_unused_bots() -> None:
         _wrap(
             DynamicResourceAllocator,
             alloc_bot=ResourceAllocationBot(context_builder=builder),
+            context_builder=builder,
         ),
         DiagnosticManager,
         KeywordBank,

--- a/model_automation_pipeline.py
+++ b/model_automation_pipeline.py
@@ -214,7 +214,8 @@ class ModelAutomationPipeline:
         self.allocator = allocator or DynamicResourceAllocator(
             alloc_bot=ResourceAllocationBot(
                 AllocationDB(), context_builder=self.context_builder
-            )
+            ),
+            context_builder=self.context_builder,
         )
         self.diagnostic_manager = diagnostic_manager or DiagnosticManager(
             context_builder=self.context_builder

--- a/tests/test_dynamic_resource_allocator_bot.py
+++ b/tests/test_dynamic_resource_allocator_bot.py
@@ -20,13 +20,15 @@ def test_allocate_and_log(tmp_path, monkeypatch):
     mdb = db.MetricsDB(tmp_path / "m.db")
     rec = db.MetricRecord("bot1", 10.0, 50.0, 0.1, 1.0, 1.0, 0)
     mdb.add(rec)
+    builder = _DummyBuilder()
     allocator = drab.DynamicResourceAllocator(
         mdb,
         rpb.ResourcePredictionBot(rpb.TemplateDB(tmp_path / "t.csv")),
         drab.DecisionLedger(tmp_path / "d.db"),
         drab.ResourceAllocationBot(
-            drab.AllocationDB(tmp_path / "a.db"), context_builder=_DummyBuilder()
+            drab.AllocationDB(tmp_path / "a.db"), context_builder=builder
         ),
+        context_builder=builder,
     )
     actions = allocator.allocate(["bot1"])
     rows = allocator.ledger.fetch()
@@ -64,14 +66,16 @@ def test_myelinated_priority(tmp_path, monkeypatch):
             roi=2.0,
         ),
     )
+    builder = _DummyBuilder()
     allocator = drab.DynamicResourceAllocator(
         mdb,
         rpb.ResourcePredictionBot(rpb.TemplateDB(tmp_path / "t.csv")),
         drab.DecisionLedger(tmp_path / "d.db"),
         drab.ResourceAllocationBot(
-            drab.AllocationDB(tmp_path / "a.db"), context_builder=_DummyBuilder()
+            drab.AllocationDB(tmp_path / "a.db"), context_builder=builder
         ),
         pdb,
+        context_builder=builder,
     )
     actions = allocator.allocate(["bot1", "bot2"])
     result = dict(actions)

--- a/tests/test_predictive_allocator_integration.py
+++ b/tests/test_predictive_allocator_integration.py
@@ -128,6 +128,7 @@ def test_scaling_hint_logged(monkeypatch, tmp_path, caplog):
         pathway_db=None,
         predictive_allocator=aem.PredictiveResourceAllocator(mdb),
         orchestrator=orch,
+        context_builder=types.SimpleNamespace(),
     )
     allocator.allocate(["bot"])
 
@@ -185,6 +186,7 @@ def test_scaling_respects_optimizer(monkeypatch, tmp_path):
         predictive_allocator=aem.PredictiveResourceAllocator(mdb),
         orchestrator=orch,
         optimizer=opt,
+        context_builder=types.SimpleNamespace(),
     )
     allocator.allocate(["bot"])
 


### PR DESCRIPTION
## Summary
- require a `ContextBuilder` when creating `DynamicResourceAllocator`
- remove implicit ContextBuilder creation and refresh logic
- adjust modules and tests to pass a ContextBuilder explicitly

## Testing
- `pre-commit run --files dynamic_resource_allocator_bot.py model_automation_pipeline.py diagnostic_manager.py menace_master.py tests/test_dynamic_resource_allocator_bot.py tests/test_predictive_allocator_integration.py` *(failed: ModuleNotFoundError: No module named 'dynamic_path_router')*
- `pytest tests/test_dynamic_resource_allocator_bot.py tests/test_predictive_allocator_integration.py tests/test_diagnostic_manager.py tests/test_menace_master.py tests/test_dependency_watchdog_events.py` *(errors: RuntimeError: vector_service import failed)*


------
https://chatgpt.com/codex/tasks/task_e_68beb38dd4f0832e812f935cd2a57949