### PR TITLE
refactor: drop legacy visual agent imports

### DIFF
--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -55,12 +55,6 @@ except Exception:  # pragma: no cover - optional dependency
 if TYPE_CHECKING:  # pragma: no cover - heavy dependency
     from .watchdog import Watchdog
 
-try:
-    import requests  # type: ignore
-except Exception:  # pragma: no cover - optional dependency
-    requests = None  # type: ignore
-
-
 try:  # pragma: no cover - optional dependency
     from .micro_models.tool_predictor import predict_tools  # type: ignore
     from .micro_models.prefix_injector import inject_prefix  # type: ignore
@@ -334,7 +328,6 @@ class BotDevelopmentBot:
         self.engine = engine
         # warn about missing optional dependencies
         for dep_name, mod in {
-            "requests": requests,
             "yaml": yaml,
             "Elasticsearch": Elasticsearch,
             "git": Repo,


### PR DESCRIPTION
## Summary
- remove deprecated visual-agent imports and references in bot development bot
- streamline optional dependency checks to include only yaml, Elasticsearch, and git

## Testing
- `pre-commit run --files bot_development_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1a27e8b48832e8b67d1f210dacdf6