### PR TITLE
Check embedding staleness before running embeddings

### DIFF
--- a/menace_cli.py
+++ b/menace_cli.py
@@ -332,15 +332,20 @@ def handle_embed(args: argparse.Namespace) -> int:
     )
 
     try:
+        out_of_sync = backfill.check_out_of_sync(dbs=args.dbs)
+        if not out_of_sync:
+            logging.info("no databases require re-embedding")
+            return 0
+
         backfill.run(
             session_id="cli",
-            dbs=args.dbs,
+            dbs=out_of_sync,
             batch_size=args.batch_size,
             backend=args.backend,
         )
         if getattr(args, "verify", False):
             be = args.backend or backfill.backend
-            subclasses = backfill._load_known_dbs(names=args.dbs)
+            subclasses = backfill._load_known_dbs(names=out_of_sync)
             for cls in subclasses:
                 try:
                     db = cls(vector_backend=be)  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary
- avoid unnecessary backfills by checking for stale embedding databases before running
- log when all embeddings are current and skip backfill

## Testing
- `PYTHONPATH=. pre-commit run --files menace_cli.py` (fails: check-governed-embeddings, check-static-paths)
- `PYTHONPATH=. pytest tests/test_menace_cli*.py tests/test_branch_log_cli.py -q` (errors: missing files during collection)


------
https://chatgpt.com/codex/tasks/task_e_68c0cbe50448832eb64b7a3c99192310