### PR TITLE
Require ContextBuilder for self bootstrap

### DIFF
--- a/menace_master.py
+++ b/menace_master.py
@@ -351,10 +351,10 @@ def _init_unused_bots() -> None:
         from vector_service.context_builder import ContextBuilder  # type: ignore
 
         builder = ContextBuilder(
-            bot_db="bots.db",
+            bots_db="bots.db",
             code_db="code.db",
-            error_db="errors.db",
-            workflow_db="workflows.db",
+            errors_db="errors.db",
+            workflows_db="workflows.db",
         )
         builder.refresh_db_weights()
     except Exception:  # pragma: no cover - optional dependency
@@ -445,20 +445,24 @@ def _init_unused_bots() -> None:
 def run_once(models: Iterable[str]) -> None:
     """Run a single automation cycle for the given models."""
     _init_unused_bots()
-    builder = None
     try:
         from vector_service.context_builder import ContextBuilder  # type: ignore
-        builder = ContextBuilder()
-    except Exception:
-        pass
-    try:
-        orchestrator = (
-            MenaceOrchestrator(context_builder=builder)  # type: ignore[arg-type]
-            if builder is not None
-            else MenaceOrchestrator()
+
+        builder = ContextBuilder(
+            bots_db="bots.db",
+            code_db="code.db",
+            errors_db="errors.db",
+            workflows_db="workflows.db",
         )
-    except TypeError:
-        orchestrator = MenaceOrchestrator()
+    except Exception:  # pragma: no cover - optional dependency
+        logger.debug("failed to initialize ContextBuilder", exc_info=True)
+
+        class _DummyBuilder:
+            def refresh_db_weights(self):
+                pass
+
+        builder = _DummyBuilder()
+    orchestrator = MenaceOrchestrator(context_builder=builder)  # type: ignore[arg-type]
     # Create a default root oversight bot
     orchestrator.create_oversight("root", "L1")
     override_svc = SelfServiceOverride(ROIDB(), MetricsDB())
@@ -632,20 +636,24 @@ def main(argv: Iterable[str] | None = None) -> None:
     )
     learning_thread.start()
 
-    builder = None
     try:
         from vector_service.context_builder import ContextBuilder  # type: ignore
-        builder = ContextBuilder()
-    except Exception:
-        pass
-    try:
-        orchestrator = (
-            MenaceOrchestrator(context_builder=builder)  # type: ignore[arg-type]
-            if builder is not None
-            else MenaceOrchestrator()
+
+        builder = ContextBuilder(
+            bots_db="bots.db",
+            code_db="code.db",
+            errors_db="errors.db",
+            workflows_db="workflows.db",
         )
-    except TypeError:
-        orchestrator = MenaceOrchestrator()
+    except Exception:  # pragma: no cover - optional dependency
+        logger.debug("failed to initialize ContextBuilder", exc_info=True)
+
+        class _DummyBuilder:
+            def refresh_db_weights(self):
+                pass
+
+        builder = _DummyBuilder()
+    orchestrator = MenaceOrchestrator(context_builder=builder)  # type: ignore[arg-type]
     orchestrator.create_oversight("root", "L1")
     orchestrator.start_scheduled_jobs()
     override_svc = SelfServiceOverride(ROIDB(), MetricsDB())

--- a/menace_orchestrator.py
+++ b/menace_orchestrator.py
@@ -249,7 +249,9 @@ class MenaceOrchestrator:
             try:
                 from .self_model_bootstrap import bootstrap as self_bootstrap
 
-                self.model_id = self_bootstrap()
+                self.model_id = self_bootstrap(
+                    context_builder=self.context_builder
+                )
             except Exception:
                 self.logger.exception("self bootstrap failed")
         self.restart_callback = on_restart

--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -7119,7 +7119,14 @@ class SelfImprovementEngine:
             except Exception as exc:
                 self.logger.exception("roi energy adjustment failed: %s", exc)
             energy = max(1, min(int(energy), 100))
-            model_id = bootstrap()
+            model_id = bootstrap(
+                context_builder=ContextBuilder(
+                    bots_db="bots.db",
+                    code_db="code.db",
+                    errors_db="errors.db",
+                    workflows_db="workflows.db",
+                )
+            )
             self.logger.info("model bootstrapped", extra=log_record(model_id=model_id))
             self.info_db.set_current_model(model_id)
             self._record_state()

--- a/self_model_bootstrap.py
+++ b/self_model_bootstrap.py
@@ -17,14 +17,17 @@ from menace.error_bot import ErrorBot
 from menace.data_bot import DataBot, MetricsDB
 from menace.capital_management_bot import CapitalManagementBot
 from menace.database_manager import add_model, update_model, DB_PATH
-from types import SimpleNamespace
+from vector_service.context_builder import ContextBuilder
 
 
-def bootstrap(context_builder: "ContextBuilder" | None = None) -> int:
+def bootstrap(*, context_builder: ContextBuilder) -> int:
     """Create the menace model and populate related tables.
 
     Returns the model identifier from ``models.db``.
     """
+    if context_builder is None:
+        raise ValueError("context_builder must be provided")
+
     # Insert or fetch the menace model using the standard helper.
     model_id = add_model("menace", source="self", tags="menace", db_path=DB_PATH)
 
@@ -32,18 +35,6 @@ def bootstrap(context_builder: "ContextBuilder" | None = None) -> int:
     capital_bot = CapitalManagementBot()
     data_bot = DataBot(MetricsDB(), capital_bot=capital_bot)
     cb = context_builder
-    if cb is None:
-        try:
-            from vector_service.context_builder import ContextBuilder
-
-            cb = ContextBuilder(
-                bots_db="bots.db",
-                code_db="code.db",
-                errors_db="errors.db",
-                workflows_db="workflows.db",
-            )
-        except Exception:  # pragma: no cover - best effort fallback
-            cb = SimpleNamespace(refresh_db_weights=lambda: None)
     err_bot = ErrorBot(data_bot=data_bot, context_builder=cb)
 
     bot_files = sorted(resolve_dir(".").glob("*_bot.py"))

--- a/tests/test_self_model_bootstrap_availability.py
+++ b/tests/test_self_model_bootstrap_availability.py
@@ -64,9 +64,20 @@ def test_self_model_bootstrap_returns_identifier(monkeypatch):
     dbm_mod.DB_PATH = ""
     monkeypatch.setitem(sys.modules, "menace.database_manager", dbm_mod)
 
+    cb_mod = types.ModuleType("vector_service.context_builder")
+
+    class DummyBuilder:
+        def refresh_db_weights(self):
+            return None
+
+    cb_mod.ContextBuilder = DummyBuilder
+    monkeypatch.setitem(sys.modules, "vector_service.context_builder", cb_mod)
+
+    sys.modules.pop("menace.self_model_bootstrap", None)
+
     import menace.self_model_bootstrap as smb
     monkeypatch.setattr(smb.Path, "glob", lambda self, pattern: [])
-    assert smb.bootstrap() == 7
+    assert smb.bootstrap(context_builder=DummyBuilder()) == 7
 
 
 def test_bootstrap_missing_module_raises(monkeypatch):


### PR DESCRIPTION
## Summary
- Make `self_model_bootstrap.bootstrap` require an explicit `ContextBuilder`
- Pass a real `ContextBuilder` to self bootstrapping in orchestrator, master script, and self-improvement engine
- Adjust tests for the new bootstrap signature

## Testing
- `pytest tests/test_self_model_bootstrap_availability.py -q`
- `pytest tests/test_self_model_bootstrap_availability.py tests/test_self_improvement_logging.py -q` *(fails: AttributeError on SandboxSettings.meta_entropy_threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68bee6828d88832ea748eb131508fead