### PR TITLE
Raise ValueError when user message missing in codex API call

### DIFF
--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -935,7 +935,9 @@ class BotDevelopmentBot:
         The final user message in ``messages`` is treated as a description of the
         desired helper.  The description is fed to
         :meth:`SelfCodingEngine.generate_helper` and no external API calls are
-        made.
+        made.  If no user message is present, the error is escalated and the
+        method returns ``None`` or raises :class:`ValueError` when
+        :data:`RAISE_ERRORS` is true.
         """
 
         prompt = ""
@@ -952,7 +954,7 @@ class BotDevelopmentBot:
             self._escalate(msg, level="warning")
             self.errors.append(msg)
             if RAISE_ERRORS:
-                raise RuntimeError(msg)
+                raise ValueError(msg)
             return None
 
         try:

--- a/tests/test_payment_notice.py
+++ b/tests/test_payment_notice.py
@@ -204,7 +204,7 @@ def test_call_codex_api_forwards_prompt_to_engine(monkeypatch):
     assert wrapper_called is False
 
 
-def test_call_codex_api_no_user_message_returns_none(monkeypatch, caplog):
+def test_call_codex_api_no_user_message_escalates(monkeypatch, caplog):
     escalated: dict[str, str] = {}
 
     def fake_escalate(msg: str, level: str = "error") -> None:
@@ -240,7 +240,7 @@ def test_call_codex_api_no_user_message_returns_none(monkeypatch, caplog):
     assert "no user message found" in caplog.text
 
 
-def test_call_codex_api_no_user_message_raises(monkeypatch):
+def test_call_codex_api_no_user_message_raises_value_error(monkeypatch):
     escalated: dict[str, str] = {}
 
     def fake_escalate(msg: str, level: str = "error") -> None:
@@ -263,7 +263,7 @@ def test_call_codex_api_no_user_message_raises(monkeypatch):
         engine_retry=RetryStrategy(),
     )
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         BotDevelopmentBot._call_codex_api(
             dummy,
             [{"role": "assistant", "content": "there"}],


### PR DESCRIPTION
## Summary
- raise `ValueError` in `_call_codex_api` when no user role is found
- test escalation path and `ValueError` trigger when user message is missing

## Testing
- `PYTHONPATH=. pre-commit run --files bot_development_bot.py tests/test_payment_notice.py`
- `pytest tests/test_payment_notice.py::test_call_codex_api_no_user_message_escalates tests/test_payment_notice.py::test_call_codex_api_no_user_message_raises_value_error`

------
https://chatgpt.com/codex/tasks/task_e_68c1573dc53c832e9e40c8e746f02b07