### PR TITLE
Use centralized secret redaction in BotDevelopmentBot

### DIFF
--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -20,6 +20,7 @@ from dynamic_path_router import resolve_path
 import uuid
 from snippet_compressor import compress_snippets
 from context_builder_util import ensure_fresh_weights
+from secret_redactor import redact_secrets
 
 try:
     from packaging.requirements import Requirement  # type: ignore
@@ -980,11 +981,7 @@ class BotDevelopmentBot:
             return EngineResult(False, None, msg)
 
         prompt_snippet = prompt[: self.config.max_prompt_log_chars]
-        prompt_snippet = re.sub(
-            r"(?i)(?:api[_-]?key|token)[=:]\s*[^\s]+",
-            "[REDACTED]",
-            prompt_snippet,
-        )
+        prompt_snippet = redact_secrets(prompt_snippet)
         self.logger.info("generate_helper prompt: %s", prompt_snippet)
 
         try:


### PR DESCRIPTION
## Summary
- import `redact_secrets` and use it to sanitize prompts before logging
- test that various secret patterns are removed from `_call_codex_api` log output

## Testing
- `pre-commit run --files bot_development_bot.py tests/test_bot_development_bot.py` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*
- `pytest tests/test_bot_development_bot.py::test_call_codex_api_redacts_secrets -q`


------
https://chatgpt.com/codex/tasks/task_e_68c16d1dd6b8832ebd095b5675ec3845