### PR TITLE
Remove nocb comments from CLIs

### DIFF
--- a/menace_cli.py
+++ b/menace_cli.py
@@ -432,7 +432,7 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     args = parser.parse_args(argv)
-    builder = ContextBuilder(  # nocb
+    builder = ContextBuilder(
         args.bots_db, args.code_db, args.errors_db, args.workflows_db
     )
     setattr(args, "builder", builder)

--- a/variant_cli.py
+++ b/variant_cli.py
@@ -31,7 +31,7 @@ def main() -> None:  # pragma: no cover - CLI glue
     # Clone the branch explicitly so operators can see the new patch id
     new_patch = lineage.clone_branch_for_ab_test(args.patch_id, args.variant)
 
-    builder = ContextBuilder(  # nocb
+    builder = ContextBuilder(
         args.bots_db, args.code_db, args.errors_db, args.workflows_db
     )
     exp_mgr = ExperimentManager(


### PR DESCRIPTION
## Summary
- enforce ContextBuilder usage in CLI by removing `# nocb` comments
- keep explicit database arguments for safety

## Testing
- `pytest` *(fails: 408 errors, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6dc7b81c832ebe2a0761931af4b9