### PR TITLE
docs: remove visual-agent db references

### DIFF
--- a/docs/autonomous_sandbox.md
+++ b/docs/autonomous_sandbox.md
@@ -927,8 +927,10 @@ SelfCodingEngine runs locally so no additional API keys are required.
 responds with HTTP `202` and a task id. Submitted tasks are appended to
 `SANDBOX_DATA_DIR/visual_agent_queue.db` and processed sequentially. Poll
 `/status/<id>` to monitor progress. The persistent queue avoids race conditions
-and survives restarts.
-The queue is stored in a SQLite database so tasks persist across restarts. A matching `visual_agent_state.json` file records the status of each job and when the last task completed. Both are loaded on startup so unfinished work continues automatically.
+and survives restarts. The database is created automatically inside the sandbox
+data directory. A matching `visual_agent_state.json` file records the status of
+each job and when the last task completed. Both are loaded on startup so
+unfinished work continues automatically.
 
 Use `menace_visual_agent_2.py --resume` to process any pending
 entries without launching the HTTP service. Stale lock and PID files are cleaned

--- a/docs/sandbox_config.sample.yaml
+++ b/docs/sandbox_config.sample.yaml
@@ -7,7 +7,6 @@ optional_service_versions:
 sandbox_required_db_files:
   - metrics.db
   - patch_history.db
-  - visual_agent_queue.db
 prompt_chunk_token_threshold: 3500
 prompt_chunk_cache_dir: chunk_summary_cache
 roi:

--- a/docs/sandbox_settings.md
+++ b/docs/sandbox_settings.md
@@ -158,14 +158,14 @@ Unset modules are ignored.
 
 `SandboxSettings.sandbox_required_db_files` lists SQLite files that should be
 present inside `sandbox_data_dir`. The bootstrap helper ensures each file
-exists, creating empty databases when necessary. Override the defaults via a
+exists, creating empty databases when necessary. By default the sandbox
+maintains `metrics.db` and `patch_history.db`. Override the defaults via a
 configuration file or the `SANDBOX_REQUIRED_DB_FILES` environment variable:
 
 ```yaml
 sandbox_required_db_files:
   - metrics.db
   - patch_history.db
-  - visual_agent_queue.db
 ```
 
 ```bash

--- a/docs/visual_agent_prompt.md
+++ b/docs/visual_agent_prompt.md
@@ -160,7 +160,12 @@ The standalone service `menace_visual_agent_2.py` exposes HTTP endpoints on the
 port specified by `MENACE_AGENT_PORT` (default 8001). Requests must include
 `VISUAL_AGENT_TOKEN` for authentication. The `/run` endpoint always returns
 HTTP `202` together with a task id. Submitted jobs are appended to
-`visual_agent_queue.db` and executed sequentially. Poll `/status/<id>` to check progress. Crash recovery and stale lock handling are automatic as detailed above. The queue uses SQLite for persistence and a `visual_agent_state.json` file records job status and the timestamp of the last completed task.
+`visual_agent_queue.db` and executed sequentially. Poll `/status/<id>` to check
+progress. The queue database is created automatically inside
+`SANDBOX_DATA_DIR` and crash recovery and stale lock handling are automatic as
+detailed above. The queue uses SQLite for persistence and a
+`visual_agent_state.json` file records job status and the timestamp of the last
+completed task.
 
 The `/status` endpoint returns a JSON object with two fields:
 


### PR DESCRIPTION
## Summary
- drop `visual_agent_queue.db` from sample sandbox config
- document only `metrics.db` and `patch_history.db` as required DBs
- note that the visual agent queue database is created automatically

## Testing
- `pytest tests/test_run_autonomous_workflow_integration.py -q` *(fails: ModuleNotFoundError: No module named 'sandbox_runner.bootstrap'; 'sandbox_runner' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68c17e0c4ad4832e83ddd90e13b07ddd