### PR TITLE
Use registry to embed all databases dynamically

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,6 +73,8 @@ menace retrieve "rate limiter" --db errors --top-k 5
 Backfill vector embeddings.
 ```bash
 menace embed --db errors --batch-size 100
+# or refresh every registered database
+menace embed --all
 ```
 
 ### Automatic vs. manual runs

--- a/docs/embedding_system.md
+++ b/docs/embedding_system.md
@@ -40,7 +40,7 @@ record-to-vector logic:
 
 Use `scripts/backfill_embeddings.py` to generate embeddings for existing
 records. Pass `--db` multiple times to target specific stores or `--all` to
-refresh every registered database:
+refresh every database discovered in the runtime registry:
 
 ```bash
 python scripts/backfill_embeddings.py --db bot --db workflow --backend annoy --batch-size 200

--- a/menace_cli.py
+++ b/menace_cli.py
@@ -330,7 +330,10 @@ def handle_embed(args: argparse.Namespace) -> int:
     if not _require_vector_service():
         return 1
     if getattr(args, "all", False):
-        args.dbs = ["code", "bot", "error", "workflow"]
+        from vector_service.embedding_backfill import _load_registry, KNOWN_DB_KINDS
+
+        registry = _load_registry()
+        args.dbs = sorted(registry.keys() or KNOWN_DB_KINDS)
     import logging
     from typing import IO
 
@@ -604,7 +607,7 @@ def main(argv: list[str] | None = None) -> int:
     p_embed.add_argument(
         "--all",
         action="store_true",
-        help="Embed code, bot, error, and workflow databases",
+        help="Embed all registered databases",
     )
     p_embed.set_defaults(func=handle_embed)
 

--- a/vector_service/embedding_scheduler.py
+++ b/vector_service/embedding_scheduler.py
@@ -12,7 +12,7 @@ from typing import Optional, Dict, List
 from unified_event_bus import UnifiedEventBus
 
 from patch_safety import PatchSafety
-from .embedding_backfill import EmbeddingBackfill, KNOWN_DB_KINDS
+from .embedding_backfill import EmbeddingBackfill, KNOWN_DB_KINDS, _load_registry
 
 try:  # pragma: no cover - optional dependency for metrics
     from . import metrics_exporter as _me  # type: ignore
@@ -30,7 +30,7 @@ _SCHED_DURATION = _me.Gauge(
 )
 
 # Database kinds recognised for on-demand backfill events.
-_SUPPORTED_SOURCES = set(KNOWN_DB_KINDS)
+_SUPPORTED_SOURCES = set(_load_registry().keys() or KNOWN_DB_KINDS)
 
 
 class EmbeddingScheduler:
@@ -53,7 +53,7 @@ class EmbeddingScheduler:
         self.interval = interval
         self.batch_size = batch_size
         self.backend = backend
-        self.sources = sources or ["code", "bot", "error", "workflow"]
+        self.sources = sources or sorted(_SUPPORTED_SOURCES)
         self.stale_threshold = stale_threshold
         self.event_bus = event_bus or UnifiedEventBus()
         self.event_topic = event_topic


### PR DESCRIPTION
## Summary
- load all database kinds for `menace embed --all` from the embedding registry
- let `EmbeddingScheduler` default to all registered databases
- document that `--all` embeds every registry entry

## Testing
- `pytest tests/test_embedding_pipeline.py tests/test_embedding_scheduler_pre_embed.py -q`
- `pytest -q` *(fails: ImportError while importing test module)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e56f0b14832e855e4a9ca3a62de8