### PR TITLE
Use registry for embedding backfill file paths

### DIFF
--- a/bot_database.py
+++ b/bot_database.py
@@ -163,6 +163,8 @@ class FailedMenace:
 class BotDB(EmbeddableDBMixin):
     """SQLite database tracking bots and relationships."""
 
+    DB_FILE = "bots.db"
+
     MAX_RETRIES = 5
 
     def __init__(

--- a/chatgpt_enhancement_bot.py
+++ b/chatgpt_enhancement_bot.py
@@ -111,6 +111,8 @@ class EnhancementHistory:
 class EnhancementDB(EmbeddableDBMixin):
     """SQLite storage for enhancement logs with vector embeddings."""
 
+    DB_FILE = "enhancements.db"
+
     def __init__(
         self,
         path: Optional[Path] = None,

--- a/code_database.py
+++ b/code_database.py
@@ -300,6 +300,8 @@ class CodeRecord:
 class CodeDB(EmbeddableDBMixin):
     """SQLite storage for code templates and relationships."""
 
+    DB_FILE = "code.db"
+
     def __init__(
         self,
         path: Path | str | None = None,

--- a/discrepancy_db.py
+++ b/discrepancy_db.py
@@ -36,6 +36,8 @@ class DiscrepancyRecord:
 class DiscrepancyDB(EmbeddableDBMixin):
     """SQLite-backed storage for discrepancy messages with embeddings."""
 
+    DB_FILE = "discrepancies.db"
+
     def __init__(
         self,
         path: str | Path = "discrepancies.db",

--- a/error_bot.py
+++ b/error_bot.py
@@ -118,6 +118,8 @@ class ErrorRecord:
 class ErrorDB(EmbeddableDBMixin):
     """SQLite-backed storage for known errors and discrepancies."""
 
+    DB_FILE = "errors.db"
+
     def __init__(
         self,
         path: Path | str | None = None,

--- a/failure_learning_system.py
+++ b/failure_learning_system.py
@@ -287,6 +287,8 @@ class DiscrepancyDB(EmbeddableDBMixin):
 class FailureDB(DiscrepancyDB):
     """Expose failure embeddings for the vector service."""
 
+    DB_FILE = "failures.db"
+
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         # provide mapping access for ``dict(row)`` calls

--- a/information_db.py
+++ b/information_db.py
@@ -46,6 +46,8 @@ class InformationRecord:
 class InformationDB(EmbeddableDBMixin):
     """SQLite-backed store for static information with embeddings."""
 
+    DB_FILE = "information.db"
+
     def __init__(
         self,
         path: str = "information.db",

--- a/intent_db.py
+++ b/intent_db.py
@@ -35,6 +35,8 @@ class IntentRecord:
 class IntentDB(EmbeddableDBMixin):
     """Persist intent embeddings for repository modules."""
 
+    DB_FILE = "intent.db"
+
     def __init__(
         self,
         path: str | Path = "intent.db",

--- a/research_aggregator_bot.py
+++ b/research_aggregator_bot.py
@@ -104,6 +104,8 @@ class ResearchMemory:
 class InfoDB(EmbeddableDBMixin):
     """SQLite storage for collected research."""
 
+    DB_FILE = "information.db"
+
     def __init__(
         self,
         path: Path = Path("information.db"),

--- a/resources_bot.py
+++ b/resources_bot.py
@@ -50,6 +50,8 @@ class ROIRecord:
 class ROIHistoryDB(EmbeddableDBMixin):
     """SQLite-backed ROI history storage with embedding support."""
 
+    DB_FILE = "roi_history.db"
+
     def __init__(
         self,
         path: str | Path = "roi_history.db",

--- a/task_handoff_bot.py
+++ b/task_handoff_bot.py
@@ -133,6 +133,8 @@ _WORKFLOW_HASH_FIELDS = sorted([
 class WorkflowDB(EmbeddableDBMixin):
     """SQLite storage for generated workflows with vector search."""
 
+    DB_FILE = "workflows.db"
+
     def __init__(
         self,
         path: Path | str = resolve_path("workflows.db"),

--- a/tests/test_dynamic_db_registration.py
+++ b/tests/test_dynamic_db_registration.py
@@ -1,0 +1,57 @@
+import sys
+import types
+
+import pytest
+
+
+def test_new_registry_entry_resolves_db_file(monkeypatch, tmp_path):
+    dummy_mod = types.ModuleType("dummy_mod")
+
+    class DummyDB:
+        DB_FILE = "custom.sqlite"
+
+        def __init__(self, *args, **kwargs):
+            self._metadata = {}
+            self.embedding_version = 1
+
+        def iter_records(self):
+            return iter([])
+
+    dummy_mod.DummyDB = DummyDB
+    sys.modules["dummy_mod"] = dummy_mod
+
+    from vector_service import registry as reg
+
+    monkeypatch.setattr(reg, "_VECTOR_REGISTRY", reg._VECTOR_REGISTRY.copy())
+    reg.register_vectorizer(
+        "dummy", "dummy_vec", "DummyVectorizer", db_module="dummy_mod", db_class="DummyDB"
+    )
+
+    import vector_service.embedding_backfill as eb
+
+    db_path = tmp_path / "custom.sqlite"
+    db_path.write_text("x")
+    monkeypatch.setattr(eb, "_TIMESTAMP_FILE", tmp_path / "ts.json")
+    eb._TIMESTAMP_FILE.write_text("{}")
+
+    resolved = []
+
+    def fake_resolve(path):
+        resolved.append(path)
+        return db_path if path == "custom.sqlite" else tmp_path / path
+
+    monkeypatch.setattr(eb, "resolve_path", fake_resolve)
+
+    called = {}
+
+    async def fake_schedule_backfill(*, dbs=None, **_):
+        called["dbs"] = dbs
+
+    monkeypatch.setattr(eb, "schedule_backfill", fake_schedule_backfill)
+
+    with pytest.raises(eb.StaleEmbeddingsError):
+        eb.ensure_embeddings_fresh(["dummy"], retries=1, delay=0)
+
+    assert "custom.sqlite" in resolved
+    assert called["dbs"] == ["dummy"]
+

--- a/tests/test_embedding_freshness.py
+++ b/tests/test_embedding_freshness.py
@@ -1,4 +1,5 @@
 import json
+import importlib
 import logging
 import time
 from pathlib import Path
@@ -21,6 +22,7 @@ def test_ensure_embeddings_fresh_logs_and_raises(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr("dynamic_path_router.resolve_path", lambda p: Path(tmp_path / p))
 
     import vector_service.embedding_backfill as eb
+    eb = importlib.reload(eb)
 
     monkeypatch.setattr(eb, "_TIMESTAMP_FILE", Path(tmp_path / "ts.json"))
     monkeypatch.setattr(eb, "_load_registry", lambda path=None: {})

--- a/vector_service/patch_vectorizer.py
+++ b/vector_service/patch_vectorizer.py
@@ -13,6 +13,8 @@ from dynamic_path_router import resolve_path
 class PatchVectorizer(EmbeddableDBMixin):
     """Embed patches by concatenating description, diff and summary."""
 
+    DB_FILE = "patch_history.db"
+
     DB_MODULE = "vector_service.patch_vectorizer"
     DB_CLASS = "PatchVectorizer"
 


### PR DESCRIPTION
## Summary
- derive database filenames from registered EmbeddableDB classes instead of a hard-coded map
- expose `DB_FILE` on EmbeddableDB implementations such as CodeDB and EnhancementDB
- add regression test ensuring new registry entries are handled automatically

## Testing
- `pytest tests/test_embedding_freshness.py tests/test_dynamic_db_registration.py tests/test_menace_cli_embed.py tests/test_menace_cli_embed_init.py tests/test_context_builder_embeddings.py tests/test_vectorizer_registry.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c11863da34832ea661c9a1e296e545