### PR TITLE
Add vector database service daemon

### DIFF
--- a/docs/vector_service_api.md
+++ b/docs/vector_service_api.md
@@ -86,3 +86,21 @@ Response:
 
 All endpoints return HTTP 500 with a `detail` message if the underlying
 service raises a `VectorServiceError`.
+
+## Vector Database Service
+
+`vector_service.vector_database_service` provides a lightweight daemon for
+embedding records and querying stored vectors. Start it with:
+
+```bash
+python -m vector_service
+```
+
+The service exposes three endpoints:
+
+* `POST /add` – vectorises a record and stores the embedding.
+* `POST /query` – returns the nearest neighbours for a supplied record.
+* `GET /status` – simple health check.
+
+Bots should call the `GET /status` endpoint and ensure the daemon is running
+before invoking `ContextBuilder` or issuing database queries.

--- a/vector_service/__main__.py
+++ b/vector_service/__main__.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""Entry point for running the vector database service.
+
+This module allows the service to be started via ``python -m vector_service``.
+Configuration is intentionally minimal; host and port or a Unix domain socket
+can be specified through environment variables.
+"""
+
+import os
+import uvicorn
+
+
+def main() -> None:
+    target = os.environ.get("VECTOR_SERVICE_SOCKET")
+    if target:
+        config = uvicorn.Config(
+            "vector_service.vector_database_service:app",
+            uds=target,
+            log_level="info",
+        )
+    else:
+        host = os.environ.get("VECTOR_SERVICE_HOST", "127.0.0.1")
+        port = int(os.environ.get("VECTOR_SERVICE_PORT", "8000"))
+        config = uvicorn.Config(
+            "vector_service.vector_database_service:app",
+            host=host,
+            port=port,
+            log_level="info",
+        )
+    uvicorn.Server(config).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/vector_service/vector_database_service.py
+++ b/vector_service/vector_database_service.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+"""Minimal service exposing vector database operations.
+
+Provides simple HTTP endpoints for adding records, querying existing
+embeddings and checking service health.  A background thread calls
+:func:`watch_databases` so newly added database records are continuously
+embedded.
+
+The service is intentionally lightweight; it is expected to run as a
+separate daemon which other bots can interact with over HTTP or a UNIX
+domain socket.
+"""
+
+from typing import Any, Dict
+import threading
+import logging
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .vectorizer import SharedVectorService
+from .embedding_backfill import watch_databases
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI()
+svc = SharedVectorService()
+
+
+def _watcher() -> None:
+    try:
+        watch_databases()
+    except Exception:  # pragma: no cover - best effort
+        logger.exception("watch_databases terminated unexpectedly")
+
+
+@app.on_event("startup")
+def _start_watcher() -> None:
+    thread = threading.Thread(target=_watcher, daemon=True)
+    thread.start()
+    app.state.watch_thread = thread
+
+
+class AddRequest(BaseModel):
+    kind: str
+    record_id: str
+    record: Dict[str, Any]
+    origin_db: str | None = None
+    metadata: Dict[str, Any] | None = None
+
+
+@app.post("/add")
+def add(req: AddRequest) -> Dict[str, Any]:
+    vec = svc.vectorise_and_store(
+        req.kind,
+        req.record_id,
+        req.record,
+        origin_db=req.origin_db,
+        metadata=req.metadata,
+    )
+    return {"status": "ok", "vector": vec}
+
+
+class QueryRequest(BaseModel):
+    kind: str
+    record: Dict[str, Any]
+    top_k: int = 5
+
+
+@app.post("/query")
+def query(req: QueryRequest) -> Dict[str, Any]:
+    vec = svc.vectorise(req.kind, req.record)
+    if svc.vector_store is None:
+        raise HTTPException(status_code=500, detail="Vector store not configured")
+    results = svc.vector_store.query(vec, top_k=req.top_k)
+    return {"status": "ok", "data": results}
+
+
+@app.get("/status")
+def status() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+__all__ = ["app"]


### PR DESCRIPTION
## Summary
- add FastAPI vector database service with add/query/status endpoints and background embedding watcher
- support launching service via `python -m vector_service`
- document daemon usage and advising bots to verify service before ContextBuilder

## Testing
- `PYTHONPATH=. pre-commit run --files vector_service/vector_database_service.py vector_service/__main__.py docs/vector_service_api.md` *(fails: check-static-paths, forbid-raw-stripe-usage)*
- `PYTHONPATH=. pytest tests/test_vector_service_api.py` *(skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c03641f24c832e8d5bcce384d26a74