### PR TITLE
Enhance error clustering and prioritization

### DIFF
--- a/unit_tests/test_error_cluster_predictor.py
+++ b/unit_tests/test_error_cluster_predictor.py
@@ -97,7 +97,8 @@ def test_best_cluster_groups_similar_traces(monkeypatch):
     ]
     db = _make_db(traces)
     predictor = ErrorClusterPredictor(db)
-    cluster_id, cluster_traces = predictor.best_cluster("mod", n_clusters=2)
+    cluster_id, cluster_traces, size = predictor.best_cluster("mod", n_clusters=2)
     assert cluster_id in (0, 1)
-    assert len(cluster_traces) == 2
+    assert size == 2
+    assert len(cluster_traces) == size
     assert all("ValueError" in t for t in cluster_traces)


### PR DESCRIPTION
## Summary
- Replace ad-hoc vectorization and k-means with TF-IDF and scikit-learn KMeans
- Allow dynamic cluster sizing and expose tuning knobs
- Factor cluster size into QuickFixEngine patch prioritization

## Testing
- `pytest -q unit_tests/test_error_cluster_predictor.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4ccfbb234832eb76bbd79f1f7f537