### PR TITLE
Require explicit context builders for meta workflow planning

### DIFF
--- a/docs/meta_workflow_planner.md
+++ b/docs/meta_workflow_planner.md
@@ -39,10 +39,14 @@ workflows = {
 # Cluster similar workflow specs
 builder = ContextBuilder()
 retr = Retriever(context_builder=builder)
-clusters = planner.cluster_workflows(workflows, retriever=retr, epsilon=0.8)
+clusters = planner.cluster_workflows(
+    workflows, retriever=retr, epsilon=0.8, context_builder=planner.context_builder
+)
 
 # Build a high‑synergy chain starting from A
-pipeline = planner.compose_pipeline("A", workflows, length=3)
+pipeline = planner.compose_pipeline(
+    "A", workflows, length=3, context_builder=planner.context_builder
+)
 ```
 
 `cluster_workflows` encodes each specification, persists the embedding and

--- a/tests/test_meta_workflow_planner_cli.py
+++ b/tests/test_meta_workflow_planner_cli.py
@@ -15,6 +15,14 @@ class DummySynergyComparator:
         return types.SimpleNamespace(aggregate=0.0)
 
 
+class DummyBuilder:
+    def build(self, *_, **__):
+        return {}
+
+    def refresh_db_weights(self) -> None:
+        pass
+
+
 def test_simulate_multi_domain_chain(monkeypatch, capsys):
     monkeypatch.setattr(mwp, "ROITracker", None)
     monkeypatch.setattr(mwp, "WorkflowStabilityDB", None)
@@ -38,11 +46,16 @@ def test_simulate_multi_domain_chain(monkeypatch, capsys):
 
     monkeypatch.setattr(mwp.MetaWorkflowPlanner, "encode_workflow", fake_encode)
 
-    def fake_find_synergy_chain(start, length=5):
-        planner = mwp.MetaWorkflowPlanner(graph=SigGraph())
-        return planner.compose_pipeline(start, workflows, length=length)
+    def fake_find_synergy_chain(start, length=5, context_builder=None):
+        planner = mwp.MetaWorkflowPlanner(
+            graph=SigGraph(), context_builder=context_builder
+        )
+        return planner.compose_pipeline(
+            start, workflows, length=length, context_builder=context_builder
+        )
 
     monkeypatch.setattr(cli, "find_synergy_chain", fake_find_synergy_chain)
+    monkeypatch.setattr(cli, "_CONTEXT_BUILDER", DummyBuilder())
 
     args = types.SimpleNamespace(start="YouTube", length=3)
     cli._cmd_simulate(args)

--- a/workflow_evolution_manager.py
+++ b/workflow_evolution_manager.py
@@ -21,6 +21,10 @@ from . import workflow_run_summary
 from . import sandbox_runner
 from .workflow_synergy_comparator import WorkflowSynergyComparator
 from .meta_workflow_planner import MetaWorkflowPlanner
+try:  # pragma: no cover - optional dependency
+    from vector_service.context_builder import ContextBuilder  # type: ignore
+except Exception:  # pragma: no cover - allow running without builder
+    ContextBuilder = None  # type: ignore
 try:  # pragma: no cover - allow running as script
     from .dynamic_path_router import resolve_path, get_project_root  # type: ignore
 except Exception:  # pragma: no cover - fallback when executed directly
@@ -75,6 +79,7 @@ def merge_variant_records(
     failure_threshold: int = 0,
     entropy_threshold: float = 2.0,
     retriever: Retriever | None = None,
+    context_builder: ContextBuilder,
 ) -> list[Dict[str, Any]]:
     """Merge high-performing variants using :class:`MetaWorkflowPlanner`.
 
@@ -83,7 +88,7 @@ def merge_variant_records(
     to combine variant pipelines that individually exceed ``roi_threshold``.
     """
 
-    planner = planner or MetaWorkflowPlanner()
+    planner = planner or MetaWorkflowPlanner(context_builder=context_builder)
     if retriever is None:
         raise ValueError("merge_variant_records requires a Retriever")
     return planner.merge_high_performing_variants(
@@ -93,6 +98,7 @@ def merge_variant_records(
         runner=runner,
         failure_threshold=failure_threshold,
         entropy_threshold=entropy_threshold,
+        context_builder=context_builder,
         retriever=retriever,
     )
 


### PR DESCRIPTION
## Summary
- require explicit context builders for `compose_pipeline`, `cluster_workflows`, and related helpers
- propagate builders to `merge_variant_records` and documentation examples
- add tests asserting missing builders raise errors

## Testing
- `pytest tests/test_meta_workflow_planner.py::test_compose_pipeline_chaining tests/test_meta_workflow_planner.py::test_compose_pipeline_requires_context_builder tests/test_meta_workflow_planner.py::test_cluster_workflows_requires_context_builder tests/test_meta_workflow_planner.py::test_merge_high_performing_variants_requires_builder tests/test_meta_workflow_planner_cross_domain.py::test_cross_domain_pipeline_with_validation -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf89fcd72c832ebcf39686f6552245