### PR TITLE
refactor: remove openai fallback retry config

### DIFF
--- a/bot_dev_config.py
+++ b/bot_dev_config.py
@@ -44,14 +44,11 @@ class BotDevConfig:
     )
     error_sinks: List[Callable[[str, str], None]] = field(default_factory=list)
     concurrency_workers: int = int(os.getenv("BOT_DEV_CONCURRENCY", "1"))
-    openai_attempts: int = int(os.getenv("OPENAI_FALLBACK_ATTEMPTS", "3"))
-    openai_fallback_model: str = os.getenv("OPENAI_FALLBACK_MODEL", "gpt-4o-mini")
     # retry/polling configuration
     file_write_attempts: int = int(os.getenv("FILE_WRITE_ATTEMPTS", "3"))
     file_write_retry_delay: float = float(os.getenv("FILE_WRITE_RETRY_DELAY", "0.5"))
     send_prompt_attempts: int = int(os.getenv("SEND_PROMPT_ATTEMPTS", "3"))
     send_prompt_retry_delay: float = float(os.getenv("SEND_PROMPT_RETRY_DELAY", "1.0"))
-    openai_retry_delay: float = float(os.getenv("OPENAI_RETRY_DELAY", "1.0"))
     visual_agent_poll_interval: float = float(os.getenv("VISUAL_AGENT_POLL_INTERVAL", "5"))
 
     def validate(self) -> None:

--- a/tests/test_bot_development_bot.py
+++ b/tests/test_bot_development_bot.py
@@ -224,7 +224,7 @@ def test_visual_and_engine_failure_fallback(tmp_path, monkeypatch, caplog):
 
     class FailVisual(bdb.BotDevelopmentBot):
         def __init__(self, repo_base: Path) -> None:  # type: ignore[override]
-            super().__init__(repo_base=repo_base, openai_attempts=2, context_builder=_ctx_builder())
+            super().__init__(repo_base=repo_base, context_builder=_ctx_builder())
 
         def _visual_build(self, prompt: str, name: str) -> bool:  # type: ignore[override]
             return False

--- a/tests/test_implementation_pipeline.py
+++ b/tests/test_implementation_pipeline.py
@@ -398,7 +398,7 @@ def test_pipeline_surfaces_openai_errors(tmp_path, monkeypatch, caplog):
 
     class FallbackDev(bdb.BotDevelopmentBot):
         def __init__(self, repo_base: Path, builder) -> None:  # type: ignore[override]
-            super().__init__(repo_base=repo_base, openai_attempts=2, context_builder=builder)
+            super().__init__(repo_base=repo_base, context_builder=builder)
 
         def _visual_build(self, prompt: str) -> bool:  # type: ignore[override]
             return False
@@ -508,7 +508,7 @@ def test_pipeline_openai_error_not_raised(tmp_path, monkeypatch, caplog):
 
     class FallbackDev(bdb.BotDevelopmentBot):
         def __init__(self, repo_base: Path, builder) -> None:  # type: ignore[override]
-            super().__init__(repo_base=repo_base, openai_attempts=1, context_builder=builder)
+            super().__init__(repo_base=repo_base, context_builder=builder)
 
         def _visual_build(self, prompt: str) -> bool:  # type: ignore[override]
             return False

--- a/tests/test_payment_notice.py
+++ b/tests/test_payment_notice.py
@@ -154,7 +154,7 @@ sys.modules.setdefault(
 
 from menace_sandbox.enhancement_bot import EnhancementBot
 from menace_sandbox.chatgpt_idea_bot import ChatGPTClient
-from menace_sandbox.bot_development_bot import BotDevelopmentBot, RetryStrategy
+from menace_sandbox.bot_development_bot import BotDevelopmentBot
 
 
 def test_payment_router_notice_mentions_central_routing_and_logging():
@@ -245,7 +245,6 @@ def test_bot_development_bot_calls_engine():
 
     dummy = types.SimpleNamespace(
         engine=Engine(),
-        fallback_retry=RetryStrategy(attempts=1),
         logger=logging.getLogger("test"),
         _escalate=lambda msg, level="error": None,
     )


### PR DESCRIPTION
## Summary
- drop unused OpenAI fallback settings from `BotDevConfig`
- simplify `BotDevelopmentBot` initialization and engine fallback logic
- update tests for the new interface

## Testing
- `pytest tests/test_bot_development_bot.py::test_visual_and_engine_failure_fallback tests/test_payment_notice.py::test_bot_development_bot_calls_engine -q`
- `pytest tests/test_implementation_pipeline.py::test_pipeline_surfaces_openai_errors tests/test_implementation_pipeline.py::test_pipeline_openai_error_not_raised -q` *(fails: `RuntimeError: vector_service import failed`)*

------
https://chatgpt.com/codex/tasks/task_e_68c129f197c4832eb36d98b2fc9a5e27