### PR TITLE
Emit bot degraded events and queue patch cycles

### DIFF
--- a/data_bot.py
+++ b/data_bot.py
@@ -1651,9 +1651,8 @@ class DataBot:
         if self.event_bus:
             try:
                 self.event_bus.publish("metrics:delta", event)
-                if event["roi_breach"] or event["error_breach"]:
-                    self.event_bus.publish("data:threshold_breach", event)
                 if degraded:
+                    self.event_bus.publish("data:threshold_breach", event)
                     self.event_bus.publish("bot:degraded", event)
                     self.event_bus.publish("self_coding:degradation", event)
             except Exception as exc:

--- a/evolution_orchestrator.py
+++ b/evolution_orchestrator.py
@@ -360,9 +360,10 @@ class EvolutionOrchestrator:
             desc = f"auto_patch_due_to_degradation:{bot}"
             try:
                 self.selfcoding_manager.register_patch_cycle(desc, context_meta)
-                self._pending_patch_cycle.add(bot)
             except Exception:
                 self.logger.exception("failed to register patch cycle for %s", bot)
+            else:
+                self._pending_patch_cycle.add(bot)
             current_roi = after_roi
             current_err = float(event.get("errors_baseline", 0.0)) + delta_errors
             predicted_roi = current_roi

--- a/tests/test_data_bot_degradation_patch_cycle.py
+++ b/tests/test_data_bot_degradation_patch_cycle.py
@@ -1,0 +1,116 @@
+import types
+import sys
+from pathlib import Path
+
+
+class DummyBus:
+    def __init__(self):
+        self.subs = {}
+        self.events = []
+
+    def subscribe(self, topic, fn):
+        self.subs.setdefault(topic, []).append(fn)
+
+    def publish(self, topic, payload):
+        self.events.append((topic, payload))
+        for fn in self.subs.get(topic, []):
+            fn(topic, payload)
+
+
+class DummySelfCodingManager:
+    def __init__(self, module: Path):
+        self.bot_name = "dummy"
+        self.bot_registry = types.SimpleNamespace(graph={"dummy": {"module": str(module)}})
+        self.calls: list[tuple[str, dict | None]] = []
+
+    def register_patch_cycle(self, desc: str, ctx=None):
+        self.calls.append((desc, ctx))
+
+
+class DummyCapital:
+    trend_predictor = object()
+
+    def energy_score(self, *a, **k):  # pragma: no cover - constant
+        return 1.0
+
+
+class DummyHistoryDB:
+    def add(self, *a, **k):  # pragma: no cover - noop
+        pass
+
+
+def test_threshold_breach_queues_patch_cycle(tmp_path, monkeypatch):
+    stub_cbi = types.ModuleType("menace.coding_bot_interface")
+    stub_cbi.self_coding_managed = lambda cls: cls
+    monkeypatch.setitem(sys.modules, "menace.coding_bot_interface", stub_cbi)
+    stub_scm = types.ModuleType("menace.self_coding_manager")
+    stub_scm.SelfCodingManager = DummySelfCodingManager
+    stub_scm.HelperGenerationError = RuntimeError
+    monkeypatch.setitem(sys.modules, "menace.self_coding_manager", stub_scm)
+    stub_cap = types.ModuleType("menace.capital_management_bot")
+    stub_cap.CapitalManagementBot = DummyCapital
+    monkeypatch.setitem(sys.modules, "menace.capital_management_bot", stub_cap)
+    stub_sem = types.ModuleType("menace.system_evolution_manager")
+    stub_sem.SystemEvolutionManager = object
+    monkeypatch.setitem(sys.modules, "menace.system_evolution_manager", stub_sem)
+    stub_ga_clone = types.ModuleType("menace.ga_clone_manager")
+    stub_ga_clone.GALearningManager = object
+    monkeypatch.setitem(sys.modules, "menace.ga_clone_manager", stub_ga_clone)
+    stub_ga_bot = types.ModuleType("menace.genetic_algorithm_bot")
+    stub_ga_bot.GeneticAlgorithmBot = object
+    stub_ga_bot.GARecord = stub_ga_bot.GAStore = object
+    monkeypatch.setitem(sys.modules, "menace.genetic_algorithm_bot", stub_ga_bot)
+    stub = types.ModuleType("vector_metrics_db")
+    monkeypatch.setitem(sys.modules, "menace.vector_metrics_db", stub)
+    import menace.data_bot as db
+    monkeypatch.setattr(db, "psutil", None)
+    monkeypatch.setattr(
+        db,
+        "adaptive_thresholds",
+        lambda *a, **k: db.ROIThresholds(
+            roi_drop=-0.1, error_threshold=1.0, test_failure_threshold=0.0
+        ),
+    )
+    monkeypatch.setattr(db, "save_sc_thresholds", lambda *a, **k: None)
+
+    settings = types.SimpleNamespace(
+        self_coding_roi_drop=-0.1,
+        self_coding_error_increase=1.0,
+        self_coding_test_failure_increase=0.0,
+        bot_thresholds={},
+    )
+
+    bus = DummyBus()
+    mdb = db.MetricsDB(tmp_path / "m.db")
+    data_bot = db.DataBot(
+        mdb,
+        settings=settings,
+        event_bus=bus,
+        roi_drop_threshold=-0.1,
+        error_threshold=1.0,
+    )
+
+    mod = tmp_path / "dummy.py"
+    mod.write_text("def foo():\n    return 1\n")
+    manager = DummySelfCodingManager(mod)
+
+    from menace.evolution_orchestrator import EvolutionOrchestrator
+
+    orch = EvolutionOrchestrator(
+        data_bot,
+        DummyCapital(),
+        types.SimpleNamespace(),
+        types.SimpleNamespace(),
+        selfcoding_manager=manager,
+        event_bus=bus,
+        history_db=DummyHistoryDB(),
+        roi_gain_floor=1.0,  # force decision skip before patching
+    )
+
+    orch.register_bot("dummy")
+    data_bot.check_degradation("dummy", roi=1.0, errors=0.0)
+    data_bot.check_degradation("dummy", roi=0.0, errors=5.0)
+
+    assert manager.calls, "patch cycle should be registered"
+    assert "dummy" in orch._pending_patch_cycle
+    assert any(t == "bot:degraded" for t, _ in bus.events)


### PR DESCRIPTION
## Summary
- always broadcast `bot:degraded` when ROI, error or test thresholds breach
- queue self-coding patch cycles from `_on_bot_degraded`
- add regression test ensuring threshold breach triggers a patch cycle

## Testing
- `pytest tests/test_data_bot_thresholds.py tests/test_evolution_orchestrator_degradation_schedule.py tests/test_data_bot_degradation_patch_cycle.py -q` *(fails: FileNotFoundError / ImportError)*
- `pytest tests/test_data_bot_degradation_patch_cycle.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4d31e8284832e9343b21f19881eda