### PR TITLE
feat: compress diff summarizer context

### DIFF
--- a/tests/test_diff_summarizer.py
+++ b/tests/test_diff_summarizer.py
@@ -40,4 +40,6 @@ def test_context_builder_prepended(monkeypatch):
     res = ds.summarize_diff("before", "after", context_builder=builder)
     assert res == "ok"
     assert builder.calls and builder.calls[0] == "before\nafter"
-    assert tok.prompt.startswith("Context:\nEXTRA\nSummarize")
+    assert tok.prompt.startswith("Context:\n")
+    assert "EXTRA" in tok.prompt
+    assert "Summarize" in tok.prompt


### PR DESCRIPTION
## Summary
- add snippet compression and retrieval context support to diff summarizer
- test diff summarizer context injection

## Testing
- `pytest tests/test_diff_summarizer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfbf1c9f80832e90bad0ad129534ca