### PR TITLE
Add embedding staleness check and integrate with daemon

### DIFF
--- a/vector_service/vector_database_service.py
+++ b/vector_service/vector_database_service.py
@@ -30,7 +30,7 @@ from pydantic import BaseModel
 import uvicorn
 
 from .vectorizer import SharedVectorService
-from .embedding_backfill import watch_databases
+from .embedding_backfill import watch_databases, check_staleness
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +52,7 @@ def _watcher() -> None:
     """
 
     try:
+        check_staleness([])
         watch_databases()
     except Exception:  # pragma: no cover - best effort logging
         logger.exception("watch_databases terminated unexpectedly")
@@ -136,7 +137,9 @@ async def status() -> Dict[str, str]:  # pragma: no cover - trivial
 def main() -> None:  # pragma: no cover - simple server runner
     target = os.environ.get("VECTOR_SERVICE_SOCKET")
     if target:
-        config = uvicorn.Config("vector_service.vector_database_service:app", uds=target, log_level="info")
+        config = uvicorn.Config(
+            "vector_service.vector_database_service:app", uds=target, log_level="info"
+        )
     else:
         host = os.environ.get("VECTOR_SERVICE_HOST", "127.0.0.1")
         port = int(os.environ.get("VECTOR_SERVICE_PORT", "8000"))
@@ -151,7 +154,4 @@ def main() -> None:  # pragma: no cover - simple server runner
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
     main()
-
-
 __all__ = ["app", "main"]
-


### PR DESCRIPTION
## Summary
- add `check_staleness` to scan metadata for outdated embeddings and trigger backfills
- monitor staleness on startup and in the periodic watcher loop
- ensure vector database service invokes staleness checks before and during polling

## Testing
- `pre-commit run --files vector_service/embedding_backfill.py vector_service/vector_database_service.py` *(fails: Ungoverned embedding calls and other repository-level hooks)*
- `PYTHONPATH=. flake8 vector_service/embedding_backfill.py vector_service/vector_database_service.py`
- `PYTHONPATH=. pytest tests/test_vector_service.py::test_embedding_backfill_run_processes_databases -q` *(fails: AttributeError: <class 'vector_service._Stub'> has no attribute '_load_known_dbs')*

------
https://chatgpt.com/codex/tasks/task_e_68c0c64447b8832ebe918e6107e27f2f