### PR TITLE
feat: rollback bot updates on failure

### DIFF
--- a/tests/test_hot_swap_bot.py
+++ b/tests/test_hot_swap_bot.py
@@ -78,7 +78,8 @@ def test_hot_swap_failure_reverts_and_persists(tmp_path, monkeypatch):
     with pytest.raises(Exception):
         reg.update_bot("dummy", module_bad.as_posix(), patch_id=2, commit="b")
     assert dummy.greet() == "old"
-    assert bus.events[-1][0] == "bot:hot_swap_failed"
+    assert bus.events[-1][0] == "bot:update_rolled_back"
+    assert bus.events[-2][0] == "bot:hot_swap_failed"
     assert reg.graph.nodes["dummy"]["version"] == 1
     node = reg.graph.nodes["dummy"]
     assert node["module"] == module_good.as_posix()
@@ -108,7 +109,8 @@ def test_health_check_failure_reverts(tmp_path, monkeypatch):
     with pytest.raises(Exception):
         reg.update_bot("dummy", module.as_posix(), patch_id=2, commit="b")
     assert dummy.greet() == "old"
-    assert bus.events[-1][0] == "bot:hot_swap_failed"
+    assert bus.events[-1][0] == "bot:update_rolled_back"
+    assert bus.events[-2][0] == "bot:hot_swap_failed"
     node = reg.graph.nodes["dummy"]
     assert node["module"] == module.as_posix()
     assert node["version"] == 1


### PR DESCRIPTION
## Summary
- rollback bot module updates when hot swap or health checks fail
- publish `bot:update_rolled_back` event and integrate optional `RollbackManager`
- update tests for rollback event

## Testing
- `pytest tests/test_bot_registry.py tests/test_hot_swap_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5279de38c832e8af3406684dad525