### PR TITLE
Tag action justifier generate call with nocb

### DIFF
--- a/action_justifier.py
+++ b/action_justifier.py
@@ -196,7 +196,7 @@ def _llm_justification(
             logger.exception("failed reading justification cache")
     try:
         tokens = tokenizer.encode(prompt, return_tensors="pt")
-        output = model.generate(tokens, max_new_tokens=60, do_sample=False)
+        output = model.generate(tokens, max_new_tokens=60, do_sample=False)  # nocb
         text = tokenizer.decode(output[0], skip_special_tokens=True)
         explanation = text[len(prompt):].strip()
     except Exception:


### PR DESCRIPTION
## Summary
- ignore context builder requirements for local model generation by tagging the call in `action_justifier.py`

## Testing
- `python scripts/check_context_builder_usage.py | head -n 50`

------
https://chatgpt.com/codex/tasks/task_e_68bfcbd3c11c832e8d3eaebf4aad8bf9