### PR TITLE
Inject helper callback into QuickFixEngine

### DIFF
--- a/coding_bot_interface.py
+++ b/coding_bot_interface.py
@@ -210,6 +210,9 @@ def self_coding_managed(*, bot_registry: BotRegistry, data_bot: DataBot) -> Call
                 try:
                     from .quick_fix_engine import QuickFixEngine  # type: ignore
                     from .error_bot import ErrorDB
+                    from .self_coding_manager import (
+                        _manager_generate_helper_with_builder as _helper_fn,
+                    )
                 except Exception as exc:  # pragma: no cover - optional dependency
                     raise RuntimeError(
                         f"{cls.__name__}: QuickFixEngine is required but could not be imported"
@@ -230,7 +233,12 @@ def self_coding_managed(*, bot_registry: BotRegistry, data_bot: DataBot) -> Call
                             f"{cls.__name__}: failed to initialise ErrorDB for QuickFixEngine"
                         ) from exc
                 try:
-                    manager.quick_fix = QuickFixEngine(error_db, manager, context_builder=builder)
+                    manager.quick_fix = QuickFixEngine(
+                        error_db,
+                        manager,
+                        context_builder=builder,
+                        helper_fn=_helper_fn,
+                    )
                     manager.error_db = error_db
                 except Exception as exc:  # pragma: no cover - instantiation errors
                     raise RuntimeError(

--- a/sandbox_runner.py
+++ b/sandbox_runner.py
@@ -953,6 +953,9 @@ def _sandbox_init(
         context_builder=context_builder,
     )
     from menace.self_coding_manager import SelfCodingManager
+    from menace.self_coding_manager import (
+        _manager_generate_helper_with_builder as _helper_fn,
+    )
     from menace.model_automation_pipeline import ModelAutomationPipeline
     from menace.unified_event_bus import UnifiedEventBus
     from menace.bot_registry import BotRegistry
@@ -969,7 +972,11 @@ def _sandbox_init(
         event_bus=bus,
     )
     quick_fix_engine = QuickFixEngine(
-        telem_db, quick_manager, graph=graph, context_builder=context_builder
+        telem_db,
+        quick_manager,
+        graph=graph,
+        context_builder=context_builder,
+        helper_fn=_helper_fn,
     )
 
     gpt_client = None

--- a/service_supervisor.py
+++ b/service_supervisor.py
@@ -52,7 +52,11 @@ from .autoscaler import Autoscaler  # noqa: E402
 from .unified_update_service import UnifiedUpdateService  # noqa: E402
 from .self_test_service import SelfTestService  # noqa: E402
 from .auto_escalation_manager import AutoEscalationManager  # noqa: E402
-from .self_coding_manager import PatchApprovalPolicy, SelfCodingManager  # noqa: E402
+from .self_coding_manager import (
+    PatchApprovalPolicy,
+    SelfCodingManager,
+    _manager_generate_helper_with_builder as _helper_fn,
+)  # noqa: E402
 from .advanced_error_management import AutomatedRollbackManager  # noqa: E402
 from .error_bot import ErrorDB  # noqa: E402
 from .self_coding_engine import SelfCodingEngine  # noqa: E402
@@ -401,6 +405,7 @@ class ServiceSupervisor:
             manager,
             graph=self.healer.graph,
             context_builder=self.context_builder,
+            helper_fn=_helper_fn,
         )
 
     def _record_failure(self, etype: str) -> None:

--- a/tests/integration/test_patch_provenance_quick_fix.py
+++ b/tests/integration/test_patch_provenance_quick_fix.py
@@ -87,6 +87,7 @@ def test_quick_fix_records_license_and_alerts(tmp_path, monkeypatch):
         retriever=Retriever(),
         patch_logger=PatchLogger(patch_db=db),
         context_builder=DummyBuilder(),
+        helper_fn=lambda *a, **k: "",
     )
     (tmp_path / "mod.py").write_text("x=1\n")  # path-ignore
     monkeypatch.chdir(tmp_path)

--- a/tests/integration/test_vector_service_clients.py
+++ b/tests/integration/test_vector_service_clients.py
@@ -93,6 +93,7 @@ def test_quick_fix_engine_uses_vector_service_retriever():
         manager=manager,
         retriever=SpyRetriever(),
         context_builder=DummyBuilder(),
+        helper_fn=lambda *a, **k: "",
     )
     hits, sid, vectors = engine._redundant_retrieve("m", 1)
     assert hits == [] and sid == "" and vectors == []

--- a/tests/test_missing_context_builder.py
+++ b/tests/test_missing_context_builder.py
@@ -61,7 +61,12 @@ def test_quick_fix_engine_requires_context_builder():
     error_db = object()
     manager = types.SimpleNamespace()
     with pytest.raises(RuntimeError):
-        QuickFixEngine(error_db, manager, context_builder=None)
+        QuickFixEngine(
+            error_db,
+            manager,
+            context_builder=None,
+            helper_fn=lambda *a, **k: "",
+        )
 
 
 def test_automated_reviewer_requires_context_builder():


### PR DESCRIPTION
## Summary
- allow QuickFixEngine to accept a helper callback and stop using global manager_generate_helper
- wire self_coding_manager, coding_bot_interface, and runners to pass the helper
- add regression test ensuring each patch cycle gets a fresh ContextBuilder

## Testing
- `pytest unit_tests/test_major_bot_context_builders.py::test_patch_cycle_uses_fresh_builder -q` *(fails: ModuleNotFoundError / heavy dependency import)*
- `pytest tests/test_missing_context_builder.py -q` *(fails: ImportError: Self-coding engine is required)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e51a6358832ea832db369fee8576