### PR TITLE
chore: run context builder check in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Enforce ContextBuilder usage
-        run: pre-commit run check-context-builder-usage --all-files
+        run: python scripts/check_context_builder_usage.py
       - name: Check for ungoverned embedding calls
         run: pre-commit run check-governed-embeddings --all-files
       - name: Check for direct sqlite3 connections

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: mypy synergy-graph install-self-improvement-deps
+.PHONY: mypy synergy-graph install-self-improvement-deps check-context-builder
 mypy:
 	mypy --config mypy.ini self_* sandbox_runner
 	python scripts/check_governed_embeddings.py
@@ -6,7 +6,10 @@ mypy:
 	python scripts/check_context_builder_usage.py
 
 synergy-graph:
-        python module_synergy_grapher.py --build
+	python module_synergy_grapher.py --build
 
 install-self-improvement-deps:
-        python scripts/install_self_improvement_deps.py
+	python scripts/install_self_improvement_deps.py
+
+check-context-builder:
+	python scripts/check_context_builder_usage.py


### PR DESCRIPTION
## Summary
- add `check-context-builder` make target
- run `check_context_builder_usage.py` directly in CI

## Testing
- `python scripts/check_context_builder_usage.py` *(fails: context_builder default None disallowed or missing context_builder)*
- `pre-commit run check-context-builder-usage --all-files` *(fails: context_builder default None disallowed or missing context_builder)*
- `make check-context-builder` *(fails: context_builder default None disallowed or missing context_builder)*

------
https://chatgpt.com/codex/tasks/task_e_68bf802854c0832ea4c4ca6116bd40c3