### PR TITLE
feat: run embedding backfills on db change events

### DIFF
--- a/bot_database.py
+++ b/bot_database.py
@@ -89,6 +89,9 @@ def _ensure_backfill_watcher(bus: "UnifiedEventBus" | None) -> None:
         logger.exception("failed to start embedding watcher")
 
 
+_ensure_backfill_watcher(UnifiedEventBus())
+
+
 # Fields that uniquely identify a bot's core identity for deduplication
 
 _BOT_HASH_FIELDS = sorted([
@@ -482,6 +485,11 @@ class BotDB(EmbeddableDBMixin):
             else:
                 publish_with_retry(
                     self.event_bus,
+                    "db:record_added",
+                    {"db": "bot"},
+                )
+                publish_with_retry(
+                    self.event_bus,
                     "embedding:backfill",
                     {"db": self.__class__.__name__},
                 )
@@ -532,6 +540,11 @@ class BotDB(EmbeddableDBMixin):
                 logger.exception("failed to publish bot:update event")
                 self.failed_events.append(FailedEvent("bot:update", payload))
             else:
+                publish_with_retry(
+                    self.event_bus,
+                    "db:record_updated",
+                    {"db": "bot"},
+                )
                 publish_with_retry(
                     self.event_bus,
                     "embedding:backfill",

--- a/code_database.py
+++ b/code_database.py
@@ -114,6 +114,9 @@ def _ensure_backfill_watcher(bus: "UnifiedEventBus" | None) -> None:
     except Exception:  # pragma: no cover - best effort
         logger.exception("failed to start embedding watcher")
 
+
+_ensure_backfill_watcher(UnifiedEventBus())
+
 SQL_DIR = resolve_path("sql_templates")
 
 
@@ -586,6 +589,11 @@ class CodeDB(EmbeddableDBMixin):
             else:
                 publish_with_retry(
                     self.event_bus,
+                    "db:record_added",
+                    {"db": "code"},
+                )
+                publish_with_retry(
+                    self.event_bus,
                     "embedding:backfill",
                     {"db": self.__class__.__name__},
                 )
@@ -704,6 +712,11 @@ class CodeDB(EmbeddableDBMixin):
             if not publish_with_retry(self.event_bus, "code:update", payload):
                 logger.exception("failed to publish code:update event")
             else:
+                publish_with_retry(
+                    self.event_bus,
+                    "db:record_updated",
+                    {"db": "code"},
+                )
                 publish_with_retry(
                     self.event_bus,
                     "embedding:backfill",


### PR DESCRIPTION
## Summary
- trigger embedding backfills immediately when code, bot, error or workflow records change
- publish `db:record_added` and `db:record_updated` events from code, bot, error and workflow modules
- start embedding backfill watcher on module import for databases

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'context_builder_util')*

------
https://chatgpt.com/codex/tasks/task_e_68c0dac99f74832ebaf6ebc5edb15943