### PR TITLE
Ensure bots use self-coding manager

### DIFF
--- a/workflow_evolution_bot.py
+++ b/workflow_evolution_bot.py
@@ -168,6 +168,9 @@ class WorkflowEvolutionBot:
         benchmarking.
         """
 
+        if self.manager and not self.manager.should_refactor():
+            return
+
         emitted: set[str] = set()
         for suggestion in self.analyse(limit):
             parts = suggestion.sequence.split("-")


### PR DESCRIPTION
## Summary
- fix ResearchAggregatorBot imports and register/data bot setup
- store manager and reference it for enhancement gating
- gate WorkflowEvolutionBot variant generation behind manager

## Testing
- `python tools/find_unmanaged_bots.py`
- `python -m py_compile research_aggregator_bot.py workflow_evolution_bot.py`
- `pytest tests/test_coding_bot_interface.py -q`
- `pytest tests/test_coding_bot_interface.py tests/test_self_coding_manager.py -q` *(fails: AttributeError: module 'menace.self_coding_manager' has no attribute 'subprocess')*


------
https://chatgpt.com/codex/tasks/task_e_68c4d17218cc832eb3120644d52fd3d4