### PR TITLE
refactor: generalize dev config retries

### DIFF
--- a/bot_dev_config.py
+++ b/bot_dev_config.py
@@ -51,14 +51,14 @@ class BotDevConfig:
     file_write_retry_delay: float = float(os.getenv("FILE_WRITE_RETRY_DELAY", "0.5"))
     send_prompt_attempts: int = int(os.getenv("SEND_PROMPT_ATTEMPTS", "3"))
     send_prompt_retry_delay: float = float(os.getenv("SEND_PROMPT_RETRY_DELAY", "1.0"))
-    fallback_attempts: int = int(
-        os.getenv("FALLBACK_ATTEMPTS", os.getenv("GENERATION_ATTEMPTS", "3"))
+    engine_attempts: int = int(
+        os.getenv("ENGINE_ATTEMPTS", os.getenv("GENERATION_ATTEMPTS", "3"))
     )
-    fallback_retry_delay: float = float(
-        os.getenv("FALLBACK_RETRY_DELAY", os.getenv("GENERATION_RETRY_DELAY", "1.0"))
+    engine_retry_delay: float = float(
+        os.getenv("ENGINE_RETRY_DELAY", os.getenv("GENERATION_RETRY_DELAY", "1.0"))
     )
-    fallback_model: str = os.getenv(
-        "FALLBACK_MODEL", os.getenv("DEFAULT_MODEL", "internal-codex")
+    engine_model: str = os.getenv(
+        "ENGINE_MODEL", os.getenv("DEFAULT_MODEL", "internal-codex")
     )
     visual_agent_poll_interval: float = float(os.getenv("VISUAL_AGENT_POLL_INTERVAL", "5"))
 

--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -311,9 +311,9 @@ class BotDevelopmentBot:
             attempts=self.config.send_prompt_attempts,
             delay=self.config.send_prompt_retry_delay,
         )
-        self.fallback_retry = RetryStrategy(
-            attempts=self.config.fallback_attempts,
-            delay=self.config.fallback_retry_delay,
+        self.engine_retry = RetryStrategy(
+            attempts=self.config.engine_attempts,
+            delay=self.config.engine_retry_delay,
         )
         self.prompt_templates_version = 1
         try:

--- a/tests/test_payment_notice.py
+++ b/tests/test_payment_notice.py
@@ -187,7 +187,7 @@ def test_call_codex_api_forwards_prompt_to_engine(monkeypatch):
         logger=logging.getLogger("test"),
         _escalate=lambda msg, level="error": None,
         errors=[],
-        fallback_retry=RetryStrategy(),
+        engine_retry=RetryStrategy(),
     )
 
     result = BotDevelopmentBot._call_codex_api(


### PR DESCRIPTION
## Summary
- rename fallback retry settings in BotDevConfig to generic engine_* fields
- update BotDevelopmentBot to use engine_* retry strategy
- align payment notice test with new engine_* naming

## Testing
- `pytest tests/test_bot_development_bot.py::test_parse_plan_yaml -q`
- `pytest tests/test_payment_notice.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c147137978832e9b8d349a810319a4