### PR TITLE
Refactor diff summarizer context handling

### DIFF
--- a/tests/test_diff_summarizer.py
+++ b/tests/test_diff_summarizer.py
@@ -4,10 +4,14 @@ import micro_models.diff_summarizer as ds
 class DummyBuilder:
     def __init__(self):
         self.calls = []
+        self.refreshed = False
 
     def build_context(self, text):
         self.calls.append(text)
         return "EXTRA"
+
+    def refresh_db_weights(self):
+        self.refreshed = True
 
 
 class DummyTokenizer:
@@ -38,8 +42,10 @@ def test_context_builder_prepended(monkeypatch):
 
     builder = DummyBuilder()
     res = ds.summarize_diff("before", "after", context_builder=builder)
-    assert res == "ok"
+    assert res.startswith("ok")
+    assert "Context:\nEXTRA" in res
     assert builder.calls and builder.calls[0] == "before\nafter"
+    assert builder.refreshed
     assert tok.prompt.startswith("Context:\n")
     assert "EXTRA" in tok.prompt
     assert "Summarize" in tok.prompt


### PR DESCRIPTION
## Summary
- remove internal sentinel and require a ContextBuilder for `summarize_diff`
- refresh builder weights and embed retrieved snippets in returned summary
- update diff summarizer tests for new interface

## Testing
- `pytest tests/test_diff_summarizer.py tests/test_micro_model_paths.py tests/test_code_summarizer.py`

------
https://chatgpt.com/codex/tasks/task_e_68bfd1b881d4832eb6101c18a45b3616