### PR TITLE
ci: run context builder check script

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,10 +44,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - name: Install pre-commit
-        run: pip install pre-commit
       - name: Enforce ContextBuilder usage
-        run: pre-commit run check-context-builder-usage --all-files
+        run: python scripts/check_context_builder_usage.py
         # Fails the build if any prompt-generating call lacks a context_builder.
 
   tests:


### PR DESCRIPTION
## Summary
- run `python scripts/check_context_builder_usage.py` in the `context-builder-check` CI job

## Testing
- `pre-commit run --files .github/workflows/tests.yml` *(fails: check-static-paths, forbid-stripe-keys)*
- `python scripts/check_context_builder_usage.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf72175cb8832eb567b120be486c87