### PR TITLE
Add bulk embed flag and scheduler health checks

### DIFF
--- a/menace_cli.py
+++ b/menace_cli.py
@@ -320,6 +320,8 @@ def handle_embed(args: argparse.Namespace) -> int:
     """Handle ``embed`` command."""
     if not _require_vector_service():
         return 1
+    if getattr(args, "all", False):
+        args.dbs = ["code", "bot", "error", "workflow"]
     import logging
     from typing import IO
 
@@ -575,6 +577,11 @@ def main(argv: list[str] | None = None) -> int:
         "--verify",
         action="store_true",
         help="Verify vector counts match record totals after backfill",
+    )
+    p_embed.add_argument(
+        "--all",
+        action="store_true",
+        help="Embed code, bot, error, and workflow databases",
     )
     p_embed.set_defaults(func=handle_embed)
 


### PR DESCRIPTION
## Summary
- Add `--all` flag to `menace embed` for batch embedding of code, bot, error and workflow databases
- Enhance embedding scheduler with periodic health checks, staleness thresholds and consolidated reports
- Support configuring staleness threshold via `EMBEDDING_SCHEDULER_STALE_THRESHOLD`

## Testing
- `PYTHONPATH=/tmp/stub:. pytest tests/test_menace_cli_embed.py tests/test_embedding_scheduler_pre_embed.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0d755ea9c832e8aff02cdee11f6f2