### PR TITLE
Introduce threshold service for coordinated threshold updates

### DIFF
--- a/bot_registry.py
+++ b/bot_registry.py
@@ -43,12 +43,7 @@ except Exception:  # pragma: no cover - flat layout fallback
 import db_router
 from db_router import DBRouter, init_db_router
 
-try:  # pragma: no cover - optional dependency
-    from .self_coding_thresholds import update_thresholds as persist_sc_thresholds
-except Exception:  # pragma: no cover - persistence optional
-    def persist_sc_thresholds(*_a: Any, **_k: Any) -> None:  # type: ignore[override]
-        """Fallback no-op when threshold persistence is unavailable."""
-        pass
+from .threshold_service import threshold_service
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
     from .self_coding_manager import SelfCodingManager
@@ -142,10 +137,10 @@ class BotRegistry:
                         )
             if roi_threshold is not None or error_threshold is not None:
                 try:
-                    persist_sc_thresholds(
+                    threshold_service.update(
                         name,
                         roi_drop=roi_threshold,
-                        error_increase=error_threshold,
+                        error_threshold=error_threshold,
                     )
                 except Exception as exc:  # pragma: no cover - best effort
                     logger.error(

--- a/threshold_service.py
+++ b/threshold_service.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+"""Service encapsulating threshold management and notifications."""
+
+from typing import Dict, Optional
+import logging
+
+try:  # pragma: no cover - optional type import
+    from .unified_event_bus import UnifiedEventBus
+except Exception:  # pragma: no cover - flat layout fallback
+    from unified_event_bus import UnifiedEventBus  # type: ignore
+
+from .roi_thresholds import ROIThresholds
+from .sandbox_settings import SandboxSettings
+from .self_coding_thresholds import (
+    get_thresholds,
+    update_thresholds,
+    SelfCodingThresholds,
+    _load_config as _load_threshold_config,
+)
+
+try:  # pragma: no cover - allow flat imports
+    from .shared_event_bus import event_bus as _SHARED_EVENT_BUS
+except Exception:  # pragma: no cover - flat layout fallback
+    from shared_event_bus import event_bus as _SHARED_EVENT_BUS  # type: ignore
+
+
+logger = logging.getLogger(__name__)
+
+
+class ThresholdService:
+    """Load, cache and persist self-coding thresholds."""
+
+    def __init__(self, event_bus: Optional[UnifiedEventBus] = None) -> None:
+        self.event_bus = event_bus or _SHARED_EVENT_BUS
+        self._thresholds: Dict[str, ROIThresholds] = {}
+
+    # ------------------------------------------------------------------
+    def _publish(self, bot: str, rt: ROIThresholds) -> None:
+        if not self.event_bus:
+            return
+        payload = {
+            "bot": bot,
+            "roi_drop": rt.roi_drop,
+            "error_threshold": rt.error_threshold,
+            "test_failure_threshold": rt.test_failure_threshold,
+        }
+        try:  # pragma: no cover - best effort
+            self.event_bus.publish("thresholds:updated", payload)
+        except Exception:
+            logger.exception("failed to publish threshold update")
+
+    # ------------------------------------------------------------------
+    def load(
+        self,
+        bot: str | None = None,
+        settings: SandboxSettings | None = None,
+    ) -> SelfCodingThresholds:
+        """Return raw thresholds for *bot* from configuration."""
+        return get_thresholds(bot, settings)
+
+    # ------------------------------------------------------------------
+    def reload(
+        self,
+        bot: str | None = None,
+        settings: SandboxSettings | None = None,
+    ) -> ROIThresholds:
+        """Refresh cached thresholds for *bot* and emit update when changed."""
+        raw = self.load(bot, settings)
+        rt = ROIThresholds(
+            roi_drop=raw.roi_drop,
+            error_threshold=raw.error_increase,
+            test_failure_threshold=raw.test_failure_increase,
+        )
+        key = bot or ""
+        prev = self._thresholds.get(key)
+        self._thresholds[key] = rt
+        if bot:
+            data = _load_threshold_config()
+            bots = data.get("bots", {}) if isinstance(data, dict) else {}
+            if bot not in bots:
+                update_thresholds(
+                    bot,
+                    roi_drop=rt.roi_drop,
+                    error_increase=rt.error_threshold,
+                    test_failure_increase=rt.test_failure_threshold,
+                )
+        if bot and prev != rt:
+            self._publish(bot, rt)
+        return rt
+
+    # ------------------------------------------------------------------
+    def get(
+        self,
+        bot: str | None = None,
+        settings: SandboxSettings | None = None,
+    ) -> ROIThresholds:
+        """Return cached thresholds for *bot* loading them if missing."""
+        key = bot or ""
+        if key not in self._thresholds:
+            return self.reload(bot, settings)
+        return self._thresholds[key]
+
+    # ------------------------------------------------------------------
+    def update(
+        self,
+        bot: str,
+        *,
+        roi_drop: float | None = None,
+        error_threshold: float | None = None,
+        test_failure_threshold: float | None = None,
+    ) -> None:
+        """Persist new thresholds for *bot* and broadcast changes."""
+        update_thresholds(
+            bot,
+            roi_drop=roi_drop,
+            error_increase=error_threshold,
+            test_failure_increase=test_failure_threshold,
+        )
+        current = self._thresholds.get(bot)
+        if current is None:
+            current = self.reload(bot)
+        new_rt = ROIThresholds(
+            roi_drop=roi_drop if roi_drop is not None else current.roi_drop,
+            error_threshold=
+                error_threshold if error_threshold is not None else current.error_threshold,
+            test_failure_threshold=
+                test_failure_threshold if test_failure_threshold is not None else current.test_failure_threshold,
+        )
+        prev = self._thresholds.get(bot)
+        self._thresholds[bot] = new_rt
+        if prev != new_rt:
+            self._publish(bot, new_rt)
+
+
+# Shared service instance used across the project
+threshold_service = ThresholdService()
+
+__all__ = ["ThresholdService", "threshold_service"]


### PR DESCRIPTION
## Summary
- add `threshold_service.py` to centralize loading, caching, and publishing of threshold changes
- refactor DataBot, SelfCodingManager, BotRegistry, and EvolutionOrchestrator to use the new service and the `thresholds:updated` event
- update tests for new event name and service integration

## Testing
- `pytest tests/test_data_bot_reload_thresholds.py tests/integration/test_threshold_runtime_reload.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c54cbe7bfc832e8a95745418392788