### PR TITLE
docs: describe self-coding engine setup

### DIFF
--- a/docs/autonomous_sandbox.md
+++ b/docs/autonomous_sandbox.md
@@ -12,7 +12,9 @@ running the fully autonomous sandbox.
 - `DATABASE_URL` – database connection string.
 - `SANDBOX_REPO_PATH` – repository root used by background services.
 - `SANDBOX_DATA_DIR` – directory where sandbox state and metrics are stored.
-- `OPENAI_API_KEY` – API key for model access.
+ - `SELF_CODING_INTERVAL`, `SELF_CODING_ROI_DROP` and `SELF_CODING_ERROR_INCREASE`
+   – tune the local `SelfCodingEngine`; code generation runs entirely offline and
+   requires no API keys.
 - `VISUAL_AGENT_MONITOR_INTERVAL` – seconds between visual agent health checks
   (default `30`).
 - `LOCAL_KNOWLEDGE_REFRESH_INTERVAL` – refresh interval for the local
@@ -853,7 +855,7 @@ python run_autonomous.py --include-orphans
 # util.py is merged into module_map.json and metrics reflect the reintroduction
 ```
 
-Additional API keys such as `OPENAI_API_KEY` may be added to the same `.env` file.
+SelfCodingEngine runs locally so no additional API keys are required.
 
 ## Launch sequence
 
@@ -1012,7 +1014,7 @@ SELF_TEST_DISABLE_ORPHANS=0
 SELF_TEST_DISCOVER_ORPHANS=1
 SANDBOX_RECURSIVE_ORPHANS=1
 SANDBOX_RECURSIVE_ISOLATED=1
-OPENAI_API_KEY=sk-xxxxx
+SELF_CODING_INTERVAL=5
 ```
 
 Edit the resulting `.env` to override any defaults as needed.

--- a/docs/implementation_pipeline.md
+++ b/docs/implementation_pipeline.md
@@ -37,7 +37,8 @@ flowchart TD
 - **Handoff failure** – network errors when contacting Stage 4 cause retries. After two failed attempts the pipeline aborts.
 - **IPO plan failure** – if `IPOBot.generate_plan` raises an exception twice, the run stops.
 - **Research failure** – problems while invoking the researcher are logged and cause the pipeline to raise.
-- **Build failure** – the developer bot may fail to generate code (e.g. due to OpenAI errors) leading to a runtime error.
+- **Build failure** – the developer bot may fail to generate code, leading to a
+  runtime error.
 - **Test failure** – if `pytest` fails for a generated repository the pipeline raises an error and logs the output.
 
 ## Usage
@@ -75,15 +76,15 @@ All repositories are verified by running `scripts/setup_tests.sh` followed by `p
 - `VISUAL_AGENT_TOKEN` – API token for visual agent helpers.
 - `VISUAL_AGENT_URLS` – semicolon separated list of visual agent endpoints.
 - `BOT_DEV_HEADLESS` – set to `1` to disable visual agent interaction.
-- `BOT_DEV_CONCURRENCY` – number of concurrent workers used during code generation.
-- `OPENAI_FALLBACK_ATTEMPTS` – attempts for OpenAI fallback when generation fails.
+ - `BOT_DEV_CONCURRENCY` – number of concurrent workers used during code generation.
+ - `SELF_CODING_INTERVAL` – run `SelfCodingEngine` after this many cycles (default `5`).
 
-### OpenAI fallback
+### SelfCodingEngine
 
-`BotDevelopmentBot` contacts the OpenAI API as a last resort when the visual
-agents cannot build a repository. The API key is read from `OPENAI_API_KEY` and
-the number of retries is determined by `OPENAI_FALLBACK_ATTEMPTS` (default 3).
-If the key is absent the fallback is skipped entirely.
+`BotDevelopmentBot` now generates code locally through `SelfCodingEngine`.
+Configure intervals and thresholds via `SELF_CODING_INTERVAL`,
+`SELF_CODING_ROI_DROP` and `SELF_CODING_ERROR_INCREASE`. All generation runs
+offline and no external API keys are required.
 
 `TaskHandoffBot` accepts an `api_url` parameter to change the HTTP endpoint used for Stage 4 handoff. Message queue integration can be enabled by providing a `pika` channel instance.
 

--- a/docs/sandbox_runner.md
+++ b/docs/sandbox_runner.md
@@ -551,7 +551,7 @@ The generative stub provider exposes several knobs via environment variables:
 
 The `concurrency_spike` failure mode starts bursts of threads and async tasks. The sandbox records how many threads and tasks were spawned in the metrics.
 
-Sections with declining ROI trigger dedicated improvement cycles. Only the flagged section is iteratively modified while metrics are tracked. When progress stalls the sandbox issues a GPT‑4 brainstorming request if `SANDBOX_BRAINSTORM_INTERVAL` is set. Consecutive low‑ROI cycles before brainstorming can be tuned via `SANDBOX_BRAINSTORM_RETRIES`.
+Sections with declining ROI trigger dedicated improvement cycles. Only the flagged section is iteratively modified while metrics are tracked. When progress stalls the sandbox issues a brainstorming request to local models if `SANDBOX_BRAINSTORM_INTERVAL` is set. Consecutive low‑ROI cycles before brainstorming can be tuned via `SANDBOX_BRAINSTORM_RETRIES`.
 
 `_SandboxMetaLogger.diminishing()` evaluates these ROI deltas using a rolling mean and standard deviation over the last `consecutive` cycles. A module is flagged when the mean is within the given threshold and the standard deviation falls below a small epsilon, preventing sporadic fluctuations from triggering improvements.
 
@@ -775,9 +775,9 @@ workflows is trending in a positive or negative direction. The reliability
 score summarises how close recent synergy predictions were to the actual
 measurements; values near `1` suggest highly consistent forecasts.
 
-## GPT‑4 Integration
+## SelfCodingEngine Integration
 
-When `OPENAI_API_KEY` is set the sandbox requests improvements from GPT‑4 after ROI gains diminish. Suggestions are applied via `SelfCodingEngine` and reverted if they fail to increase ROI. Set `SANDBOX_BRAINSTORM_INTERVAL` to a positive integer to periodically ask GPT‑4 for high level ideas during the run. Use `SANDBOX_BRAINSTORM_RETRIES` to specify how many consecutive low‑ROI cycles trigger extra brainstorming.
+The sandbox requests improvements from local models after ROI gains diminish. Suggestions are applied via `SelfCodingEngine` and reverted if they fail to increase ROI. Set `SANDBOX_BRAINSTORM_INTERVAL` to a positive integer to periodically ask the local models for high‑level ideas during the run. Use `SANDBOX_BRAINSTORM_RETRIES` to specify how many consecutive low‑ROI cycles trigger extra brainstorming. No external API keys are required.
 ## Metric Tracking and Prediction Bots
 
 Sandbox cycles record extended metrics such as `security_score`, `safety_rating`,


### PR DESCRIPTION
## Summary
- replace OpenAI key instructions with SelfCodingEngine configuration in README and bot docs
- clarify that code generation runs locally without external API keys

## Testing
- `pre-commit run --files README.md docs/implementation_pipeline.md docs/autonomous_sandbox.md docs/sandbox_runner.md` *(failed: ModuleNotFoundError: No module named 'dynamic_path_router')*

------
https://chatgpt.com/codex/tasks/task_e_68c12e4be138832ea502966b4b29c10b