### PR TITLE
refactor: remove vector service globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,8 @@ message if installation fails.
   accessing databases or retrievers directly. See
   [docs/vector_service.md](docs/vector_service.md) for detailed API
   documentation. A lightweight FastAPI app in `vector_service_api.py`,
-  initialised via `create_app(ContextBuilder(...))`, provides `/search`,
+  initialised via `create_app(ContextBuilder(...))` which stores the builder on
+  `app.state`, provides `/search`,
   `/build-context`, `/track-contributors` and `/backfill-embeddings` endpoints.
 - Overview of the vectorised cognition pipeline – from embedding backfills to
   ranking with ROI feedback – is available in

--- a/docs/upgrade_notes.md
+++ b/docs/upgrade_notes.md
@@ -16,7 +16,8 @@ The `vector_service` package provides retrieval helpers and HTTP endpoints
 (`/search`, `/build-context`, `/track-contributors`,
 `/backfill-embeddings`). Ensure imports use `vector_service` helpers and
 consult `vector_service_api.py` for usage details. Initialising the HTTP API
-now requires an explicit `ContextBuilder` passed to `create_app`.
+now requires an explicit `ContextBuilder` passed to `create_app` and the
+builder is stored on `app.state` for access via `request.app.state`.
 
 ## Recursive orphan scanning default
 

--- a/docs/vector_service.md
+++ b/docs/vector_service.md
@@ -230,6 +230,8 @@ python - <<'PY'
 from context_builder_util import create_context_builder
 import vector_service_api
 
+# create_app stores the builder and services on ``app.state`` so the API
+# handlers can access them via ``request.app.state``.
 vector_service_api.create_app(create_context_builder())
 
 import uvicorn

--- a/docs/vector_service_api.md
+++ b/docs/vector_service_api.md
@@ -4,7 +4,8 @@ The `vector_service_api` module exposes a tiny [FastAPI](https://fastapi.tiangol
 application that wraps helpers from [`vector_service`](vector_service.md).
 Each endpoint returns a JSON object with a `status` field and timing metrics.
 Before sending requests, initialise the app with an explicit
-`ContextBuilder`:
+`ContextBuilder`.  The builder and related services are stored on
+`app.state` so handlers can access them via `request.app.state`:
 
 ```python
 from context_builder_util import create_context_builder


### PR DESCRIPTION
## Summary
- store `ContextBuilder` and dependent services on `app.state`
- update API endpoints to read services from `request.app.state`
- document and test the new explicit builder access

## Testing
- `pytest tests/test_vector_service_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bff088e0f8832ea7ea62ded72b56f6