### PR TITLE
Ensure engine fallback uses retry with unified error handling

### DIFF
--- a/tests/test_implementation_pipeline.py
+++ b/tests/test_implementation_pipeline.py
@@ -57,12 +57,21 @@ class _WFDB:
     def try_upgrade_schema(self):
         pass
 
+    def try_add_embedding(self, *_a, **_k):
+        pass
+
 
 wf_db_stub.WorkflowDB = _WFDB
 sys.modules["workflow_db"] = wf_db_stub
 sys.modules["menace.workflow_db"] = wf_db_stub
 vec_stub = types.ModuleType("vector_service")
 vec_stub.__path__ = []
+
+class _EmbeddableDBMixin:
+    def try_add_embedding(self, *_a, **_k):
+        pass
+
+vec_stub.EmbeddableDBMixin = _EmbeddableDBMixin
 
 text_pre = types.ModuleType("text_preprocessor")
 text_pre.generalise = lambda *_a, **_k: None
@@ -612,7 +621,7 @@ def test_pipeline_engine_error_not_raised(tmp_path, monkeypatch, caplog):
     caplog.set_level(logging.ERROR)
     result = pipeline.run(tasks)
     assert isinstance(result, ip.PipelineResult)
-    assert "engine fallback failed" in developer.errors
+    assert any("engine request failed" in e for e in developer.errors)
 
 
 def test_pipeline_surfaces_build_errors(tmp_path, caplog):


### PR DESCRIPTION
## Summary
- wrap engine fallback in `BotDevelopmentBot` with `engine_retry.run` for consistent retry behavior
- unify exception logging and escalation across engine requests
- expand tests to cover engine retry and escalation logic during fallback

## Testing
- `pytest tests/test_bot_development_bot.py::test_visual_and_engine_failure_fallback -q`
- `pytest tests/test_implementation_pipeline.py -k engine_error_not_raised` *(fails: AttributeError: 'WorkflowDB' object has no attribute 'try_add_embedding')*


------
https://chatgpt.com/codex/tasks/task_e_68c152680f14832e884b1282098685a0