### PR TITLE
Require context builder for chunk summary helpers

### DIFF
--- a/docs/prompt_chunking.md
+++ b/docs/prompt_chunking.md
@@ -23,7 +23,7 @@ contain before it is split. Adjust it via
 
 ## Cache semantics
 
-`get_chunk_summaries(path, token_limit)` uses
+`get_chunk_summaries(path, token_limit, context_builder)` uses
 `chunk_summary_cache.ChunkSummaryCache` to persist summaries for each file. The
 cache tracks the file's content hash and automatically invalidates entries when
 the source changes. Subsequent calls for unchanged files reuse the stored

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -96,9 +96,12 @@ Populate the summary cache ahead of time to avoid first‑run latency:
 ```python
 from pathlib import Path
 from chunking import get_chunk_summaries
+from vector_service.context_builder import ContextBuilder
+
+builder = ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
 
 # Populate chunk_summary_cache/ with summaries
-get_chunk_summaries(Path("bots/example.py"), 800)
+get_chunk_summaries(Path("bots/example.py"), 800, context_builder=builder)
 ```
 
 All prompt‑generating bots require an explicit `ContextBuilder`; omitting it
@@ -114,7 +117,9 @@ from vector_service.context_builder import ContextBuilder
 
 builder = ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
 engine = PromptEngine(context_builder=builder)
-chunks = get_chunk_summaries(Path("bots/example.py"), 800)
+chunks = get_chunk_summaries(
+    Path("bots/example.py"), 800, context_builder=builder
+)
 prompt = engine.build_prompt(
     "refactor helper",
     summaries=[c["summary"] for c in chunks],

--- a/unit_tests/test_chunking.py
+++ b/unit_tests/test_chunking.py
@@ -4,7 +4,13 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import tiktoken  # noqa: E402
+import pytest
 from chunking import chunk_file, summarize_code  # noqa: E402
+
+
+class DummyBuilder:
+    def build(self, text: str) -> str:  # pragma: no cover - simple stub
+        return ""
 
 
 def test_token_counting_respects_limit(tmp_path):
@@ -44,5 +50,10 @@ def test_ast_boundary_accuracy(tmp_path):
 
 def test_summarize_code_fallback():
     code = '# comment\n\nclass Foo:\n    pass\n'
-    summary = summarize_code(code, None, context_builder=None)
+    summary = summarize_code(code, None, context_builder=DummyBuilder())
     assert summary.startswith('class Foo')
+
+
+def test_summarize_code_requires_builder():
+    with pytest.raises(ValueError):
+        summarize_code("print('x')", None, context_builder=None)


### PR DESCRIPTION
## Summary
- require `context_builder` for `summarize_snippet` and `get_chunk_summaries`
- update all callers and docs to pass a context builder
- add tests ensuring calls without a builder raise `ValueError`

## Testing
- `pytest tests/test_chunk_workflow.py tests/test_chunk_summary_cache.py tests/test_chunking_cache.py tests/test_chunking_split.py tests/test_chunking_summarize_cache.py unit_tests/test_chunking.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bfaba29e48832ea63f24ae0c4f2b27