### PR TITLE
feat: generalize text before embedding

### DIFF
--- a/embeddable_db_mixin.py
+++ b/embeddable_db_mixin.py
@@ -25,6 +25,7 @@ from security.secret_redactor import redact
 from analysis.semantic_diff_filter import find_semantic_risks
 from governed_embeddings import governed_embed
 from chunking import split_into_chunks, summarize_snippet
+from vector_service.text_preprocessor import generalise
 
 # Lightweight license detection based on SPDX‑style fingerprints.  This avoids
 # embedding content that is under GPL or non‑commercial restrictions.
@@ -209,11 +210,12 @@ class EmbeddableDBMixin:
         summaries: List[str] = []
         for ch in chunks:
             try:
-                summaries.append(
-                    summarize_snippet(ch.text, context_builder=builder)
-                )
+                summary = summarize_snippet(ch.text, context_builder=builder)
             except Exception:  # pragma: no cover - summariser issues
-                summaries.append(ch.text)
+                summary = ch.text
+            summary = generalise(summary)
+            if summary:
+                summaries.append(summary)
         return " ".join(s for s in summaries if s)
 
     # ------------------------------------------------------------------

--- a/tests/test_text_preprocessor.py
+++ b/tests/test_text_preprocessor.py
@@ -1,0 +1,29 @@
+import importlib.util
+from pathlib import Path
+
+
+# Import module directly to avoid executing heavy package-level imports
+spec = importlib.util.spec_from_file_location(
+    "text_preprocessor",
+    Path(__file__).resolve().parents[1] / "vector_service" / "text_preprocessor.py",
+)
+text_preprocessor = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(text_preprocessor)
+generalise = text_preprocessor.generalise
+
+
+def test_generalise_shorter_and_semantic():
+    text = "The quick brown foxes were jumping quickly over the lazy dogs."
+    result = generalise(text)
+
+    # Output should be lowercase and shorter
+    assert result == result.lower()
+    assert len(result.split()) < len(text.split())
+
+    tokens = set(result.split())
+    # Core meaning should be preserved
+    assert {"quick", "brown"} <= tokens
+    assert tokens.intersection({"fox", "foxes"})
+    assert tokens.intersection({"dog", "dogs"})
+    assert "the" not in tokens

--- a/vector_service/text_preprocessor.py
+++ b/vector_service/text_preprocessor.py
@@ -1,0 +1,100 @@
+"""Utility functions for text preprocessing before embedding.
+
+This module exposes :func:`generalise` which performs basic text
+normalisation such as lowercasing, stop word removal and optional
+lemmatisation.  The lemmatisation step is attempted if NLTK is available
+with the required corpora; otherwise the function gracefully degrades to
+simple stop word removal.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+# A tiny English stop word list.  This keeps the implementation light and
+# avoids pulling in heavy dependencies for the common case.
+_STOP_WORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "by",
+    "for",
+    "from",
+    "has",
+    "he",
+    "in",
+    "is",
+    "it",
+    "its",
+    "of",
+    "on",
+    "that",
+    "the",
+    "to",
+    "was",
+    "were",
+    "will",
+    "with",
+}
+
+try:  # pragma: no cover - optional dependency
+    from nltk.stem import WordNetLemmatizer  # type: ignore
+    from nltk.corpus import wordnet  # type: ignore  # noqa: F401
+
+    _LEMMATIZER = WordNetLemmatizer()
+except Exception:  # pragma: no cover - nltk or data missing
+    _LEMMATIZER = None  # type: ignore
+
+
+def _lemmatise(token: str) -> str:
+    """Return the lemmatised form of ``token`` if possible."""
+
+    if _LEMMATIZER is None:  # pragma: no cover - fallback path
+        return token
+    try:  # pragma: no cover - best effort
+        return _LEMMATIZER.lemmatize(token)
+    except Exception:
+        return token
+
+
+def generalise(text: str) -> str:
+    """Return a condensed representation of ``text``.
+
+    The function performs the following steps:
+
+    * lowercases the input text
+    * tokenises on word boundaries
+    * removes common English stop words
+    * optionally lemmatises tokens when NLTK and its WordNet data are
+      available
+
+    Parameters
+    ----------
+    text:
+        The input text to normalise.
+
+    Returns
+    -------
+    str
+        A space separated string of processed tokens.
+    """
+
+    if not isinstance(text, str):  # pragma: no cover - defensive
+        return text
+
+    tokens = re.findall(r"\b\w+\b", text.lower())
+    processed = []
+    for tok in tokens:
+        if tok in _STOP_WORDS:
+            continue
+        tok = _lemmatise(tok)
+        processed.append(tok)
+    return " ".join(processed)
+
+
+__all__ = ["generalise"]


### PR DESCRIPTION
## Summary
- add `generalise` text preprocessing with stop-word removal, lowercasing and optional lemmatisation
- invoke `generalise` on chunk summaries before encoding
- test `generalise` ensures shorter text while retaining key meaning

## Testing
- `pytest menace_sandbox/tests/test_text_preprocessor.py -q --import-mode=importlib --noconftest` *(fails: ModuleNotFoundError: No module named 'context_builder_util')*

------
https://chatgpt.com/codex/tasks/task_e_68c031b1ece0832ebe76ff7116b9cfc0