### PR TITLE
Handle context builder failures in GUI

### DIFF
--- a/tests/test_menace_gui.py
+++ b/tests/test_menace_gui.py
@@ -4,9 +4,6 @@ from unittest import mock
 
 pytest.importorskip("tkinter")
 
-import tkinter as tk
-import importlib
-
 
 @pytest.mark.skipif(not os.environ.get("DISPLAY"), reason="requires display")
 def test_gui_init(monkeypatch):
@@ -27,11 +24,10 @@ def test_gui_uses_context_builder(monkeypatch):
     from menace import menace_gui as mg
 
     builder = mock.MagicMock()
-    monkeypatch.setattr(mg, "create_context_builder", lambda: builder)
     monkeypatch.setattr(mg.ChatGPTClient, "__post_init__", lambda self: None)
     monkeypatch.setattr(mg, "OPENAI_API_KEY", "key")
 
-    gui = mg.MenaceGUI()
+    gui = mg.MenaceGUI(context_builder=builder)
 
     assert builder.refresh_db_weights.called
     assert gui.context_builder is builder
@@ -39,3 +35,17 @@ def test_gui_uses_context_builder(monkeypatch):
     assert gui.conv_bot.client.context_builder is builder
     assert gui.error_bot.context_builder is builder
 
+
+@pytest.mark.skipif(not os.environ.get("DISPLAY"), reason="requires display")
+def test_refresh_failure_disables_prompts(monkeypatch):
+    from menace import menace_gui as mg
+
+    builder = mock.MagicMock()
+    builder.refresh_db_weights.side_effect = RuntimeError("boom")
+    monkeypatch.setattr(mg.ChatGPTClient, "__post_init__", lambda self: None)
+    monkeypatch.setattr(mg, "OPENAI_API_KEY", "key")
+
+    gui = mg.MenaceGUI(context_builder=builder)
+
+    assert gui.conv_bot is None
+    assert not gui.chatgpt_enabled


### PR DESCRIPTION
## Summary
- Allow passing a `ContextBuilder` to `MenaceGUI` for easier testing
- Guard `refresh_db_weights` with logging and disable prompt widgets on failure
- Disable stats widgets when prompt features are unavailable and add tests for failure paths

## Testing
- `python -m pytest tests/test_menace_gui.py -q`
- `pre-commit run --files menace_gui.py tests/test_menace_gui.py` *(fails: No module named 'dynamic_path_router')*


------
https://chatgpt.com/codex/tasks/task_e_68bfafa00ce4832e8c84b141d21c65ee