### PR TITLE
Wrap SelfCodingEngine usage with SelfCodingManager

### DIFF
--- a/stripe_watchdog.py
+++ b/stripe_watchdog.py
@@ -1930,7 +1930,7 @@ def main(
             try:
                 bus = UnifiedEventBus()
                 registry = BotRegistry(event_bus=bus) if BotRegistry else None
-                data_bot = DataBot() if DataBot else None
+                data_bot = DataBot(event_bus=bus) if DataBot else None
                 pipeline = ModelAutomationPipeline(
                     context_builder=builder, event_bus=bus, bot_registry=registry
                 )
@@ -1941,6 +1941,7 @@ def main(
                     data_bot=data_bot,
                     event_bus=bus,
                 )
+                manager.register_bot("StripeWatchdog")
                 telemetry = TelemetryFeedback(
                     ErrorLogger(context_builder=builder),
                     manager,


### PR DESCRIPTION
## Summary
- ensure engine-based services use SelfCodingManager with proper bot registration
- decorate AutoEscalationManager, ServiceSupervisor, Watchdog for self-coding management
- register StripeWatchdog telemetry manager with BotRegistry

## Testing
- `pre-commit run --files auto_escalation_manager.py service_supervisor.py stripe_watchdog.py watchdog.py`
- `pytest tests/test_coding_bot_interface.py -q` *(fails: DummyRegistry.register_bot() got an unexpected keyword argument 'roi_threshold')*
- `pytest tests/test_self_coding_manager.py::test_init_requires_helpers -q`

------
https://chatgpt.com/codex/tasks/task_e_68c53cd596c8832ea22f3026f92ee1fc