### PR TITLE
Enhance codex fallback with context builder

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -37,6 +37,7 @@ except Exception:  # pragma: no cover - degrade gracefully when missing
 from .llm_interface import Prompt, LLMResult, LLMClient
 from .llm_router import client_from_settings
 from .resilience import retry_with_backoff, RetryError
+from context_builder_util import create_context_builder
 try:  # shared GPT memory instance
     from .shared_gpt_memory import GPT_MEMORY_MANAGER
 except Exception:  # pragma: no cover - fallback for flat layout
@@ -1479,7 +1480,10 @@ class SelfCodingEngine:
             getattr(_settings, "codex_retry_queue_path", "codex_retry_queue.jsonl")
         )
         alt = codex_fallback_handler.handle(
-            self.simplify_prompt(prompt), reason, queue_path=queue_path
+            self.simplify_prompt(prompt),
+            reason,
+            context_builder=create_context_builder(),
+            queue_path=queue_path,
         )
         if not getattr(alt, "text", "").strip():
             return result, None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,15 @@ def _ensure_fresh_weights(builder):
     except Exception:
         pass
 context_builder_util_stub.ensure_fresh_weights = _ensure_fresh_weights
+# Provide a minimal create_context_builder used by fallback tests
+class _CB:
+    def refresh_db_weights(self, *a, **k):
+        return None
+
+    def build(self, *a, **k):
+        return ""
+
+context_builder_util_stub.create_context_builder = lambda: _CB()
 sys.modules.setdefault("context_builder_util", context_builder_util_stub)
 
 # Stub synergy_history_db to avoid database router initialisation

--- a/tests/test_codex_fallback.py
+++ b/tests/test_codex_fallback.py
@@ -30,6 +30,17 @@ vector_stub = sys.modules.setdefault("vector_service", types.ModuleType("vector_
 vector_stub.SharedVectorService = object
 vector_stub.CognitionLayer = object
 vector_stub.PatchLogger = object
+class _CB:
+    def __init__(self, *a, **k):
+        pass
+
+    def refresh_db_weights(self, *a, **k):
+        return None
+
+    def build(self, *a, **k):
+        return ""
+
+vector_stub.ContextBuilder = _CB
 vector_stub.VectorServiceError = Exception
 sys.modules.setdefault("menace.vector_service", vector_stub)
 
@@ -64,6 +75,13 @@ def make_engine(mock_llm, monkeypatch):
     engine.simplify_prompt = self_coding_engine.simplify_prompt
     monkeypatch.setattr(
         self_coding_engine, "_settings", types.SimpleNamespace(codex_retry_delays=[2, 5, 10])
+    )
+    monkeypatch.setattr(
+        self_coding_engine,
+        "create_context_builder",
+        lambda: types.SimpleNamespace(
+            refresh_db_weights=lambda *a, **k: None, build=lambda *a, **k: ""
+        ),
     )
     return engine
 
@@ -131,7 +149,7 @@ def test_codex_fallback_queue_on_malformed(monkeypatch):
         raising=False,
     )
 
-    def handle(prompt, reason, **_):
+    def handle(prompt, reason, *, context_builder, **_):
         self_coding_engine.codex_fallback_handler.queue_for_retry(prompt)
         return LLMResult(text="")
 

--- a/tests/test_self_coding_engine.py
+++ b/tests/test_self_coding_engine.py
@@ -614,11 +614,18 @@ def test_codex_fallback_handler_invoked(monkeypatch, tmp_path):
 
     calls: list[Path] = []
 
-    def handle(prompt, reason, *, queue_path=None, **_):
+    def handle(prompt, reason, *, context_builder, queue_path=None, **_):
         calls.append(queue_path)
         return LLMResult(text="def good():\n    pass\n")
 
     monkeypatch.setattr(sce.codex_fallback_handler, "handle", handle)
+    monkeypatch.setattr(
+        sce,
+        "create_context_builder",
+        lambda: types.SimpleNamespace(
+            refresh_db_weights=lambda *a, **k: None, build=lambda *a, **k: ""
+        ),
+    )
 
     qpath = tmp_path / "queue.jsonl"
     monkeypatch.setattr(

--- a/unit_tests/test_codex_fallback_handler.py
+++ b/unit_tests/test_codex_fallback_handler.py
@@ -6,6 +6,14 @@ from menace.prompt_types import Prompt
 from menace.llm_interface import LLMResult
 
 
+class DummyBuilder:
+    def refresh_db_weights(self, *a, **k):
+        return None
+
+    def build(self, *a, **k):
+        return ""
+
+
 def test_queue_failed_writes_jsonl(tmp_path):
     path = tmp_path / "queue.jsonl"
     cf._settings = types.SimpleNamespace(codex_retry_queue_path=str(path))
@@ -27,13 +35,13 @@ def test_handle_reroutes(monkeypatch, tmp_path):
         codex_fallback_strategy="reroute",
     )
 
-    def fake_reroute(p: Prompt) -> LLMResult:
+    def fake_reroute(p: Prompt, *, context_builder=None) -> LLMResult:
         called["prompt"] = p.user
         return LLMResult(text="ok", raw={"model": cf._settings.codex_fallback_model})
 
     monkeypatch.setattr(cf, "reroute_to_fallback_model", fake_reroute)
 
-    result = cf.handle(prompt, "oops")
+    result = cf.handle(prompt, "oops", context_builder=DummyBuilder())
     assert called["prompt"] == "hi"
     assert isinstance(result, LLMResult)
     assert result.text == "ok"
@@ -46,12 +54,12 @@ def test_handle_queues_on_failure(tmp_path, monkeypatch):
         codex_retry_queue_path=str(queue_path), codex_fallback_strategy="reroute"
     )
 
-    def boom(_: Prompt) -> LLMResult:
+    def boom(_: Prompt, *, context_builder=None) -> LLMResult:
         raise RuntimeError("fail")
 
     monkeypatch.setattr(cf, "reroute_to_fallback_model", boom)
 
-    result = cf.handle(Prompt("bye"), "bad news")
+    result = cf.handle(Prompt("bye"), "bad news", context_builder=DummyBuilder())
     assert isinstance(result, LLMResult)
     assert result.text == ""
     assert result.raw["reason"] == "bad news"
@@ -69,12 +77,12 @@ def test_handle_returns_reason_on_empty_completion(tmp_path, monkeypatch):
         codex_fallback_strategy="reroute",
     )
 
-    def empty(_: Prompt) -> LLMResult:
+    def empty(_: Prompt, *, context_builder=None) -> LLMResult:
         return LLMResult(text="", raw={"model": cf._settings.codex_fallback_model})
 
     monkeypatch.setattr(cf, "reroute_to_fallback_model", empty)
 
-    result = cf.handle(Prompt("zap"), "no text")
+    result = cf.handle(Prompt("zap"), "no text", context_builder=DummyBuilder())
     assert isinstance(result, LLMResult)
     assert result.text == ""
     assert result.raw["reason"] == "no text"
@@ -91,13 +99,13 @@ def test_handle_queue_strategy(monkeypatch, tmp_path):
         codex_retry_queue_path=str(queue_path), codex_fallback_strategy="queue"
     )
 
-    def fake_reroute(p: Prompt) -> LLMResult:
+    def fake_reroute(p: Prompt, *, context_builder=None) -> LLMResult:
         called["prompt"] = p.user
         return LLMResult(text="ok")
 
     monkeypatch.setattr(cf, "reroute_to_fallback_model", fake_reroute)
 
-    result = cf.handle(Prompt("hi"), "boom")
+    result = cf.handle(Prompt("hi"), "boom", context_builder=DummyBuilder())
     assert "prompt" not in called
     assert result.text == ""
     record = json.loads(queue_path.read_text().strip())
@@ -122,7 +130,7 @@ def test_reroute_uses_configured_model(monkeypatch, tmp_path):
         codex_fallback_model="dummy-model", codex_retry_queue_path=str(tmp_path / "queue.jsonl")
     )
 
-    result = cf.reroute_to_fallback_model(Prompt("hi"))
+    result = cf.reroute_to_fallback_model(Prompt("hi"), context_builder=DummyBuilder())
     assert captured["model"] == "dummy-model"
     assert captured["prompt"] == "hi"
     assert result.raw["model"] == "dummy-model"


### PR DESCRIPTION
## Summary
- pass a ContextBuilder into codex fallback reroutes
- refresh DB weights and augment fallback prompts with retrieved context
- ensure self-coding engine provides a create_context_builder() at fallback call sites

## Testing
- `pre-commit run --files codex_fallback_handler.py self_coding_engine.py tests/conftest.py tests/test_codex_fallback.py tests/test_codex_fallback_behavior.py tests/test_self_coding_codex_fallback.py tests/test_self_coding_engine.py unit_tests/test_codex_fallback_handler.py` *(missing: command not found)*
- `pytest unit_tests/test_codex_fallback_handler.py tests/test_codex_fallback.py tests/test_codex_fallback_behavior.py tests/test_self_coding_codex_fallback.py` *(failed: ImportError and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bf928208ec832e90ded28f252407a1