### PR TITLE
Use generate_and_patch in degradation callback

### DIFF
--- a/bot_registry.py
+++ b/bot_registry.py
@@ -115,8 +115,8 @@ class BotRegistry:
                             desc = f"auto_patch_due_to_degradation:{_bot}"
                             _mgr.register_patch_cycle(desc, event)
                             module = self.graph.nodes[_bot].get("module")
-                            if module and hasattr(_mgr, "run_patch"):
-                                _mgr.run_patch(Path(module), desc, context_meta=event)
+                            if module and hasattr(_mgr, "generate_and_patch"):
+                                _mgr.generate_and_patch(Path(module), desc, context_meta=event)[0]
                         except Exception as exc:  # pragma: no cover - best effort
                             logger.error("degradation callback failed for %s: %s", _bot, exc)
 


### PR DESCRIPTION
## Summary
- ensure degradation patches use generate_and_patch, triggering a fresh context builder and QuickFixEngine validation

## Testing
- `pytest tests/test_bot_registry_save.py::test_update_bot_persists_module -q`


------
https://chatgpt.com/codex/tasks/task_e_68c53bc87708832e84430fd081fd5ca8