### PR TITLE
Pass vector metadata to escalation

### DIFF
--- a/auto_escalation_manager.py
+++ b/auto_escalation_manager.py
@@ -132,6 +132,7 @@ class AutoEscalationManager:
         message: str,
         attachments: Iterable[str] | None = None,
         session_id: str | None = None,
+        vector_metadata: list[tuple[str, str, float]] | None = None,
     ) -> None:
         """Attempt automated recovery actions."""
         try:


### PR DESCRIPTION
## Summary
- Request retrieval vectors from context builder when escalating critical reviews
- Forward compressed context and vector metadata to the escalation manager
- Accept optional vector metadata in AutoEscalationManager.handle

## Testing
- `PYTHONPATH=. pytest tests/test_automated_reviewer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c026710c6c832ea6d912e34d045c84