### PR TITLE
Load preprocessing configs for vector DBs

### DIFF
--- a/code_database.py
+++ b/code_database.py
@@ -1532,7 +1532,7 @@ class PatchHistoryDB:
                 "language": row[3],
             }
             text = self._record_text(data)
-            prepared = self._prepare_text_for_embedding(text)
+            prepared = self._prepare_text_for_embedding(text, db_key="code")
             return self.encode_text(prepared) if prepared else None
         if isinstance(rec, CodeRecord):
             data = asdict(rec)
@@ -1541,7 +1541,7 @@ class PatchHistoryDB:
         else:
             return None
         text = self._record_text(data)
-        prepared = self._prepare_text_for_embedding(text)
+        prepared = self._prepare_text_for_embedding(text, db_key="code")
         return self.encode_text(prepared) if prepared else None
 
     def search_by_vector(

--- a/task_handoff_bot.py
+++ b/task_handoff_bot.py
@@ -555,7 +555,7 @@ class WorkflowDB(EmbeddableDBMixin):
         elif not isinstance(rec, WorkflowRecord):
             raise TypeError("unsupported record type")
         text = self._vector_text(rec)
-        prepared = self._prepare_text_for_embedding(text)
+        prepared = self._prepare_text_for_embedding(text, db_key="workflow")
         return self._embed(prepared)
 
     def _embed(self, text: str) -> list[float]:

--- a/unit_tests/test_preprocess_configs.py
+++ b/unit_tests/test_preprocess_configs.py
@@ -1,0 +1,32 @@
+import re
+
+import pytest
+
+from vector_service.text_preprocessor import get_config
+
+
+def _simulate(text: str, db_key: str):
+    cfg = get_config(db_key)
+    if cfg.split_sentences:
+        sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", text) if s.strip()]
+    else:
+        sentences = [text]
+    joined = "\n".join(sentences)
+    chunks = [joined[i:i + cfg.chunk_size] for i in range(0, len(joined), cfg.chunk_size)]
+    return cfg, sentences, chunks
+
+
+@pytest.mark.parametrize(
+    "db_key, text, expected_sentences, expected_chunk_size",
+    [
+        ("code", "One. Two.", ["One. Two."], 50),
+        ("bot", "One. Two.", ["One.", "Two."], 60),
+        ("error", "One. Two.", ["One.", "Two."], 70),
+        ("workflow", "One. Two.", ["One. Two."], 80),
+    ],
+)
+def test_preprocess_configs(db_key, text, expected_sentences, expected_chunk_size):
+    cfg, sentences, chunks = _simulate(text, db_key)
+    assert sentences == expected_sentences
+    assert cfg.chunk_size == expected_chunk_size
+    assert all(len(c) <= expected_chunk_size for c in chunks)

--- a/vector_service/preprocess.yml
+++ b/vector_service/preprocess.yml
@@ -1,0 +1,16 @@
+code:
+  chunk_size: 50
+  split_sentences: false
+  filter_semantic_risks: true
+bot:
+  chunk_size: 60
+  split_sentences: true
+  filter_semantic_risks: true
+error:
+  chunk_size: 70
+  split_sentences: true
+  filter_semantic_risks: false
+workflow:
+  chunk_size: 80
+  split_sentences: false
+  filter_semantic_risks: true

--- a/vector_service/text_preprocessor.py
+++ b/vector_service/text_preprocessor.py
@@ -162,6 +162,12 @@ def load_db_configs(path: str) -> None:
         )
 
 
+# Load default preprocessing configs from the packaged ``preprocess.yml`` at import
+# time so databases automatically pick up their settings without manual
+# registration.
+load_db_configs(os.path.join(os.path.dirname(__file__), "preprocess.yml"))
+
+
 def _resolve_config(
     db_key: Optional[str], config: Optional[PreprocessingConfig]
 ) -> PreprocessingConfig:


### PR DESCRIPTION
## Summary
- load default DB preprocessing configs from `vector_service/preprocess.yml`
- wire code and workflow databases to use named preprocess configs
- add basic tests asserting chunk size and sentence splitting per DB key

## Testing
- `PYTHONPATH=. pre-commit run --files vector_service/text_preprocessor.py vector_service/preprocess.yml code_database.py task_handoff_bot.py unit_tests/test_preprocess_configs.py`
- `PYTHONPATH=. pytest unit_tests/test_preprocess_configs.py`


------
https://chatgpt.com/codex/tasks/task_e_68c102e2f2a8832ea58a4dab42c9cb4a