### PR TITLE
Inject context builder into self test service

### DIFF
--- a/run_autonomous.py
+++ b/run_autonomous.py
@@ -2152,10 +2152,11 @@ def bootstrap(
     cleanup_funcs.append(learn_stop)
 
     from vector_service.context_builder import ContextBuilder
+    from context_builder_util import ensure_fresh_weights
 
     builder = ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
     try:
-        builder.refresh_db_weights()
+        ensure_fresh_weights(builder)
     except Exception:  # pragma: no cover - log and skip self-test when init fails
         logger.exception(
             "ContextBuilder initialisation failed; self-test loop disabled"

--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -7986,12 +7986,13 @@ def try_integrate_into_workflows(
     test_paths = [
         (repo / m).as_posix() for mods in candidates.values() for m in mods
     ]
+    builder = create_context_builder()
     svc = SelfTestService(
         include_orphans=False,
         discover_orphans=False,
         discover_isolated=False,
         integration_callback=None,
-        context_builder=create_context_builder(),
+        context_builder=builder,
     )
     try:
         loop = asyncio.new_event_loop()
@@ -8751,6 +8752,7 @@ def auto_include_modules(
     failed_mods: list[str] = []
     heavy_side_effects: dict[str, float] = {}
 
+    builder = create_context_builder()
     for mod in mods:
         path = repo / mod
         need_validate = validate or mod in new_paths
@@ -8768,7 +8770,7 @@ def auto_include_modules(
                     auto_include_isolated=True,
                     include_redundant=settings.test_redundant_modules,
                     disable_auto_integration=True,
-                    context_builder=create_context_builder(),
+                    context_builder=builder,
                 )
                 res = svc.run_once()
                 result = res[0] if isinstance(res, tuple) else res

--- a/service_supervisor.py
+++ b/service_supervisor.py
@@ -284,10 +284,9 @@ def _update_worker() -> None:
         stop.set()
 
 
-def _self_test_worker() -> None:
+def _self_test_worker(builder: ContextBuilder) -> None:
     """Execute the self test suite periodically."""
     logger = logging.getLogger("self_test_worker")
-    builder = create_context_builder()
     svc = SelfTestService(context_builder=builder)
     stop = Event()
     interval = float(os.getenv("SELF_TEST_INTERVAL", "86400"))
@@ -527,7 +526,7 @@ def main() -> None:
     sup.register("dependency_monitor", _dependency_monitor_worker)
     sup.register("environment_restoration", _env_restore_worker)
     sup.register("unified_update_service", _update_worker)
-    sup.register("self_test_service", _self_test_worker)
+    sup.register("self_test_service", partial(_self_test_worker, builder))
     if os.getenv("ENABLE_AUTOSCALER") == "1":
         sup.register("autoscaler", _autoscale_worker)
     if os.getenv("AUTO_ROTATE_SECRETS") == "1":


### PR DESCRIPTION
## Summary
- allow injecting a ContextBuilder into SelfTestService and refresh weights via `ensure_fresh_weights`
- reuse a provided ContextBuilder in CLI and service supervisor
- call `ensure_fresh_weights` when bootstrapping self tests in runtime helpers

## Testing
- `pytest tests/test_create_context_builder.py::test_ensure_fresh_weights_invokes_builder -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfeb428e30832e908f87bae1b2a8a3