### PR TITLE
Require explicit context builders for workflow integration helpers

### DIFF
--- a/menace_orchestrator.py
+++ b/menace_orchestrator.py
@@ -506,7 +506,9 @@ class MenaceOrchestrator:
                     added_modules: set[str] = set()
                     try:
                         _, tested = environment.auto_include_modules(
-                            sorted(modules), recursive=True
+                            sorted(modules),
+                            recursive=True,
+                            context_builder=self.context_builder,
                         )
                         added_modules.update(tested.get("added", []))
                     except Exception:

--- a/sandbox_runner/cycle.py
+++ b/sandbox_runner/cycle.py
@@ -617,7 +617,11 @@ def include_orphan_modules(ctx: "SandboxContext") -> None:
 
     try:
         tracker, tested = auto_include_modules(
-            sorted(candidates), recursive=True, validate=True, router=GLOBAL_ROUTER
+            sorted(candidates),
+            recursive=True,
+            validate=True,
+            router=GLOBAL_ROUTER,
+            context_builder=ctx.context_builder,
         )
     except Exception:
         logger.exception("auto include modules failed")

--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -4484,13 +4484,18 @@ class SelfImprovementEngine:
         added_modules: set[str] = set()
         try:
             _tracker, tested = environment.auto_include_modules(
-                sorted(modules), recursive=True, validate=True
+                sorted(modules),
+                recursive=True,
+                validate=True,
+                context_builder=self.self_coding_engine.context_builder,
             )
             added_modules.update(tested.get("added", []))
         except Exception:
             try:
                 _tracker, tested = environment.auto_include_modules(
-                    sorted(modules), recursive=True
+                    sorted(modules),
+                    recursive=True,
+                    context_builder=self.self_coding_engine.context_builder,
                 )
                 added_modules.update(tested.get("added", []))
             except Exception:
@@ -5377,7 +5382,10 @@ class SelfImprovementEngine:
                     added_modules: set[str] = set()
                     try:
                         _tracker, tested = environment.auto_include_modules(
-                            sorted(safe), recursive=True, validate=True
+                            sorted(safe),
+                            recursive=True,
+                            validate=True,
+                            context_builder=self.self_coding_engine.context_builder,
                         )
                         added_modules.update(tested.get("added", []))
                         try:
@@ -5395,7 +5403,9 @@ class SelfImprovementEngine:
                             except Exception:
                                 logger.exception("Unhandled exception in self_improvement")
                             environment.try_integrate_into_workflows(
-                                sorted(safe), **kwargs
+                                sorted(safe),
+                                **kwargs,
+                                context_builder=self.self_coding_engine.context_builder,
                             )
                         except Exception as exc:  # pragma: no cover - best effort
                             self.logger.exception(
@@ -5595,7 +5605,10 @@ class SelfImprovementEngine:
                 added_modules: set[str] = set()
                 try:
                     _tracker, tested = environment.auto_include_modules(
-                        sorted(safe), recursive=True, validate=True
+                        sorted(safe),
+                        recursive=True,
+                        validate=True,
+                        context_builder=self.self_coding_engine.context_builder,
                     )
                     added_modules.update(tested.get("added", []))
                     try:
@@ -5612,7 +5625,11 @@ class SelfImprovementEngine:
                                 }
                         except Exception:
                             logger.exception("Unhandled exception in self_improvement")
-                        environment.try_integrate_into_workflows(sorted(safe), **kwargs)
+                        environment.try_integrate_into_workflows(
+                            sorted(safe),
+                            **kwargs,
+                            context_builder=self.self_coding_engine.context_builder,
+                        )
                     except Exception as exc:  # pragma: no cover - best effort
                         self.logger.exception(
                             "workflow integration failed: %s", exc
@@ -5715,7 +5732,10 @@ class SelfImprovementEngine:
         added_modules: set[str] = set()
         try:
             _tracker, tested = environment.auto_include_modules(
-                sorted(redundant), recursive=True, validate=True
+                sorted(redundant),
+                recursive=True,
+                validate=True,
+                context_builder=self.self_coding_engine.context_builder,
             )
             added_modules.update(tested.get("added", []))
         except Exception as exc:  # pragma: no cover - best effort
@@ -5742,18 +5762,26 @@ class SelfImprovementEngine:
                 added_modules: set[str] = set()
                 try:
                     _tracker, tested = environment.auto_include_modules(
-                        sorted(passing), recursive=True, validate=True
+                        sorted(passing),
+                        recursive=True,
+                        validate=True,
+                        context_builder=self.self_coding_engine.context_builder,
                     )
                     added_modules.update(tested.get("added", []))
                 except Exception:
                     try:
                         _tracker, tested = auto_include_modules(
-                            sorted(passing), recursive=True, validate=True
+                            sorted(passing),
+                            recursive=True,
+                            validate=True,
+                            context_builder=self.self_coding_engine.context_builder,
                         )
                         added_modules.update(tested.get("added", []))
                     except TypeError:
                         _tracker, tested = auto_include_modules(
-                            sorted(passing), recursive=True
+                            sorted(passing),
+                            recursive=True,
+                            context_builder=self.self_coding_engine.context_builder,
                         )
                         added_modules.update(tested.get("added", []))
                     except Exception as exc:  # pragma: no cover - best effort
@@ -5879,7 +5907,10 @@ class SelfImprovementEngine:
                 abs_deps = [str(repo / p) for p in deps]
                 try:
                     _tracker, tested = environment.auto_include_modules(
-                        sorted(deps), recursive=True, validate=True
+                        sorted(deps),
+                        recursive=True,
+                        validate=True,
+                        context_builder=self.self_coding_engine.context_builder,
                     )
                     record_new = getattr(self, "_record_new_modules", None)
                     if record_new:
@@ -6813,7 +6844,10 @@ class SelfImprovementEngine:
                     added_modules: set[str] = set()
                     try:
                         _tracker, tested = environment.auto_include_modules(
-                            sorted(pending), recursive=True, validate=True
+                            sorted(pending),
+                            recursive=True,
+                            validate=True,
+                            context_builder=self.self_coding_engine.context_builder,
                         )
                         added_modules.update(tested.get("added", []))
                     except Exception as exc:  # pragma: no cover - best effort
@@ -6911,7 +6945,10 @@ class SelfImprovementEngine:
                     added_modules: set[str] = set()
                     try:
                         _tracker, tested = environment.auto_include_modules(
-                            sorted(passing), recursive=True, validate=True
+                            sorted(passing),
+                            recursive=True,
+                            validate=True,
+                            context_builder=self.self_coding_engine.context_builder,
                         )
                         added_modules.update(tested.get("added", []))
                     except Exception as exc:  # pragma: no cover - best effort

--- a/service_supervisor.py
+++ b/service_supervisor.py
@@ -424,7 +424,9 @@ class ServiceSupervisor:
             if added_modules:
                 try:
                     from sandbox_runner import try_integrate_into_workflows
-                    try_integrate_into_workflows(added_modules)
+                    try_integrate_into_workflows(
+                        added_modules, context_builder=self.context_builder
+                    )
                 except Exception as wf_exc:
                     self.logger.warning(
                         "workflow integration failed after patch: %s", wf_exc

--- a/tests/integration/test_auto_include_isolated_dependency.py
+++ b/tests/integration/test_auto_include_isolated_dependency.py
@@ -4,6 +4,7 @@ import types
 from pathlib import Path
 
 import pytest
+from context_builder_util import create_context_builder
 
 
 def _setup(monkeypatch, tmp_path, *, redundant=False):
@@ -58,10 +59,10 @@ def _setup(monkeypatch, tmp_path, *, redundant=False):
     import sandbox_runner.environment as env
     generated: list[list[str]] = []
     integrated: list[str] = []
-    def fake_generate(mods, workflows_db="workflows.db"):
+    def fake_generate(mods, workflows_db="workflows.db", context_builder=None):
         generated.append(sorted(mods))
         return [1]
-    def fake_integrate(mods):
+    def fake_integrate(mods, context_builder=None):
         integrated.extend(sorted(mods))
         data = json.loads(map_path.read_text())
         for m in mods:
@@ -76,7 +77,9 @@ def _setup(monkeypatch, tmp_path, *, redundant=False):
 
 def test_auto_include_isolated_dependency(tmp_path, monkeypatch):
     env, map_path, data_dir, generated, integrated = _setup(monkeypatch, tmp_path)
-    env.auto_include_modules(["iso.py"], recursive=True, validate=True)  # path-ignore
+    env.auto_include_modules(
+        ["iso.py"], recursive=True, validate=True, context_builder=create_context_builder()
+    )  # path-ignore
 
     assert generated and generated[0] == ["dep.py", "iso.py"]  # path-ignore
     assert integrated == ["dep.py", "iso.py"]  # path-ignore
@@ -89,7 +92,9 @@ def test_auto_include_isolated_dependency(tmp_path, monkeypatch):
 
 def test_auto_include_isolated_skips_redundant(tmp_path, monkeypatch):
     env, map_path, data_dir, generated, integrated = _setup(monkeypatch, tmp_path, redundant=True)
-    env.auto_include_modules(["iso.py"], recursive=True, validate=True)  # path-ignore
+    env.auto_include_modules(
+        ["iso.py"], recursive=True, validate=True, context_builder=create_context_builder()
+    )  # path-ignore
 
     assert generated and generated[0] == ["iso.py"]  # path-ignore
     assert integrated == ["iso.py"]  # path-ignore

--- a/tests/integration/test_orphan_pipeline_metrics.py
+++ b/tests/integration/test_orphan_pipeline_metrics.py
@@ -129,14 +129,17 @@ def test_orphan_pipelines_prune_and_record_metrics(tmp_path, monkeypatch):
 
     calls: dict[str, list[list[str]]] = {"include": [], "workflows": []}
 
-    def fake_auto_include(mods, recursive=False, validate=True):
+    def fake_auto_include(mods, recursive=False, validate=True, context_builder=None):
         calls["include"].append(sorted(mods))
         return [1]
 
-    def fake_try(mods):
+    def fake_try(mods, context_builder=None):
         calls["workflows"].append(sorted(mods))
 
-    env = types.SimpleNamespace(auto_include_modules=fake_auto_include, try_integrate_into_workflows=fake_try)
+    env = types.SimpleNamespace(
+        auto_include_modules=fake_auto_include,
+        try_integrate_into_workflows=fake_try,
+    )
     monkeypatch.setattr(sie, "environment", env)
 
     class DummySTS:

--- a/tests/integration/test_recursive_paths.py
+++ b/tests/integration/test_recursive_paths.py
@@ -82,7 +82,7 @@ def test_recursive_paths(tmp_path, monkeypatch):
 
     calls: list[list[str]] = []
 
-    def fake_auto_include(mods, recursive=False, validate=False):
+    def fake_auto_include(mods, recursive=False, validate=False, context_builder=None):
         calls.append(sorted(mods))
         return [1]
 
@@ -95,7 +95,7 @@ def test_recursive_paths(tmp_path, monkeypatch):
         for m in mods:
             data["modules"][Path(m).as_posix()] = 1
         map_path.write_text(json.dumps(data))
-        env_mod.auto_include_modules(mods, recursive=True)
+        env_mod.auto_include_modules(mods, recursive=True, context_builder=None)
 
     svc = sts.SelfTestService(
         include_orphans=True,

--- a/tests/test_auto_include_metrics.py
+++ b/tests/test_auto_include_metrics.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import sandbox_runner.environment as env
 from dynamic_path_router import resolve_path
+from context_builder_util import create_context_builder
 
 
 class DummyTracker:
@@ -45,7 +46,9 @@ def test_auto_include_modules_saves_roi(monkeypatch, tmp_path):
     )
 
     MOD = resolve_path("mod.py").as_posix()  # path-ignore
-    result, tested = env.auto_include_modules([MOD])
+    result, tested = env.auto_include_modules(
+        [MOD], context_builder=create_context_builder()
+    )
 
     assert result is tracker
     assert tested == {"added": [MOD], "failed": [], "redundant": []}

--- a/tests/test_auto_include_module_map.py
+++ b/tests/test_auto_include_module_map.py
@@ -7,6 +7,7 @@ import pytest
 
 import sandbox_runner.environment as env
 from dynamic_path_router import resolve_path
+from context_builder_util import create_context_builder
 
 MOD = resolve_path("mod.py").as_posix()  # path-ignore
 
@@ -59,7 +60,7 @@ def test_auto_include_updates_module_map(monkeypatch, tmp_path):
         ),
     )
 
-    env.auto_include_modules([MOD])
+    env.auto_include_modules([MOD], context_builder=create_context_builder())
 
     map_path = Path(tmp_path, "module_map.json")
     assert map_path.exists()
@@ -118,7 +119,7 @@ def test_auto_include_skips_existing(monkeypatch, tmp_path, existing):
     )
     monkeypatch.setenv("SANDBOX_RECURSIVE_ORPHANS", "0")
 
-    env.auto_include_modules([MOD])
+    env.auto_include_modules([MOD], context_builder=create_context_builder())
 
     assert json.loads(map_path.read_text()) == existing
     assert not called["gen"]
@@ -178,7 +179,9 @@ def test_redundant_module_validated_and_skipped(monkeypatch, tmp_path):
         ),
     )
 
-    result, tested = env.auto_include_modules([MOD], validate=True)
+    result, tested = env.auto_include_modules(
+        [MOD], validate=True, context_builder=create_context_builder()
+    )
 
     assert result is tracker
     assert calls.get("selftest") == MOD
@@ -242,7 +245,9 @@ def test_redundant_module_integrated_when_flag_set(monkeypatch, tmp_path):
         ),
     )
 
-    result, tested = env.auto_include_modules([MOD], validate=True)
+    result, tested = env.auto_include_modules(
+        [MOD], validate=True, context_builder=create_context_builder()
+    )
 
     assert result is tracker
     assert calls.get("selftest") == MOD
@@ -308,7 +313,9 @@ def test_module_skipped_below_roi_threshold(monkeypatch, tmp_path):
         ),
     )
 
-    result, tested = env.auto_include_modules([MOD])
+    result, tested = env.auto_include_modules(
+        [MOD], context_builder=create_context_builder()
+    )
 
     assert calls["integrate"] == []
     map_path = Path(tmp_path, "module_map.json")

--- a/tests/test_auto_include_recursive_validation.py
+++ b/tests/test_auto_include_recursive_validation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import sandbox_runner.environment as env
 from dynamic_path_router import resolve_path
+from context_builder_util import create_context_builder
 
 
 class DummyTracker:
@@ -61,7 +62,9 @@ def test_recursive_skips_redundant(monkeypatch, tmp_path):
 
     good = resolve_path(GOOD).as_posix()
     bad = resolve_path(BAD).as_posix()
-    result, tested = env.auto_include_modules([good, bad])
+    result, tested = env.auto_include_modules(
+        [good, bad], context_builder=create_context_builder()
+    )
 
     assert result is tracker
     assert tested == {"added": [bad, good], "failed": [], "redundant": [bad]}
@@ -126,7 +129,9 @@ def test_recursive_validated_integration(monkeypatch, tmp_path):
     )
 
     good = resolve_path(GOOD).as_posix()
-    result, tested = env.auto_include_modules([good], validate=True)
+    result, tested = env.auto_include_modules(
+        [good], validate=True, context_builder=create_context_builder()
+    )
 
     assert result is tracker
     assert tested == {"added": [good], "failed": [], "redundant": []}

--- a/tests/test_auto_include_roi_rollback.py
+++ b/tests/test_auto_include_roi_rollback.py
@@ -4,6 +4,7 @@ import types
 from pathlib import Path
 
 import sandbox_runner.environment as env
+from context_builder_util import create_context_builder
 
 
 class DummyTracker:
@@ -57,7 +58,9 @@ def test_auto_include_reverts_on_negative_roi(monkeypatch, tmp_path):
         ),
     )
 
-    result, tested = env.auto_include_modules(["mod.py"])  # path-ignore
+    result, tested = env.auto_include_modules(
+        ["mod.py"], context_builder=create_context_builder()
+    )  # path-ignore
 
     map_path = Path(tmp_path, "module_map.json")
     assert not map_path.exists()

--- a/tests/test_orphan_auto_indexing.py
+++ b/tests/test_orphan_auto_indexing.py
@@ -88,7 +88,7 @@ def test_generate_workflows_for_modules_auto_indexes(tmp_path, monkeypatch):
     monkeypatch.setitem(sys.modules, "sandbox_runner.orphan_discovery", orphan_mod)
 
     auto_called: dict[str, list[str]] = {}
-    def fake_auto(mods, recursive=True, router=None):
+    def fake_auto(mods, recursive=True, router=None, context_builder=None):
         auto_called["mods"] = list(mods)
         return None, {"added": ["extra/mod.py"]}  # path-ignore
     monkeypatch.setattr(env, "auto_include_modules", fake_auto)
@@ -182,7 +182,7 @@ def test_evolve_auto_indexes_promoted_orphans(tmp_path, monkeypatch):
     sys.modules["sandbox_runner"] = sr_pkg
 
     env_mod = types.ModuleType("sandbox_runner.environment")
-    def fake_auto(mods, recursive=True, validate=True, router=None):
+    def fake_auto(mods, recursive=True, validate=True, router=None, context_builder=None):
         auto_called["mods"] = list(mods)
         return None, {"added": ["extra/mod.py"]}  # path-ignore
     env_mod.auto_include_modules = fake_auto
@@ -190,7 +190,9 @@ def test_evolve_auto_indexes_promoted_orphans(tmp_path, monkeypatch):
 
     def integrate_orphans(repo, router=None):
         from sandbox_runner.environment import auto_include_modules
-        auto_include_modules(["extra/mod.py"], recursive=True, router=router)  # path-ignore
+        auto_include_modules(
+            ["extra/mod.py"], recursive=True, router=router, context_builder=None
+        )  # path-ignore
         from module_synergy_grapher import ModuleSynergyGrapher
         ModuleSynergyGrapher(repo).update_graph(["extra.mod"])
         from intent_clusterer import IntentClusterer

--- a/tests/test_orphan_inclusion_after_synthesis.py
+++ b/tests/test_orphan_inclusion_after_synthesis.py
@@ -35,11 +35,11 @@ def test_orphan_inclusion_after_synthesis(monkeypatch, tmp_path):
 
     auto_called: dict[str, list[str]] = {}
 
-    def fake_auto(paths, recursive=True, router=None):
+    def fake_auto(paths, recursive=True, router=None, context_builder=None):
         auto_called["auto"] = list(paths)
         return None, {"added": list(paths)}
 
-    def fake_try(mods, router=None):
+    def fake_try(mods, router=None, context_builder=None):
         auto_called["workflow"] = list(mods)
 
     env_mod = types.ModuleType("sandbox_runner.environment")
@@ -79,10 +79,14 @@ def test_orphan_inclusion_after_synthesis(monkeypatch, tmp_path):
             try_integrate_into_workflows,
         )
 
-        _, res = auto_include_modules(["extra/mod.py"], recursive=True, router=router)  # path-ignore
+        _, res = auto_include_modules(
+            ["extra/mod.py"], recursive=True, router=router, context_builder=None
+        )  # path-ignore
         added = res.get("added", [])
         if added:
-            try_integrate_into_workflows(sorted(added), router=router)
+            try_integrate_into_workflows(
+                sorted(added), router=router, context_builder=None
+            )
         return added, True, True
 
     pkg = types.ModuleType("sandbox_runner")

--- a/tests/test_orphan_integration_rounds.py
+++ b/tests/test_orphan_integration_rounds.py
@@ -152,11 +152,11 @@ def test_quick_fix_patch_cycle_indexes_orphans(tmp_path, monkeypatch):
     # Stub orphan integration utilities
     auto_called: dict[str, list[str]] = {}
 
-    def fake_auto(paths, recursive=True, router=None):
+    def fake_auto(paths, recursive=True, router=None, context_builder=None):
         auto_called["mods"] = list(paths)
         return None, {"added": list(paths)}
 
-    def fake_try(mods, router=None):
+    def fake_try(mods, router=None, context_builder=None):
         auto_called["workflow"] = list(mods)
 
     env_mod = types.ModuleType("sandbox_runner.environment")
@@ -203,12 +203,19 @@ def test_quick_fix_patch_cycle_indexes_orphans(tmp_path, monkeypatch):
             try_integrate_into_workflows,
         )
 
-        auto_include_modules(["extra/mod.py"], recursive=True, router=router)  # path-ignore
+        auto_include_modules(
+            ["extra/mod.py"],
+            recursive=True,
+            router=router,
+            context_builder=None,
+        )  # path-ignore
         from module_synergy_grapher import ModuleSynergyGrapher
         ModuleSynergyGrapher(repo).update_graph(["extra.mod"])
         from intent_clusterer import IntentClusterer
         IntentClusterer(None, None).index_modules([Path(repo) / "extra/mod.py"])  # path-ignore
-        try_integrate_into_workflows(["extra/mod.py"], router=router)  # path-ignore
+        try_integrate_into_workflows(
+            ["extra/mod.py"], router=router, context_builder=None
+        )  # path-ignore
         return ["extra/mod.py"], True, True  # path-ignore
 
     pkg = types.ModuleType("sandbox_runner")

--- a/tests/test_post_round_orphan_scan_invocations.py
+++ b/tests/test_post_round_orphan_scan_invocations.py
@@ -226,10 +226,10 @@ def test_new_module_included_after_scan(monkeypatch, tmp_path):
 
     workflow_list: list[str] = []
 
-    def auto_include_modules(paths, recursive=True, router=None):
+    def auto_include_modules(paths, recursive=True, router=None, context_builder=None):
         return None, {"added": list(paths)}
 
-    def try_integrate_into_workflows(mods, router=None):
+    def try_integrate_into_workflows(mods, router=None, context_builder=None):
         workflow_list.extend(mods)
 
     env_mod = types.ModuleType("sandbox_runner.environment")

--- a/tests/test_post_synthesis_orphan_inclusion.py
+++ b/tests/test_post_synthesis_orphan_inclusion.py
@@ -73,7 +73,7 @@ def test_post_synthesis_orphan_inclusion(monkeypatch, tmp_path):
     ic_mod.IntentClusterer = DummyClusterer
     monkeypatch.setitem(sys.modules, "intent_clusterer", ic_mod)
 
-    def auto_include_modules(paths, recursive=True, router=None):
+    def auto_include_modules(paths, recursive=True, router=None, context_builder=None):
         data = json.loads(module_map_path.read_text())
         modules = data.get("modules", data)
         for p in paths:
@@ -92,7 +92,9 @@ def test_post_synthesis_orphan_inclusion(monkeypatch, tmp_path):
 
     def integrate_orphans(repo_path, router=None):
         from sandbox_runner.environment import auto_include_modules
-        auto_include_modules(["helper.py", "new_module.py"])  # path-ignore
+        auto_include_modules(
+            ["helper.py", "new_module.py"], context_builder=None
+        )  # path-ignore
         return ["helper.py", "new_module.py"]  # path-ignore
 
     pkg = types.ModuleType("sandbox_runner")

--- a/tests/test_recursive_inclusion_integration.py
+++ b/tests/test_recursive_inclusion_integration.py
@@ -4,6 +4,7 @@ import types
 from pathlib import Path
 
 import sandbox_runner.environment as env
+from context_builder_util import create_context_builder
 
 
 class DummyTracker:
@@ -78,7 +79,9 @@ def test_recursive_inclusion_integration(tmp_path, monkeypatch):
     monkeypatch.setattr(env, "try_integrate_into_workflows", lambda mods: None)
     monkeypatch.setattr(env, "run_workflow_simulations", lambda *a, **k: DummyTracker())
 
-    env.auto_include_modules(["iso.py"], recursive=True, validate=True)  # path-ignore
+    env.auto_include_modules(
+        ["iso.py"], recursive=True, validate=True, context_builder=create_context_builder()
+    )  # path-ignore
 
     map_data = json.loads((data_dir / "module_map.json").read_text())
     assert set(map_data) == {"iso.py", "helper.py"}  # path-ignore

--- a/tests/test_recursive_orphans.py
+++ b/tests/test_recursive_orphans.py
@@ -50,17 +50,17 @@ def _load_methods():
         ),
         "classify_module": lambda path, include_meta=True: ("candidate", {}),
         "build_module_map": lambda repo, ignore=None: {},
-        "generate_workflows_for_modules": lambda mods: None,
-        "try_integrate_into_workflows": lambda mods: None,
+        "generate_workflows_for_modules": lambda mods, context_builder=None: None,
+        "try_integrate_into_workflows": lambda mods, context_builder=None: None,
         "run_workflow_simulations": lambda *a, **k: None,
         "run_repo_section_simulations": _run_repo_section_simulations,
         "log_record": lambda **k: k,
         "analyze_redundancy": lambda p: False,
     }
-    def auto_include_modules(mods, recursive=False):
-        generate_workflows_for_modules(mods)
-        try_integrate_into_workflows(mods)
-        run_workflow_simulations()
+    def auto_include_modules(mods, recursive=False, context_builder=None):
+        generate_workflows_for_modules(mods, context_builder=context_builder)
+        try_integrate_into_workflows(mods, context_builder=context_builder)
+        run_workflow_simulations(context_builder=context_builder)
     mod_dict["auto_include_modules"] = auto_include_modules
     mod_dict["environment"] = types.SimpleNamespace(
         auto_include_modules=auto_include_modules

--- a/tests/test_repo_root_overrides.py
+++ b/tests/test_repo_root_overrides.py
@@ -5,6 +5,7 @@ import types
 from pathlib import Path
 
 import pytest
+from context_builder_util import create_context_builder
 
 
 class ContextBuilder:
@@ -68,7 +69,9 @@ def test_environment_respects_sandbox_repo_path(tmp_path, monkeypatch):
     called = []
     monkeypatch.setattr(env, "integrate_new_orphans", lambda repo, router=None: called.append(repo))
 
-    env.try_integrate_into_workflows([str(mod.resolve())])
+    env.try_integrate_into_workflows(
+        [str(mod.resolve())], context_builder=create_context_builder()
+    )
 
     assert called and called[0] == repo.resolve()
     assert records and records[0].workflow == ["submodule.helper"]

--- a/tests/test_self_test_service_recursive_integration.py
+++ b/tests/test_self_test_service_recursive_integration.py
@@ -139,7 +139,7 @@ def _load_refresh_methods(fake_generate, fake_try, fake_run=lambda *a, **k: None
         "log_record": lambda **k: {},
         "analyze_redundancy": lambda p: False,
     }
-    def auto_include_modules(mods, recursive=False):
+    def auto_include_modules(mods, recursive=False, context_builder=None):
         fake_generate(mods)
         fake_try(mods)
         fake_run()


### PR DESCRIPTION
## Summary
- propagate context_builder to auto-inclusion and workflow integration helpers
- ensure supervisor, orchestrator, and runner provide their builders
- update tests to supply context_builder or accept it in stubs

## Testing
- `python scripts/check_context_builder_usage.py`
- `pytest tests/test_auto_include_module_map.py tests/test_workflow_update.py sandbox_runner/tests/test_orphan_cycle_integration.py -q` *(fails: AttributeError: <module 'sandbox_runner.environment'> has no attribute 'generate_workflows_for_modules')*


------
https://chatgpt.com/codex/tasks/task_e_68c0190681ec832e910cc9cb27fc505f