### PR TITLE
Propagate chunk metadata in bot embeddings

### DIFF
--- a/bot_database.py
+++ b/bot_database.py
@@ -24,7 +24,6 @@ from .auto_link import auto_link
 from .unified_event_bus import UnifiedEventBus
 from .retry_utils import publish_with_retry
 from vector_service import EmbeddableDBMixin, EmbeddingBackfill
-from vector_service.text_preprocessor import generalise
 import warnings
 try:
     from .menace_memory_manager import _summarise_text  # type: ignore
@@ -614,7 +613,7 @@ class BotDB(EmbeddableDBMixin):
             return []
         joined = " ".join(filtered)
         summary = _summarise_text(joined) or joined
-        prepared = generalise(summary)
+        prepared = self._prepare_text_for_embedding(summary)
         return self.encode_text(prepared) if prepared else []
 
     def search_by_vector(

--- a/embeddable_db_mixin.py
+++ b/embeddable_db_mixin.py
@@ -442,6 +442,7 @@ class EmbeddableDBMixin:
 
         start = perf_counter()
         vec = self.vector(record)
+        chunk_meta = getattr(self, "_last_chunk_meta", chunk_meta)
         wall_time = perf_counter() - start
         tokens = getattr(self, "_last_embedding_tokens", 0)
         if not tokens and isinstance(record, str):  # pragma: no cover - best effort


### PR DESCRIPTION
## Summary
- Use EmbeddableDBMixin text preparation in BotDB vectorisation
- Persist chunk metadata from `_prepare_text_for_embedding`

## Testing
- `pre-commit run --files bot_database.py embeddable_db_mixin.py` *(fails: No module named 'dynamic_path_router')*

------
https://chatgpt.com/codex/tasks/task_e_68c0c940d960832ebd44d441efdb3937