### PR TITLE
Integrate contextual snippets into UserStyleModel generation

### DIFF
--- a/tests/test_user_style_model.py
+++ b/tests/test_user_style_model.py
@@ -1,17 +1,69 @@
-import pytest
-pytest.skip("optional dependencies not installed", allow_module_level=True)
+from __future__ import annotations
 import menace.user_style_model as usm
-import menace.mirror_bot as mb
 
 
-def test_train_and_generate(tmp_path):
-    db = mb.MirrorDB(tmp_path / "m.db")
-    bot = mb.MirrorBot(db)
-    bot.log_interaction("hi", "hello", feedback="good")
-    model = usm.UserStyleModel(db)
+def test_generate_requires_context_builder():
+    class DummyDB:
+        def fetch(self, n):  # pragma: no cover - simple stub
+            return []
+
+    model = usm.UserStyleModel(DummyDB())
+
+    class DummyModel:
+        def generate(self, **_):
+            return [[0]]
+
+    class DummyTokenizer:
+        def __call__(self, text, return_tensors=None):  # pragma: no cover - simple stub
+            return {"input_ids": [1]}
+
+        def decode(self, ids, skip_special_tokens=True):  # pragma: no cover - simple stub
+            return "out"
+
+    model.model = DummyModel()
+    model.tokenizer = DummyTokenizer()
+
     try:
-        model.train()
-    except RuntimeError:
-        pytest.skip("transformers not available")
-    text = model.generate("test")
-    assert isinstance(text, str)
+        model.generate("hi")  # type: ignore[misc]
+    except TypeError:
+        pass
+    else:  # pragma: no cover - defensive
+        raise AssertionError("context_builder was not required")
+
+
+def test_generate_injects_context(monkeypatch):
+    captured: dict[str, str] = {}
+
+    class DummyModel:
+        def generate(self, **_):
+            return [[0]]
+
+    class DummyTokenizer:
+        def __call__(self, text, return_tensors=None):
+            captured["prompt"] = text
+            return {"input_ids": [1]}
+
+        def decode(self, ids, skip_special_tokens=True):
+            return "out"
+
+    class DummyBuilder:
+        def build(self, query, include_vectors=False):  # pragma: no cover - simple stub
+            return "context"
+
+    def fake_compress(meta, **_):
+        return {"snippet": "COMP-" + meta.get("snippet", "")}
+
+    monkeypatch.setattr(usm, "compress_snippets", fake_compress)
+
+    class DummyDB:
+        def fetch(self, n):  # pragma: no cover - simple stub
+            return []
+
+    model = usm.UserStyleModel(DummyDB())
+    model.model = DummyModel()
+    model.tokenizer = DummyTokenizer()
+
+    result = model.generate("hello", context_builder=DummyBuilder())
+    assert result == "out"
+    assert captured["prompt"] == "COMP-context\n\nhello"
+


### PR DESCRIPTION
## Summary
- require a context_builder when generating with UserStyleModel
- prepend compressed context snippets to prompts
- test that generation enforces context_builder and injects context

## Testing
- `python tests/test_user_style_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfba76d8e0832e9035caf5b6f38782