### PR TITLE
chore: remove unused blinker dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,6 @@ beautifulsoup4==4.13.4
     # via menace (pyproject.toml)
 billiard==4.2.1
     # via celery
-blinker==1.9.0
-    # via flask
 boto3==1.39.3
     # via menace (pyproject.toml)
 botocore==1.39.3


### PR DESCRIPTION
## Summary
- remove blinker from requirements
- verify repository doesn't import blinker

## Testing
- `rg -l "blinker" -g "*.py"`
- `pytest tests/test_context_builder_static.py -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68c14dcf30c0832e8c04c5329674320b