### PR TITLE
Refactor QuickFixEngine to depend on shared SelfCodingManager

### DIFF
--- a/tests/integration/test_patch_provenance_quick_fix.py
+++ b/tests/integration/test_patch_provenance_quick_fix.py
@@ -50,8 +50,15 @@ def test_quick_fix_records_license_and_alerts(tmp_path, monkeypatch):
     patch_id = db.add(PatchRecord("mod.py", "desc", 1.0, 2.0))  # path-ignore
 
     class Manager:
+        def __init__(self):
+            self.bot_registry = types.SimpleNamespace()
+            self.data_bot = types.SimpleNamespace()
+
         def run_patch(self, path, desc, context_meta=None, **kw):
             return types.SimpleNamespace(patch_id=patch_id)
+
+        def register_bot(self, *a, **k):
+            return None
 
     class Retriever:
         def search(self, query, top_k, session_id):

--- a/tests/integration/test_vector_service_clients.py
+++ b/tests/integration/test_vector_service_clients.py
@@ -85,10 +85,12 @@ def test_quick_fix_engine_uses_vector_service_retriever():
 
         def build(self, query, session_id=None, include_vectors=False):
             return ""
-
+    manager = types.SimpleNamespace(
+        bot_registry=object(), data_bot=object(), register_bot=lambda *a, **k: None
+    )
     engine = QuickFixEngine(
         error_db=object(),
-        manager=object(),
+        manager=manager,
         retriever=SpyRetriever(),
         context_builder=DummyBuilder(),
     )

--- a/unit_tests/test_major_bot_context_builders.py
+++ b/unit_tests/test_major_bot_context_builders.py
@@ -209,7 +209,9 @@ def test_apply_validated_patch_emits_rejection_event(tmp_path, monkeypatch):
         engine=object(),
         event_bus=bus,
         data_bot=DB(),
+        bot_registry=object(),
         bot_name="bot",
+        register_bot=lambda *a, **k: None,
     )
     monkeypatch.setattr(qfe, "generate_patch", lambda *a, **k: (1, ["flag"]))
     monkeypatch.setattr(qfe.subprocess, "run", lambda *a, **k: None)


### PR DESCRIPTION
## Summary
- remove global `BotRegistry` and `DataBot` singletons from quick_fix_engine
- require `SelfCodingManager` with existing registry and metrics in QuickFixEngine constructor
- adjust tests to supply manager stubs with registry and data bot

## Testing
- `python -m py_compile quick_fix_engine.py`
- `pytest unit_tests/test_major_bot_context_builders.py tests/integration/test_patch_provenance_quick_fix.py tests/integration/test_vector_service_clients.py tests/test_missing_context_builder.py unit_tests/test_quick_fix_engine.py` *(fails: FileNotFoundError: No such file or directory: '')*
- `flake8 quick_fix_engine.py unit_tests/test_major_bot_context_builders.py tests/integration/test_patch_provenance_quick_fix.py tests/integration/test_vector_service_clients.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4cacab178832e9fc5ea25b730d116