### PR TITLE
Enforce explicit ContextBuilder.build usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,10 @@ bot = PromptingBot(planner, context_builder=builder)
 
 Violations are detected by `scripts/check_context_builder_usage.py`, which
 flags any `_build_prompt`, `build_prompt`, `generate_patch` or `.generate()`
-call on `LLMClient`-like instances missing `context_builder`. Variables
-assigned from these classes are tracked and aliases such as `llm` or `model`
-are heuristically inspected:
+call on `LLMClient`-like instances missing `context_builder`. Functions that
+invoke `ContextBuilder.build` while allowing a `None` default or fallback
+builder are reported as well. Variables assigned from these classes are
+tracked and aliases such as `llm` or `model` are heuristically inspected:
 
 ```bash
 python scripts/check_context_builder_usage.py
@@ -818,7 +819,8 @@ engine = PromptEngine(context_builder=builder)
 prompt = engine.build_prompt("Expand tests", context_builder=builder)
 ```
 
-Internal helpers follow the same pattern:
+Internal helpers follow the same pattern, and any helper that calls
+`ContextBuilder.build` must require an injected builder:
 
 ```python
 from menace.bot_development_bot import BotDevelopmentBot, BotSpec

--- a/docs/context_builder.md
+++ b/docs/context_builder.md
@@ -178,6 +178,19 @@ tracked so that subsequent ``instance.generate(...)`` invocations require the
 keyword as well; aliases such as ``llm`` or ``model`` are heuristically checked
 even without a prior assignment.
 
+Functions that invoke ``ContextBuilder.build`` must accept an explicit builder
+argument.  A parameter defaulting to ``None`` or falling back to a new builder
+inside the function body triggers an error.  This prevents helpers from silently
+creating builders when callers forget to provide one.
+
+```python
+def demo(builder=None):  # flagged
+    builder.build()
+
+def ok(builder):
+    builder.build()  # passes
+```
+
 ```python
 import openai
 

--- a/tests/test_context_builder_static.py
+++ b/tests/test_context_builder_static.py
@@ -156,3 +156,47 @@ def test_allows_getattr_with_nocb(tmp_path):
     path = tmp_path / "snippet.py"
     path.write_text(code)
     assert check_file(path) == []
+
+
+def test_flags_build_with_optional_builder(tmp_path):
+    from scripts.check_context_builder_usage import check_file
+
+    code = (
+        "from vector_service.context_builder import ContextBuilder\n"
+        "def demo(builder=None):\n"
+        "    builder.build()\n"
+    )
+    path = tmp_path / "snippet.py"
+    path.write_text(code)
+    assert check_file(path) == [
+        (3, "builder.build disallowed or missing context_builder")
+    ]
+
+
+def test_flags_build_with_fallback_builder(tmp_path):
+    from scripts.check_context_builder_usage import check_file
+
+    code = (
+        "from vector_service.context_builder import ContextBuilder\n"
+        "def demo(builder):\n"
+        "    builder = builder or ContextBuilder('bots.db', 'code.db', 'errors.db', 'workflows.db')\n"
+        "    builder.build()\n"
+    )
+    path = tmp_path / "snippet.py"
+    path.write_text(code)
+    assert check_file(path) == [
+        (4, "builder.build disallowed or missing context_builder")
+    ]
+
+
+def test_allows_build_with_required_builder(tmp_path):
+    from scripts.check_context_builder_usage import check_file
+
+    code = (
+        "from vector_service.context_builder import ContextBuilder\n"
+        "def demo(builder):\n"
+        "    builder.build()\n"
+    )
+    path = tmp_path / "snippet.py"
+    path.write_text(code)
+    assert check_file(path) == []


### PR DESCRIPTION
## Summary
- flag functions calling `ContextBuilder.build` when the builder parameter can be `None` or falls back to a new instance
- document the new lint rule and add examples of failing and passing code
- extend static checker tests with cases covering optional builders and fallbacks

## Testing
- `python scripts/check_context_builder_usage.py`
- `pytest tests/test_context_builder_static.py`

------
https://chatgpt.com/codex/tasks/task_e_68bff37de734832e92709de00cb00bd4