### PR TITLE
ci: run context builder check in path checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,8 @@ jobs:
         run: "python tools/check_static_paths.py $(git ls-files '*.py')"
       - name: Check for dynamic path references
         run: "python tools/check_dynamic_paths.py $(git ls-files '*.py')"
+      - name: Enforce ContextBuilder usage
+        run: python scripts/check_context_builder_usage.py
 
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- enforce ContextBuilder usage during path checks

## Testing
- `pre-commit run forbid-stripe-keys --files .github/workflows/tests.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c006dc5c50832e89efcd559ae6f190