### PR TITLE
Inject context builder into EnhancementBot LLM calls

### DIFF
--- a/enhancement_bot.py
+++ b/enhancement_bot.py
@@ -8,6 +8,7 @@ informative :class:`ImportError` is raised at import time.
 """
 
 import hashlib
+import logging
 import subprocess
 import time
 from dataclasses import dataclass
@@ -42,6 +43,9 @@ try:  # pragma: no cover - allow flat imports
     from .dynamic_path_router import resolve_path
 except Exception:  # pragma: no cover - fallback for flat layout
     from dynamic_path_router import resolve_path  # type: ignore
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -156,9 +160,14 @@ class EnhancementBot:
             return ""
 
         try:
-            result = self.llm_client.generate(prompt)
+            result = self.llm_client.generate(prompt, context_builder=self.context_builder)
             return result.text.strip()
+        except TypeError as exc:
+            raise RuntimeError(
+                "llm_client.generate missing context_builder support"
+            ) from exc
         except Exception:  # pragma: no cover - llm failures are non fatal
+            logger.exception("LLM generation failed")
             return ""
 
     # ------------------------------------------------------------------

--- a/tests/test_enhancement_bot.py
+++ b/tests/test_enhancement_bot.py
@@ -62,10 +62,12 @@ def test_codex_summarize_injects_context():
     class DummyLLM(LLMClient):
         def __init__(self) -> None:
             self.prompt = None
+            self.ctx = None
             super().__init__(model="dummy", backends=[])
 
-        def generate(self, prompt):  # type: ignore[override]
+        def generate(self, prompt, *, context_builder=None):  # type: ignore[override]
             self.prompt = prompt
+            self.ctx = context_builder
             return LLMResult(text="summary")
 
     builder = DummyBuilder()
@@ -76,6 +78,7 @@ def test_codex_summarize_injects_context():
     assert calls["desc"] == "diff"
     assert calls["top_k"] == 5
     assert llm.prompt and "CTX" in llm.prompt.user
+    assert llm.ctx is builder
 
 
 def test_codex_summarize_compresses_context():
@@ -93,10 +96,12 @@ def test_codex_summarize_compresses_context():
     class DummyLLM(LLMClient):
         def __init__(self) -> None:
             self.prompt = None
+            self.ctx = None
             super().__init__(model="dummy", backends=[])
 
-        def generate(self, prompt):  # type: ignore[override]
+        def generate(self, prompt, *, context_builder=None):  # type: ignore[override]
             self.prompt = prompt
+            self.ctx = context_builder
             return LLMResult(text="summary")
 
     bot = EnhancementBot(context_builder=DummyBuilder(), llm_client=DummyLLM())


### PR DESCRIPTION
## Summary
- pass EnhancementBot's context builder through to `llm_client.generate` and fail fast when unsupported
- log LLM generation failures and ensure builders are provided to test stubs

## Testing
- `pytest tests/test_enhancement_bot.py tests/test_payment_notice.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf9e68e870832e83722c614d4e1e09