### PR TITLE
feat: runtime threshold management

### DIFF
--- a/tests/test_data_bot_reload_thresholds.py
+++ b/tests/test_data_bot_reload_thresholds.py
@@ -1,0 +1,31 @@
+import yaml
+
+
+def test_reload_thresholds_persists_and_broadcasts(tmp_path, monkeypatch):
+    cfg = tmp_path / "self_coding_thresholds.yaml"
+    cfg.write_text(
+        """default:\n  roi_drop: -0.1\n  error_increase: 1.0\n  test_failure_increase: 0.0\nbots: {}\n""",
+        encoding="utf-8",
+    )
+
+    import menace.self_coding_thresholds as sct
+
+    monkeypatch.setattr(sct, "_CONFIG_PATH", cfg)
+
+    class DummyBus:
+        def __init__(self) -> None:
+            self.events: list[tuple[str, object]] = []
+
+        def publish(self, topic: str, payload: object) -> None:
+            self.events.append((topic, payload))
+
+    from menace.data_bot import DataBot, MetricsDB
+
+    bus = DummyBus()
+    db = MetricsDB(path=tmp_path / "metrics.db")
+    bot = DataBot(db=db, event_bus=bus, start_server=False)
+    bot.reload_thresholds("alpha")
+
+    data = yaml.safe_load(cfg.read_text())
+    assert "alpha" in data.get("bots", {})
+    assert any(topic == "self_coding:thresholds_updated" for topic, _ in bus.events)


### PR DESCRIPTION
## Summary
- ensure DataBot persists per-bot threshold overrides and broadcasts `self_coding:thresholds_updated`
- add CLI command for updating self-coding thresholds at runtime
- test threshold reload persistence and event publication

## Testing
- `pytest tests/test_data_bot_reload_thresholds.py -q`
- `pytest tests/integration/test_threshold_runtime_reload.py -q`
- `pytest -q` *(fails: import errors and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d888c348832ea0d01dc77fa97553