### PR TITLE
Require explicit ContextBuilder in sandbox environment helpers

### DIFF
--- a/sandbox_runner/tests/test_orphan_cycle_integration.py
+++ b/sandbox_runner/tests/test_orphan_cycle_integration.py
@@ -34,12 +34,12 @@ def test_orphan_cycle_integration(tmp_path, monkeypatch):
     def fake_run_tests():
         calls["tests"] = True
 
-    def auto_include_modules(paths, recursive=True, router=None):
+    def auto_include_modules(paths, recursive=True, router=None, context_builder=None):
         fake_run_tests()
         calls["auto_include"] = list(paths)
         return object(), {"added": list(paths)}
 
-    def try_integrate_into_workflows(mods, router=None):
+    def try_integrate_into_workflows(mods, router=None, context_builder=None):
         calls["workflows"] = list(mods)
         return mods
 


### PR DESCRIPTION
## Summary
- require an explicit ContextBuilder in sandbox runner helpers
- propagate provided builder to error logging and workflow integration utilities
- adjust orphan integration and tests for new ContextBuilder requirement

## Testing
- `python -m py_compile sandbox_runner/environment.py sandbox_runner/orphan_integration.py sandbox_runner/tests/test_orphan_cycle_integration.py`
- `python scripts/check_context_builder_usage.py`
- `pytest sandbox_runner/tests/test_orphan_cycle_integration.py -q` *(fails: ModuleNotFoundError: No module named 'sandbox_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68c01082d6f0832e9e32e12e1a481159