### PR TITLE
Remove unused model parameter from _call_codex_api

### DIFF
--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -929,9 +929,7 @@ class BotDevelopmentBot:
                 self._escalate(f"visual token refresh failed: {output}")
         return False
 
-    def _call_codex_api(
-        self, model: str, messages: list[dict[str, str]]
-    ) -> Any:
+    def _call_codex_api(self, messages: list[dict[str, str]]) -> Any:
         """Produce helper code via :class:`SelfCodingEngine`.
 
         The final user message in ``messages`` is treated as a description of the

--- a/tests/test_payment_notice.py
+++ b/tests/test_payment_notice.py
@@ -193,7 +193,6 @@ def test_call_codex_api_forwards_prompt_to_engine(monkeypatch):
 
     result = BotDevelopmentBot._call_codex_api(
         dummy,
-        "m",
         [
             {"role": "user", "content": "hi"},
             {"role": "assistant", "content": "there"},
@@ -232,7 +231,6 @@ def test_call_codex_api_no_user_message_returns_none(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING):
         result = BotDevelopmentBot._call_codex_api(
             dummy,
-            "m",
             [{"role": "assistant", "content": "there"}],
         )
 
@@ -268,7 +266,6 @@ def test_call_codex_api_no_user_message_raises(monkeypatch):
     with pytest.raises(RuntimeError):
         BotDevelopmentBot._call_codex_api(
             dummy,
-            "m",
             [{"role": "assistant", "content": "there"}],
         )
 


### PR DESCRIPTION
## Summary
- Drop `model` argument from `_call_codex_api` and simplify docstring
- Adjust `_call_codex_api` invocations in tests to new signature

## Testing
- `pytest tests/test_payment_notice.py::test_call_codex_api_forwards_prompt_to_engine`
- `pytest tests/test_payment_notice.py::test_call_codex_api_no_user_message_returns_none`
- `pytest tests/test_payment_notice.py::test_call_codex_api_no_user_message_raises`
- `pytest tests/test_payment_notice.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1517bc14c832eacbf5c09a3e728a9