### PR TITLE
Ensure sandbox helpers require explicit ContextBuilder

### DIFF
--- a/automated_debugger.py
+++ b/automated_debugger.py
@@ -208,7 +208,9 @@ class AutomatedDebugger:
                 try:
                     from sandbox_runner import integrate_new_orphans  # type: ignore
 
-                    integrate_new_orphans(Path.cwd())
+                    integrate_new_orphans(
+                        Path.cwd(), context_builder=self.context_builder
+                    )
                 except Exception:
                     self.logger.exception(
                         "integrate_new_orphans after apply_patch failed",

--- a/error_logger.py
+++ b/error_logger.py
@@ -755,7 +755,11 @@ class ErrorLogger:
                         try:
                             from sandbox_runner import integrate_new_orphans
 
-                            integrate_new_orphans(Path.cwd(), router=GLOBAL_ROUTER)
+                            integrate_new_orphans(
+                                Path.cwd(),
+                                router=GLOBAL_ROUTER,
+                                context_builder=self.context_builder,
+                            )
                         except Exception as e2:  # pragma: no cover - integration issues
                             self.logger.error(
                                 "integrate_new_orphans after patch for %s failed: %s",

--- a/module_retirement_service.py
+++ b/module_retirement_service.py
@@ -101,7 +101,9 @@ class ModuleRetirementService:
                 try:
                     from sandbox_runner import integrate_new_orphans
 
-                    integrate_new_orphans(self.root)
+                    integrate_new_orphans(
+                        self.root, context_builder=self._context_builder
+                    )
                 except Exception:
                     self.logger.exception(
                         "integrate_new_orphans after compression failed"
@@ -133,7 +135,9 @@ class ModuleRetirementService:
                 try:
                     from sandbox_runner import integrate_new_orphans
 
-                    integrate_new_orphans(self.root)
+                    integrate_new_orphans(
+                        self.root, context_builder=self._context_builder
+                    )
                 except Exception:
                     self.logger.exception(
                         "integrate_new_orphans after replacement failed"

--- a/quick_fix_engine.py
+++ b/quick_fix_engine.py
@@ -335,7 +335,7 @@ def generate_patch(
             try:
                 from sandbox_runner import post_round_orphan_scan
 
-                post_round_orphan_scan(Path.cwd())
+                post_round_orphan_scan(Path.cwd(), context_builder=builder)
             except Exception:
                 logger.exception(
                     "post_round_orphan_scan after preemptive patch failed"

--- a/sandbox_runner/post_update.py
+++ b/sandbox_runner/post_update.py
@@ -8,18 +8,23 @@ from .orphan_integration import integrate_and_graph_orphans
 logger = get_logger(__name__)
 
 
-def integrate_orphans(repo: Path, router=None) -> list[str]:
+def integrate_orphans(
+    repo: Path,
+    router=None,
+    *,
+    context_builder: "ContextBuilder",
+) -> list[str]:
     """Integrate newly created orphan modules.
 
     This function now delegates to
     :func:`sandbox_runner.orphan_integration.integrate_and_graph_orphans`
     so that discovery, module inclusion and graph updates follow a single
-    implementation.
+    implementation. ``context_builder`` is forwarded to that helper.
     """
 
     try:
         _, tested, _, _, _ = integrate_and_graph_orphans(
-            repo, logger=logger, router=router
+            repo, logger=logger, router=router, context_builder=context_builder
         )
     except Exception:  # pragma: no cover - best effort
         logger.exception("orphan integration failed")

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -2647,7 +2647,9 @@ class SelfCodingEngine:
                     self.logger.exception("git push failed: %s", exc)
             try:
                 from sandbox_runner import post_round_orphan_scan
-                post_round_orphan_scan(Path.cwd(), router=self.router)
+                post_round_orphan_scan(
+                    Path.cwd(), router=self.router, context_builder=self.context_builder
+                )
             except Exception:
                 self.logger.exception(
                     "post_round_orphan_scan after apply_patch failed"

--- a/self_debugger_sandbox.py
+++ b/self_debugger_sandbox.py
@@ -442,7 +442,10 @@ class SelfDebuggerSandbox(AutomatedDebugger):
                     if patch_id is not None:
                         try:
                             post_round_orphan_scan(
-                                Path.cwd(), logger=self.logger, router=router
+                                Path.cwd(),
+                                logger=self.logger,
+                                router=router,
+                                context_builder=self.context_builder,
                             )
                         except Exception:
                             self.logger.exception(
@@ -1951,7 +1954,10 @@ class SelfDebuggerSandbox(AutomatedDebugger):
                     )
                     try:
                         post_round_orphan_scan(
-                            Path.cwd(), logger=self.logger, router=router
+                            Path.cwd(),
+                            logger=self.logger,
+                            router=router,
+                            context_builder=self.context_builder,
                         )
                     except Exception:
                         self.logger.exception(

--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -2336,7 +2336,11 @@ class SelfImprovementEngine:
                                     )
                                     try:
                                         repo = resolve_path(".")
-                                        self._sandbox_integrate(repo, router=GLOBAL_ROUTER)
+                                        self._sandbox_integrate(
+                                            repo,
+                                            router=GLOBAL_ROUTER,
+                                            context_builder=self.self_coding_engine.context_builder,
+                                        )
                                     except Exception:
                                         self.logger.exception(
                                             "post_patch_orphan_integration_failed"
@@ -5009,6 +5013,7 @@ class SelfImprovementEngine:
                 modules=sorted(mods),
                 logger=self.logger,
                 router=GLOBAL_ROUTER,
+                context_builder=self.self_coding_engine.context_builder,
             )
             if updated_wfs:
                 try:
@@ -5228,7 +5233,10 @@ class SelfImprovementEngine:
         repo = _repo_path()
         try:
             added, syn_ok, intent_ok = self._post_round_scan(
-                repo, logger=self.logger, router=GLOBAL_ROUTER
+                repo,
+                logger=self.logger,
+                router=GLOBAL_ROUTER,
+                context_builder=self.self_coding_engine.context_builder,
             )
         except RuntimeError as exc:
             self.logger.error("post_round_orphan_scan unavailable: %s", exc)
@@ -6029,7 +6037,11 @@ class SelfImprovementEngine:
                         )
                         try:
                             repo = resolve_path(".")
-                            self._sandbox_integrate(repo, router=GLOBAL_ROUTER)
+                            self._sandbox_integrate(
+                                repo,
+                                router=GLOBAL_ROUTER,
+                                context_builder=self.self_coding_engine.context_builder,
+                            )
                         except Exception:
                             self.logger.exception(
                                 "post_patch_orphan_integration_failed"
@@ -6078,7 +6090,11 @@ class SelfImprovementEngine:
                     extra=log_record(module=mod),
                 )
                 repo = resolve_path(".")
-                self._sandbox_integrate(repo, router=GLOBAL_ROUTER)
+                self._sandbox_integrate(
+                    repo,
+                    router=GLOBAL_ROUTER,
+                    context_builder=self.self_coding_engine.context_builder,
+                )
             except Exception:
                 self.logger.exception(
                     "post_patch_orphan_discovery_failed",
@@ -6179,7 +6195,11 @@ class SelfImprovementEngine:
                             )
                             try:
                                 repo = resolve_path(".")
-                                self._sandbox_integrate(repo, router=GLOBAL_ROUTER)
+                                self._sandbox_integrate(
+                                    repo,
+                                    router=GLOBAL_ROUTER,
+                                    context_builder=self.self_coding_engine.context_builder,
+                                )
                             except Exception:
                                 self.logger.exception(
                                     "post_patch_orphan_integration_failed"
@@ -6228,7 +6248,11 @@ class SelfImprovementEngine:
                         extra=log_record(module=mod),
                     )
                     repo = resolve_path(".")
-                    self._sandbox_integrate(repo, router=GLOBAL_ROUTER)
+                    self._sandbox_integrate(
+                        repo,
+                        router=GLOBAL_ROUTER,
+                        context_builder=self.self_coding_engine.context_builder,
+                    )
                 except Exception:
                     self.logger.exception(
                         "post_patch_orphan_discovery_failed",
@@ -6870,7 +6894,11 @@ class SelfImprovementEngine:
 
                 try:
                     repo = resolve_path(".")
-                    self._sandbox_integrate(repo, router=GLOBAL_ROUTER)
+                    self._sandbox_integrate(
+                        repo,
+                        router=GLOBAL_ROUTER,
+                        context_builder=self.self_coding_engine.context_builder,
+                    )
                 except Exception as exc:  # pragma: no cover - best effort
                     self.logger.exception(
                         "recursive orphan inclusion failed: %s", exc

--- a/workflow_evolution_manager.py
+++ b/workflow_evolution_manager.py
@@ -21,6 +21,7 @@ from . import workflow_run_summary
 from . import sandbox_runner
 from .workflow_synergy_comparator import WorkflowSynergyComparator
 from .meta_workflow_planner import MetaWorkflowPlanner
+from context_builder_util import create_context_builder
 try:  # pragma: no cover - optional dependency
     from vector_service.context_builder import ContextBuilder  # type: ignore
 except Exception:  # pragma: no cover - allow running without builder
@@ -714,7 +715,8 @@ def evolve(
             integrate_orphans = None  # type: ignore
         if integrate_orphans is not None:
             repo = get_project_root()
-            integrate_orphans(repo, router=GLOBAL_ROUTER)
+            builder = create_context_builder()
+            integrate_orphans(repo, router=GLOBAL_ROUTER, context_builder=builder)
 
         # Deduplicate against existing stable workflows
         comparator = WorkflowSynergyComparator()

--- a/workflow_synthesizer.py
+++ b/workflow_synthesizer.py
@@ -51,6 +51,7 @@ from typing import (
     get_origin,
     get_type_hints,
 )
+from context_builder_util import create_context_builder
 
 try:  # pragma: no cover - allow running as script
     from .dynamic_path_router import resolve_path  # type: ignore
@@ -1381,8 +1382,9 @@ class WorkflowSynthesizer:
         try:
             import sandbox_runner
 
+            builder = create_context_builder()
             added, syn_ok, intent_ok = sandbox_runner.post_round_orphan_scan(
-                Path.cwd(), router=GLOBAL_ROUTER
+                Path.cwd(), router=GLOBAL_ROUTER, context_builder=builder
             )
             logger.info(
                 "post_round_orphan_scan added=%d synergy_ok=%s intent_ok=%s",
@@ -1749,8 +1751,9 @@ def generate_workflow_variants(
         try:  # pragma: no cover - optional dependency
             import sandbox_runner
 
+            builder = create_context_builder()
             added, syn_ok, intent_ok = sandbox_runner.post_round_orphan_scan(
-                Path.cwd(), router=GLOBAL_ROUTER
+                Path.cwd(), router=GLOBAL_ROUTER, context_builder=builder
             )
             logger.info(
                 "post_round_orphan_scan added=%d synergy_ok=%s intent_ok=%s",
@@ -1888,8 +1891,9 @@ def generate_variants(
         try:  # pragma: no cover - optional dependency
             import sandbox_runner
 
+            builder = create_context_builder()
             added, syn_ok, intent_ok = sandbox_runner.post_round_orphan_scan(
-                Path.cwd(), router=GLOBAL_ROUTER
+                Path.cwd(), router=GLOBAL_ROUTER, context_builder=builder
             )
             logger.info(
                 "post_round_orphan_scan added=%d synergy_ok=%s intent_ok=%s",


### PR DESCRIPTION
## Summary
- require a ContextBuilder for orphan integration helpers
- thread builder through sandbox environment utilities and orchestrators
- forward builders when invoking post-round scans and orphan integration

## Testing
- `python scripts/check_context_builder_usage.py`

------
https://chatgpt.com/codex/tasks/task_e_68c01ff4e4b0832e86ed6bd2b549c815