### PR TITLE
Refactor bot developer to use SelfCodingEngine directly

### DIFF
--- a/tests/test_payment_notice.py
+++ b/tests/test_payment_notice.py
@@ -246,7 +246,7 @@ def test_bot_development_bot_calls_engine(monkeypatch):
     monkeypatch.setattr(engine, "generate_helper", fake_generate)
 
     dummy = types.SimpleNamespace(
-        engine=engine,
+        self_coding_engine=engine,
         logger=logging.getLogger("test"),
         _escalate=lambda msg, level="error": None,
         errors=[],
@@ -261,7 +261,7 @@ def test_bot_development_bot_calls_engine(monkeypatch):
         ],
     )
 
-    assert captured["desc"] == "hi\nthere"
+    assert captured["desc"] == "hi"
     assert result == "code"
 
 


### PR DESCRIPTION
## Summary
- accept optional SelfCodingEngine and store on `self.self_coding_engine`
- simplify `_call_codex_api` to forward final user prompt to `SelfCodingEngine`
- adjust tests for new engine usage

## Testing
- `PYTHONPATH=. pre-commit run --files bot_development_bot.py tests/test_payment_notice.py`
- `pytest tests/test_payment_notice.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1302a5378832ebe32c5de209c0628