### PR TITLE
Require context builder for snippet summarization

### DIFF
--- a/chunking.py
+++ b/chunking.py
@@ -149,7 +149,6 @@ def split_into_chunks(
         for start, end, text in segments:
             curr_start = start
             curr_lines = text.splitlines()
-            offset = 0
             for b in (b for b in boundaries if start < b <= end):
                 rel = b - curr_start
                 part = "\n".join(curr_lines[:rel]).rstrip()
@@ -246,7 +245,7 @@ def _split_by_lines(lines: List[str], start: int, limit: int) -> List[CodeChunk]
     return out
 
 
-def summarize_code(
+def summarize_snippet(
     text: str,
     llm: LLMClient | None = None,
     *,
@@ -257,6 +256,9 @@ def summarize_code(
     text = text.strip()
     if not text:
         return ""
+
+    if llm is not None and context_builder is None:
+        raise ValueError("context_builder is required when llm is provided")
 
     digest = _hash_snippet(text)
     cached = _load_snippet_summary(digest)
@@ -348,6 +350,10 @@ def summarize_code(
     return summary
 
 
+# Backwards compatibility alias
+summarize_code = summarize_snippet
+
+
 _SETTINGS = SandboxSettings() if SandboxSettings else None
 
 # Global cache instance used by :func:`get_chunk_summaries`.  The directory can
@@ -405,6 +411,7 @@ __all__ = [
     "CodeChunk",
     "split_into_chunks",
     "chunk_file",
+    "summarize_snippet",
     "summarize_code",
     "get_chunk_summaries",
 ]

--- a/tests/integration/test_chunked_patch_flow.py
+++ b/tests/integration/test_chunked_patch_flow.py
@@ -106,6 +106,8 @@ _setmod(
 roi_mod = types.ModuleType("roi_tracker")
 roi_mod.ROITracker = lambda: object()
 _setmod("roi_tracker", roi_mod)
+
+
 class _BT:
     def __init__(self, *a, **k):
         pass
@@ -113,7 +115,10 @@ class _BT:
     def update(self, *a, **k):
         pass
 
+
 baseline_mod = types.SimpleNamespace(BaselineTracker=_BT, TRACKER=_BT())
+
+
 class _FL:
     def __init__(self, *a, **k):
         pass
@@ -124,6 +129,7 @@ class _FL:
     def __exit__(self, *a):
         return False
 
+
 init_mod = types.SimpleNamespace(FileLock=_FL, _atomic_write=lambda *a, **k: None)
 _setmod("self_improvement.baseline_tracker", baseline_mod)
 _setmod("self_improvement.init", init_mod)
@@ -131,9 +137,10 @@ si_pkg = types.ModuleType("self_improvement")
 si_pkg.__path__ = []
 _setmod("self_improvement", si_pkg)
 
+
 import menace_sandbox.self_coding_engine as sce  # noqa: E402
 from chunking import CodeChunk  # noqa: E402
-import ast
+import ast  # noqa: E402
 
 
 class DummyLLM:
@@ -189,7 +196,9 @@ def test_multi_chunk_patch_success(tmp_path, monkeypatch):
     )
     import chunking as pc
 
-    monkeypatch.setattr(pc, "summarize_code", lambda text, llm: text.splitlines()[0])
+    monkeypatch.setattr(
+        pc, "summarize_code", lambda text, llm, context_builder=None: text.splitlines()[0]
+    )
 
     calls = []
 
@@ -228,7 +237,9 @@ def test_multi_chunk_patch_with_rollback(tmp_path, monkeypatch):
     )
     import chunking as pc
 
-    monkeypatch.setattr(pc, "summarize_code", lambda text, llm: text.splitlines()[0])
+    monkeypatch.setattr(
+        pc, "summarize_code", lambda text, llm, context_builder=None: text.splitlines()[0]
+    )
 
     calls = []
 

--- a/tests/test_chunk_workflow.py
+++ b/tests/test_chunk_workflow.py
@@ -81,19 +81,25 @@ class DummyLLM:
     def __init__(self):
         self.calls = 0
 
-    def generate(self, prompt):  # pragma: no cover - simple stub
+    def generate(self, prompt, context_builder=None):  # pragma: no cover - simple stub
         self.calls += 1
         return types.SimpleNamespace(text="stub")
+
+
+class DummyBuilder:
+    def build(self, text: str):  # pragma: no cover - simple stub
+        return ""
 
 
 def test_summary_cache_reused(tmp_path, monkeypatch):
     monkeypatch.setattr(chunking, "SNIPPET_CACHE_DIR", tmp_path)
     llm = DummyLLM()
+    builder = DummyBuilder()
     code = "print('hello')"
-    s1 = chunking.summarize_code(code, llm)
+    s1 = chunking.summarize_code(code, llm, context_builder=builder)
     assert s1 == "stub"
     assert llm.calls == 1
-    s2 = chunking.summarize_code(code, llm)
+    s2 = chunking.summarize_code(code, llm, context_builder=builder)
     assert s2 == "stub"
     assert llm.calls == 1
 

--- a/tests/test_chunked_patch_parallel.py
+++ b/tests/test_chunked_patch_parallel.py
@@ -23,7 +23,9 @@ def _prepare_engine(tmp_path: Path, monkeypatch):
             CodeChunk(4, 5, "def b():\n    pass", "h2", 5),
         ],
     )
-    monkeypatch.setattr(pc, "summarize_code", lambda text, llm: text.splitlines()[0])
+    monkeypatch.setattr(
+        pc, "summarize_code", lambda text, llm, context_builder=None: text.splitlines()[0]
+    )
     return engine, path
 
 

--- a/tests/test_chunking_summarize_cache.py
+++ b/tests/test_chunking_summarize_cache.py
@@ -10,21 +10,27 @@ class DummyLLM(LLMClient):
         super().__init__(model="dummy")
         self.calls = 0
 
-    def _generate(self, prompt):  # pragma: no cover - simple stub
+    def _generate(self, prompt, context_builder=None):  # pragma: no cover - simple stub
         self.calls += 1
         return LLMResult(text="stub summary")
+
+
+class DummyBuilder:
+    def build(self, text: str):  # pragma: no cover - simple stub
+        return ""
 
 
 def test_summarize_code_uses_cache(monkeypatch, tmp_path):
     monkeypatch.setattr(pc, "SNIPPET_CACHE_DIR", tmp_path)
     llm = DummyLLM()
+    builder = DummyBuilder()
     code = "print('hello')"
 
-    summary1 = pc.summarize_code(code, llm)
+    summary1 = pc.summarize_code(code, llm, context_builder=builder)
     assert summary1 == "stub summary"
     assert llm.calls == 1
 
-    summary2 = pc.summarize_code(code, llm)
+    summary2 = pc.summarize_code(code, llm, context_builder=builder)
     assert summary2 == "stub summary"
     assert llm.calls == 1
 

--- a/tests/test_prompt_engine_chunk_summaries.py
+++ b/tests/test_prompt_engine_chunk_summaries.py
@@ -33,7 +33,7 @@ def test_prompt_engine_auto_summarises_when_limit_exceeded(monkeypatch):
 
     calls: list[str] = []
 
-    def fake_summarize(text: str, llm: object) -> str:
+    def fake_summarize(text: str, llm: object, context_builder=None) -> str:
         calls.append(text)
         return f"sum:{text}"
 


### PR DESCRIPTION
## Summary
- enforce providing a ContextBuilder when summarizing snippets via LLMs
- pipe ContextBuilder through snippet summarizer and related tests
- expose new `summarize_snippet` helper and keep legacy alias

## Testing
- `pre-commit run --files chunking.py tests/test_chunk_workflow.py tests/test_chunking_summarize_cache.py tests/test_chunked_patch_parallel.py tests/test_prompt_engine_chunk_summaries.py tests/integration/test_chunked_patch_flow.py` *(fails: No module named 'dynamic_path_router')*
- `pytest tests/test_chunk_workflow.py tests/test_chunking_summarize_cache.py tests/test_prompt_engine_chunk_summaries.py -q`
- `pytest tests/test_chunk_workflow.py tests/test_chunking_summarize_cache.py tests/test_chunked_patch_parallel.py tests/test_prompt_engine_chunk_summaries.py tests/integration/test_chunked_patch_flow.py -q` *(fails: No module named 'self_improvement.target_region')*

------
https://chatgpt.com/codex/tasks/task_e_68bf9fbd5098832e98273de6fcb49958