### PR TITLE
feat: add configurable text preprocessing

### DIFF
--- a/bot_database.py
+++ b/bot_database.py
@@ -24,6 +24,7 @@ from .auto_link import auto_link
 from .unified_event_bus import UnifiedEventBus
 from .retry_utils import publish_with_retry
 from vector_service import EmbeddableDBMixin, EmbeddingBackfill
+from vector_service.text_preprocessor import get_config
 import warnings
 try:
     from .menace_memory_manager import _summarise_text  # type: ignore
@@ -626,7 +627,8 @@ class BotDB(EmbeddableDBMixin):
             return []
         joined = " ".join(filtered)
         summary = _summarise_text(joined) or joined
-        prepared = self._prepare_text_for_embedding(summary)
+        cfg = get_config("bot")
+        prepared = self._prepare_text_for_embedding(summary, config=cfg, db_key="bot")
         return self.encode_text(prepared) if prepared else []
 
     def search_by_vector(

--- a/error_bot.py
+++ b/error_bot.py
@@ -41,6 +41,7 @@ from jinja2 import Template
 import yaml
 
 from vector_service import EmbeddableDBMixin, EmbeddingBackfill
+from vector_service.text_preprocessor import get_config
 
 try:  # pragma: no cover - optional dependency for type hints
     from vector_service.context_builder import ContextBuilder
@@ -339,7 +340,8 @@ class ErrorDB(EmbeddableDBMixin):
         if not filtered:
             return None
         joined = " ".join(filtered)
-        prepared = self._prepare_text_for_embedding(joined)
+        cfg = get_config("error")
+        prepared = self._prepare_text_for_embedding(joined, config=cfg, db_key="error")
         return self._embed(prepared) if prepared else None
 
     def _embed(self, text: str) -> list[float]:

--- a/tests/test_dynamic_preprocessing.py
+++ b/tests/test_dynamic_preprocessing.py
@@ -1,0 +1,61 @@
+import json
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+tp_spec = importlib.util.spec_from_file_location(
+    "text_preprocessor", Path(__file__).resolve().parents[1] / "vector_service" / "text_preprocessor.py"
+)
+tp = importlib.util.module_from_spec(tp_spec)
+assert tp_spec.loader is not None
+sys.modules[tp_spec.name] = tp
+tp_spec.loader.exec_module(tp)
+
+wf_spec = importlib.util.spec_from_file_location(
+    "workflow_vectorizer", Path(__file__).resolve().parents[1] / "workflow_vectorizer.py"
+)
+wf_mod = importlib.util.module_from_spec(wf_spec)
+assert wf_spec.loader is not None
+sys.modules[wf_spec.name] = wf_mod
+wf_spec.loader.exec_module(wf_mod)
+WorkflowVectorizer = wf_mod.WorkflowVectorizer
+_EMBED_DIM = wf_mod._EMBED_DIM
+
+
+def test_load_db_configs_json_yaml(tmp_path):
+    cfg_json = tmp_path / "cfg.json"
+    cfg_json.write_text(json.dumps({"code": {"chunk_size": 123}}))
+    tp.load_db_configs(str(cfg_json))
+    assert tp.get_config("code").chunk_size == 123
+
+    cfg_yaml = tmp_path / "cfg.yaml"
+    cfg_yaml.write_text("workflow:\n  split_sentences: false\n")
+    tp.load_db_configs(str(cfg_yaml))
+    assert tp.get_config("workflow").split_sentences is False
+def test_workflow_transform_respects_config(monkeypatch):
+    cfg = tp.PreprocessingConfig(split_sentences=False, filter_semantic_risks=False)
+    tp.register_preprocessor("workflow", cfg)
+
+    captured = {}
+
+    def fake_embed(texts):
+        captured["texts"] = texts
+        return [[0.0] * _EMBED_DIM for _ in texts]
+
+    monkeypatch.setattr("workflow_vectorizer._embed_texts", fake_embed)
+    monkeypatch.setattr("workflow_vectorizer.compress_snippets", lambda d: d)
+
+    wf = {"name": "", "description": "A. B."}
+    WorkflowVectorizer().transform(wf, config=cfg)
+    assert captured["texts"] == ["\nA. B."]
+
+    cfg2 = tp.PreprocessingConfig(split_sentences=True, filter_semantic_risks=True)
+    tp.register_preprocessor("workflow", cfg2)
+    monkeypatch.setattr(
+        "workflow_vectorizer.find_semantic_risks",
+        lambda lines: [1] if "B" in lines[0] else [],
+    )
+    WorkflowVectorizer().transform(wf, config=cfg2)
+    assert captured["texts"] == ["A."]
+


### PR DESCRIPTION
## Summary
- support per-database text preprocessing config with sentence splitting, chunk size, and risk filter options
- apply dynamic chunking/filters in code, workflow, bot, and error embedding paths
- add tests for config loading and workflow vectorisation behaviour

## Testing
- `PYTHONPATH=/workspace/menace_sandbox pytest tests/test_dynamic_preprocessing.py tests/test_text_preprocessor.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0de8dd0a0832eb18c597db61a5ef4