### PR TITLE
Refactor build_section_prompt to require keyword context builder

### DIFF
--- a/sandbox_runner.py
+++ b/sandbox_runner.py
@@ -471,10 +471,10 @@ def prepare_snippet(
 def build_section_prompt(
     section: str,
     tracker: "ROITracker",
+    *,
     context_builder: ContextBuilder,
     snippet: str | None = None,
     prior: str | None = None,
-    *,
     max_length: int = 1000,
     max_prompt_length: int | None = GPT_SECTION_PROMPT_MAX_LENGTH,
     summary_depth: int = GPT_SECTION_SUMMARY_DEPTH,
@@ -503,15 +503,14 @@ def build_section_prompt(
                 "Suggest a concise improvement:\n{{ snippet }}"
             )
 
-    builder = context_builder
-    if id(builder) not in _REFRESHED_BUILDERS:
-        ensure_fresh_weights(builder)
-        _REFRESHED_BUILDERS.add(id(builder))
+    if id(context_builder) not in _REFRESHED_BUILDERS:
+        ensure_fresh_weights(context_builder)
+        _REFRESHED_BUILDERS.add(id(context_builder))
 
     vec_ctx = ""
     try:
         query = snippet or section
-        vec_ctx_raw = builder.build(query)
+        vec_ctx_raw = context_builder.build(query)
         if not isinstance(vec_ctx_raw, (FallbackResult, ErrorResult)):
             vec_ctx = compress_snippets({"snippet": vec_ctx_raw}).get("snippet", "")
     except Exception:

--- a/sandbox_runner/cycle.py
+++ b/sandbox_runner/cycle.py
@@ -752,8 +752,8 @@ def _sandbox_cycle_runner(
     global SANDBOX_ENV_PRESETS
     from sandbox_runner import (
         build_section_prompt,
-        GPT_SECTION_PROMPT_MAX_LENGTH,
         GPT_KNOWLEDGE_SERVICE,
+        GPT_SECTION_PROMPT_MAX_LENGTH,
     )
 
     knowledge_service = GPT_KNOWLEDGE_SERVICE

--- a/tests/test_sandbox_runner_metrics.py
+++ b/tests/test_sandbox_runner_metrics.py
@@ -1069,16 +1069,22 @@ def test_auto_prompt_selection(monkeypatch):
             return 0.01
 
     importlib.reload(sandbox_runner)
-    prompt = sandbox_runner.build_section_prompt("a", T(sec_drop=True), DummyBuilder())
+    prompt = sandbox_runner.build_section_prompt(
+        "a", T(sec_drop=True), context_builder=DummyBuilder()
+    )
     assert "SECURITY FOCUS" in prompt
     assert len(sandbox_runner._AUTO_TEMPLATES) >= 3
     cached = sandbox_runner._AUTO_TEMPLATES
 
-    prompt = sandbox_runner.build_section_prompt("a", T(eff_drop=True), DummyBuilder())
+    prompt = sandbox_runner.build_section_prompt(
+        "a", T(eff_drop=True), context_builder=DummyBuilder()
+    )
     assert "EFFICIENCY FOCUS" in prompt
     assert sandbox_runner._AUTO_TEMPLATES is cached
 
-    prompt = sandbox_runner.build_section_prompt("a", T(), DummyBuilder())
+    prompt = sandbox_runner.build_section_prompt(
+        "a", T(), context_builder=DummyBuilder()
+    )
     assert "ROI IMPROVEMENT" in prompt
 
 
@@ -1154,7 +1160,7 @@ def test_prompt_truncation_and_metrics(monkeypatch):
     prompt = sandbox_runner.build_section_prompt(
         "mod:sec",
         T(),
-        DummyBuilder(),
+        context_builder=DummyBuilder(),
         snippet=snippet,
         max_length=50,
         summary_depth=1,
@@ -1240,7 +1246,7 @@ def test_prompt_synergy_and_length(monkeypatch):
     prompt = sandbox_runner.build_section_prompt(
         "mod:sec",
         T(),
-        DummyBuilder(""),
+        context_builder=DummyBuilder(""),
         snippet=snippet,
         max_length=50,
         summary_depth=1,
@@ -1263,7 +1269,9 @@ def test_build_section_prompt_vector_context():
             return 0.01
 
     builder = DummyBuilder("vector ctx")
-    prompt = sandbox_runner.build_section_prompt("mod", T(), builder)
+    prompt = sandbox_runner.build_section_prompt(
+        "mod", T(), context_builder=builder
+    )
     assert "vector ctx" in prompt
 
 


### PR DESCRIPTION
## Summary
- require `context_builder` as a keyword-only parameter in `build_section_prompt`
- fetch context via `context_builder.build` and update cycle runner imports
- adjust tests for new `build_section_prompt` signature

## Testing
- `pytest tests/test_sandbox_runner_metrics.py::test_auto_prompt_selection` *(fails: FileNotFoundError: 'menace_retrieval_cache_local.db' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bffc9102a8832e82280d646115b8cb