### PR TITLE
Use SharedVectorService fallback for vectorizers

### DIFF
--- a/bot_vectorizer.py
+++ b/bot_vectorizer.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List
+import json
+import os
 import re
+import urllib.request
 import numpy as np
 
 from analysis.semantic_diff_filter import find_semantic_risks
@@ -15,6 +18,11 @@ try:  # pragma: no cover - heavy dependency
 except Exception:  # pragma: no cover - fallback when package missing
     SentenceTransformer = None  # type: ignore
 
+try:  # pragma: no cover - optional service
+    from vector_service.vectorizer import SharedVectorService  # type: ignore
+except Exception:  # pragma: no cover - dependency may be missing
+    SharedVectorService = None  # type: ignore
+
 _MODEL = None
 _EMBED_DIM = 384
 if SentenceTransformer is not None:  # pragma: no cover - model download may be slow
@@ -24,6 +32,21 @@ if SentenceTransformer is not None:  # pragma: no cover - model download may be 
     except Exception:
         _MODEL = None
 
+_SERVICE: SharedVectorService | None = None
+_REMOTE_URL = os.environ.get("VECTOR_SERVICE_URL")
+
+
+def _remote_embed(text: str) -> List[float]:
+    data = json.dumps({"kind": "text", "record": {"text": text}}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{_REMOTE_URL.rstrip('/')}/vectorise",
+        data=data,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req) as resp:  # pragma: no cover - network
+        payload = json.loads(resp.read().decode("utf-8"))
+    return payload.get("vector", [])
+
 
 def _split_sentences(text: str) -> List[str]:
     return [s.strip() for s in re.split(r"(?<=[.!?])\s+", text) if s.strip()]
@@ -32,10 +55,36 @@ def _split_sentences(text: str) -> List[str]:
 def _embed_texts(texts: List[str]) -> List[List[float]]:
     if not texts:
         return []
-    if _MODEL is None:  # pragma: no cover - dependency missing
-        return [[0.0] * _EMBED_DIM for _ in texts]
-    vecs = _MODEL.encode(texts)
-    return [list(map(float, v)) for v in np.atleast_2d(vecs)]
+    if _MODEL is not None:
+        vecs = _MODEL.encode(texts)
+        return [list(map(float, v)) for v in np.atleast_2d(vecs)]
+
+    global _SERVICE
+    if SharedVectorService is not None:
+        if _SERVICE is None:
+            try:
+                embedder = None
+                if SentenceTransformer is not None:
+                    try:
+                        embedder = SentenceTransformer("all-MiniLM-L6-v2")
+                    except Exception:
+                        embedder = None
+                _SERVICE = SharedVectorService(embedder)
+            except Exception:
+                _SERVICE = None
+        if _SERVICE is not None:
+            try:
+                return [_SERVICE.vectorise("text", {"text": t}) for t in texts]
+            except Exception:
+                pass
+
+    if _REMOTE_URL:
+        try:
+            return [_remote_embed(t) for t in texts]
+        except Exception:
+            pass
+
+    raise RuntimeError("No embedding backend available")
 
 
 @dataclass

--- a/error_vectorizer.py
+++ b/error_vectorizer.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List
+import json
+import os
 import re
+import urllib.request
 import numpy as np
 
 from analysis.semantic_diff_filter import find_semantic_risks
@@ -17,6 +20,11 @@ try:  # pragma: no cover - heavy dependency
 except Exception:  # pragma: no cover - fallback when package missing
     SentenceTransformer = None  # type: ignore
 
+try:  # pragma: no cover - optional service
+    from vector_service.vectorizer import SharedVectorService  # type: ignore
+except Exception:  # pragma: no cover - dependency may be missing
+    SharedVectorService = None  # type: ignore
+
 _MODEL = None
 _EMBED_DIM = 384
 if SentenceTransformer is not None:  # pragma: no cover - model download may be slow
@@ -26,6 +34,21 @@ if SentenceTransformer is not None:  # pragma: no cover - model download may be 
     except Exception:
         _MODEL = None
 
+_SERVICE: SharedVectorService | None = None
+_REMOTE_URL = os.environ.get("VECTOR_SERVICE_URL")
+
+
+def _remote_embed(text: str) -> List[float]:
+    data = json.dumps({"kind": "text", "record": {"text": text}}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{_REMOTE_URL.rstrip('/')}/vectorise",
+        data=data,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req) as resp:  # pragma: no cover - network
+        payload = json.loads(resp.read().decode("utf-8"))
+    return payload.get("vector", [])
+
 
 def _split_sentences(text: str) -> List[str]:
     return [s.strip() for s in re.split(r"(?<=[.!?])\s+", text) if s.strip()]
@@ -34,10 +57,36 @@ def _split_sentences(text: str) -> List[str]:
 def _embed_texts(texts: List[str]) -> List[List[float]]:
     if not texts:
         return []
-    if _MODEL is None:  # pragma: no cover - dependency missing
-        return [[0.0] * _EMBED_DIM for _ in texts]
-    vecs = _MODEL.encode(texts)
-    return [list(map(float, v)) for v in np.atleast_2d(vecs)]
+    if _MODEL is not None:
+        vecs = _MODEL.encode(texts)
+        return [list(map(float, v)) for v in np.atleast_2d(vecs)]
+
+    global _SERVICE
+    if SharedVectorService is not None:
+        if _SERVICE is None:
+            try:
+                embedder = None
+                if SentenceTransformer is not None:
+                    try:
+                        embedder = SentenceTransformer("all-MiniLM-L6-v2")
+                    except Exception:
+                        embedder = None
+                _SERVICE = SharedVectorService(embedder)
+            except Exception:
+                _SERVICE = None
+        if _SERVICE is not None:
+            try:
+                return [_SERVICE.vectorise("text", {"text": t}) for t in texts]
+            except Exception:
+                pass
+
+    if _REMOTE_URL:
+        try:
+            return [_remote_embed(t) for t in texts]
+        except Exception:
+            pass
+
+    raise RuntimeError("No embedding backend available")
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- replace zero-vector fallbacks with SharedVectorService or VECTOR_SERVICE_URL calls in code, bot, error, and workflow vectorizers
- raise RuntimeError when no embedding backend is reachable

## Testing
- `pytest tests/test_information_code_discrepancy_vectorizers.py tests/test_shared_vector_interface.py tests/test_vector_service_bot.py tests/test_workflow_vectorizer.py -q` *(fails: AttributeError: '_Stub' object has no attribute 'vectorise')*

------
https://chatgpt.com/codex/tasks/task_e_68c0cea2e010832eb2fed7d597d8abc2