### PR TITLE
Require explicit ContextBuilder for vector service API

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,9 +365,9 @@ message if installation fails.
   Other modules should interact with embeddings through this layer rather than
   accessing databases or retrievers directly. See
   [docs/vector_service.md](docs/vector_service.md) for detailed API
-  documentation. A lightweight FastAPI app in `vector_service_api.py`
-  provides `/search`, `/build-context`, `/track-contributors` and
-  `/backfill-embeddings` endpoints.
+  documentation. A lightweight FastAPI app in `vector_service_api.py`,
+  initialised via `create_app(ContextBuilder(...))`, provides `/search`,
+  `/build-context`, `/track-contributors` and `/backfill-embeddings` endpoints.
 - Overview of the vectorised cognition pipeline – from embedding backfills to
   ranking with ROI feedback – is available in
   [docs/vectorized_cognition.md](docs/vectorized_cognition.md).

--- a/docs/upgrade_notes.md
+++ b/docs/upgrade_notes.md
@@ -15,7 +15,8 @@ router are no longer supported.
 The `vector_service` package provides retrieval helpers and HTTP endpoints
 (`/search`, `/build-context`, `/track-contributors`,
 `/backfill-embeddings`). Ensure imports use `vector_service` helpers and
-consult `vector_service_api.py` for usage details.
+consult `vector_service_api.py` for usage details. Initialising the HTTP API
+now requires an explicit `ContextBuilder` passed to `create_app`.
 
 ## Recursive orphan scanning default
 

--- a/docs/vector_service.md
+++ b/docs/vector_service.md
@@ -226,7 +226,15 @@ Example usage:
 ```bash
 export VECTOR_SERVICE_API_TOKEN="secret"
 export VECTOR_SERVICE_RATE_LIMIT=30
-uvicorn vector_service_api:app
+python - <<'PY'
+from context_builder_util import create_context_builder
+import vector_service_api
+
+vector_service_api.create_app(create_context_builder())
+
+import uvicorn
+uvicorn.run(vector_service_api.app, host="0.0.0.0", port=8000)
+PY
 
 # Authenticated request
 curl -H "X-API-Token: secret" -d '{"query": "upload failed"}' \

--- a/docs/vector_service_api.md
+++ b/docs/vector_service_api.md
@@ -3,6 +3,15 @@
 The `vector_service_api` module exposes a tiny [FastAPI](https://fastapi.tiangolo.com/)
 application that wraps helpers from [`vector_service`](vector_service.md).
 Each endpoint returns a JSON object with a `status` field and timing metrics.
+Before sending requests, initialise the app with an explicit
+`ContextBuilder`:
+
+```python
+from context_builder_util import create_context_builder
+import vector_service_api
+
+vector_service_api.create_app(create_context_builder())
+```
 
 ## `POST /search`
 Run semantic search through `vector_service.Retriever`.

--- a/vector_service/README.md
+++ b/vector_service/README.md
@@ -219,7 +219,8 @@ Use `--interval 3600` to keep retraining hourly.
 
 `analytics/ranker_scheduler.py` can run the retrainer on a timer. Set
 environment variables and invoke the module to enable it or rely on
-`vector_service_api.py` which calls `start_scheduler_from_env` during startup.
+`vector_service_api.py` which calls `start_scheduler_from_env` during startup
+once initialised via `create_app(ContextBuilder(...))`.
 
 ```bash
 export RANKER_SCHEDULER_INTERVAL=3600  # seconds between retrains (0 disables)


### PR DESCRIPTION
## Summary
- require a ContextBuilder when initialising the vector service API
- validate builders with ensure_fresh_weights and wire them to runtime services
- document how to start the API with an explicit builder

## Testing
- `pytest tests/test_vector_service_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfd408c5f8832eb87d0e90648b23e0