### PR TITLE
test: enforce self-coding decorators

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,11 @@ pre-commit run find-unmanaged-bots --all-files
 
 CI fails if unmanaged bots are detected.
 
+For additional assurance, the test suite includes
+`tests/test_self_coding_compliance.py`, which executes the same scan during
+`pytest`. The test fails if any `*_bot.py` module defines a bot class without
+`@self_coding_managed`, ensuring new bots remain self-coding compliant.
+
 
 ## Helper generation wrappers
 

--- a/tests/test_self_coding_compliance.py
+++ b/tests/test_self_coding_compliance.py
@@ -1,0 +1,11 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_no_unmanaged_bots():
+    """Fail if any *_bot.py modules lack @self_coding_managed."""
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "tools" / "find_unmanaged_bots.py"
+    result = subprocess.run([sys.executable, str(script)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tools/check_self_coding_registration.py
+++ b/tools/check_self_coding_registration.py
@@ -32,6 +32,8 @@ EXCLUDED_PATHS = {
     Path("investment_engine.py"),
     Path("revenue_amplifier.py"),
     Path("plugins/metrics_prediction.py"),
+    # ``data_bot.py`` is a metrics helper rather than a self-coding bot.
+    Path("data_bot.py"),
 }
 
 

--- a/tools/find_unmanaged_bots.py
+++ b/tools/find_unmanaged_bots.py
@@ -15,6 +15,11 @@ from pathlib import Path
 
 KNOWN_BOT_BASES = {"AdminBotBase"}
 
+# Some modules share the ``Bot`` suffix but are infrastructure helpers rather
+# than self-coding bots.  Listing them here prevents false positives when this
+# script runs under pre-commit or the test suite.
+EXCLUDED_PATHS = {Path("data_bot.py")}
+
 
 def _inherits_bot_base(cls: ast.ClassDef) -> bool:
     for base in cls.bases:
@@ -62,6 +67,9 @@ def main() -> None:
     offenders: list[tuple[Path, list[str]]] = []
     for path in root.rglob("*_bot.py"):
         if "tests" in path.parts or "unit_tests" in path.parts:
+            continue
+        rel = path.relative_to(root)
+        if rel in EXCLUDED_PATHS:
             continue
         try:
             tree = ast.parse(path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- add pytest check for unmanaged bots
- skip DataBot in self-coding registration scans
- document self-coding bot validation in contribution guide

## Testing
- `pytest tests/test_self_coding_compliance.py`
- `pre-commit run --files tools/find_unmanaged_bots.py tests/test_self_coding_compliance.py CONTRIBUTING.md` *(fails: No module named 'dynamic_path_router', static path references, enforce context builder)*

------
https://chatgpt.com/codex/tasks/task_e_68c4cf964934832e912728cc50c8634f