### PR TITLE
ci: enforce self coding decorator

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,18 @@ on:
         default: 'false'
 
 jobs:
+  check-coding-bot-decorators:
+    runs-on: ubuntu-latest
+    env:
+      MENACE_SAFE: "1"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Ensure SelfCodingEngine bots use @self_coding_managed
+        run: python tools/check_coding_bot_decorators.py
+
   path-checks:
     runs-on: ubuntu-latest
     env:
@@ -59,6 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - path-checks
+      - check-coding-bot-decorators
     env:
       MENACE_SAFE: "1"
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,7 @@ repos:
         language: system
         pass_filenames: false
         files: '\.py$'
+      # Verify that SelfCodingEngine bots declare the self_coding_managed decorator
       - id: check-coding-bot-decorators
         name: Ensure SelfCodingEngine bots use @self_coding_managed
         entry: python tools/check_coding_bot_decorators.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,6 +168,9 @@ adds an extra safeguard by scanning for modules that import
 pre-commit run check-coding-bot-decorators --all-files
 ```
 
+CI runs the same script directly via `python tools/check_coding_bot_decorators.py`
+to ensure the build fails if any `*_bot.py` misses the decorator.
+
 For additional assurance, the test suite includes
 `tests/test_self_coding_compliance.py`, which executes the same scan during
 `pytest`. The test fails if any `*_bot.py` module defines a bot class without


### PR DESCRIPTION
## Summary
- run check_coding_bot_decorators.py in CI to ensure SelfCodingEngine bots are decorated
- document new self-coding decorator check in contributing guide

## Testing
- `pre-commit run check-coding-bot-decorators --all-files`
- `pre-commit run --files .pre-commit-config.yaml` *(fails: static path references and Stripe check)*
- `pytest tests/test_self_coding_compliance.py -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fa35f30c832e8233a002965007c6