### PR TITLE
Validate patches post-run and hot swap bots

### DIFF
--- a/self_coding_manager.py
+++ b/self_coding_manager.py
@@ -1418,6 +1418,19 @@ class SelfCodingManager:
                     )
                 except Exception:
                     self.logger.exception("failed to record patch outcome")
+            if self.quick_fix is not None:
+                try:
+                    _src = path.read_text(encoding="utf-8")
+                    valid_post, _flags_post = self.quick_fix.validate_patch(
+                        str(path), description
+                    )
+                    path.write_text(_src, encoding="utf-8")
+                    if not valid_post:
+                        raise RuntimeError("quick fix validation failed")
+                except Exception as exc:
+                    raise RuntimeError(
+                        "QuickFixEngine validation unavailable"
+                    ) from exc
             conf = 1.0
             if result is not None and getattr(result, "roi", None) is not None:
                 conf = getattr(result.roi, "confidence", None)  # type: ignore[attr-defined]
@@ -1641,7 +1654,7 @@ class SelfCodingManager:
                             )
                     raise
                 try:
-                    self.bot_registry.hot_swap_bot(self.bot_name)
+                    self.bot_registry.hot_swap(self.bot_name, module_path)
                     self.bot_registry.health_check_bot(self.bot_name, prev_state)
                 except Exception:  # pragma: no cover - best effort
                     self.logger.exception(


### PR DESCRIPTION
## Summary
- validate patched modules after `SelfCodingManager.run_patch`
- allow reloading patched bots via new `BotRegistry.hot_swap`
- test post-patch validation, registry hot swap, and event emission

## Testing
- `pre-commit run --files self_coding_manager.py bot_registry.py tests/test_self_coding_manager.py`
- `pytest tests/test_self_coding_manager.py -k post_patch_validation_and_hot_swap -q`

------
https://chatgpt.com/codex/tasks/task_e_68c533af92c8832eb904bfec8a5bed0e