### PR TITLE
Process pending patch cycles in orchestrator

### DIFF
--- a/evolution_orchestrator.py
+++ b/evolution_orchestrator.py
@@ -684,6 +684,16 @@ class EvolutionOrchestrator:
                 self.analysis_bot.train()
             except Exception:
                 self.logger.exception("analysis training failed")
+        if self.selfcoding_manager and self._pending_patch_cycle:
+            pending = list(self._pending_patch_cycle)
+            for bot in pending:
+                try:
+                    self._on_bot_degraded({"bot": bot})
+                except Exception:
+                    self.logger.exception(
+                        "failed to process pending patch for %s", bot
+                    )
+            self._pending_patch_cycle.clear()
         before_roi = self._latest_roi()
         delta_roi = before_roi - self.prev_roi
         self.prev_roi = before_roi

--- a/tests/test_evolution_orchestrator_degradation_schedule.py
+++ b/tests/test_evolution_orchestrator_degradation_schedule.py
@@ -28,6 +28,9 @@ class DummyDataBot:
     def check_degradation(self, *args, **kwargs):  # pragma: no cover - noop
         pass
 
+    def reload_thresholds(self, _bot):  # pragma: no cover - simple defaults
+        return types.SimpleNamespace(roi_drop=-0.1, error_threshold=1.0)
+
 
 class DummySelfCodingManager:
     def __init__(self, module: Path):

--- a/tests/test_pending_patch_cycle_run.py
+++ b/tests/test_pending_patch_cycle_run.py
@@ -1,0 +1,87 @@
+import sys
+import types
+
+
+class DummyDB:
+    def fetch(self, limit=50):
+        return []
+
+
+class DummyDataBot:
+    def __init__(self):
+        self.db = DummyDB()
+
+    def subscribe_degradation(self, cb):
+        pass
+
+
+class DummyCapital:
+    def energy_score(self, *a, **k):
+        return 1.0
+
+
+class DummyHistoryDB:
+    def add(self, *a, **k):
+        pass
+
+
+def test_pending_patch_cycle_processed(monkeypatch):
+    stub_cbi = types.ModuleType("menace.coding_bot_interface")
+    stub_cbi.self_coding_managed = lambda cls: cls
+    monkeypatch.setitem(sys.modules, "menace.coding_bot_interface", stub_cbi)
+    stub_scm = types.ModuleType("menace.self_coding_manager")
+    stub_scm.SelfCodingManager = object
+    stub_scm.HelperGenerationError = RuntimeError
+    monkeypatch.setitem(sys.modules, "menace.self_coding_manager", stub_scm)
+    stub_cap = types.ModuleType("menace.capital_management_bot")
+    stub_cap.CapitalManagementBot = DummyCapital
+    monkeypatch.setitem(sys.modules, "menace.capital_management_bot", stub_cap)
+    stub_sem = types.ModuleType("menace.system_evolution_manager")
+    stub_sem.SystemEvolutionManager = object
+    monkeypatch.setitem(sys.modules, "menace.system_evolution_manager", stub_sem)
+    stub_ga_clone = types.ModuleType("menace.ga_clone_manager")
+    stub_ga_clone.GALearningManager = object
+    monkeypatch.setitem(sys.modules, "menace.ga_clone_manager", stub_ga_clone)
+    stub_ga_bot = types.ModuleType("menace.genetic_algorithm_bot")
+    stub_ga_bot.GeneticAlgorithmBot = object
+    stub_ga_bot.GARecord = stub_ga_bot.GAStore = object
+    monkeypatch.setitem(sys.modules, "menace.genetic_algorithm_bot", stub_ga_bot)
+    stub = types.ModuleType("vector_metrics_db")
+    monkeypatch.setitem(sys.modules, "menace.vector_metrics_db", stub)
+    import menace.data_bot as db
+    monkeypatch.setattr(db, "psutil", None)
+    monkeypatch.setattr(
+        db,
+        "adaptive_thresholds",
+        lambda *a, **k: db.ROIThresholds(
+            roi_drop=-0.1, error_threshold=1.0, test_failure_threshold=0.0
+        ),
+    )
+    monkeypatch.setattr(db, "save_sc_thresholds", lambda *a, **k: None)
+
+    from menace.evolution_orchestrator import EvolutionOrchestrator, EvolutionTrigger
+
+    data_bot = DummyDataBot()
+    capital = DummyCapital()
+    history = DummyHistoryDB()
+    scm = object()
+    orch = EvolutionOrchestrator(
+        data_bot,
+        capital,
+        types.SimpleNamespace(),
+        types.SimpleNamespace(),
+        selfcoding_manager=scm,
+        history_db=history,
+        triggers=EvolutionTrigger(error_rate=1.0, roi_drop=-1.0, energy_threshold=0.0),
+    )
+
+    calls = []
+
+    def fake_degraded(event):
+        calls.append(event["bot"])
+
+    orch._on_bot_degraded = fake_degraded  # type: ignore
+    orch._pending_patch_cycle.add("dummy")
+    orch.run_cycle()
+    assert calls == ["dummy"]
+    assert not orch._pending_patch_cycle


### PR DESCRIPTION
## Summary
- Trigger pending self-coding patch cycles during `run_cycle`
- Ensure dummy DataBot stubs provide threshold defaults
- Cover pending patch cycle handling with new test

## Testing
- `pytest tests/test_pending_patch_cycle_run.py tests/test_data_bot_degradation_patch_cycle.py tests/test_evolution_orchestrator_degradation_schedule.py`

------
https://chatgpt.com/codex/tasks/task_e_68c4dc6b605c832eaf8b475a6b1d1509