### PR TITLE
Clarify SelfCodingEngine usage for BotDevelopmentBot

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,22 @@ builder = ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
 
 ```python
 from bot_development_bot import BotDevelopmentBot, BotSpec
+from self_coding_engine import SelfCodingEngine
+from menace_memory_manager import MenaceMemoryManager
 
-bot = BotDevelopmentBot(context_builder=builder)
+memory_mgr = MenaceMemoryManager()
+engine = SelfCodingEngine("code.db", memory_mgr, context_builder=builder)
+bot = BotDevelopmentBot(context_builder=builder, engine=engine)
 bot._build_prompt(BotSpec(name="demo", purpose="test"), context_builder=builder)
 ```
 
 BotDevelopmentBot now routes generation through the local `SelfCodingEngine`.
 All prompts are processed on your machine and never sent to external
-services.
+services. Supply your own engine by instantiating
+`SelfCodingEngine` and passing it via the ``engine`` argument. Runtime
+behaviour can be tuned with the ``SELF_CODING_INTERVAL``,
+``SELF_CODING_ROI_DROP`` and ``SELF_CODING_ERROR_INCREASE`` environment
+variables.
 
 ### AutomatedReviewer
 

--- a/docs/context_builder.md
+++ b/docs/context_builder.md
@@ -122,8 +122,12 @@ builder = ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
 
 ```python
 from bot_development_bot import BotDevelopmentBot, BotSpec
+from self_coding_engine import SelfCodingEngine
+from menace_memory_manager import MenaceMemoryManager
 
-bot = BotDevelopmentBot(context_builder=builder)
+memory_mgr = MenaceMemoryManager()
+engine = SelfCodingEngine("code.db", memory_mgr, context_builder=builder)
+bot = BotDevelopmentBot(context_builder=builder, engine=engine)
 bot._build_prompt(BotSpec(name="demo", purpose="test"), context_builder=builder)
 ```
 
@@ -169,15 +173,14 @@ to ensure a ``context_builder`` keyword is threaded through common prompt
 helpers.  It flags calls to ``PromptEngine``, ``_build_prompt``,
 ``generate_patch``, bare ``build_prompt(...)`` helpers and methods named
 ``build_prompt_with_memory`` when they omit the keyword. The checker also
-inspects any legacy OpenAI API calls along with the ``chat_completion_create``
-wrapper. SelfCodingEngine now handles code generation locally, but the checker
-retains support for these patterns. To intentionally skip a call, append
-``# nocb`` on the call line (or the line above). Only direct
-``build_prompt(...)`` calls are checked to avoid warning on unrelated methods
-with the same name. Variables assigned from ``LLMClient``-like classes are
-tracked so that subsequent ``instance.generate(...)`` invocations require the
-keyword as well; aliases such as ``llm`` or ``model`` are heuristically checked
-even without a prior assignment.
+inspects any direct chat-completion or other remote LLM calls so that
+generation consistently routes through ``SelfCodingEngine``. To intentionally
+skip a call, append ``# nocb`` on the call line (or the line above). Only
+direct ``build_prompt(...)`` calls are checked to avoid warning on unrelated
+methods with the same name. Variables assigned from ``LLMClient``-like classes
+are tracked so that subsequent ``instance.generate(...)`` invocations require
+the keyword as well; aliases such as ``llm`` or ``model`` are heuristically
+checked even without a prior assignment.
 
 Functions that invoke ``ContextBuilder.build`` must accept an explicit builder
 argument.  A parameter defaulting to ``None`` or falling back to a new builder

--- a/docs/implementation_pipeline.md
+++ b/docs/implementation_pipeline.md
@@ -84,7 +84,18 @@ All repositories are verified by running `scripts/setup_tests.sh` followed by `p
 `BotDevelopmentBot` now generates code locally through `SelfCodingEngine`.
 Configure intervals and thresholds via `SELF_CODING_INTERVAL`,
 `SELF_CODING_ROI_DROP` and `SELF_CODING_ERROR_INCREASE`. All generation runs
-offline and no external API keys are required.
+offline and no external API keys are required. Provide a custom engine by
+instantiating ``SelfCodingEngine`` and passing it to ``BotDevelopmentBot``:
+
+```python
+from bot_development_bot import BotDevelopmentBot
+from self_coding_engine import SelfCodingEngine
+from menace_memory_manager import MenaceMemoryManager
+
+memory_mgr = MenaceMemoryManager()
+engine = SelfCodingEngine("code.db", memory_mgr, context_builder=builder)
+bot = BotDevelopmentBot(context_builder=builder, engine=engine)
+```
 
 `TaskHandoffBot` accepts an `api_url` parameter to change the HTTP endpoint used for Stage 4 handoff. Message queue integration can be enabled by providing a `pika` channel instance.
 

--- a/docs/models_repo_workflow.md
+++ b/docs/models_repo_workflow.md
@@ -1,6 +1,6 @@
 # Models Repository Workflow
 
-`ImplementationPipeline` and `BotDevelopmentBot` share a single git repository where all models are developed. The path defaults to `models_repo` next to the main codebase and is created with `ensure_models_repo()` when missing.
+`ImplementationPipeline` and `BotDevelopmentBot` share a single git repository where all models are developed. The path defaults to `models_repo` next to the main codebase and is created with `ensure_models_repo()` when missing. Code generation runs through the local ``SelfCodingEngine`` so no external API keys are required.
 
 ## Visual agent integration
 

--- a/docs/visual_agent_prompt.md
+++ b/docs/visual_agent_prompt.md
@@ -1,7 +1,8 @@
 # Visual Agent Prompt Format
 
-`BotDevelopmentBot` sends instructions to visual code generators. The prompt is
-composed of several sections. Each section guides the agent to create a
+`BotDevelopmentBot` sends instructions to visual code generators through the
+local ``SelfCodingEngine``. The prompt is composed of several sections. Each
+section guides the agent to create a
 complete, testable repository. The list below summarises the required headings:
 
 1. **Introduction** – states the target language, bot name and short


### PR DESCRIPTION
## Summary
- Document supplying and configuring a local SelfCodingEngine in README
- Explain local SelfCodingEngine use in BotDevelopmentBot docs and workflows
- Remove legacy OpenAI references across documentation

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'WorkflowRecord' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c14ba94f18832eb70d606f0154cf76