### PR TITLE
refactor: generalize fallback configuration

### DIFF
--- a/bot_dev_config.py
+++ b/bot_dev_config.py
@@ -13,7 +13,9 @@ from typing import List, Callable, Dict, Tuple
 class BotDevConfig:
     """Central configuration for bot development."""
 
-    repo_base: Path = field(default_factory=lambda: Path(os.getenv("BOT_DEV_REPO_BASE", "dev_repos")))
+    repo_base: Path = field(
+        default_factory=lambda: Path(os.getenv("BOT_DEV_REPO_BASE", "dev_repos"))
+    )
     es_url: str | None = os.getenv("BOT_DEV_ES_URL")
     es_index: str = os.getenv("BOT_DEV_ES_INDEX", "patterns")
     desktop_url: str = os.getenv("VISUAL_DESKTOP_URL", "http://127.0.0.1:8001")
@@ -49,9 +51,15 @@ class BotDevConfig:
     file_write_retry_delay: float = float(os.getenv("FILE_WRITE_RETRY_DELAY", "0.5"))
     send_prompt_attempts: int = int(os.getenv("SEND_PROMPT_ATTEMPTS", "3"))
     send_prompt_retry_delay: float = float(os.getenv("SEND_PROMPT_RETRY_DELAY", "1.0"))
-    generation_attempts: int = int(os.getenv("GENERATION_ATTEMPTS", "3"))
-    generation_retry_delay: float = float(os.getenv("GENERATION_RETRY_DELAY", "1.0"))
-    default_model: str = os.getenv("DEFAULT_MODEL", "internal-codex")
+    fallback_attempts: int = int(
+        os.getenv("FALLBACK_ATTEMPTS", os.getenv("GENERATION_ATTEMPTS", "3"))
+    )
+    fallback_retry_delay: float = float(
+        os.getenv("FALLBACK_RETRY_DELAY", os.getenv("GENERATION_RETRY_DELAY", "1.0"))
+    )
+    fallback_model: str = os.getenv(
+        "FALLBACK_MODEL", os.getenv("DEFAULT_MODEL", "internal-codex")
+    )
     visual_agent_poll_interval: float = float(os.getenv("VISUAL_AGENT_POLL_INTERVAL", "5"))
 
     def validate(self) -> None:
@@ -64,4 +72,3 @@ class BotDevConfig:
             self.concurrency_workers = 1
         if not self.es_index:
             self.es_index = "patterns"
-

--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -311,9 +311,9 @@ class BotDevelopmentBot:
             attempts=self.config.send_prompt_attempts,
             delay=self.config.send_prompt_retry_delay,
         )
-        self.generation_retry = RetryStrategy(
-            attempts=self.config.generation_attempts,
-            delay=self.config.generation_retry_delay,
+        self.fallback_retry = RetryStrategy(
+            attempts=self.config.fallback_attempts,
+            delay=self.config.fallback_retry_delay,
         )
         self.prompt_templates_version = 1
         try:
@@ -961,7 +961,7 @@ class BotDevelopmentBot:
 
         try:
             result = self._call_codex_api(
-                self.config.default_model, [{"role": "user", "content": prompt}]
+                self.config.fallback_model, [{"role": "user", "content": prompt}]
             )
         except Exception as exc:  # pragma: no cover - defensive
             self.logger.error("internal fallback failed: %s", exc, exc_info=True)

--- a/tests/test_payment_notice.py
+++ b/tests/test_payment_notice.py
@@ -42,7 +42,9 @@ sys.modules["menace_sandbox.memory_logging"] = memory_logging
 memory_client = types.SimpleNamespace(ask_with_memory=lambda *a, **k: {})
 sys.modules["menace_sandbox.memory_aware_gpt_client"] = memory_client
 
-db_router_stub = types.SimpleNamespace(DBRouter=object(), init_db_router=lambda *a, **k: None)
+db_router_stub = types.SimpleNamespace(
+    DBRouter=object(), init_db_router=lambda *a, **k: None, GLOBAL_ROUTER=None
+)
 sys.modules["db_router"] = db_router_stub
 sys.modules["menace_sandbox.db_router"] = db_router_stub
 sys.modules["menace_sandbox"].db_router = db_router_stub  # type: ignore[attr-defined]
@@ -172,7 +174,7 @@ def test_bot_development_bot_calls_engine(monkeypatch):
         logger=logging.getLogger("test"),
         _escalate=lambda msg, level="error": None,
         errors=[],
-        generation_retry=RetryStrategy(),
+        fallback_retry=RetryStrategy(),
     )
 
     result = BotDevelopmentBot._call_codex_api(


### PR DESCRIPTION
## Summary
- rename OpenAI-specific dev config to generic fallback_* fields
- use new fallback fields in BotDevelopmentBot retry and internal fallback
- adjust tests for new fallback configuration

## Testing
- `pre-commit run --files bot_dev_config.py bot_development_bot.py tests/test_payment_notice.py` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*
- `pytest tests/test_bot_development_bot.py tests/test_payment_notice.py` *(fails: RuntimeError: vector_service import failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c13cc5cfe4832e8d3accebff5cac61