### PR TITLE
Require explicit context builder for SelfTestService

### DIFF
--- a/docs/self_test_service.md
+++ b/docs/self_test_service.md
@@ -83,12 +83,14 @@ modules were incorporated or skipped.
 
 ```python
 from menace.self_test_service import SelfTestService
+from menace.context_builder_util import create_context_builder
 
 def integrate(paths):
     # decide which modules to merge
     return {"integrated": paths, "redundant": []}
 
-svc = SelfTestService(integration_callback=integrate)
+builder = create_context_builder()
+svc = SelfTestService(integration_callback=integrate, context_builder=builder)
 results, passed = svc.run_once()
 print(results["integration"])
 ```

--- a/self_test_service.py
+++ b/self_test_service.py
@@ -567,15 +567,17 @@ class SelfTestService:
             environment created via
             :func:`sandbox_runner.environment.create_ephemeral_env`.
         context_builder:
-            Optional :class:`~vector_service.context_builder.ContextBuilder`
-            instance used by the internal :class:`~error_logger.ErrorLogger`
-            and to gather context for self‑test prompts.  If ``None``, a
-            builder is created via :func:`create_context_builder`.
+            :class:`~vector_service.context_builder.ContextBuilder` instance
+            used by the internal :class:`~error_logger.ErrorLogger` and to
+            gather context for self‑test prompts. ``None`` is not allowed and
+            will raise :class:`ValueError`.
         """
 
         self.logger = logging.getLogger(self.__class__.__name__)
         self.graph = graph or KnowledgeGraph()
-        self.context_builder = context_builder or create_context_builder()
+        if context_builder is None:
+            raise ValueError("context_builder is required")
+        self.context_builder = context_builder
         try:
             ensure_fresh_weights(self.context_builder)
         except Exception:  # pragma: no cover - best effort

--- a/tests/integration/test_full_cycle_failure_recovery.py
+++ b/tests/integration/test_full_cycle_failure_recovery.py
@@ -53,7 +53,11 @@ def test_full_cycle_failure_and_recovery(monkeypatch, tmp_path, caplog):
 
     # ---- SelfTestService: missing dependency then recovery ----
     db = DummyDB()
-    svc = sts.SelfTestService(db=db, history_path=tmp_path / "hist.json")
+    svc = sts.SelfTestService(
+        db=db,
+        history_path=tmp_path / "hist.json",
+        context_builder=DummyBuilder(),
+    )
     mod = tmp_path / "test_mod.py"  # path-ignore
     mod.write_text("def test_a():\n    assert True\n")
 

--- a/tests/integration/test_orphan_chain_module_map_logging.py
+++ b/tests/integration/test_orphan_chain_module_map_logging.py
@@ -43,6 +43,14 @@ sys.modules["menace.self_test_service"] = sts
 spec.loader.exec_module(sts)
 
 
+class DummyBuilder:
+    def refresh_db_weights(self):
+        pass
+
+    def build_context(self, *a, **k):
+        return "", "", {}
+
+
 # ---------------------------------------------------------------------------
 
 def test_orphan_chain_logging(tmp_path, monkeypatch):
@@ -115,6 +123,7 @@ def test_orphan_chain_logging(tmp_path, monkeypatch):
         recursive_orphans=True,
         clean_orphans=True,
         integration_callback=integrate,
+        context_builder=DummyBuilder(),
     )
     svc.run_once()
 

--- a/tests/integration/test_orphan_chain_services.py
+++ b/tests/integration/test_orphan_chain_services.py
@@ -42,6 +42,14 @@ menace_pkg = sys.modules.setdefault("menace", types.ModuleType("menace"))
 sys.modules["menace.self_test_service"] = sts
 spec_sts.loader.exec_module(sts)
 
+
+class DummyBuilder:
+    def refresh_db_weights(self):
+        pass
+
+    def build_context(self, *a, **k):
+        return "", "", {}
+
 env_mod = types.ModuleType("menace.environment_generator")
 env_mod._CPU_LIMITS = {}
 env_mod._MEMORY_LIMITS = {}
@@ -196,6 +204,7 @@ def test_self_test_service_executes_and_cleans(tmp_path, monkeypatch):
         recursive_orphans=True,
         clean_orphans=True,
         integration_callback=integrate,
+        context_builder=DummyBuilder(),
     )
     svc.run_once()
 

--- a/tests/integration/test_recursive_module_inclusion.py
+++ b/tests/integration/test_recursive_module_inclusion.py
@@ -120,9 +120,10 @@ def test_recursive_module_inclusion(tmp_path, monkeypatch):
 
     svc = sts.SelfTestService(
         include_orphans=True,
-       recursive_orphans=True,
+        recursive_orphans=True,
         clean_orphans=True,
         integration_callback=integrate,
+        context_builder=DummyBuilder(),
     )
     svc.logger = types.SimpleNamespace(info=lambda *a, **k: None, exception=lambda *a, **k: None)
     svc.run_once()

--- a/tests/integration/test_recursive_orphan_chain.py
+++ b/tests/integration/test_recursive_orphan_chain.py
@@ -44,6 +44,14 @@ sys.modules["menace.self_test_service"] = sts
 spec.loader.exec_module(sts)
 
 
+class DummyBuilder:
+    def refresh_db_weights(self):
+        pass
+
+    def build_context(self, *a, **k):
+        return "", "", {}
+
+
 # ---------------------------------------------------------------------------
 
 def test_recursive_orphan_chain(tmp_path, monkeypatch):
@@ -115,6 +123,7 @@ def test_recursive_orphan_chain(tmp_path, monkeypatch):
         recursive_orphans=True,
         clean_orphans=True,
         integration_callback=integrate,
+        context_builder=DummyBuilder(),
     )
     svc.run_once()
 

--- a/tests/integration/test_recursive_orphan_chain_redundant.py
+++ b/tests/integration/test_recursive_orphan_chain_redundant.py
@@ -44,6 +44,14 @@ sys.modules["menace.self_test_service"] = sts
 spec.loader.exec_module(sts)
 
 
+class DummyBuilder:
+    def refresh_db_weights(self):
+        pass
+
+    def build_context(self, *a, **k):
+        return "", "", {}
+
+
 # ---------------------------------------------------------------------------
 
 def test_orphan_chain_skips_redundant(tmp_path, monkeypatch):
@@ -116,6 +124,7 @@ def test_orphan_chain_skips_redundant(tmp_path, monkeypatch):
         recursive_orphans=True,
         clean_orphans=True,
         integration_callback=integrate,
+        context_builder=DummyBuilder(),
     )
     svc.run_once()
 

--- a/tests/integration/test_recursive_paths.py
+++ b/tests/integration/test_recursive_paths.py
@@ -44,6 +44,14 @@ sys.modules["menace.self_test_service"] = sts
 spec.loader.exec_module(sts)
 
 
+class DummyBuilder:
+    def refresh_db_weights(self):
+        pass
+
+    def build_context(self, *a, **k):
+        return "", "", {}
+
+
 # ---------------------------------------------------------------------------
 
 def test_recursive_paths(tmp_path, monkeypatch):
@@ -94,6 +102,7 @@ def test_recursive_paths(tmp_path, monkeypatch):
         recursive_orphans=True,
         clean_orphans=True,
         integration_callback=integrate,
+        context_builder=DummyBuilder(),
     )
     mods = [Path(*name.split(".")).with_suffix(".py").as_posix() for name in mapping]  # path-ignore
     svc.integration_callback(mods)

--- a/tests/test_async_scheduler.py
+++ b/tests/test_async_scheduler.py
@@ -25,6 +25,14 @@ def load_mod(name, file):
 cms = load_mod('cross_model_scheduler', resolve_path('cross_model_scheduler.py'))  # path-ignore
 sts = load_mod('self_test_service', resolve_path('self_test_service.py'))  # path-ignore
 
+
+class DummyBuilder:
+    def refresh_db_weights(self):
+        pass
+
+    def build_context(self, *a, **k):
+        return "", "", {}
+
 class DummyThread:
     def __init__(self, target=None, daemon=None):
         self.target = target
@@ -56,7 +64,7 @@ def test_self_test_async_records(monkeypatch):
             self.results.append((p, f))
 
     db = DummyDB()
-    svc = sts.SelfTestService(db=db)
+    svc = sts.SelfTestService(db=db, context_builder=DummyBuilder())
 
     async def fake_run_once():
         db.add_test_result(1, 0)

--- a/tests/test_isolated_workflows.py
+++ b/tests/test_isolated_workflows.py
@@ -144,10 +144,18 @@ def test_isolated_modules_written_to_workflows(tmp_path, monkeypatch):
     index = DummyIndex(map_path)
     eng = SimpleEngine(index, wf_db_path)
 
+    class DummyBuilder:
+        def refresh_db_weights(self):
+            pass
+
+        def build_context(self, *a, **k):
+            return "", "", {}
+
     svc = sts.SelfTestService(
         discover_isolated=True,
         recursive_isolated=True,
         integration_callback=eng.refresh_module_map,
+        context_builder=DummyBuilder(),
     )
     svc.run_once()
     passed = svc.results.get("orphan_passed") or []

--- a/tests/test_orphan_redundancy.py
+++ b/tests/test_orphan_redundancy.py
@@ -22,6 +22,14 @@ REGISTRY._names_to_collectors.clear()
 spec.loader.exec_module(sts)
 
 
+class DummyBuilder:
+    def refresh_db_weights(self):
+        pass
+
+    def build_context(self, *a, **k):
+        return "", "", {}
+
+
 class DummyLogger:
     def __init__(self) -> None:
         self.info_msgs: list[str] = []
@@ -234,7 +242,7 @@ def test_update_orphan_modules_tests_redundant_when_enabled(monkeypatch, tmp_pat
 
 def test_discover_orphans_filters_recursive(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
-    svc = sts.SelfTestService(discover_isolated=False)
+    svc = sts.SelfTestService(discover_isolated=False, context_builder=DummyBuilder())
     svc.logger = DummyLogger()
 
     sr = types.ModuleType("sandbox_runner")
@@ -260,7 +268,11 @@ def test_discover_orphans_filters_recursive(monkeypatch, tmp_path):
 
 def test_discover_isolated_filters(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
-    svc = sts.SelfTestService(discover_isolated=True, discover_orphans=False)
+    svc = sts.SelfTestService(
+        discover_isolated=True,
+        discover_orphans=False,
+        context_builder=DummyBuilder(),
+    )
     svc.logger = DummyLogger()
 
     mod = types.ModuleType("scripts.discover_isolated_modules")
@@ -291,7 +303,11 @@ def test_discover_isolated_filters(monkeypatch, tmp_path):
 
 def test_discover_orphans_filters_non_recursive(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
-    svc = sts.SelfTestService(discover_isolated=False, recursive_orphans=False)
+    svc = sts.SelfTestService(
+        discover_isolated=False,
+        recursive_orphans=False,
+        context_builder=DummyBuilder(),
+    )
     svc.logger = DummyLogger()
 
     def fake_find(root: Path):
@@ -318,7 +334,7 @@ def test_discover_orphans_filters_non_recursive(monkeypatch, tmp_path):
 
 def test_discover_orphans_records_redundant_metadata(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
-    svc = sts.SelfTestService(discover_isolated=False)
+    svc = sts.SelfTestService(discover_isolated=False, context_builder=DummyBuilder())
     svc.logger = DummyLogger()
 
     sr = types.ModuleType("sandbox_runner")

--- a/tests/test_recursive_self_improvement.py
+++ b/tests/test_recursive_self_improvement.py
@@ -40,6 +40,14 @@ sys.modules["menace.self_test_service"] = sts
 spec.loader.exec_module(sts)
 
 
+class DummyBuilder:
+    def refresh_db_weights(self):
+        pass
+
+    def build_context(self, *a, **k):
+        return "", "", {}
+
+
 def _setup(monkeypatch, tmp_path, chain_len):
     monkeypatch.setenv("MENACE_LIGHT_IMPORTS", "1")
     monkeypatch.chdir(tmp_path)
@@ -122,7 +130,10 @@ def _run_and_assert(monkeypatch, tmp_path, chain_len):
     commands, generated, map_path, data_dir, integrate = _setup(monkeypatch, tmp_path, chain_len)
 
     svc = sts.SelfTestService(
-        include_orphans=True, integration_callback=integrate, clean_orphans=True
+        include_orphans=True,
+        integration_callback=integrate,
+        clean_orphans=True,
+        context_builder=DummyBuilder(),
     )
     svc.run_once()
 

--- a/tests/test_self_test_service_auto_include.py
+++ b/tests/test_self_test_service_auto_include.py
@@ -55,6 +55,17 @@ def test_auto_include_isolated_settings(monkeypatch):
         recursive_isolated = True
 
     monkeypatch.setattr(mod, "SandboxSettings", lambda: DummySettings())
-    svc = mod.SelfTestService(discover_isolated=False, recursive_isolated=False)
+    class DummyBuilder:
+        def refresh_db_weights(self):
+            pass
+
+        def build_context(self, *a, **k):
+            return "", "", {}
+
+    svc = mod.SelfTestService(
+        discover_isolated=False,
+        recursive_isolated=False,
+        context_builder=DummyBuilder(),
+    )
     assert svc.discover_isolated is True
     assert svc.recursive_isolated is True

--- a/tests/test_self_test_service_health.py
+++ b/tests/test_self_test_service_health.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.test_self_test_service_async import load_self_test_service
+from tests.test_self_test_service_async import load_self_test_service, DummyBuilder
 
 sts = load_self_test_service()
 
@@ -21,7 +21,10 @@ def _free_port() -> int:
 
 @pytest.mark.asyncio
 async def test_health_endpoint(monkeypatch, tmp_path: Path) -> None:
-    svc = sts.SelfTestService(history_path=tmp_path / "hist.json")
+    svc = sts.SelfTestService(
+        history_path=tmp_path / "hist.json",
+        context_builder=DummyBuilder(),
+    )
 
     async def fake_run_once(self) -> None:  # type: ignore[override]
         self.results = {"passed": 2, "failed": 1, "coverage": 100.0, "runtime": 0.05}

--- a/tests/test_self_test_service_lock_stress.py
+++ b/tests/test_self_test_service_lock_stress.py
@@ -73,6 +73,14 @@ sts = load_self_test_service()
 SelfTestService = sts.SelfTestService
 
 
+class DummyBuilder:
+    def refresh_db_weights(self):
+        pass
+
+    def build_context(self, *a, **k):
+        return "", "", {}
+
+
 def test_cleanup_lock_stress(monkeypatch):
     concurrent = 0
     max_concurrent = 0
@@ -116,8 +124,8 @@ def test_cleanup_lock_stress(monkeypatch):
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
 
-    svc1 = SelfTestService(use_container=True)
-    svc2 = SelfTestService(use_container=True)
+    svc1 = SelfTestService(use_container=True, context_builder=DummyBuilder())
+    svc2 = SelfTestService(use_container=True, context_builder=DummyBuilder())
 
     async def run():
         await asyncio.gather(

--- a/tests/test_self_test_service_recursive_integration.py
+++ b/tests/test_self_test_service_recursive_integration.py
@@ -78,6 +78,14 @@ else:
 from prometheus_client import REGISTRY
 REGISTRY._names_to_collectors.clear()
 spec.loader.exec_module(self_test_mod)
+
+
+class DummyBuilder:
+    def refresh_db_weights(self):
+        pass
+
+    def build_context(self, *a, **k):
+        return "", "", {}
 self_test_mod.analyze_redundancy = lambda p: False
 
 # stub ModuleIndexDB
@@ -259,6 +267,7 @@ def test_recursive_isolated_integration(monkeypatch, tmp_path):
         discover_isolated=True,
         recursive_isolated=True,
         integration_callback=integration,
+        context_builder=DummyBuilder(),
     )
     asyncio.run(svc._run_once())
 
@@ -388,6 +397,7 @@ def test_recursive_orphan_integration(monkeypatch, tmp_path):
         recursive_orphans=True,
         clean_orphans=True,
         integration_callback=integration,
+        context_builder=DummyBuilder(),
     )
     asyncio.run(svc._run_once())
 
@@ -422,7 +432,10 @@ def test_generate_stub_with_scenarios(monkeypatch, tmp_path):
     }
 
     monkeypatch.setenv("SANDBOX_REPO_PATH", str(tmp_path))
-    svc = self_test_mod.SelfTestService(stub_scenarios={str(module_path): scenarios})
+    svc = self_test_mod.SelfTestService(
+        stub_scenarios={str(module_path): scenarios},
+        context_builder=DummyBuilder(),
+    )
     stub = svc._generate_pytest_stub(str(module_path), scenarios)
 
     cmd = [sys.executable, "-m", "pytest", "-q", str(stub)]

--- a/unit_tests/test_exception_handling.py
+++ b/unit_tests/test_exception_handling.py
@@ -16,6 +16,14 @@ sys.path.insert(0, str(repo_root))
 from menace_sandbox.self_test_service import SelfTestService  # noqa: E402
 
 
+class DummyBuilder:
+    def refresh_db_weights(self):
+        pass
+
+    def build_context(self, *a, **k):
+        return "", "", {}
+
+
 class DummySandbox:
     """Minimal stand-in for SelfDebuggerSandbox._history_db."""
 
@@ -57,6 +65,6 @@ def test_state_file_load_failure_logs(tmp_path, caplog):
     bad = resolve_path("state.json", tmp_path)
     bad.write_text("{")
     with caplog.at_level(logging.ERROR):
-        svc = SelfTestService(state_path=bad)
+        svc = SelfTestService(state_path=bad, context_builder=DummyBuilder())
     assert "failed to load state file" in caplog.text
     assert svc._state is None


### PR DESCRIPTION
## Summary
- Require callers to provide a `ContextBuilder` to `SelfTestService` and raise `ValueError` when missing
- Update documentation and tests to always supply a context builder

## Testing
- `pytest tests/test_self_test_service.py::test_context_builder_required unit_tests/test_exception_handling.py::test_state_file_load_failure_logs tests/test_self_test_service_lock_stress.py::test_cleanup_lock_stress tests/test_recursive_self_improvement.py::test_recursive_self_improvement_simple tests/test_isolated_workflows.py::test_isolated_modules_written_to_workflows tests/test_self_test_service_auto_include.py::test_auto_include_isolated_settings tests/test_async_scheduler.py::test_self_test_async_records tests/integration/test_recursive_orphan_chain.py::test_recursive_orphan_chain tests/test_self_test_service_health.py::test_health_endpoint tests/test_self_test_service_cleanup.py::test_cleanup_handles_missing_history -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '')*

------
https://chatgpt.com/codex/tasks/task_e_68c001cb073c832ea3314b5cb23a7c83