### PR TITLE
ci: enforce context builder usage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,24 +35,10 @@ jobs:
       - name: Check for dynamic path references
         run: "python tools/check_dynamic_paths.py $(git ls-files '*.py')"
 
-  context-builder-check:
-    runs-on: ubuntu-latest
-    env:
-      MENACE_SAFE: "1"
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-      - name: Enforce ContextBuilder usage
-        run: python scripts/check_context_builder_usage.py
-        # Fails the build if any prompt-generating call lacks a context_builder.
-
   tests:
     runs-on: ubuntu-latest
     needs:
       - path-checks
-      - context-builder-check
     env:
       MENACE_SAFE: "1"
     steps:
@@ -64,6 +50,8 @@ jobs:
         run: bash ./setup_env.sh
       - name: Install pre-commit
         run: pip install pre-commit
+      - name: Enforce ContextBuilder usage
+        run: pre-commit run check-context-builder-usage --all-files
       - name: Check for ungoverned embedding calls
         run: pre-commit run check-governed-embeddings --all-files
       - name: Check for direct sqlite3 connections

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,9 @@ pre-commit run check-context-builder-usage --all-files
 ```
 
 Continuous integration runs this hook and fails the build when missing or
-implicit `ContextBuilder` usage is detected.
+implicit `ContextBuilder` usage is detected. The script also flags disallowed
+defaults such as `context_builder=None` or imports of
+`get_default_context_builder`, and CI fails when these patterns appear.
 
 ## Stripe integration
 


### PR DESCRIPTION
## Summary
- run ContextBuilder check in GitHub Actions via pre-commit
- document that CI rejects missing ContextBuilder usage and disallowed defaults

## Testing
- `python scripts/check_context_builder_usage.py` *(fails: context_builder default None disallowed or missing context_builder in meta_workflow_planner.py)*
- `pre-commit run --files .github/workflows/tests.yml CONTRIBUTING.md` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*

------
https://chatgpt.com/codex/tasks/task_e_68bf76768950832ea438a70f388a9563