### PR TITLE
Add readiness polling for vector service

### DIFF
--- a/menace_cli.py
+++ b/menace_cli.py
@@ -542,6 +542,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Do not automatically start the vector service",
     )
+    parser.add_argument(
+        "--check-vector-service",
+        action="store_true",
+        help="Verify vector service readiness before executing commands",
+    )
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     sub.add_parser("setup", help="Install dependencies and bootstrap the env")
@@ -697,6 +702,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     global SKIP_VECTOR_AUTOSTART
     SKIP_VECTOR_AUTOSTART = args.no_vector_autostart
+    if args.check_vector_service and not _require_vector_service():
+        return 1
     builder = create_context_builder()
     setattr(args, "builder", builder)
 

--- a/tests/test_menace_cli_service_flag.py
+++ b/tests/test_menace_cli_service_flag.py
@@ -1,0 +1,28 @@
+import argparse
+
+import menace_cli
+import types
+import sys
+
+
+def test_cli_check_vector_service(monkeypatch):
+    called = {"count": 0}
+
+    def fake_require(*a, **k):
+        called["count"] += 1
+        return False
+
+    monkeypatch.setattr(menace_cli, "_require_vector_service", fake_require)
+    monkeypatch.setattr(menace_cli, "handle_patch", lambda args: 0)
+    dummy_plugins = types.SimpleNamespace(load_plugins=lambda sub: None)
+    monkeypatch.setitem(sys.modules, "menace.plugins", dummy_plugins)
+
+    exit_code = menace_cli.main([
+        "--check-vector-service",
+        "patch",
+        "mod",
+        "--desc",
+        "d",
+    ])
+    assert exit_code == 1
+    assert called["count"] == 1

--- a/tests/test_vector_service_startup.py
+++ b/tests/test_vector_service_startup.py
@@ -1,0 +1,68 @@
+import pytest
+
+
+def test_ensure_vector_service_retries(monkeypatch):
+    import vector_service.context_builder as cb
+
+    calls = {"count": 0}
+
+    class DummyResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def fake_urlopen(url, timeout=2):
+        calls["count"] += 1
+        if calls["count"] < 3:
+            raise OSError("not ready")
+        return DummyResponse()
+
+    import urllib.request
+    import subprocess
+
+    monkeypatch.setenv("VECTOR_SERVICE_URL", "http://example")
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    popen_called = {"called": False}
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: popen_called.__setitem__("called", True))
+    monkeypatch.setattr(cb.time, "sleep", lambda s: None)
+
+    cb._ensure_vector_service()
+    assert calls["count"] == 3
+    assert not popen_called["called"]
+
+
+def test_ensure_vector_service_raises_after_attempts(monkeypatch):
+    import vector_service.context_builder as cb
+
+    calls = {"count": 0}
+
+    class DummyResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def fake_urlopen(url, timeout=2):
+        calls["count"] += 1
+        raise OSError("not ready")
+
+    import urllib.request
+    import subprocess
+
+    monkeypatch.setenv("VECTOR_SERVICE_URL", "http://example")
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    popen_called = {"count": 0}
+    monkeypatch.setattr(
+        subprocess,
+        "Popen",
+        lambda *a, **k: popen_called.__setitem__("count", popen_called["count"] + 1),
+    )
+    monkeypatch.setattr(cb.time, "sleep", lambda s: None)
+
+    with pytest.raises(cb.VectorServiceError):
+        cb._ensure_vector_service()
+    assert popen_called["count"] == 1
+    assert calls["count"] == 10


### PR DESCRIPTION
## Summary
- poll `/health/ready` with exponential backoff before using vector service
- add `--check-vector-service` CLI flag to fail fast when service is unreachable
- tests for startup retries and CLI pre-checks

## Testing
- `pytest tests/test_vector_service_startup.py tests/test_menace_cli_service_flag.py tests/test_context_builder_embeddings.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c10162119c832e9fef51fce86a7f3c