### PR TITLE
Require explicit context builder for neurosales responses

### DIFF
--- a/neurosales/neurosales/cortex_responder.py
+++ b/neurosales/neurosales/cortex_responder.py
@@ -51,7 +51,9 @@ class CortexAwareResponder:
             pinecone_index, api_key=pinecone_key, environment=pinecone_env
         )
         self.pg = pg or InMemoryResponseDB()
-        self.generator = ResponseCandidateGenerator()
+        self.generator = ResponseCandidateGenerator(
+            context_builder=create_context_builder()
+        )
         self.scorer = CandidateResponseScorer()
         self.queue = ResponsePriorityQueue()
 

--- a/neurosales/neurosales/orchestrator.py
+++ b/neurosales/neurosales/orchestrator.py
@@ -6,6 +6,7 @@ from .memory import DatabaseConversationMemory
 from .embedding_memory import EmbeddingConversationMemory
 from .user_preferences import PreferenceEngine, PreferenceProfile
 from .response_generation import ResponseCandidateGenerator
+from context_builder_util import create_context_builder
 from .scoring import CandidateResponseScorer
 from .rl_integration import DatabaseRLResponseRanker
 from .self_learning import SelfLearningEngine
@@ -29,7 +30,9 @@ class SandboxOrchestrator:
         self.memories: Dict[str, DatabaseConversationMemory | EmbeddingConversationMemory] = {}
         self.reactions: Dict[str, ReactionHistory] = {}
         self.preferences = PreferenceEngine()
-        self.generator = ResponseCandidateGenerator()
+        self.generator = ResponseCandidateGenerator(
+            context_builder=create_context_builder()
+        )
         self.scorer = CandidateResponseScorer()
         self.ranker = DatabaseRLResponseRanker(
             session_factory=session_factory, db_url=db_url
@@ -85,7 +88,9 @@ class SandboxOrchestrator:
         state = self._pending_state.pop(user_id)
 
         self._get_reactions(user_id).add_pair(last_reply, followup)
-        self.learner.log_interaction(last_reply, followup, correction=correction, engagement=engagement)
+        self.learner.log_interaction(
+            last_reply, followup, correction=correction, engagement=engagement
+        )
 
         mem = self._get_memory(user_id)
         next_state = (len(mem.get_recent_messages()),)

--- a/neurosales/tests/test_response_generation.py
+++ b/neurosales/tests/test_response_generation.py
@@ -18,7 +18,11 @@ def test_redundancy_filter_removes_duplicates():
 
 
 def test_generate_candidates_pool():
-    gen = ResponseCandidateGenerator()
+    class DummyBuilder:
+        def build(self, message, **_):
+            return ""
+
+    gen = ResponseCandidateGenerator(context_builder=DummyBuilder())
     gen.add_past_response("Sure, I can assist you.")
     gen.add_past_response("Let me show you how to proceed.")
     candidates = gen.generate_candidates("I need help", ["Hi"], "helper")


### PR DESCRIPTION
## Summary
- enforce ContextBuilder as a required dependency for `ResponseCandidateGenerator`
- wire `create_context_builder()` through orchestrator and cortex responder
- silence lint for HF model.generate via `# nocb`

## Testing
- `pre-commit run --files neurosales/neurosales/response_generation.py neurosales/neurosales/orchestrator.py neurosales/neurosales/cortex_responder.py neurosales/tests/test_response_generation.py` *(fails: ModuleNotFoundError: dynamic_path_router; context builder usage errors in unrelated files)*
- `pytest neurosales/tests/test_response_generation.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfca11478c832ea264eb77c849c5ac