### PR TITLE
Require context builder for LLM generation

### DIFF
--- a/anthropic_client.py
+++ b/anthropic_client.py
@@ -12,6 +12,11 @@ import llm_config
 import llm_pricing
 
 from llm_interface import Prompt, LLMResult, LLMClient
+try:  # pragma: no cover - optional during tests
+    from vector_service.context_builder import ContextBuilder
+except Exception:  # pragma: no cover - allow stub
+    class ContextBuilder:  # type: ignore
+        pass
 
 
 class AnthropicClient(LLMClient):
@@ -46,7 +51,9 @@ class AnthropicClient(LLMClient):
         return {"model": self.model, "max_tokens": 1024, "messages": messages}
 
     # ------------------------------------------------------------------
-    def _generate(self, prompt: Prompt) -> LLMResult:
+    def _generate(
+        self, prompt: Prompt, *, context_builder: ContextBuilder
+    ) -> LLMResult:
         payload = self._prepare_payload(prompt)
         headers = {
             "x-api-key": self.api_key,

--- a/local_client.py
+++ b/local_client.py
@@ -15,6 +15,11 @@ import requests
 import rate_limit
 
 from llm_interface import Prompt, LLMResult, LLMClient
+try:  # pragma: no cover - optional during tests
+    from vector_service.context_builder import ContextBuilder
+except Exception:  # pragma: no cover - allow stub
+    class ContextBuilder:  # type: ignore
+        pass
 
 
 @dataclass
@@ -38,7 +43,9 @@ class OllamaClient(_BaseLocalClient, LLMClient):
         LLMClient.__init__(self, model)
         _BaseLocalClient.__init__(self, model=model, base_url=base_url)
 
-    def _generate(self, prompt: Prompt) -> LLMResult:
+    def _generate(
+        self, prompt: Prompt, *, context_builder: ContextBuilder
+    ) -> LLMResult:
         payload = {"model": self.model, "prompt": prompt.text}
         raw = self._post("api/generate", payload)
         text = raw.get("response", "") or raw.get("text", "")
@@ -63,7 +70,9 @@ class VLLMClient(_BaseLocalClient, LLMClient):
         LLMClient.__init__(self, model)
         _BaseLocalClient.__init__(self, model=model, base_url=base_url)
 
-    def _generate(self, prompt: Prompt) -> LLMResult:
+    def _generate(
+        self, prompt: Prompt, *, context_builder: ContextBuilder
+    ) -> LLMResult:
         payload = {"model": self.model, "prompt": prompt.text}
         raw = self._post("generate", payload)
         text = raw.get("text") or raw.get("generated_text", "")


### PR DESCRIPTION
## Summary
- require a ContextBuilder when generating with LLMClient and propagate it through async paths
- log token usage and retrieval metadata via ContextBuilder's ROI tracker
- extend context builder enforcement script to cover async_generate calls

## Testing
- `PYTHONPATH=. pre-commit run --files llm_interface.py local_client.py private_backend.py anthropic_client.py scripts/check_context_builder_usage.py`
- `python -m py_compile llm_interface.py local_client.py private_backend.py anthropic_client.py scripts/check_context_builder_usage.py`
- `PYTHONPATH=. pre-commit run --files local_backend.py`
- `python -m py_compile local_backend.py`

------
https://chatgpt.com/codex/tasks/task_e_68bf9a157888832eb1a90be4b2b1318f