### PR TITLE
validate user prompt before code generation

### DIFF
--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -934,8 +934,8 @@ class BotDevelopmentBot:
 
         All ``system`` and ``user`` messages are concatenated with their role
         tags to form a single prompt for
-        :meth:`SelfCodingEngine.generate_helper`.  If no user message is
-        present, the error is escalated and the method returns ``None`` or
+        :meth:`SelfCodingEngine.generate_helper`.  If no user prompt is
+        provided, the error is escalated and the method returns ``None`` or
         raises :class:`ValueError` when :data:`RAISE_ERRORS` is true.
         """
 
@@ -947,16 +947,17 @@ class BotDevelopmentBot:
                 prompt_parts.append(f"{role}: {message.get('content', '')}")
                 if role == "user":
                     user_found = True
-        prompt = "\n".join(prompt_parts)
 
         if not user_found:
-            msg = "no user message found"
+            msg = "no user prompt provided"
             self.logger.warning(msg)
             self._escalate(msg, level="warning")
             self.errors.append(msg)
             if RAISE_ERRORS:
                 raise ValueError(msg)
             return None
+
+        prompt = "\n".join(prompt_parts)
 
         if not prompt.strip():
             msg = "empty prompt"

--- a/tests/test_payment_notice.py
+++ b/tests/test_payment_notice.py
@@ -289,8 +289,9 @@ def test_call_codex_api_no_user_message_escalates(monkeypatch, caplog):
 
     assert result is None
     assert escalated["level"] == "warning"
-    assert "no user message found" in escalated["msg"]
-    assert "no user message found" in caplog.text
+    assert "no user prompt provided" in escalated["msg"]
+    assert "no user prompt provided" in caplog.text
+    assert dummy.errors == ["no user prompt provided"]
     assert run_called is False
 
 
@@ -332,6 +333,7 @@ def test_call_codex_api_no_user_message_raises_value_error(monkeypatch):
         )
 
     assert escalated["level"] == "warning"
+    assert dummy.errors == ["no user prompt provided"]
     assert run_called is False
 
 
@@ -372,8 +374,9 @@ def test_call_codex_api_empty_messages_escalates(monkeypatch, caplog):
 
     assert result is None
     assert escalated["level"] == "warning"
-    assert "no user message found" in escalated["msg"]
-    assert "no user message found" in caplog.text
+    assert "no user prompt provided" in escalated["msg"]
+    assert "no user prompt provided" in caplog.text
+    assert dummy.errors == ["no user prompt provided"]
     assert run_called is False
 
 


### PR DESCRIPTION
## Summary
- ensure `_call_codex_api` checks for a user prompt before invoking `generate_helper`
- clarify error message when user prompt is missing
- extend payment notice tests to cover missing user prompt path

## Testing
- `pytest tests/test_payment_notice.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c15f248da8832e9bd162c5445e80b5