### PR TITLE
Ensure prompt helpers require context builders

### DIFF
--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -1021,6 +1021,8 @@ class BotDevelopmentBot:
         sample_with_vectors:
             Whether to request embedding vectors for the training examples.
         """
+        if context_builder is None:
+            raise ValueError("context_builder is required")
         query = spec.description or spec.purpose or spec.name
         session_id = uuid.uuid4().hex
         ctx_result = context_builder.build(

--- a/chatgpt_idea_bot.py
+++ b/chatgpt_idea_bot.py
@@ -490,6 +490,8 @@ def build_prompt(
     prior: str | None = None,
 ) -> List[Dict[str, Any]]:
     """Construct a prompt and fetch memory-aware messages via ``client``."""
+    if context_builder is None:
+        raise ValueError("context_builder is required")
     parts = ["Suggest five new online business models"]
     if prior:
         parts.append(f"building on {prior}")

--- a/quick_fix_engine.py
+++ b/quick_fix_engine.py
@@ -141,6 +141,8 @@ def generate_patch(
     """
 
     logger = logging.getLogger("QuickFixEngine")
+    if context_builder is None:
+        raise TypeError("context_builder is required")
     builder = context_builder
     try:
         builder.refresh_db_weights()

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -1077,6 +1077,9 @@ class SelfCodingEngine:
         resolved = path_for_prompt(path) if path else None
         self._apply_prompt_style(description, module=resolved or "visual_agent")
         retry_trace = self._last_retry_trace
+        builder = self.context_builder
+        if builder is None:
+            raise RuntimeError("context_builder is required for prompt generation")
         try:
             prompt_obj = build_prompt(
                 description,
@@ -1086,7 +1089,7 @@ class SelfCodingEngine:
                 tone=self.prompt_tone,
                 target_region=target_region,
                 strategy=strategy,
-                context_builder=self.context_builder,
+                context_builder=builder,
             )
         except TypeError:
             prompt_obj = build_prompt(
@@ -1094,7 +1097,7 @@ class SelfCodingEngine:
                 context="\n".join([p for p in (context.strip(), repo_layout) if p]),
                 retrieval_context=retrieval_context or "",
                 retry_trace=retry_trace,
-                context_builder=self.context_builder,
+                context_builder=builder,
             )
         self._last_prompt = prompt_obj
         body = prompt_obj.text if isinstance(prompt_obj, Prompt) else str(prompt_obj)

--- a/self_improvement/patch_generation.py
+++ b/self_improvement/patch_generation.py
@@ -49,6 +49,8 @@ def generate_patch(
     :class:`RuntimeError` with logging instead of returning ``None``.
     """
 
+    if context_builder is None:
+        raise TypeError("context_builder is required")
     logger = logging.getLogger(__name__)
     try:
         func = _load_callable("quick_fix_engine", "generate_patch")


### PR DESCRIPTION
## Summary
- validate `context_builder` in `bot_development_bot._build_prompt`
- enforce explicit `context_builder` in top-level `build_prompt` and patch helpers
- require context builders for quick-fix and visual agent prompts

## Testing
- `python scripts/check_context_builder_usage.py` (warnings: meta_workflow_planner missing `context_builder`)
- `pytest tests/self_improvement/test_patch_generation_wrapper.py -q`
- `pytest tests/test_quick_fix_engine.py::test_run_context_compression -q`
- `pytest tests/test_build_visual_agent_prompt.py tests/test_chatgpt_idea_bot.py tests/test_resource_allocation_bot.py -q` *(fails: vector_service import missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7dd98500832e83806c63be52736a