### PR TITLE
Emit db change events and batch embedding backfill

### DIFF
--- a/bot_database.py
+++ b/bot_database.py
@@ -491,6 +491,11 @@ class BotDB(EmbeddableDBMixin):
                 )
                 publish_with_retry(
                     self.event_bus,
+                    "db.record_changed",
+                    {"db": "bot"},
+                )
+                publish_with_retry(
+                    self.event_bus,
                     "embedding:backfill",
                     {"db": self.__class__.__name__},
                 )
@@ -544,6 +549,11 @@ class BotDB(EmbeddableDBMixin):
                 publish_with_retry(
                     self.event_bus,
                     "db:record_updated",
+                    {"db": "bot"},
+                )
+                publish_with_retry(
+                    self.event_bus,
+                    "db.record_changed",
                     {"db": "bot"},
                 )
                 publish_with_retry(

--- a/code_database.py
+++ b/code_database.py
@@ -594,6 +594,11 @@ class CodeDB(EmbeddableDBMixin):
                 )
                 publish_with_retry(
                     self.event_bus,
+                    "db.record_changed",
+                    {"db": "code"},
+                )
+                publish_with_retry(
+                    self.event_bus,
                     "embedding:backfill",
                     {"db": self.__class__.__name__},
                 )
@@ -715,6 +720,11 @@ class CodeDB(EmbeddableDBMixin):
                 publish_with_retry(
                     self.event_bus,
                     "db:record_updated",
+                    {"db": "code"},
+                )
+                publish_with_retry(
+                    self.event_bus,
+                    "db.record_changed",
                     {"db": "code"},
                 )
                 publish_with_retry(

--- a/error_bot.py
+++ b/error_bot.py
@@ -288,8 +288,10 @@ class ErrorDB(EmbeddableDBMixin):
                 self.event_bus.publish(topic, payload)
                 if topic.endswith(":new"):
                     self.event_bus.publish("db:record_added", {"db": "error"})
+                    self.event_bus.publish("db.record_changed", {"db": "error"})
                 elif topic.endswith(":update"):
                     self.event_bus.publish("db:record_updated", {"db": "error"})
+                    self.event_bus.publish("db.record_changed", {"db": "error"})
             except Exception as exc:
                 logger.exception("publish failed: %s", exc)
                 if error_bot_exceptions:

--- a/task_handoff_bot.py
+++ b/task_handoff_bot.py
@@ -414,6 +414,7 @@ class WorkflowDB(EmbeddableDBMixin):
         if self.event_bus:
             try:
                 self.event_bus.publish("workflows:new", asdict(wf))
+                self.event_bus.publish("db.record_changed", {"db": "workflow"})
                 self.event_bus.publish(
                     "embedding:backfill", {"db": self.__class__.__name__}
                 )

--- a/tests/test_embedding_events.py
+++ b/tests/test_embedding_events.py
@@ -1,0 +1,52 @@
+import asyncio
+import pytest
+
+from vector_service.embedding_backfill import consume_record_changes, EmbeddingBackfill
+
+
+def test_event_consumer_batches_concurrent_events(monkeypatch):
+    async def _run():
+        calls: list[list[str]] = []
+
+        class DummyBus:
+            def __init__(self) -> None:
+                self.subs: dict[str, list[callable]] = {}
+
+            def subscribe_async(self, topic: str, cb):
+                self.subs.setdefault(topic, []).append(cb)
+
+            def publish(self, topic: str, event):
+                for cb in self.subs.get(topic, []):
+                    asyncio.create_task(cb(topic, event))
+
+        bus = DummyBus()
+
+        def fake_run(self, *, dbs=None, db=None, **_k):
+            if dbs:
+                calls.append(sorted(dbs))
+            elif db:
+                calls.append([db])
+
+        monkeypatch.setattr(EmbeddingBackfill, "run", fake_run)
+
+        consumer = asyncio.create_task(
+            consume_record_changes(bus=bus, backend="annoy", batch_size=1)
+        )
+
+        async def publish(name: str):
+            bus.publish("db.record_changed", {"db": name})
+
+        await asyncio.gather(
+            *[publish("code") for _ in range(3)],
+            *[publish("bot") for _ in range(3)],
+        )
+
+        await asyncio.sleep(0.1)
+        consumer.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await consumer
+
+        processed = {n for call in calls for n in call}
+        assert {"code", "bot"} <= processed
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- publish `db.record_changed` events from code, bot, error, and workflow databases
- add async event consumer that batches DB changes and triggers EmbeddingBackfill
- test that concurrent events are batched and processed

## Testing
- `pytest tests/test_embedding_events.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0fd67abc8832e9a1eae248d2e082e