### PR TITLE
Add vector context support in section prompts

### DIFF
--- a/sandbox_runner/cycle.py
+++ b/sandbox_runner/cycle.py
@@ -1425,10 +1425,10 @@ def _sandbox_cycle_runner(
                     prompt = build_section_prompt(
                         mod,
                         tracker,
-                        text,
+                        context_builder=ctx.context_builder,
+                        snippet=text,
                         prior=brainstorm_summary if brainstorm_summary else None,
                         max_prompt_length=GPT_SECTION_PROMPT_MAX_LENGTH,
-                        context_builder=ctx.context_builder,
                     )
                     if insight:
                         prompt = f"{insight}\n\n{prompt}"
@@ -1695,10 +1695,10 @@ def _sandbox_cycle_runner(
                         prompt = build_section_prompt(
                             "overall",
                             tracker,
-                            f"ROI stalled. Current metrics: {summary}",
+                            context_builder=ctx.context_builder,
+                            snippet=f"ROI stalled. Current metrics: {summary}",
                             prior=prior if prior else None,
                             max_prompt_length=GPT_SECTION_PROMPT_MAX_LENGTH,
-                            context_builder=ctx.context_builder,
                         )
                         if insight:
                             prompt = f"{insight}\n\n{prompt}"
@@ -1800,10 +1800,10 @@ def _sandbox_cycle_runner(
                     prompt = build_section_prompt(
                         "overall",
                         tracker,
-                        "Brainstorm high level improvements to increase ROI.",
+                        context_builder=ctx.context_builder,
+                        snippet="Brainstorm high level improvements to increase ROI.",
                         prior=summary if summary else None,
                         max_prompt_length=GPT_SECTION_PROMPT_MAX_LENGTH,
-                        context_builder=ctx.context_builder,
                     )
                     if insight:
                         prompt = f"{insight}\n\n{prompt}"


### PR DESCRIPTION
## Summary
- pull contextual snippets via ContextBuilder within `build_section_prompt`
- pass sandbox context builder to all section prompt callsites
- test that section prompts include vector context

## Testing
- `PYTHONPATH=. pre-commit run --files sandbox_runner.py sandbox_runner/cycle.py`
- `pytest tests/test_sandbox_runner_metrics.py::test_auto_template_selection tests/test_sandbox_runner_metrics.py::test_prompt_truncation_and_metrics tests/test_sandbox_runner_metrics.py::test_prompt_synergy_and_length tests/test_sandbox_runner_metrics.py::test_build_section_prompt_vector_context -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '')*

------
https://chatgpt.com/codex/tasks/task_e_68bff5091be8832e8a743c2392704bf3