### PR TITLE
Use retry strategy for helper generation

### DIFF
--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -961,12 +961,13 @@ class BotDevelopmentBot:
                 logger=self.logger,
             )
         except Exception as exc:
-            self.logger.exception("engine call failed: %s", exc)
-            self._escalate(f"engine request failed: {exc}")
-            self.errors.append(f"engine request failed: {exc}")
+            msg = f"engine request failed after retries: {exc}"
+            self.logger.exception(msg)
+            self._escalate(msg)
+            self.errors.append(msg)
             if RAISE_ERRORS:
                 raise
-            return {"error": f"engine request failed: {exc}"}
+            return {"error": msg}
 
     def _send_prompt(self, base: str, prompt: str, name: str) -> tuple[bool, str]:
         if not requests:

--- a/tests/test_payment_notice.py
+++ b/tests/test_payment_notice.py
@@ -304,10 +304,10 @@ def test_call_codex_api_engine_failure_retries_and_escalates(monkeypatch, caplog
         )
 
     assert calls["n"] == 2
-    assert result == {"error": "engine request failed: boom"}
-    assert escalated["msg"] == "engine request failed: boom"
+    assert result == {"error": "engine request failed after retries: boom"}
+    assert escalated["msg"] == "engine request failed after retries: boom"
     assert escalated["level"] == "error"
-    assert dummy.errors == ["engine request failed: boom"]
+    assert dummy.errors == ["engine request failed after retries: boom"]
     assert "retry 1/2 after error: boom" in caplog.text
 
 
@@ -343,6 +343,6 @@ def test_call_codex_api_engine_failure_raises(monkeypatch):
         )
 
     assert calls["n"] == 2
-    assert escalated["msg"] == "engine request failed: boom"
+    assert escalated["msg"] == "engine request failed after retries: boom"
     assert escalated["level"] == "error"
-    assert dummy.errors == ["engine request failed: boom"]
+    assert dummy.errors == ["engine request failed after retries: boom"]


### PR DESCRIPTION
## Summary
- retry helper generation via SelfCodingEngine and escalate failure
- clarify error message when retries are exhausted
- update tests for new messaging

## Testing
- `PYTHONPATH=. pre-commit run --files bot_development_bot.py tests/test_payment_notice.py`
- `pytest tests/test_payment_notice.py::test_call_codex_api_forwards_prompt_to_engine tests/test_payment_notice.py::test_call_codex_api_no_user_message_returns_none tests/test_payment_notice.py::test_call_codex_api_no_user_message_raises tests/test_payment_notice.py::test_call_codex_api_engine_failure_retries_and_escalates tests/test_payment_notice.py::test_call_codex_api_engine_failure_raises`
- `pytest tests/test_bot_development_bot.py::test_visual_and_engine_failure_fallback tests/test_implementation_pipeline.py::test_pipeline_engine_error_not_raised` *(fails: AttributeError: 'NoneType' object has no attribute 'get_connection')*


------
https://chatgpt.com/codex/tasks/task_e_68c1560069e8832ea517496fbf12dfc7