### PR TITLE
Refactor embedding preparation with metadata-aware preprocessing

### DIFF
--- a/bot_database.py
+++ b/bot_database.py
@@ -556,10 +556,16 @@ class BotDB(EmbeddableDBMixin):
                 if isinstance(tc_val, str)
                 else list(tc_val)
             )
-        text = " ".join(
-            filter(None, [purpose, ",".join(tags), ",".join(toolchain)])
-        )
-        return self.encode_text(text)
+        parts: list[str] = []
+        if purpose:
+            parts.append(f"purpose: {purpose}")
+        if tags:
+            parts.append("tags: " + ",".join(tags))
+        if toolchain:
+            parts.append("toolchain: " + ",".join(toolchain))
+        text = "\n".join(parts)
+        prepared = self._prepare_text_for_embedding(text)
+        return self.encode_text(prepared) if prepared else []
 
     def search_by_vector(
         self,

--- a/task_handoff_bot.py
+++ b/task_handoff_bot.py
@@ -211,12 +211,22 @@ class WorkflowDB(EmbeddableDBMixin):
         sequence = rec.task_sequence if rec.workflow != rec.task_sequence else []
         parts: list[str] = []
         if actions:
-            parts.append(" -> ".join(actions))
+            parts.append("workflow: " + " -> ".join(actions))
         if sequence:
             parts.append("sequence: " + " -> ".join(sequence))
         if rec.argument_strings:
             parts.append("args: " + ", ".join(rec.argument_strings))
-        return " | ".join(parts)
+        if rec.title:
+            parts.append(f"title: {rec.title}")
+        if rec.description:
+            parts.append(f"description: {rec.description}")
+        if rec.tags:
+            parts.append("tags: " + ", ".join(rec.tags))
+        if rec.category:
+            parts.append(f"category: {rec.category}")
+        if rec.type_:
+            parts.append(f"type: {rec.type_}")
+        return "\n".join(parts)
 
     def usage_rate(self, workflow_id: int) -> int:
         """Return count of bots using a workflow.
@@ -509,7 +519,8 @@ class WorkflowDB(EmbeddableDBMixin):
         elif not isinstance(rec, WorkflowRecord):
             raise TypeError("unsupported record type")
         text = self._vector_text(rec)
-        return self._embed(text)
+        prepared = self._prepare_text_for_embedding(text)
+        return self._embed(prepared)
 
     def _embed(self, text: str) -> list[float]:
         """Encode ``text`` to a vector (overridable for tests)."""


### PR DESCRIPTION
## Summary
- Replace legacy `_embed_text` calls with `_prepare_text_for_embedding` across code, bot, error and workflow databases
- Assemble metadata-rich text (tags, template types, etc.) before embedding for improved weighting
- Normalize vector routines to preprocess text consistently

## Testing
- `pytest bot_database.py code_database.py error_bot.py task_handoff_bot.py -q` *(fails: ModuleNotFoundError: No module named 'context_builder_util')*
- `PYTHONPATH=$PWD pytest bot_database.py code_database.py error_bot.py task_handoff_bot.py -q` *(fails: RuntimeError: vector_service import failed)*
- `python -m py_compile bot_database.py code_database.py error_bot.py task_handoff_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0331a3204832ea620837ca89f9c02