### PR TITLE
feat: enhance text preprocessing

### DIFF
--- a/tests/test_text_preprocessor.py
+++ b/tests/test_text_preprocessor.py
@@ -1,4 +1,5 @@
 import importlib.util
+import sys
 from pathlib import Path
 
 
@@ -9,8 +10,12 @@ spec = importlib.util.spec_from_file_location(
 )
 text_preprocessor = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
+sys.modules[spec.name] = text_preprocessor
 spec.loader.exec_module(text_preprocessor)
 generalise = text_preprocessor.generalise
+PreprocessingConfig = text_preprocessor.PreprocessingConfig
+load_stop_words = text_preprocessor.load_stop_words
+register_preprocessor = text_preprocessor.register_preprocessor
 
 
 def test_generalise_shorter_and_semantic():
@@ -27,3 +32,25 @@ def test_generalise_shorter_and_semantic():
     assert tokens.intersection({"fox", "foxes"})
     assert tokens.intersection({"dog", "dogs"})
     assert "the" not in tokens
+
+
+def test_load_stop_words_and_config(tmp_path):
+    stop_file = tmp_path / "stop.txt"
+    stop_file.write_text("hello\n")
+    stop_words = load_stop_words(str(stop_file))
+    cfg = PreprocessingConfig(stop_words=stop_words)
+
+    assert generalise("Hello world", config=cfg) == "world"
+
+
+def test_language_detection_and_stemming():
+    cfg = PreprocessingConfig(stop_words={"los"})
+    text = "Los gatos corriendo perezosos eran"
+    result = generalise(text, config=cfg)
+    assert set(result.split()) == {"gat", "corr", "perez", "eran"}
+
+
+def test_database_specific_configuration():
+    cfg = PreprocessingConfig(stop_words={"alpha"})
+    register_preprocessor("db1", cfg)
+    assert generalise("alpha beta", db_key="db1") == "beta"

--- a/vector_service/text_preprocessor.py
+++ b/vector_service/text_preprocessor.py
@@ -1,16 +1,18 @@
 """Utility functions for text preprocessing before embedding.
 
-This module exposes :func:`generalise` which performs basic text
-normalisation such as lowercasing, stop word removal and optional
-lemmatisation.  The lemmatisation step is attempted if NLTK is available
-with the required corpora; otherwise the function gracefully degrades to
-simple stop word removal.
+This module exposes :func:`generalise` which performs language-aware text
+normalisation.  It supports configurable stop word lists, optional language
+detection and lemmatisation/stemming.  Databases may register their own
+pre-processing configuration which will be used when ``generalise`` is invoked
+with a ``db_key``.
 """
 
 from __future__ import annotations
 
+import os
 import re
-from typing import Iterable
+from dataclasses import dataclass
+from typing import Dict, Iterable, Optional, Set
 
 # A tiny English stop word list.  This keeps the implementation light and
 # avoids pulling in heavy dependencies for the common case.
@@ -50,6 +52,80 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - nltk or data missing
     _LEMMATIZER = None  # type: ignore
 
+try:  # pragma: no cover - optional dependency
+    from nltk.stem import SnowballStemmer  # type: ignore
+
+    _STEMMER_FACTORY = SnowballStemmer
+except Exception:  # pragma: no cover - nltk missing
+    _STEMMER_FACTORY = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from langdetect import detect  # type: ignore
+
+    _LANG_DETECT = detect
+except Exception:  # pragma: no cover - dependency missing
+    _LANG_DETECT = None  # type: ignore
+
+
+_LANG_MAP = {
+    "en": "english",
+    "es": "spanish",
+    "fr": "french",
+    "de": "german",
+    "it": "italian",
+    "pt": "portuguese",
+}
+
+
+@dataclass
+class PreprocessingConfig:
+    """Configuration controlling text normalisation."""
+
+    stop_words: Optional[Set[str]] = None
+    language: Optional[str] = None
+    use_lemmatizer: bool = True
+
+
+def load_stop_words(source: str | Iterable[str]) -> Set[str]:
+    """Return a set of stop words from ``source``.
+
+    ``source`` may be an iterable, a path to a file containing one word per
+    line, or a spaCy language code (when spaCy is available).  The function
+    gracefully falls back to an empty set when a source cannot be resolved.
+    """
+
+    if isinstance(source, str):
+        if os.path.exists(source):
+            with open(source, "r", encoding="utf8") as fh:
+                return {line.strip() for line in fh if line.strip()}
+        try:  # pragma: no cover - spaCy is optional
+            import spacy  # type: ignore
+
+            nlp = spacy.blank(source)
+            return set(nlp.Defaults.stop_words)
+        except Exception:
+            return set()
+    return {w.strip() for w in source if isinstance(w, str) and w.strip()}
+
+
+_CONFIGS: Dict[str, PreprocessingConfig] = {}
+
+
+def register_preprocessor(db_key: str, config: PreprocessingConfig) -> None:
+    """Register a :class:`PreprocessingConfig` for ``db_key``."""
+
+    _CONFIGS[db_key] = config
+
+
+def _resolve_config(
+    db_key: Optional[str], config: Optional[PreprocessingConfig]
+) -> PreprocessingConfig:
+    if config is not None:
+        return config
+    if db_key and db_key in _CONFIGS:
+        return _CONFIGS[db_key]
+    return PreprocessingConfig()
+
 
 def _lemmatise(token: str) -> str:
     """Return the lemmatised form of ``token`` if possible."""
@@ -62,21 +138,30 @@ def _lemmatise(token: str) -> str:
         return token
 
 
-def generalise(text: str) -> str:
+def generalise(
+    text: str, *, config: PreprocessingConfig | None = None, db_key: str | None = None
+) -> str:
     """Return a condensed representation of ``text``.
 
     The function performs the following steps:
 
     * lowercases the input text
     * tokenises on word boundaries
-    * removes common English stop words
-    * optionally lemmatises tokens when NLTK and its WordNet data are
-      available
+    * removes stop words (configurable)
+    * optionally lemmatises or stems tokens depending on the detected or
+      configured language
 
     Parameters
     ----------
     text:
         The input text to normalise.
+    config:
+        Optional :class:`PreprocessingConfig` describing how ``text`` should be
+        processed.  If not supplied, a configuration registered for ``db_key``
+        will be used if available.
+    db_key:
+        Identifier of the database requesting the preprocessing.  This allows
+        different databases to specify custom preprocessing behaviour.
 
     Returns
     -------
@@ -87,14 +172,45 @@ def generalise(text: str) -> str:
     if not isinstance(text, str):  # pragma: no cover - defensive
         return text
 
+    cfg = _resolve_config(db_key, config)
+    lang = cfg.language
+    if lang is None and _LANG_DETECT is not None:
+        try:  # pragma: no cover - best effort
+            lang = _LANG_DETECT(text)
+        except Exception:
+            lang = "en"
+    lang = lang or "en"
+
+    stop_words = cfg.stop_words or _STOP_WORDS
+
     tokens = re.findall(r"\b\w+\b", text.lower())
     processed = []
+
+    stemmer = None
+    if lang != "en" and _STEMMER_FACTORY is not None and cfg.use_lemmatizer:
+        stem_lang = _LANG_MAP.get(lang, lang)
+        try:  # pragma: no cover - best effort
+            stemmer = _STEMMER_FACTORY(stem_lang)
+        except Exception:
+            stemmer = None
+
     for tok in tokens:
-        if tok in _STOP_WORDS:
+        if tok in stop_words:
             continue
-        tok = _lemmatise(tok)
+        if stemmer is not None:
+            try:  # pragma: no cover - best effort
+                tok = stemmer.stem(tok)
+            except Exception:
+                pass
+        elif cfg.use_lemmatizer:
+            tok = _lemmatise(tok)
         processed.append(tok)
     return " ".join(processed)
 
 
-__all__ = ["generalise"]
+__all__ = [
+    "PreprocessingConfig",
+    "load_stop_words",
+    "register_preprocessor",
+    "generalise",
+]


### PR DESCRIPTION
## Summary
- make text preprocessing configurable with pluggable stop words and DB-specific hooks
- add optional language detection with stemming/lemmatization for non-English
- expand tests for custom stop words and multilingual processing

## Testing
- `PYTHONPATH=. pytest tests/test_text_preprocessor.py --confcutdir=tests -q`
- `PYTHONPATH=. pytest tests/integration/test_vector_service_layer.py --confcutdir=tests -q` *(fails: AttributeError: <class 'vector_service._Stub'> has no attribute '_load_known_dbs')*


------
https://chatgpt.com/codex/tasks/task_e_68c0d409ef5c832eb296cce32eb91f3a