### PR TITLE
Refresh context builder in response generator

### DIFF
--- a/neurosales/neurosales/cortex_responder.py
+++ b/neurosales/neurosales/cortex_responder.py
@@ -100,7 +100,6 @@ class CortexAwareResponder:
             text,
             history_texts,
             profile.archetype,
-            context_builder=self.client.context_builder,
         )
         if first_pass not in candidates:
             candidates.append(first_pass)

--- a/neurosales/tests/test_cortex_responder.py
+++ b/neurosales/tests/test_cortex_responder.py
@@ -12,6 +12,9 @@ def test_cortex_pipeline_basic(monkeypatch):
         def build(self, query: str) -> str:
             return ""
 
+        def refresh_db_weights(self):
+            return None
+
     dummy_mod = types.SimpleNamespace(ContextBuilder=DummyCB)
     monkeypatch.setitem(sys.modules, "vector_service", types.SimpleNamespace(context_builder=dummy_mod))
     monkeypatch.setitem(sys.modules, "vector_service.context_builder", dummy_mod)

--- a/neurosales/tests/test_response_generation.py
+++ b/neurosales/tests/test_response_generation.py
@@ -22,6 +22,9 @@ def test_generate_candidates_pool():
         def build(self, message, **_):
             return ""
 
+        def refresh_db_weights(self):
+            return None
+
     gen = ResponseCandidateGenerator(context_builder=DummyBuilder())
     gen.add_past_response("Sure, I can assist you.")
     gen.add_past_response("Let me show you how to proceed.")
@@ -38,6 +41,9 @@ def test_dynamic_candidates_include_context(monkeypatch):
         def build(self, message, **_):
             self.calls.append(message)
             return "RAWCTX"
+
+        def refresh_db_weights(self):
+            return None
 
     class DummyTokenizer:
         def encode(self, prompt, return_tensors=None):


### PR DESCRIPTION
## Summary
- Refresh context builder DB weights on ResponseCandidateGenerator init
- Use stored context builder for candidate generation and compress retrieved context
- Adjust CortexAwareResponder and tests for new generator behavior

## Testing
- `pytest neurosales/tests/test_response_generation.py neurosales/tests/test_cortex_responder.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfd2caab24832e82a4b2be1722c330