### PR TITLE
Remove visual agent client from sandbox runner

### DIFF
--- a/sandbox_runner.py
+++ b/sandbox_runner.py
@@ -945,34 +945,10 @@ def _sandbox_init(
     # UnboundLocalError during argument evaluation.
     suggestion_db: PatchSuggestionDB | None = None
 
-    try:
-        from menace.visual_agent_client import VisualAgentClient
-    except Exception as exc:
-        logger.warning("VisualAgentClient import failed: %s", exc)
-        try:
-            from menace.visual_agent_client import (
-                VisualAgentClientStub as VisualAgentClient,
-            )
-        except Exception:
-            VisualAgentClient = None  # type: ignore
-
-    va_client = None
-    if VisualAgentClient:
-        try:
-            va_client = VisualAgentClient()
-        except Exception as exc:
-            logger.warning("VisualAgentClient init failed: %s", exc)
-            try:
-                from menace.visual_agent_client import VisualAgentClientStub
-
-                va_client = VisualAgentClientStub()
-                logger.info("using VisualAgentClientStub due to failure")
-            except Exception:
-                va_client = None
     engine = SelfCodingEngine(
         CodeDB(),
         MenaceMemoryManager(),
-        llm_client=va_client,
+        llm_client=None,
         patch_suggestion_db=suggestion_db,
         gpt_memory=gpt_memory,
         context_builder=context_builder,


### PR DESCRIPTION
## Summary
- Remove VisualAgentClient/VisualAgentClientStub imports and fallbacks from `sandbox_runner.py`
- Initialize `SelfCodingEngine` without an external visual agent client

## Testing
- `pytest -q tests/test_generate_helper_fallback.py` *(fails: ImportError: cannot import name 'CodeDB' from 'code_database')*

------
https://chatgpt.com/codex/tasks/task_e_68c18aa84944832ea6c3e956dd04c144