### PR TITLE
Validate user message before calling codex

### DIFF
--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -941,10 +941,21 @@ class BotDevelopmentBot:
         """
 
         prompt = ""
+        user_found = False
         for message in reversed(messages):
             if message.get("role") == "user":
                 prompt = message.get("content", "")
+                user_found = True
                 break
+
+        if not user_found:
+            msg = "no user message found"
+            self.logger.warning(msg)
+            self._escalate(msg, level="warning")
+            self.errors.append(msg)
+            if RAISE_ERRORS:
+                raise RuntimeError(msg)
+            return None
 
         try:
             return self.engine_retry.run(


### PR DESCRIPTION
## Summary
- handle missing user message in `_call_codex_api` by logging, escalating, and returning `None` or raising depending on `RAISE_ERRORS`
- add tests covering the no-user-message path

## Testing
- `pytest tests/test_payment_notice.py::test_call_codex_api_no_user_message_returns_none -q`
- `pytest tests/test_payment_notice.py::test_call_codex_api_no_user_message_raises -q`
- `pytest tests/test_payment_notice.py::test_call_codex_api_forwards_prompt_to_engine -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1509e10bc832eb3808bb63b634661