### PR TITLE
Ensure default embeddings freshness and add tests

### DIFF
--- a/tests/test_context_builder_embeddings.py
+++ b/tests/test_context_builder_embeddings.py
@@ -1,0 +1,49 @@
+import sys
+import types
+
+import pytest
+
+dummy_patch_logger = types.ModuleType("vector_service.patch_logger")
+
+dummy_patch_logger._VECTOR_RISK = 0
+sys.modules.setdefault("vector_service.patch_logger", dummy_patch_logger)
+
+
+class DummyRetriever:
+    def search(self, *args, **kwargs):
+        return []
+
+
+def make_builder(monkeypatch):
+    import vector_service.context_builder as cb
+
+    monkeypatch.setattr(cb.ContextBuilder, "refresh_db_weights", lambda self, *a, **k: None)
+    monkeypatch.setattr(cb, "_ensure_vector_service", lambda: None)
+    dummy_patch = types.SimpleNamespace(search=lambda *a, **k: [])
+    builder = cb.ContextBuilder(retriever=DummyRetriever(), patch_retriever=dummy_patch, db_weights={})
+    monkeypatch.setattr(builder.patch_safety, "load_failures", lambda: None)
+    return builder, cb
+
+
+def test_builder_falls_back_to_core_dbs(monkeypatch):
+    builder, cb = make_builder(monkeypatch)
+    called: dict[str, list[str]] = {}
+
+    def fake_ensure(dbs):
+        called["dbs"] = list(dbs)
+
+    monkeypatch.setattr(cb, "ensure_embeddings_fresh", fake_ensure)
+    builder.build("query")
+    assert set(called["dbs"]) == {"code", "bot", "error", "workflow"}
+
+
+def test_builder_surfaces_stale_embedding_error(monkeypatch):
+    builder, cb = make_builder(monkeypatch)
+
+    def fake_ensure(dbs):
+        raise cb.StaleEmbeddingsError({"code": "missing"})
+
+    monkeypatch.setattr(cb, "ensure_embeddings_fresh", fake_ensure)
+    with pytest.raises(RuntimeError) as exc:
+        builder.build("query")
+    assert "code" in str(exc.value)


### PR DESCRIPTION
## Summary
- fallback to core databases when db weights are empty before embedding checks
- surface detailed VectorServiceError when embeddings remain stale
- test builder fallback behavior and stale embedding error propagation

## Testing
- `pytest tests/test_context_builder_embeddings.py -q`
- `pytest tests/test_embedding_freshness.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0f7749d94832eaae6c1752b380fdb