### PR TITLE
feat: adapt thresholds via trend forecasts

### DIFF
--- a/tests/test_data_bot_degradation_patch_cycle.py
+++ b/tests/test_data_bot_degradation_patch_cycle.py
@@ -64,14 +64,7 @@ def test_threshold_breach_queues_patch_cycle(tmp_path, monkeypatch):
     monkeypatch.setitem(sys.modules, "menace.vector_metrics_db", stub)
     import menace.data_bot as db
     monkeypatch.setattr(db, "psutil", None)
-    monkeypatch.setattr(
-        db,
-        "adaptive_thresholds",
-        lambda *a, **k: db.ROIThresholds(
-            roi_drop=-0.1, error_threshold=1.0, test_failure_threshold=0.0
-        ),
-    )
-    monkeypatch.setattr(db, "save_sc_thresholds", lambda *a, **k: None)
+    monkeypatch.setattr(db, "persist_sc_thresholds", lambda *a, **k: None)
 
     settings = types.SimpleNamespace(
         self_coding_roi_drop=-0.1,

--- a/tests/test_data_bot_thresholds.py
+++ b/tests/test_data_bot_thresholds.py
@@ -3,9 +3,19 @@ import types
 
 stub_cbi = types.ModuleType("menace.coding_bot_interface")
 stub_cbi.self_coding_managed = lambda cls: cls
+stub_cbi.manager_generate_helper = lambda *_a, **_k: None
 sys.modules["menace.coding_bot_interface"] = stub_cbi
 
-from menace.unified_event_bus import UnifiedEventBus
+class UnifiedEventBus:
+    def __init__(self) -> None:
+        self._subs: dict[str, list] = {}
+
+    def subscribe(self, topic: str, handler):
+        self._subs.setdefault(topic, []).append(handler)
+
+    def publish(self, topic: str, payload):
+        for h in self._subs.get(topic, []):
+            h(topic, payload)
 
 
 def test_threshold_event_published(monkeypatch, tmp_path):

--- a/tests/test_pending_patch_cycle_run.py
+++ b/tests/test_pending_patch_cycle_run.py
@@ -50,14 +50,7 @@ def test_pending_patch_cycle_processed(monkeypatch):
     monkeypatch.setitem(sys.modules, "menace.vector_metrics_db", stub)
     import menace.data_bot as db
     monkeypatch.setattr(db, "psutil", None)
-    monkeypatch.setattr(
-        db,
-        "adaptive_thresholds",
-        lambda *a, **k: db.ROIThresholds(
-            roi_drop=-0.1, error_threshold=1.0, test_failure_threshold=0.0
-        ),
-    )
-    monkeypatch.setattr(db, "save_sc_thresholds", lambda *a, **k: None)
+    monkeypatch.setattr(db, "persist_sc_thresholds", lambda *a, **k: None)
 
     from menace.evolution_orchestrator import EvolutionOrchestrator, EvolutionTrigger
 


### PR DESCRIPTION
## Summary
- forecast ROI and error metrics in `DataBot.check_degradation`
- tune degradation thresholds using prediction confidence and recent baselines
- persist refreshed thresholds for reload by the self-coding system

## Testing
- `pytest tests/test_data_bot_thresholds.py tests/test_data_bot_threshold_error_handling.py tests/test_data_bot_degradation_patch_cycle.py tests/test_threshold_adaptation.py tests/test_pending_patch_cycle_run.py`

------
https://chatgpt.com/codex/tasks/task_e_68c4f7c6ef5c832eb63f921a0d0fd1ef