### PR TITLE
feat: refresh quick fix context

### DIFF
--- a/evolution_orchestrator.py
+++ b/evolution_orchestrator.py
@@ -570,6 +570,7 @@ class EvolutionOrchestrator:
                                 "failed to publish patch_failed for %s", bot
                             )
                     return
+                self.selfcoding_manager.refresh_quick_fix_context()
                 self.selfcoding_manager.run_patch(
                     module_path,
                     desc,


### PR DESCRIPTION
## Summary
- add helper to refresh quick fix engine context
- refresh quick fix context before running patches and when handling bot degradation

## Testing
- `pre-commit run --files self_coding_manager.py evolution_orchestrator.py`

------
https://chatgpt.com/codex/tasks/task_e_68c523440aac832eb8f277810683070c