### PR TITLE
Require explicit ContextBuilder for run_scheduler

### DIFF
--- a/tests/test_run_scheduler_requires_context_builder.py
+++ b/tests/test_run_scheduler_requires_context_builder.py
@@ -1,0 +1,55 @@
+import sys
+import types
+import importlib
+import pytest
+
+# Stub modules to avoid heavy dependencies during import
+wc_suggester = types.ModuleType('workflow_chain_suggester')
+class WorkflowChainSuggester:
+    pass
+wc_suggester.WorkflowChainSuggester = WorkflowChainSuggester
+sys.modules['workflow_chain_suggester'] = wc_suggester
+
+we_manager = types.ModuleType('workflow_evolution_manager')
+we_manager._build_callable = lambda seq: None
+sys.modules['workflow_evolution_manager'] = we_manager
+
+cws = types.ModuleType('composite_workflow_scorer')
+class CompositeWorkflowScorer:
+    pass
+cws.CompositeWorkflowScorer = CompositeWorkflowScorer
+sys.modules['composite_workflow_scorer'] = cws
+
+wsc = types.ModuleType('workflow_synergy_comparator')
+class WorkflowSynergyComparator:
+    @staticmethod
+    def _entropy(spec):  # pragma: no cover - not used
+        return 0.0
+wsc.WorkflowSynergyComparator = WorkflowSynergyComparator
+sys.modules['workflow_synergy_comparator'] = wsc
+
+wsd = types.ModuleType('workflow_stability_db')
+class WorkflowStabilityDB:
+    pass
+wsd.WorkflowStabilityDB = WorkflowStabilityDB
+sys.modules['workflow_stability_db'] = wsd
+
+meta_mod = types.ModuleType('meta_workflow_planner')
+class MetaWorkflowPlanner:
+    def __init__(self, *a, **k):
+        pass
+    def schedule(self, *a, **k):  # pragma: no cover - not used
+        return []
+meta_mod.MetaWorkflowPlanner = MetaWorkflowPlanner
+meta_mod.simulate_meta_workflow = lambda *a, **k: {}
+sys.modules['meta_workflow_planner'] = meta_mod
+
+sys.modules['workflow_run_summary'] = types.ModuleType('workflow_run_summary')
+
+# Import the module under test after stubbing dependencies
+workflow_chain_simulator = importlib.import_module('workflow_chain_simulator')
+
+
+def test_run_scheduler_requires_context_builder():
+    with pytest.raises(TypeError):
+        workflow_chain_simulator.run_scheduler({})

--- a/workflow_chain_simulator.py
+++ b/workflow_chain_simulator.py
@@ -14,7 +14,6 @@ import json
 from pathlib import Path
 import logging
 from dynamic_path_router import resolve_path
-from context_builder_util import create_context_builder
 
 try:  # pragma: no cover - optional dependency
     from vector_service.context_builder import ContextBuilder  # type: ignore
@@ -125,11 +124,10 @@ def run_scheduler(
     roi_delta_threshold: float = 0.01,
     entropy_delta_threshold: float = 0.01,
     runs: int = 3,
-    context_builder: ContextBuilder | None = None,  # nocb - internal default
+    context_builder: ContextBuilder,
 ) -> List[Dict[str, Any]]:
     """Execute :class:`MetaWorkflowPlanner` scheduler and persist results."""
 
-    context_builder = context_builder or create_context_builder()
     planner = MetaWorkflowPlanner(context_builder=context_builder)
     records = planner.schedule(
         workflows,


### PR DESCRIPTION
## Summary
- Make `run_scheduler` require a `ContextBuilder` argument and use it directly
- Add regression test ensuring missing `context_builder` raises `TypeError`

## Testing
- `pytest tests/test_run_scheduler_requires_context_builder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfaa59668c832ebd377a209ae43a68