### PR TITLE
Require explicit context builder for dynamic response candidates

### DIFF
--- a/neurosales/neurosales/response_generation.py
+++ b/neurosales/neurosales/response_generation.py
@@ -141,9 +141,9 @@ class ResponseCandidateGenerator:
         archetype: str,
         n: int = 3,
         *,
-        context_builder: ContextBuilder | None = None,  # nocb
+        context_builder: ContextBuilder,
     ) -> List[str]:
-        builder = context_builder or self.context_builder
+        builder = context_builder
         if self.tokenizer and self.model and torch is not None and builder is not None:
             try:
                 prompt = " ".join(history + [message, archetype])
@@ -191,6 +191,7 @@ class ResponseCandidateGenerator:
                 message,
                 history,
                 archetype,
+                context_builder=self.context_builder,
             )
         )
         candidates.extend(self._past_candidates(message))

--- a/neurosales/tests/test_response_generation.py
+++ b/neurosales/tests/test_response_generation.py
@@ -66,7 +66,9 @@ def test_dynamic_candidates_include_context(monkeypatch):
     gen = ResponseCandidateGenerator(context_builder=builder)
     gen.tokenizer = DummyTokenizer()
     gen.model = DummyModel()
-    res = gen._dynamic_candidates("hello", ["hi"], "arch", n=1)
+    res = gen._dynamic_candidates(
+        "hello", ["hi"], "arch", n=1, context_builder=builder
+    )
     assert builder.calls == ["hello"]
     assert "COMPCTX" in res[0]
     assert "RAWCTX" not in res[0]


### PR DESCRIPTION
## Summary
- require ContextBuilder when generating dynamic candidates
- pass context builder explicitly from generate_candidates
- adjust tests for new signature

## Testing
- `pytest neurosales/tests/test_response_generation.py`
- `pre-commit run --files neurosales/neurosales/response_generation.py neurosales/tests/test_response_generation.py` *(fails: ModuleNotFoundError: dynamic_path_router)*

------
https://chatgpt.com/codex/tasks/task_e_68bfefa747e8832e95fb9bdce60d4eaf