### PR TITLE
feat: track embedding freshness

### DIFF
--- a/menace_cli.py
+++ b/menace_cli.py
@@ -402,6 +402,15 @@ def handle_embed(args: argparse.Namespace) -> int:
 
     try:
         out_of_sync = backfill.check_out_of_sync(dbs=args.dbs)
+        if getattr(args, "verify_only", False):
+            if out_of_sync:
+                logging.warning(
+                    "databases out of sync: %s", ", ".join(sorted(out_of_sync))
+                )
+                return 1
+            logging.info("no databases require re-embedding")
+            return 0
+
         if not out_of_sync:
             logging.info("no databases require re-embedding")
             return 0
@@ -586,6 +595,11 @@ def main(argv: list[str] | None = None) -> int:
         "--verify",
         action="store_true",
         help="Verify vector counts match record totals after backfill",
+    )
+    p_embed.add_argument(
+        "--verify-only",
+        action="store_true",
+        help="Only check for out-of-sync databases without running a backfill",
     )
     p_embed.add_argument(
         "--all",

--- a/vector_service/context_builder.py
+++ b/vector_service/context_builder.py
@@ -1311,7 +1311,11 @@ class ContextBuilder:
         forwards the call so legacy imports continue to function.
         """
 
-        return self.build_context(query, **kwargs)
+        try:
+            return self.build_context(query, **kwargs)
+        except RuntimeError as exc:
+            raise RuntimeError(
+                f"embedding verification failed: {exc}") from exc
 
     # ------------------------------------------------------------------
     @log_and_measure


### PR DESCRIPTION
## Summary
- track last vectorisation timestamps for embedding databases and validate against code/bot/error/workflow DB files
- add `menace embed --verify-only` CLI flag to check embedding freshness without backfilling
- raise clear error from `ContextBuilder.build` when embeddings are stale

## Testing
- `pre-commit run --files menace_cli.py vector_service/context_builder.py vector_service/embedding_backfill.py` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'context_builder_util')*


------
https://chatgpt.com/codex/tasks/task_e_68c0dd38f1f0832e933bcca3bdcaa4b1