### PR TITLE
Improve chunk summarization with contextual data

### DIFF
--- a/docs/prompt_chunking.md
+++ b/docs/prompt_chunking.md
@@ -44,8 +44,9 @@ To target other languages or LLMs you can drop in a custom implementation:
 ```python
 from my_llm import client
 
-def summarize_code(code: str) -> str:
-    return client.summarize(code, language="rust")
+def summarize_code(code: str, context_builder) -> str:
+    ctx = context_builder.build(code)
+    return client.summarize(f"{code}\n\nContext:\n{ctx}", language="rust")
 ```
 
 Monkeypatching `chunking.summarize_code` or providing an alternative

--- a/prompt_engine.py
+++ b/prompt_engine.py
@@ -869,7 +869,9 @@ class PromptEngine:
             summaries = []
             for i, ch in enumerate(chunks):
                 summary_text = (
-                    summarize_code(ch.text, self.llm)
+                    summarize_code(
+                        ch.text, self.llm, context_builder=self.context_builder
+                    )
                     if self.llm
                     else ch.text.splitlines()[0][:80]
                 )

--- a/quick_fix_engine.py
+++ b/quick_fix_engine.py
@@ -226,7 +226,9 @@ def generate_patch(
             if get_chunk_summaries is not None:
                 token_limit = getattr(engine, "prompt_chunk_token_threshold", 1000)
                 try:
-                    chunks = get_chunk_summaries(path, token_limit)
+                    chunks = get_chunk_summaries(
+                        path, token_limit, context_builder=builder
+                    )
                 except Exception:
                     chunks = []
             patch_ids: List[int | None] = []

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -999,7 +999,11 @@ class SelfCodingEngine:
                 summaries: List[str] = []
                 for i, ch in enumerate(chunks):
                     if not (start <= ch.start_line and ch.end_line <= end):
-                        summary = summarize_code(ch.text, self.llm_client)
+                        summary = summarize_code(
+                            ch.text,
+                            self.llm_client,
+                            context_builder=self.context_builder,
+                        )
                         summaries.append(f"Chunk {i}: {summary}")
                 return snippet, summaries or None
             return snippet, None
@@ -1008,7 +1012,10 @@ class SelfCodingEngine:
         if code and threshold and _count_tokens(code) > threshold:
             try:
                 summary_entries = get_chunk_summaries(
-                    path, threshold, self.llm_client
+                    path,
+                    threshold,
+                    self.llm_client,
+                    context_builder=self.context_builder,
                 )
             except Exception:
                 self.logger.exception(

--- a/tests/test_chunk_summary_cache.py
+++ b/tests/test_chunk_summary_cache.py
@@ -45,7 +45,7 @@ def test_file_change_invalidates_cache_via_chunking(tmp_path: Path, monkeypatch)
 
     calls: list[str] = []
 
-    def fake_sum(code: str, llm=None) -> str:
+    def fake_sum(code: str, llm=None, context_builder=None) -> str:
         calls.append(code)
         return "sum"
 
@@ -74,7 +74,7 @@ def test_concurrent_requests_use_per_path_lock(tmp_path: Path, monkeypatch) -> N
 
     calls: list[str] = []
 
-    def fake_sum(code: str, llm=None) -> str:
+    def fake_sum(code: str, llm=None, context_builder=None) -> str:
         calls.append(code)
         return "sum"
 

--- a/tests/test_chunk_workflow.py
+++ b/tests/test_chunk_workflow.py
@@ -113,7 +113,7 @@ def test_prompt_from_summaries_under_limit(tmp_path, monkeypatch):
 
     summaries = [{"summary": "sumA"}, {"summary": "sumB"}]
 
-    def fake_get_chunk_summaries(path: Path, limit: int):
+    def fake_get_chunk_summaries(path: Path, limit: int, **kwargs):
         assert path == file
         assert limit == 20
         return summaries

--- a/tests/test_chunking_cache.py
+++ b/tests/test_chunking_cache.py
@@ -37,7 +37,7 @@ def test_get_chunk_summaries_cache(tmp_path: Path, monkeypatch) -> None:
 
     calls: List[str] = []
 
-    def fake_sum(code: str, llm=None) -> str:
+    def fake_sum(code: str, llm=None, context_builder=None) -> str:
         calls.append(code)
         return f"summary-{len(calls)}"
 
@@ -69,7 +69,7 @@ def test_get_chunk_summaries_concurrent(tmp_path: Path, monkeypatch) -> None:
 
     calls: List[str] = []
 
-    def fake_sum(code: str, llm=None) -> str:
+    def fake_sum(code: str, llm=None, context_builder=None) -> str:
         calls.append(code)
         return "sum"
 
@@ -109,7 +109,7 @@ def test_large_file_chunking_and_cache(tmp_path: Path, monkeypatch) -> None:
 
     calls: List[str] = []
 
-    def fake_sum(code: str, llm=None) -> str:
+    def fake_sum(code: str, llm=None, context_builder=None) -> str:
         calls.append(code)
         return f"summary-{len(calls)}"
 

--- a/tests/test_chunking_split.py
+++ b/tests/test_chunking_split.py
@@ -44,7 +44,7 @@ def test_get_chunk_summaries_cache_hit(tmp_path, monkeypatch):
 
     calls = {"n": 0}
 
-    def fake_summary(code: str, llm=None) -> str:
+    def fake_summary(code: str, llm=None, context_builder=None) -> str:
         calls["n"] += 1
         return "sum"
 
@@ -67,7 +67,7 @@ def test_get_chunk_summaries_cache_invalidation(tmp_path, monkeypatch):
 
     calls = {"n": 0}
 
-    def fake_summary(code: str, llm=None) -> str:
+    def fake_summary(code: str, llm=None, context_builder=None) -> str:
         calls["n"] += 1
         return "sum"
 

--- a/tests/test_self_coding_engine_chunking.py
+++ b/tests/test_self_coding_engine_chunking.py
@@ -199,7 +199,9 @@ def test_generate_helper_injects_chunk_summaries(monkeypatch, tmp_path):
 
     called: dict[str, int] = {}
 
-    def fake_get_chunk_summaries(path: Path, limit: int, llm=None, cache=None):
+    def fake_get_chunk_summaries(
+        path: Path, limit: int, llm=None, cache=None, context_builder=None
+    ):
         called["limit"] = limit
         return [
             {"start_line": 1, "end_line": 2, "summary": "sum1"},
@@ -386,7 +388,9 @@ def test_generate_helper_builds_line_range_prompt(monkeypatch, tmp_path):
 def test_patch_file_uses_chunk_summaries(monkeypatch, tmp_path):
     monkeypatch.setattr(sce, "_count_tokens", lambda text: 1000)
 
-    def fake_get_chunk_summaries(path: Path, limit: int, llm=None, cache=None):
+    def fake_get_chunk_summaries(
+        path: Path, limit: int, llm=None, cache=None, context_builder=None
+    ):
         return [
             {"start_line": 1, "end_line": 1, "summary": "sum1"},
             {"start_line": 2, "end_line": 2, "summary": "sum2"},


### PR DESCRIPTION
## Summary
- allow `chunking.summarize_code` to accept a ContextBuilder and add compressed context to LLM prompts
- thread ContextBuilder through `get_chunk_summaries` and all call sites
- document new summarizer signature

## Testing
- `pytest tests/test_chunking_split.py tests/test_chunking_cache.py tests/test_chunk_summary_cache.py tests/test_chunking_summarize_cache.py tests/test_chunk_workflow.py unit_tests/test_chunking.py`
- `pytest tests/test_chunking_split.py tests/test_chunking_cache.py tests/test_chunk_summary_cache.py tests/test_chunking_summarize_cache.py tests/test_chunk_workflow.py tests/test_quick_fix_engine.py unit_tests/test_chunking.py` *(fails: AttributeError: 'DummyManager' object has no attribute 'history')*


------
https://chatgpt.com/codex/tasks/task_e_68bf9642314c832eaeee32583e5b923b