### PR TITLE
Ensure helper generation uses managed interface

### DIFF
--- a/automated_reviewer.py
+++ b/automated_reviewer.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 from .bot_registry import BotRegistry
 from .data_bot import DataBot
-from .coding_bot_interface import self_coding_managed
+from .coding_bot_interface import self_coding_managed, manager_generate_helper
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
     from .auto_escalation_manager import AutoEscalationManager
@@ -136,10 +136,7 @@ class AutomatedReviewer:
                 ctx = ""
                 vectors = []
             try:
-                self.manager.manager_generate_helper(
-                    f"review for bot {bot_id}",
-                    context_builder=self.context_builder,
-                )
+                manager_generate_helper(self.manager, f"review for bot {bot_id}")
             except Exception:
                 self.logger.exception("helper generation failed")
             try:


### PR DESCRIPTION
## Summary
- use `coding_bot_interface.manager_generate_helper` in automated reviewer
- wrap internal self-coding engine calls in `manager_generate_helper`

## Testing
- `pre-commit run --files automated_reviewer.py self_coding_engine.py`
- `pytest tests/test_self_coding_engine.py tests/test_automated_reviewer.py` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '')*
- `pytest tests/test_automated_reviewer.py` *(fails: ImportError: cannot import name 'manager_generate_helper')*

------
https://chatgpt.com/codex/tasks/task_e_68c4d56af550832ea7e30731717a604e