### PR TITLE
refactor: centralize context builder

### DIFF
--- a/adaptive_roi_cli.py
+++ b/adaptive_roi_cli.py
@@ -21,7 +21,7 @@ from .roi_tracker import ROITracker
 from .truth_adapter import TruthAdapter
 from .composite_workflow_scorer import CompositeWorkflowScorer
 from .roi_results_db import ROIResultsDB
-from vector_service.context_builder import ContextBuilder
+from context_builder_util import create_context_builder
 import db_router
 from .dynamic_path_router import resolve_path
 
@@ -206,7 +206,7 @@ def _workflow_eval(args: argparse.Namespace) -> None:
     scorer = CompositeWorkflowScorer(
         tracker=ROITracker(), results_db=ROIResultsDB(args.db_path)
     )
-    builder = ContextBuilder()
+    builder = create_context_builder()
     try:
         builder.refresh_db_weights()
     except Exception:  # pragma: no cover - best effort refresh

--- a/config/create_context_builder.py
+++ b/config/create_context_builder.py
@@ -1,0 +1,6 @@
+from vector_service import ContextBuilder
+
+
+def create_context_builder() -> ContextBuilder:
+    """Return a :class:`ContextBuilder` wired to the standard local databases."""
+    return ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")

--- a/context_builder_util.py
+++ b/context_builder_util.py
@@ -1,0 +1,9 @@
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+_create_module = SourceFileLoader(
+    "config.create_context_builder",
+    str(Path(__file__).resolve().parent / "config" / "create_context_builder.py"),
+).load_module()
+
+create_context_builder = _create_module.create_context_builder

--- a/menace_cli.py
+++ b/menace_cli.py
@@ -429,7 +429,7 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     args = parser.parse_args(argv)
-    builder = ContextBuilder(
+    builder = ContextBuilder(  # nocb
         args.bots_db, args.code_db, args.errors_db, args.workflows_db
     )
     setattr(args, "builder", builder)

--- a/neurosales/neurosales/cortex_responder.py
+++ b/neurosales/neurosales/cortex_responder.py
@@ -8,6 +8,7 @@ from .response_generation import ResponseCandidateGenerator
 from .scoring import CandidateResponseScorer, ResponsePriorityQueue
 from .external_integrations import GPT4Client, PineconeLogger
 from typing import TYPE_CHECKING
+from context_builder_util import create_context_builder
 
 if TYPE_CHECKING:  # pragma: no cover - hints only
     from .user_preferences import PreferenceProfile
@@ -45,9 +46,7 @@ class CortexAwareResponder:
         pinecone_env: str,
         pg: Optional[InMemoryResponseDB] = None,
     ) -> None:
-        from vector_service.context_builder import ContextBuilder
-
-        self.client = GPT4Client(openai_key, context_builder=ContextBuilder())
+        self.client = GPT4Client(openai_key, context_builder=create_context_builder())
         self.pinecone = PineconeLogger(
             pinecone_index, api_key=pinecone_key, environment=pinecone_env
         )

--- a/neurosales/neurosales/trend_monitor.py
+++ b/neurosales/neurosales/trend_monitor.py
@@ -12,6 +12,7 @@ from .external_integrations import (
     GPT4Client,
     PineconeLogger,
 )
+from context_builder_util import create_context_builder
 
 logger = logging.getLogger(__name__)
 
@@ -64,9 +65,7 @@ class TrendMonitor:
         self.twitter = twitter
         self.medium = medium
         if gpt4 is None:
-            from vector_service.context_builder import ContextBuilder
-
-            self.gpt4 = GPT4Client(openai_key, context_builder=ContextBuilder())
+            self.gpt4 = GPT4Client(openai_key, context_builder=create_context_builder())
         else:
             self.gpt4 = gpt4
         if vector is None:

--- a/neurosales/scripts/check_external_services.py
+++ b/neurosales/scripts/check_external_services.py
@@ -3,7 +3,7 @@ import sys
 from dotenv import load_dotenv
 from neurosales import config
 from billing.openai_wrapper import chat_completion_create
-from vector_service.context_builder import ContextBuilder
+from context_builder_util import create_context_builder
 
 load_dotenv()
 
@@ -13,7 +13,7 @@ def check_openai(cfg: config.ServiceConfig) -> bool:
         print("OpenAI disabled")
         return True
     try:
-        builder = ContextBuilder()
+        builder = create_context_builder()
     except Exception as e:
         print(f"ContextBuilder initialization error: {e}")
         return False

--- a/sandbox_runner/cli.py
+++ b/sandbox_runner/cli.py
@@ -14,7 +14,7 @@ import platform
 import subprocess
 from sandbox_settings import SandboxSettings, load_sandbox_settings
 from dynamic_path_router import resolve_path, path_for_prompt
-from vector_service.context_builder import ContextBuilder
+from context_builder_util import create_context_builder
 try:  # optional dependency
     from scipy.stats import pearsonr, t, levene
 except Exception:  # pragma: no cover - fallback when scipy is missing
@@ -169,7 +169,7 @@ def _run_sandbox(args: argparse.Namespace, sandbox_main=None) -> None:
         return
 
     preset = presets[0]
-    builder = ContextBuilder()
+    builder = create_context_builder()
     sandbox_main(preset, args, builder)
     if _SandboxMetaLogger is not None:
         try:
@@ -402,7 +402,7 @@ def _capture_run(preset: dict[str, str], args: argparse.Namespace):
     from sandbox_runner import _sandbox_main
 
     holder: dict[str, Any] = {}
-    builder = ContextBuilder()
+    builder = create_context_builder()
 
     def wrapper(p: dict[str, str], a: argparse.Namespace):
         holder["tracker"] = _sandbox_main(p, a, builder)
@@ -1875,7 +1875,7 @@ def main(argv: List[str] | None = None) -> None:
             run_workflow_simulations,
             load_scenario_summary,
         )
-        builder = ContextBuilder()
+        builder = create_context_builder()
         run_workflow_simulations(
             args.workflow_db,
             dynamic_workflows=args.dynamic_workflows,

--- a/scripts/check_context_builder_usage.py
+++ b/scripts/check_context_builder_usage.py
@@ -22,7 +22,8 @@ partials are likewise validated.
 Furthermore, the linter searches for imports or calls to
 ``get_default_context_builder`` outside of test directories.  Such usage is
 reported unless the offending line (or the one immediately above it) contains a
-``# nocb`` marker.
+``# nocb`` marker.  Calls to ``create_context_builder`` are allowed and
+considered valid ``ContextBuilder`` instantiations.
 """
 from __future__ import annotations
 
@@ -34,6 +35,12 @@ ROOT = Path(__file__).resolve().parent.parent
 NOCB_MARK = "# nocb"
 
 DEFAULT_BUILDER_NAME = "get_default_context_builder"
+HELPER_NAMES = {
+    "create_context_builder",
+    "config.create_context_builder.create_context_builder",
+    "menace_sandbox.config.create_context_builder.create_context_builder",
+    "context_builder_util.create_context_builder",
+}
 REQUIRED_NAMES = {
     "PromptEngine",
     "_build_prompt",
@@ -317,9 +324,9 @@ def check_file(path: Path) -> list[tuple[int, str]]:
         if not isinstance(node, ast.Call):
             continue
         name = full_name(node.func)
-        if not name or (
-            name != "ContextBuilder" and not name.endswith(".ContextBuilder")
-        ):
+        if not name or name in HELPER_NAMES:
+            continue
+        if name != "ContextBuilder" and not name.endswith(".ContextBuilder"):
             continue
 
         strings: list[str] = []

--- a/scripts/full_autonomous_run.py
+++ b/scripts/full_autonomous_run.py
@@ -12,14 +12,14 @@ from metrics_dashboard import MetricsDashboard
 from dynamic_path_router import resolve_path
 from pathlib import Path
 from threading import Thread
-from vector_service.context_builder import ContextBuilder
+from context_builder_util import create_context_builder
 
 
 def _capture_run(preset: Dict[str, str], args: argparse.Namespace):
     holder = {}
 
     def wrapper(p: Dict[str, str], a: argparse.Namespace):
-        builder = ContextBuilder()
+        builder = create_context_builder()
         holder['tracker'] = _sandbox_main(p, a, builder)
 
     _run_sandbox(args, sandbox_main=wrapper)

--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -372,6 +372,7 @@ from ..model_automation_pipeline import (
     AutomationResult,
 )
 from vector_service.context_builder import ContextBuilder
+from context_builder_util import create_context_builder
 from ..diagnostic_manager import DiagnosticManager
 from ..error_bot import ErrorBot, ErrorDB
 from ..data_bot import MetricsDB, DataBot
@@ -548,7 +549,7 @@ class SelfImprovementEngine:
         self.interval = interval
         self.bot_name = bot_name
         self.info_db = info_db or InfoDB()
-        builder = ContextBuilder()
+        builder = create_context_builder()
         try:
             builder.refresh_db_weights()
         except Exception:

--- a/self_test_service.py
+++ b/self_test_service.py
@@ -42,6 +42,7 @@ try:  # pragma: no cover - optional dependency for type hints
     from vector_service.context_builder import ContextBuilder
 except Exception:  # pragma: no cover - fallback for flat layout
     from vector_service.context_builder import ContextBuilder  # type: ignore
+from context_builder_util import create_context_builder
 MENACE_ID = uuid.uuid4().hex
 
 try:  # pragma: no cover - compatibility with pydantic v1/v2
@@ -3321,7 +3322,7 @@ def cli(argv: list[str] | None = None) -> int:
             include_redundant=args.include_redundant,
             report_dir=args.report_dir,
             ephemeral=args.ephemeral,
-            context_builder=ContextBuilder(),
+            context_builder=create_context_builder(),
         )
         try:
             asyncio.run(service._run_once(refresh_orphans=args.refresh_orphans))
@@ -3367,7 +3368,7 @@ def cli(argv: list[str] | None = None) -> int:
             include_redundant=args.include_redundant,
             report_dir=args.report_dir,
             ephemeral=args.ephemeral,
-            context_builder=ContextBuilder(),
+            context_builder=create_context_builder(),
         )
         try:
             service.run_scheduled(
@@ -3393,7 +3394,7 @@ def cli(argv: list[str] | None = None) -> int:
             container_runtime=args.container_runtime,
             docker_host=args.docker_host,
             container_retries=args.retries,
-            context_builder=ContextBuilder(),
+            context_builder=create_context_builder(),
         )
         try:
             asyncio.run(service._cleanup_containers())

--- a/service_supervisor.py
+++ b/service_supervisor.py
@@ -61,6 +61,7 @@ from .menace_memory_manager import MenaceMemoryManager  # noqa: E402
 from .model_automation_pipeline import ModelAutomationPipeline  # noqa: E402
 from .quick_fix_engine import QuickFixEngine  # noqa: E402
 from vector_service.context_builder import ContextBuilder  # noqa: E402
+from context_builder_util import create_context_builder
 
 try:  # optional dependency
     import psutil  # type: ignore
@@ -286,7 +287,7 @@ def _update_worker() -> None:
 def _self_test_worker() -> None:
     """Execute the self test suite periodically."""
     logger = logging.getLogger("self_test_worker")
-    builder = ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
+    builder = create_context_builder()
     svc = SelfTestService(context_builder=builder)
     stop = Event()
     interval = float(os.getenv("SELF_TEST_INTERVAL", "86400"))
@@ -511,7 +512,7 @@ def main() -> None:
     """Entry point starting the service supervisor."""
     logging.basicConfig(level=logging.INFO)
     EnvironmentBootstrapper().bootstrap()
-    builder = ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
+    builder = create_context_builder()
     sup = ServiceSupervisor(context_builder=builder)
     sup.register("orchestrator", partial(_orchestrator_worker, builder))
     sup.register("microtrend_service", _microtrend_worker)

--- a/tests/test_create_context_builder.py
+++ b/tests/test_create_context_builder.py
@@ -1,0 +1,23 @@
+import sys
+import types
+
+# Stub heavy ``vector_service`` before importing the helper
+sys.modules.setdefault("vector_service", types.SimpleNamespace(ContextBuilder=object))
+
+import context_builder_util as cbu
+
+
+def test_create_context_builder_paths(monkeypatch):
+    captured = {}
+
+    class DummyBuilder:
+        pass
+
+    def fake_cb(*args):
+        captured['args'] = args
+        return DummyBuilder()
+
+    monkeypatch.setattr(cbu._create_module, 'ContextBuilder', fake_cb)
+    builder = cbu.create_context_builder()
+    assert captured['args'] == ("bots.db", "code.db", "errors.db", "workflows.db")
+    assert isinstance(builder, DummyBuilder)

--- a/variant_cli.py
+++ b/variant_cli.py
@@ -31,7 +31,7 @@ def main() -> None:  # pragma: no cover - CLI glue
     # Clone the branch explicitly so operators can see the new patch id
     new_patch = lineage.clone_branch_for_ab_test(args.patch_id, args.variant)
 
-    builder = ContextBuilder(
+    builder = ContextBuilder(  # nocb
         args.bots_db, args.code_db, args.errors_db, args.workflows_db
     )
     exp_mgr = ExperimentManager(

--- a/vector_service_api.py
+++ b/vector_service_api.py
@@ -29,6 +29,7 @@ from vector_service import (
     FallbackResult,
 )
 from vector_service.context_builder import ContextBuilder
+from context_builder_util import create_context_builder
 from vector_service.patch_logger import RoiTag
 try:  # pragma: no cover - optional dependency
     from roi_tracker import ROITracker
@@ -80,7 +81,7 @@ def create_app(builder: ContextBuilder | None = None) -> FastAPI:
 
     global _builder, _cognition_layer, _patch_logger, _backfill, _ranker_scheduler, _retriever
 
-    _builder = builder or ContextBuilder()
+    _builder = builder or create_context_builder()
     _retriever = Retriever(context_builder=_builder)
     try:
         _builder.refresh_db_weights()


### PR DESCRIPTION
## Summary
- add context builder helper returning standard database paths
- replace direct ContextBuilder() calls with create_context_builder()
- allow linter and tests to recognise the helper

## Testing
- `python scripts/check_context_builder_usage.py`
- `pytest tests/test_create_context_builder.py`


------
https://chatgpt.com/codex/tasks/task_e_68beea341be0832ebdf6245e1224021e