### PR TITLE
Use factory for context builder in GUI

### DIFF
--- a/menace_gui.py
+++ b/menace_gui.py
@@ -17,7 +17,7 @@ from .bot_database import BotDB
 from .resources_bot import ROIHistoryDB
 from .resource_prediction_bot import ResourcePredictionBot, ResourceMetrics
 from .resource_allocation_bot import ResourceAllocationBot, AllocationDB
-from vector_service.context_builder import ContextBuilder
+from context_builder_util import create_context_builder
 from .scope_utils import Scope, build_scope_clause, apply_scope
 try:  # shared GPT memory instance
     from .shared_gpt_memory import GPT_MEMORY_MANAGER
@@ -36,12 +36,7 @@ class MenaceGUI(tk.Tk):
         self.memory = MenaceMemoryManager()
         self.report_bot = ReportGenerationBot()
         self.chatgpt_enabled = bool(OPENAI_API_KEY)
-        self.context_builder = ContextBuilder(
-            bot_db="bots.db",
-            code_db="code.db",
-            error_db="errors.db",
-            workflow_db="workflows.db",
-        )
+        self.context_builder = create_context_builder()
         self.context_builder.refresh_db_weights()
         if self.chatgpt_enabled:
             client = ChatGPTClient(

--- a/tests/test_menace_gui.py
+++ b/tests/test_menace_gui.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+from unittest import mock
 
 pytest.importorskip("tkinter")
 
@@ -19,4 +20,22 @@ def test_gui_init(monkeypatch):
         "Overview",
         "Forecast Chains",
     ]
+
+
+@pytest.mark.skipif(not os.environ.get("DISPLAY"), reason="requires display")
+def test_gui_uses_context_builder(monkeypatch):
+    from menace import menace_gui as mg
+
+    builder = mock.MagicMock()
+    monkeypatch.setattr(mg, "create_context_builder", lambda: builder)
+    monkeypatch.setattr(mg.ChatGPTClient, "__post_init__", lambda self: None)
+    monkeypatch.setattr(mg, "OPENAI_API_KEY", "key")
+
+    gui = mg.MenaceGUI()
+
+    assert builder.refresh_db_weights.called
+    assert gui.context_builder is builder
+    assert gui.conv_bot is not None
+    assert gui.conv_bot.client.context_builder is builder
+    assert gui.error_bot.context_builder is builder
 


### PR DESCRIPTION
## Summary
- Replace manual ContextBuilder setup in Menace GUI with `create_context_builder`
- Test that GUI uses shared context builder and that downstream bots receive it

## Testing
- `pytest tests/test_menace_gui.py::test_gui_init tests/test_menace_gui.py::test_gui_uses_context_builder -q` *(skipped: requires display)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6ba8f318832ea8f8a7cb13bdcd58