### PR TITLE
Use mixin text prep for error embeddings

### DIFF
--- a/embeddable_db_mixin.py
+++ b/embeddable_db_mixin.py
@@ -467,6 +467,7 @@ class EmbeddableDBMixin:
             "redacted": True,
             "record": record,
             **(chunk_meta or {}),
+            "_last_chunk_meta": chunk_meta or {},
         }
         if last_updated:
             self._metadata[rid]["last_updated"] = last_updated

--- a/error_bot.py
+++ b/error_bot.py
@@ -27,7 +27,7 @@ from .auto_link import auto_link
 from typing import Any, Optional, Iterable, List, TYPE_CHECKING, Sequence, Iterator, Literal
 
 from .unified_event_bus import EventBus
-from .menace_memory_manager import MenaceMemoryManager, MemoryEntry, _summarise_text
+from .menace_memory_manager import MenaceMemoryManager, MemoryEntry
 from db_router import (
     DBRouter,
     GLOBAL_ROUTER,
@@ -39,7 +39,6 @@ import asyncio
 import threading
 from jinja2 import Template
 import yaml
-from vector_service.text_preprocessor import generalise
 
 from vector_service import EmbeddableDBMixin, EmbeddingBackfill
 
@@ -333,8 +332,7 @@ class ErrorDB(EmbeddableDBMixin):
         if not filtered:
             return None
         joined = " ".join(filtered)
-        summary = _summarise_text(joined) or joined
-        prepared = generalise(summary)
+        prepared = self._prepare_text_for_embedding(joined)
         return self._embed(prepared) if prepared else None
 
     def _embed(self, text: str) -> list[float]:


### PR DESCRIPTION
## Summary
- ensure ErrorDB embeds errors using `_prepare_text_for_embedding`
- persist `_last_chunk_meta` alongside embeddings for traceability

## Testing
- `PYTHONPATH=. pre-commit run --files embeddable_db_mixin.py error_bot.py`
- `PYTHONPATH=. pytest tests/test_vector_service_edge_cases.py -q` *(fails: AttributeError: '_Stub' object has no attribute 'search')*

------
https://chatgpt.com/codex/tasks/task_e_68c0ca71ffa8832eba66f5c2c41c145e