### PR TITLE
Delegate degradation patching to orchestrator

### DIFF
--- a/bot_registry.py
+++ b/bot_registry.py
@@ -118,11 +118,17 @@ class BotRegistry:
                         if str(event.get("bot")) != _bot:
                             return
                         try:
-                            desc = f"auto_patch_due_to_degradation:{_bot}"
-                            _mgr.register_patch_cycle(desc, event)
-                            module = self.graph.nodes[_bot].get("module")
-                            if module and hasattr(_mgr, "generate_and_patch"):
-                                _mgr.generate_and_patch(Path(module), desc, context_meta=event)[0]
+                            orchestrator = getattr(_mgr, "evolution_orchestrator", None)
+                            if orchestrator is not None:
+                                orchestrator.register_patch_cycle(event)
+                            else:
+                                desc = f"auto_patch_due_to_degradation:{_bot}"
+                                _mgr.register_patch_cycle(desc, event)
+                                module = self.graph.nodes[_bot].get("module")
+                                if module and hasattr(_mgr, "generate_and_patch"):
+                                    _mgr.generate_and_patch(
+                                        Path(module), desc, context_meta=event
+                                    )[0]
                         except Exception as exc:  # pragma: no cover - best effort
                             logger.error("degradation callback failed for %s: %s", _bot, exc)
 

--- a/tests/test_bot_registry_degradation_orchestrator.py
+++ b/tests/test_bot_registry_degradation_orchestrator.py
@@ -1,0 +1,60 @@
+from menace_sandbox.bot_registry import BotRegistry
+
+
+class DummyDataBot:
+    def __init__(self):
+        self.callbacks = []
+
+    def subscribe_degradation(self, cb):
+        self.callbacks.append(cb)
+
+    def check_degradation(self, bot, roi=0.0, errors=0.0, test_failures=0.0):
+        event = {
+            "bot": bot,
+            "delta_roi": roi - 1.0,
+            "delta_errors": float(errors),
+            "delta_tests_failed": float(test_failures),
+            "roi_baseline": 1.0,
+            "errors_baseline": 0.0,
+            "tests_failed_baseline": 0.0,
+        }
+        for cb in list(self.callbacks):
+            cb(event)
+
+
+class DummyManager:
+    def __init__(self):
+        self.calls = []
+        self.evolution_orchestrator = None
+
+    def register_patch_cycle(self, desc, context_meta=None):
+        self.calls.append((desc, context_meta))
+
+
+class DummyOrchestrator:
+    def __init__(self, manager):
+        self.events = []
+        self.manager = manager
+
+    def register_patch_cycle(self, event):
+        self.events.append(event)
+        desc = f"auto_patch_due_to_degradation:{event.get('bot', '')}"
+        self.manager.register_patch_cycle(desc, event)
+
+
+def test_degradation_flows_through_orchestrator():
+    data_bot = DummyDataBot()
+    manager = DummyManager()
+    orchestrator = DummyOrchestrator(manager)
+    manager.evolution_orchestrator = orchestrator
+
+    registry = BotRegistry()
+    registry.register_bot("sample", manager=manager, data_bot=data_bot)
+
+    data_bot.check_degradation("sample", roi=0.0, errors=5.0)
+
+    assert orchestrator.events, "orchestrator should receive degradation event"
+    assert manager.calls, "manager.register_patch_cycle should be invoked"
+    desc, ctx = manager.calls[0]
+    assert "sample" in desc
+    assert ctx["delta_errors"] == 5.0


### PR DESCRIPTION
## Summary
- route bot degradation events through EvolutionOrchestrator when available
- add regression test ensuring degradation flows DataBot -> EvolutionOrchestrator -> SelfCodingManager

## Testing
- `pytest tests/test_bot_registry_degradation_orchestrator.py -q`
- `pytest tests/test_self_coding_degradation_patch.py tests/test_data_bot_degradation_patch_cycle.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c549912d0c832e8afa6cabd2ccd3ee