### PR TITLE
feat: add vector database service daemon

### DIFF
--- a/vector_service/context_builder.py
+++ b/vector_service/context_builder.py
@@ -14,6 +14,7 @@ import asyncio
 import uuid
 import time
 import threading
+import os
 
 from dynamic_path_router import resolve_path
 
@@ -201,6 +202,7 @@ class ContextBuilder:
                 metric=similarity_metric,
                 enhancement_weight=enhancement_weight,
                 context_builder=self,
+                service_url=os.environ.get("VECTOR_SERVICE_URL"),
             )
         else:
             self.patch_retriever = patch_retriever


### PR DESCRIPTION
## Summary
- add async FastAPI daemon wrapping SharedVectorService with vectorise and search endpoints
- allow SharedVectorService, PatchRetriever and ContextBuilder to call daemon when `VECTOR_SERVICE_URL` is set

## Testing
- `pytest tests/test_vectorizer_text_embeddings.py -q` *(fails: ImportError: cannot import name 'AutoModel' from 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_68c0c4e0e87c832e8a4e2fa2b93b6c1c