### PR TITLE
feat: inject context builder into orchestrator

### DIFF
--- a/neurosales/neurosales/api_gateway.py
+++ b/neurosales/neurosales/api_gateway.py
@@ -25,6 +25,7 @@ from .rl_training import schedule_periodic_training, schedule_feedback_export
 from .db_backup import schedule_database_backup
 from .user_preferences import PreferenceProfile
 from .orchestrator import SandboxOrchestrator
+from context_builder_util import create_context_builder
 
 load_dotenv()
 
@@ -156,6 +157,7 @@ def create_app(session_factory=None, memory_session_factory=None) -> FastAPI:
 
     orch_session_factory = memory_session_factory or session_factory
     orchestrator = SandboxOrchestrator(
+        context_builder=create_context_builder(),
         persistent=memory_session_factory is not None,
         session_factory=orch_session_factory,
     )

--- a/neurosales/neurosales/orchestrator.py
+++ b/neurosales/neurosales/orchestrator.py
@@ -6,7 +6,7 @@ from .memory import DatabaseConversationMemory
 from .embedding_memory import EmbeddingConversationMemory
 from .user_preferences import PreferenceEngine, PreferenceProfile
 from .response_generation import ResponseCandidateGenerator
-from context_builder_util import create_context_builder
+from vector_service import ContextBuilder
 from .scoring import CandidateResponseScorer
 from .rl_integration import DatabaseRLResponseRanker
 from .self_learning import SelfLearningEngine
@@ -20,6 +20,7 @@ class SandboxOrchestrator:
     def __init__(
         self,
         *,
+        context_builder: ContextBuilder,
         persistent: bool = False,
         session_factory: Optional[callable] = None,
         db_url: Optional[str] = None,
@@ -27,10 +28,10 @@ class SandboxOrchestrator:
         self.persistent = persistent
         self.session_factory = session_factory
         self.db_url = db_url
+        self.context_builder = context_builder
         self.memories: Dict[str, DatabaseConversationMemory | EmbeddingConversationMemory] = {}
         self.reactions: Dict[str, ReactionHistory] = {}
         self.preferences = PreferenceEngine()
-        self.context_builder = create_context_builder()
         self.generator = ResponseCandidateGenerator(
             context_builder=self.context_builder
         )

--- a/neurosales/tests/test_orchestrator.py
+++ b/neurosales/tests/test_orchestrator.py
@@ -2,15 +2,20 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from unittest.mock import patch
+from unittest.mock import patch  # noqa: E402
 
-from neurosales.orchestrator import SandboxOrchestrator
-from neurosales.sql_db import create_session as create_sql_session
+from neurosales.orchestrator import SandboxOrchestrator  # noqa: E402
+from neurosales.sql_db import create_session as create_sql_session  # noqa: E402
+from context_builder_util import create_context_builder  # noqa: E402
 
 
 def test_orchestrator_chat_and_learning():
     Session = create_sql_session("sqlite://")
-    orch = SandboxOrchestrator(persistent=True, session_factory=Session)
+    orch = SandboxOrchestrator(
+        context_builder=create_context_builder(),
+        persistent=True,
+        session_factory=Session,
+    )
 
     with patch("neurosales.embedding.embed_text", return_value=[0.0]):
         with patch.object(orch.ranker, "rank", wraps=orch.ranker.rank) as mock_rank:

--- a/neurosales/tests/test_orchestrator_feedback.py
+++ b/neurosales/tests/test_orchestrator_feedback.py
@@ -2,13 +2,18 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from neurosales.orchestrator import SandboxOrchestrator
-from neurosales.sql_db import create_session as create_sql_session
+from neurosales.orchestrator import SandboxOrchestrator  # noqa: E402
+from neurosales.sql_db import create_session as create_sql_session  # noqa: E402
+from context_builder_util import create_context_builder  # noqa: E402
 
 
 def test_followup_updates_rl():
     Session = create_sql_session("sqlite://")
-    orch = SandboxOrchestrator(persistent=True, session_factory=Session)
+    orch = SandboxOrchestrator(
+        context_builder=create_context_builder(),
+        persistent=True,
+        session_factory=Session,
+    )
 
     first_reply, _ = orch.handle_chat("u1", "hello")
     second_reply, _ = orch.handle_chat("u1", "thanks")

--- a/neurosales/tests/test_orchestrator_persistence.py
+++ b/neurosales/tests/test_orchestrator_persistence.py
@@ -4,8 +4,9 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from neurosales.orchestrator import SandboxOrchestrator
-from neurosales.sql_db import create_session, RLFeedback
+from neurosales.orchestrator import SandboxOrchestrator  # noqa: E402
+from neurosales.sql_db import create_session, RLFeedback  # noqa: E402
+from context_builder_util import create_context_builder  # noqa: E402
 
 
 def test_orchestrator_persistence(tmp_path):
@@ -14,12 +15,20 @@ def test_orchestrator_persistence(tmp_path):
     Session = create_session(url)
 
     with patch("neurosales.embedding.embed_text", return_value=[0.0]):
-        orch = SandboxOrchestrator(persistent=True, session_factory=Session)
+        orch = SandboxOrchestrator(
+            context_builder=create_context_builder(),
+            persistent=True,
+            session_factory=Session,
+        )
         orch.handle_chat("u1", "hello")
         orch.handle_chat("u1", "thanks")
 
     with patch("neurosales.embedding.embed_text", return_value=[0.0]):
-        orch2 = SandboxOrchestrator(persistent=True, session_factory=Session)
+        orch2 = SandboxOrchestrator(
+            context_builder=create_context_builder(),
+            persistent=True,
+            session_factory=Session,
+        )
 
     mem = orch2._get_memory("u1")
     msgs = [m.content for m in mem.get_recent_messages()]

--- a/neurosales/tests/test_performance.py
+++ b/neurosales/tests/test_performance.py
@@ -4,13 +4,18 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from neurosales.orchestrator import SandboxOrchestrator
-from neurosales.sql_db import create_session
+from neurosales.orchestrator import SandboxOrchestrator  # noqa: E402
+from neurosales.sql_db import create_session  # noqa: E402
+from context_builder_util import create_context_builder  # noqa: E402
 
 
 def test_handle_chat_benchmark(benchmark):
     Session = create_session("sqlite://")
-    orch = SandboxOrchestrator(persistent=True, session_factory=Session)
+    orch = SandboxOrchestrator(
+        context_builder=create_context_builder(),
+        persistent=True,
+        session_factory=Session,
+    )
     with patch("neurosales.embedding.embed_text", return_value=[0.0]):
         reply, conf = benchmark.pedantic(
             lambda: orch.handle_chat("u1", "hello"),


### PR DESCRIPTION
## Summary
- allow SandboxOrchestrator to receive a ContextBuilder
- wire ContextBuilder through API gateway and tests

## Testing
- `pre-commit run --files neurosales/neurosales/orchestrator.py neurosales/neurosales/api_gateway.py neurosales/tests/test_orchestrator_feedback.py neurosales/tests/test_performance.py neurosales/tests/test_orchestrator_persistence.py neurosales/tests/test_orchestrator.py`
- `pytest neurosales/tests/test_orchestrator_feedback.py -vv` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68bfce8bf5a8832ea39b7dc2ad6436da