### PR TITLE
Use context builder utility in CLI

### DIFF
--- a/menace_cli.py
+++ b/menace_cli.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 from dynamic_path_router import resolve_path
 from db_router import init_db_router
-from vector_service.context_builder import ContextBuilder
+from context_builder_util import create_context_builder
 
 # Expose a DBRouter for CLI operations early so imported modules can rely on
 # ``GLOBAL_ROUTER``.
@@ -432,9 +432,7 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     args = parser.parse_args(argv)
-    builder = ContextBuilder(
-        args.bots_db, args.code_db, args.errors_db, args.workflows_db
-    )
+    builder = create_context_builder()
     setattr(args, "builder", builder)
 
     if hasattr(args, "func"):


### PR DESCRIPTION
## Summary
- create context builders with helper function

## Testing
- `python scripts/check_context_builder_usage.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx' and other missing files)*
- `PYTHONPATH=. pre-commit run --files menace_cli.py` *(fails: check-static-paths, forbid-raw-stripe-usage)*

------
https://chatgpt.com/codex/tasks/task_e_68bf711755cc832e947d850eee5ed6b4