### PR TITLE
refactor: remove visual agent config fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1893,9 +1893,6 @@ Troubleshooting tips:
   restarting unexpectedly.
 - If synergy metrics diverge wildly, verify that ``synergy_history.db`` is
   writable and consider adjusting ``--synergy-threshold-weight``.
-- HTTP 401 errors from the visual agent usually mean ``VISUAL_AGENT_TOKEN`` is
-  missing or mismatched. Confirm the token matches the secret configured in
-  ``menace_visual_agent_2.py``.
 QEMU must be installed separately for cross-platform tests. Place your QCOW2 files in `qemu_images` and reference them via `VM_SETTINGS` so presets with `OS_TYPE` `windows` or `macos` boot automatically.
 
 ### Maintenance logs and audit signing
@@ -1973,7 +1970,6 @@ start unattended.  At minimum the following variables must be defined:
 - ``MENACE_SANITY_OPTIONAL`` – set to any value in development to allow missing
   ``menace_sanity_layer`` modules. Without this the Stripe watchdog raises
   ``SanityLayerUnavailableError`` when feedback hooks are invoked.
-- ``VISUAL_AGENT_TOKEN`` – shared secret used by ``menace_visual_agent_2.py`` for authentication.
 - ``SANDBOX_REPO_PATH`` – path to the local sandbox repository clone processed during self-improvement cycles.
 - ``SANDBOX_DATA_DIR`` – directory storing ROI history, presets and patch metrics.
 
@@ -2055,21 +2051,10 @@ HTTP ``202`` and a task id. Submitted tasks are appended to
 the job completes. This persistent queue allows multiple clients to share the
 agent safely and ensures tasks survive restarts.
 
-Set the environment variable ``VISUAL_TOKEN_REFRESH_CMD`` to a shell command returning a fresh token. ``VisualAgentClient`` runs the command automatically when authentication fails.
-
-``VISUAL_AGENT_TOKEN`` **must** be set and is hashed for comparison. Requests may provide a ``Bearer`` token via the ``Authorization`` header or the legacy ``x-token`` field.
-
-When launched via ``run_autonomous.py`` a ``VisualAgentMonitor`` thread keeps
-``menace_visual_agent_2.py`` running. If the process stops responding or the
-queue database disappears the monitor restarts the service and posts to
-``/recover`` so queued tasks resume. This relies on ``VISUAL_AGENT_AUTO_RECOVER=1``.
-
 The service automatically recovers queued tasks and clears stale locks on
-startup. Set ``VISUAL_AGENT_AUTO_RECOVER=0`` or pass ``--no-auto-recover`` to
-disable this behaviour. If the SQLite queue is corrupted the file is renamed
-to ``visual_agent_queue.db.corrupt.<timestamp>`` and rebuilt from
-``visual_agent_state.json`` when available.
-Database errors encountered during normal operation now trigger the same
+startup. If the SQLite queue is corrupted the file is renamed to
+``visual_agent_queue.db.corrupt.<timestamp>`` and rebuilt from
+``visual_agent_state.json`` when available. Database errors encountered during normal operation now trigger the same
 recovery automatically, so ``--recover-queue`` is rarely necessary.
 
 These manual tools are mainly useful for troubleshooting when the monitor fails to restart the service.

--- a/auto_env_setup.py
+++ b/auto_env_setup.py
@@ -27,10 +27,7 @@ RECURSIVE_ISOLATED_VARS = (
     "SELF_TEST_RECURSIVE_ISOLATED",
 )
 
-SENSITIVE_VARS = (
-    "VISUAL_AGENT_TOKEN",
-    "VISUAL_AGENT_URLS",
-)
+SENSITIVE_VARS = ()
 
 # Default environment variables with fallbacks
 # These are persisted to ``.env`` when missing so the application can

--- a/bot_dev_config.py
+++ b/bot_dev_config.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 import os
-import logging
 from typing import List, Callable, Dict, Tuple
 
 from . import RAISE_ERRORS
@@ -20,16 +19,6 @@ class BotDevConfig:
     )
     es_url: str | None = os.getenv("BOT_DEV_ES_URL")
     es_index: str = os.getenv("BOT_DEV_ES_INDEX", "patterns")
-    desktop_url: str = os.getenv("VISUAL_DESKTOP_URL", "http://127.0.0.1:8001")
-    laptop_url: str = os.getenv("VISUAL_LAPTOP_URL", "http://127.0.0.1:8002")
-    visual_agent_urls: List[str] = field(
-        default_factory=lambda: (
-            os.getenv("VISUAL_AGENT_URLS")
-            or ""  # sentinel so split works
-        ).split(";")
-    )
-    visual_agent_token: str = field(default_factory=lambda: os.getenv("VISUAL_AGENT_TOKEN", ""))
-    visual_token_refresh_cmd: str | None = os.getenv("VISUAL_TOKEN_REFRESH_CMD")
     denial_phrases: List[str] = field(
         default_factory=lambda: os.getenv(
             "BOT_DEV_DENIAL_PHRASES",
@@ -64,14 +53,9 @@ class BotDevConfig:
         "ENGINE_MODEL", os.getenv("DEFAULT_MODEL", "internal-codex")
     )
     max_prompt_log_chars: int = int(os.getenv("MAX_PROMPT_LOG_CHARS", "200"))
-    visual_agent_poll_interval: float = float(os.getenv("VISUAL_AGENT_POLL_INTERVAL", "5"))
 
     def validate(self) -> None:
         """Warn if important settings are missing."""
-        if not self.visual_agent_token:
-            logging.getLogger("BotDev").warning("VISUAL_AGENT_TOKEN not set")
-        if not any(self.visual_agent_urls):
-            self.visual_agent_urls = [self.desktop_url, self.laptop_url]
         if self.concurrency_workers < 1:
             self.concurrency_workers = 1
         if not self.es_index:

--- a/conftest.py
+++ b/conftest.py
@@ -73,5 +73,3 @@ sys.modules.setdefault(
     ),
 )
 
-os.environ.setdefault("VISUAL_AGENT_URLS", "http://127.0.0.1:8001")
-os.environ.setdefault("VISUAL_AGENT_TOKEN", "test-token")

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -483,7 +483,6 @@ class SandboxSettings(BaseSettings):
         default_factory=lambda: [
             "metrics.db",
             "patch_history.db",
-            "visual_agent_queue.db",
         ],
         env="SANDBOX_REQUIRED_DB_FILES",
         description="SQLite database files expected in the sandbox data directory.",
@@ -529,9 +528,6 @@ class SandboxSettings(BaseSettings):
         gt=0,
         description="Rotate logs after this many seconds; when set, overrides size-based rotation.",
     )
-    visual_agent_monitor_interval: float = Field(
-        30.0, env="VISUAL_AGENT_MONITOR_INTERVAL"
-    )
     local_knowledge_refresh_interval: float = Field(
         600.0, env="LOCAL_KNOWLEDGE_REFRESH_INTERVAL"
     )
@@ -540,8 +536,6 @@ class SandboxSettings(BaseSettings):
         (resolve_path(".") / "shared" / "global.db").as_posix(),
         env="MENACE_SHARED_DB_PATH",
     )
-    visual_agent_token: str = Field("", env="VISUAL_AGENT_TOKEN")
-    visual_agent_token_rotate: str | None = Field(None, env="VISUAL_AGENT_TOKEN_ROTATE")
     sandbox_volatility_threshold: float = Field(1.0, env="SANDBOX_VOLATILITY_THRESHOLD")
     gpt_memory_compact_interval: float | None = Field(
         None, env="GPT_MEMORY_COMPACT_INTERVAL"
@@ -1568,11 +1562,6 @@ class SandboxSettings(BaseSettings):
         description="Multiplier applied to marginal growth predictions.",
     )
     auto_dashboard_port: int | None = Field(None, env="AUTO_DASHBOARD_PORT")
-    visual_agent_autostart: bool = Field(True, env="VISUAL_AGENT_AUTOSTART")
-    visual_agent_urls: str = Field("", env="VISUAL_AGENT_URLS")
-    va_prompt_template: str | None = Field(None, env="VA_PROMPT_TEMPLATE")
-    va_prompt_prefix: str = Field("", env="VA_PROMPT_PREFIX")
-    va_repo_layout_lines: int = Field(20, env="VA_REPO_LAYOUT_LINES")
     use_memory: bool = Field(
         True,
         env="SANDBOX_USE_MEMORY",


### PR DESCRIPTION
## Summary
- strip legacy visual agent settings from BotDevConfig
- drop visual agent options from SandboxSettings and environment helpers
- update docs and tests to reflect removal

## Testing
- `python -m py_compile bot_dev_config.py sandbox_settings.py auto_env_setup.py conftest.py`
- `pytest tests/test_call_codex_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c17c2795e4832eaac06566b636a5c4