### PR TITLE
Run unmanaged bot check directly in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
       - name: ensure all bots are self-coding managed
         run: pre-commit run self-coding-registration --all-files
       - name: Check for unmanaged bots
-        run: pre-commit run find-unmanaged-bots --all-files
+        run: python tools/find_unmanaged_bots.py
       - name: Prevent unwrapped engine.generate_helper usage
         run: "python tools/check_engine_generate_helper_wrapping.py $(git ls-files '*.py')"
       - name: Verify patch provenance tags
@@ -98,7 +98,7 @@ jobs:
       - name: ensure all bots are self-coding managed
         run: pre-commit run self-coding-registration --all-files
       - name: Check for unmanaged bots
-        run: pre-commit run find-unmanaged-bots --all-files
+        run: python tools/find_unmanaged_bots.py
       - name: Prevent unwrapped engine.generate_helper usage
         run: pre-commit run check-engine-generate-helper --all-files
       - name: Run flake8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,12 +134,14 @@ appear.
 ## Coding bot registration
 
 All new coding bots must be created via the `@self_coding_managed` decorator
-from `coding_bot_interface`. Decorating a bot automatically registers it with
-`BotRegistry` and wires ROI and error metrics into `DataBot`, allowing the
-system to track and improve the bot over time. Bot constructors **must** accept
-`bot_registry`, `data_bot`, and `selfcoding_manager` parameters and forward
-them to the decorator to ensure proper registration. Avoid instantiating new
-coding bots without this decorator.
+from `coding_bot_interface`. Pre-commit and CI run
+`tools/find_unmanaged_bots.py`, which exits with a non-zero status when any
+`*_bot.py` lacks this decorator, causing the build to fail. Decorating a bot
+automatically registers it with `BotRegistry` and wires ROI and error metrics
+into `DataBot`, allowing the system to track and improve the bot over time. Bot
+constructors **must** accept `bot_registry`, `data_bot`, and
+`selfcoding_manager` parameters and forward them to the decorator to ensure
+proper registration. Avoid instantiating new coding bots without this decorator.
 The pre-commit hook `self-coding-registration` (backed by
 `tools/check_self_coding_registration.py`) scans all Python sources for classes
 whose names end with `Bot` and verifies they are decorated with


### PR DESCRIPTION
## Summary
- ensure CI fails if unmanaged bots are present by running `python tools/find_unmanaged_bots.py` in path-checks and tests jobs
- document that pre-commit and CI run the unmanaged bot check and require `@self_coding_managed` on all bots

## Testing
- `pre-commit run flake8 --files .github/workflows/tests.yml CONTRIBUTING.md`
- `python tools/find_unmanaged_bots.py`


------
https://chatgpt.com/codex/tasks/task_e_68c506ae7600832ea8f68d449fa3f17a