### PR TITLE
Track LLMClient instance generate usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,11 @@ planner = Planner(context_builder=builder)
 bot = PromptingBot(planner, context_builder=builder)
 ```
 
-Violations are detected by `scripts/check_context_builder_usage.py`, which flags
-any `_build_prompt`, `build_prompt`, `generate_patch` or `generate` call missing
-`context_builder`:
+Violations are detected by `scripts/check_context_builder_usage.py`, which
+flags any `_build_prompt`, `build_prompt`, `generate_patch` or `.generate()`
+call on `LLMClient`-like instances missing `context_builder`. Variables
+assigned from these classes are tracked and aliases such as `llm` or `model`
+are heuristically inspected:
 
 ```bash
 python scripts/check_context_builder_usage.py

--- a/action_justifier.py
+++ b/action_justifier.py
@@ -144,7 +144,7 @@ def _llm_justification(action_log: Dict[str, Any], violation_flags: List[str], r
             logger.exception("failed reading justification cache")
     try:
         tokens = tokenizer.encode(prompt, return_tensors="pt")
-        output = model.generate(tokens, max_new_tokens=60, do_sample=False)
+        output = model.generate(tokens, max_new_tokens=60, do_sample=False)  # nocb
         text = tokenizer.decode(output[0], skip_special_tokens=True)
         explanation = text[len(prompt):].strip()
     except Exception:

--- a/chunking.py
+++ b/chunking.py
@@ -250,7 +250,7 @@ def summarize_code(
     text: str,
     llm: LLMClient | None = None,
     *,
-    context_builder: "ContextBuilder" | None = None,
+    context_builder: "ContextBuilder" | None = None,  # nocb
 ) -> str:
     """Return a short summary for ``text`` using available helpers with caching."""
 
@@ -309,7 +309,7 @@ def summarize_code(
             user=user_text,
         )
         try:  # pragma: no cover - llm failures
-            result = llm.generate(prompt)
+            result = llm.generate(prompt, context_builder=context_builder)
             if getattr(result, "text", "").strip():
                 summary = result.text.strip()
         except Exception:
@@ -368,7 +368,7 @@ def get_chunk_summaries(
     llm: LLMClient | None = None,
     *,
     cache: ChunkSummaryCache | None = None,
-    context_builder: "ContextBuilder" | None = None,
+    context_builder: "ContextBuilder" | None = None,  # nocb
 ) -> List[Dict[str, str]]:
     """Return cached summaries for ``path`` split into ``max_tokens`` chunks."""
 

--- a/code_summarizer.py
+++ b/code_summarizer.py
@@ -134,7 +134,7 @@ def summarize_code(
                 text += f"\nContext:\n{vec_ctx}\n"
             text += "Summary:"
             prompt = Prompt(text=text, metadata={"small_task": True})
-            result = client.generate(prompt)
+            result = client.generate(prompt, context_builder=context_builder)
             summary = getattr(result, "text", "").strip()
             if summary:
                 return _truncate_tokens(summary, max_summary_tokens)

--- a/codex_fallback_handler.py
+++ b/codex_fallback_handler.py
@@ -84,7 +84,7 @@ class _ContextClient:
                 tags=prompt.tags,
                 metadata=prompt.metadata,
             )
-        return self._client.generate(prompt)
+        return self._client.generate(prompt)  # nocb
 
 
 def reroute_to_fallback_model(prompt: Prompt, *, context_builder: ContextBuilder) -> LLMResult:

--- a/docs/context_builder.md
+++ b/docs/context_builder.md
@@ -173,7 +173,10 @@ inspects direct ``openai.Completion.create`` and ``openai.ChatCompletion.create`
 invocations along with the ``chat_completion_create`` wrapper.  To intentionally
 skip a call, append ``# nocb`` on the call line (or the line above).  Only direct
 ``build_prompt(...)`` calls are checked to avoid warning on unrelated methods
-with the same name.
+with the same name.  Variables assigned from ``LLMClient``-like classes are
+tracked so that subsequent ``instance.generate(...)`` invocations require the
+keyword as well; aliases such as ``llm`` or ``model`` are heuristically checked
+even without a prior assignment.
 
 ```python
 import openai

--- a/micro_models/diff_summarizer.py
+++ b/micro_models/diff_summarizer.py
@@ -52,7 +52,9 @@ def summarize_diff(before: str, after: str, max_new_tokens: int = 128) -> str:
     inputs = tokenizer(prompt, return_tensors="pt")  # type: ignore[call-arg]
     if torch is not None:
         inputs = {k: v.to(model.device) for k, v in inputs.items()}  # type: ignore[attr-defined]
-    output = model.generate(**inputs, max_new_tokens=max_new_tokens)  # type: ignore[call-arg]
+    output = model.generate(  # nocb
+        **inputs, max_new_tokens=max_new_tokens
+    )  # type: ignore[call-arg]
     text = tokenizer.decode(output[0], skip_special_tokens=True)  # type: ignore[call-arg]
     return text.split("Summary:")[-1].strip()
 

--- a/neurosales/neurosales/response_generation.py
+++ b/neurosales/neurosales/response_generation.py
@@ -123,7 +123,7 @@ class ResponseCandidateGenerator:
             try:
                 prompt = " ".join(history + [message, archetype])
                 input_ids = self.tokenizer.encode(prompt, return_tensors="pt")
-                outputs = self.model.generate(
+                outputs = self.model.generate(  # nocb
                     input_ids,
                     max_length=input_ids.shape[1] + 20,
                     num_return_sequences=n,

--- a/resource_allocation_bot.py
+++ b/resource_allocation_bot.py
@@ -342,7 +342,7 @@ class ResourceAllocationBot:
         if engine.llm is None:
             return "upgrade"
         try:
-            result = engine.llm.generate(prompt)
+            result = engine.llm.generate(prompt, context_builder=builder)
             return (getattr(result, "text", "") or "").strip()
         except Exception:  # pragma: no cover - local LLM failures
             self.logger.exception("Improvement suggestion failed for %s", bot)

--- a/user_style_model.py
+++ b/user_style_model.py
@@ -86,7 +86,9 @@ class UserStyleModel:
         if not self.model or not self.tokenizer:
             return text
         inputs = self.tokenizer(text, return_tensors="pt")
-        outputs = self.model.generate(**inputs, max_length=50, num_return_sequences=1)
+        outputs = self.model.generate(  # nocb
+            **inputs, max_length=50, num_return_sequences=1
+        )
         return self.tokenizer.decode(outputs[0], skip_special_tokens=True)
 
 


### PR DESCRIPTION
## Summary
- extend context builder linter to remember variables assigned from LLMClient-like classes
- flag `.generate()` calls invoked through common aliases like `llm` or `model`
- document instance tracking rule and annotate existing calls to satisfy the linter

## Testing
- `python scripts/check_context_builder_usage.py`
- `pre-commit run flake8 --files scripts/check_context_builder_usage.py`
- `pre-commit run --files scripts/check_context_builder_usage.py README.md docs/context_builder.md` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*


------
https://chatgpt.com/codex/tasks/task_e_68bf97f56f48832e84c817a3cfdcaf5d