### PR TITLE
Pass context builder through LLM generation

### DIFF
--- a/resource_allocation_bot.py
+++ b/resource_allocation_bot.py
@@ -25,11 +25,17 @@ from .contrarian_db import ContrarianDB
 from db_router import GLOBAL_ROUTER, init_db_router
 from snippet_compressor import compress_snippets
 
+try:  # pragma: no cover - optional dependency
+    from vector_service.context_builder import ContextBuilder
+except Exception:  # pragma: no cover - allow stub in tests
+    class ContextBuilder:  # type: ignore
+        """Fallback stub used when context builder isn't available."""
+        pass
+
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from .resources_bot import ResourcesBot
     from .contrarian_model_bot import ContrarianModelBot
     from .bot_database import BotDB
-    from vector_service.context_builder import ContextBuilder
 
 
 @dataclass
@@ -314,7 +320,7 @@ class ResourceAllocationBot:
 
     def suggest_improvement(self, bot: str) -> str:
         builder = self.context_builder
-        if builder is None:
+        if not isinstance(builder, ContextBuilder):
             self.logger.error("context_builder is required for improvement prompts")
             return "upgrade"
         try:

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -8,6 +8,7 @@ from llm_router import LLMRouter
 from prompt_db import PromptDB
 from completion_parsers import parse_json
 import asyncio
+from context_builder_util import create_context_builder
 
 
 def test_promptdb_logs_to_memory(tmp_path):
@@ -234,11 +235,14 @@ def test_generate_applies_parse_fn():
         def __init__(self):
             super().__init__("dummy", log_prompts=False)
 
-        def _generate(self, prompt: Prompt) -> LLMResult:
+        def _generate(self, prompt: Prompt, *, context_builder) -> LLMResult:
             return LLMResult(text="{\"a\":1}")
 
     client = Dummy()
-    res = client.generate(Prompt(text="hi"), parse_fn=parse_json)
+    builder = create_context_builder()
+    res = client.generate(
+        Prompt(text="hi"), parse_fn=parse_json, context_builder=builder
+    )
     assert res.parsed == {"a": 1}
 
 


### PR DESCRIPTION
## Summary
- ensure `ResourceAllocationBot` validates context builder and forwards it when generating improvements
- support context builder in LLM router and OpenAI provider implementations
- update tests for new `LLMClient.generate` signature

## Testing
- `pytest tests/test_prompt_db.py tests/test_openai_client_http.py tests/test_llm_interface.py::test_generate_applies_parse_fn -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf9c840aac832ea09262cd788dea40