### PR TITLE
Require explicit SelfCodingManager for managed bots

### DIFF
--- a/automated_debugger.py
+++ b/automated_debugger.py
@@ -34,7 +34,7 @@ data_bot = DataBot(start_server=False)
 class AutomatedDebugger:
     """Analyse telemetry logs and trigger self-coding fixes."""
 
-    manager: "SelfCodingManager | None" = None
+    manager: SelfCodingManager
 
     def __init__(
         self,
@@ -53,6 +53,14 @@ class AutomatedDebugger:
         self.context_builder = context_builder
         self.logger = logging.getLogger("AutomatedDebugger")
         self._tracker = PatchAttemptTracker()
+        try:
+            name = getattr(self, "name", getattr(self, "bot_name", self.__class__.__name__))
+            self.manager.register_bot(name)
+            orch = getattr(self.manager, "evolution_orchestrator", None)
+            if orch:
+                orch.register_bot(name)
+        except Exception:
+            self.logger.exception("bot registration failed")
 
     # ------------------------------------------------------------------
     def _recent_logs(self, limit: int = 5) -> Iterable[str]:

--- a/automated_reviewer.py
+++ b/automated_reviewer.py
@@ -49,7 +49,7 @@ data_bot = DataBot(start_server=False)
 class AutomatedReviewer:
     """Analyse review events and trigger remediation."""
 
-    manager: "SelfCodingManager | None" = None
+    manager: SelfCodingManager
 
     def __init__(
         self,
@@ -71,6 +71,14 @@ class AutomatedReviewer:
         self.escalation_manager = escalation_manager
         self.logger = logging.getLogger(self.__class__.__name__)
         self.manager = manager
+        try:
+            name = getattr(self, "name", getattr(self, "bot_name", self.__class__.__name__))
+            self.manager.register_bot(name)
+            orch = getattr(self.manager, "evolution_orchestrator", None)
+            if orch:
+                orch.register_bot(name)
+        except Exception:  # pragma: no cover - best effort
+            self.logger.exception("bot registration failed")
         evo = getattr(self.manager, "evolution_orchestrator", None)
         if evo:
             try:  # pragma: no cover - best effort registration

--- a/bot_creation_bot.py
+++ b/bot_creation_bot.py
@@ -76,13 +76,13 @@ class BotCreationBot(AdminBotBase):
     COOLDOWN_PERIOD = 3600  # seconds
     MAX_BOTS_PER_PERIOD = 5
 
-    manager: "SelfCodingManager | None" = None
+    manager: SelfCodingManager
 
     def __init__(
         self,
         context_builder: ContextBuilder,
         *,
-        manager: SelfCodingManager | None = None,
+        manager: SelfCodingManager,
         metrics_db: MetricsDB | None = None,
         planner: BotPlanningBot | None = None,
         developer: BotDevelopmentBot | None = None,
@@ -125,15 +125,14 @@ class BotCreationBot(AdminBotBase):
         self.workflow_bot = workflow_bot
         self.trending_scraper = trending_scraper
         self.intent_clusterer = intent_clusterer or IntentClusterer(UniversalRetriever())
-        if self.manager is not None:
-            try:
-                name = getattr(self, "name", getattr(self, "bot_name", self.__class__.__name__))
-                self.manager.register_bot(name)
-                orch = getattr(self.manager, "evolution_orchestrator", None)
-                if orch:
-                    orch.register_bot(name)
-            except Exception:
-                logger.exception("bot registration failed")
+        try:
+            name = getattr(self, "name", getattr(self, "bot_name", self.__class__.__name__))
+            self.manager.register_bot(name)
+            orch = getattr(self.manager, "evolution_orchestrator", None)
+            if orch:
+                orch.register_bot(name)
+        except Exception:
+            logger.exception("bot registration failed")
         self.assigned_prediction_bots = []
         if self.prediction_manager:
             try:

--- a/bot_planning_bot.py
+++ b/bot_planning_bot.py
@@ -70,12 +70,21 @@ class BotPlan:
 class BotPlanningBot:
     """Analyse tasks and plan bots with hierarchy mapping."""
 
-    manager: "SelfCodingManager | None" = None
+    manager: SelfCodingManager
 
-    def __init__(self, template_manager: Optional[TemplateManager] = None) -> None:
+    def __init__(self, manager: SelfCodingManager, template_manager: Optional[TemplateManager] = None) -> None:
         self.tm = template_manager or TemplateManager()
         self.graph = nx.DiGraph()
         self.regressor = LinearRegression()
+        self.manager = manager
+        try:
+            name = getattr(self, "name", getattr(self, "bot_name", self.__class__.__name__))
+            self.manager.register_bot(name)
+            orch = getattr(self.manager, "evolution_orchestrator", None)
+            if orch:
+                orch.register_bot(name)
+        except Exception:
+            logger.exception("bot registration failed")
 
     def evaluate_tasks(self, tasks: Iterable[PlanningTask]) -> List[float]:
         """Predict creation time from task attributes."""

--- a/bot_testing_bot.py
+++ b/bot_testing_bot.py
@@ -195,10 +195,11 @@ class TestingLogDB:
 class BotTestingBot:
     """Run unit and basic integration tests for bots."""
 
-    manager: "SelfCodingManager | None" = None
+    manager: SelfCodingManager
 
     def __init__(
         self,
+        manager: SelfCodingManager,
         db: TestingLogDB | None = None,
         *,
         settings: BotTestingSettings | None = None,
@@ -236,6 +237,14 @@ class BotTestingBot:
             self.logger.warning("Faker not installed; randomized testing disabled")
         self.name = getattr(self, "name", self.__class__.__name__)
         self.data_bot = DataBot()
+        self.manager = manager
+        try:
+            self.manager.register_bot(self.name)
+            orch = getattr(self.manager, "evolution_orchestrator", None)
+            if orch:
+                orch.register_bot(self.name)
+        except Exception:
+            logger.exception("bot registration failed")
 
     def _random_arg(self, param: inspect.Parameter) -> Any:
         ann = param.annotation

--- a/enhancement_bot.py
+++ b/enhancement_bot.py
@@ -81,7 +81,7 @@ class EnhancementBot:
         *,
         context_builder: ContextBuilder,
         llm_client: LLMClient | None = None,
-        manager: SelfCodingManager | None = None,
+        manager: SelfCodingManager,
     ) -> None:
         if context_builder is None:
             raise ValueError("context_builder is required")
@@ -93,15 +93,14 @@ class EnhancementBot:
         self.db_weights = self.context_builder.refresh_db_weights()
         self.llm_client = llm_client
         self.manager = manager
-        if self.manager is not None:
-            try:
-                name = getattr(self, "name", getattr(self, "bot_name", self.__class__.__name__))
-                self.manager.register_bot(name)
-                orch = getattr(self.manager, "evolution_orchestrator", None)
-                if orch:
-                    orch.register_bot(name)
-            except Exception:  # pragma: no cover - best effort
-                logger.exception("bot registration failed")
+        try:
+            name = getattr(self, "name", getattr(self, "bot_name", self.__class__.__name__))
+            self.manager.register_bot(name)
+            orch = getattr(self.manager, "evolution_orchestrator", None)
+            if orch:
+                orch.register_bot(name)
+        except Exception:  # pragma: no cover - best effort
+            logger.exception("bot registration failed")
 
     # ------------------------------------------------------------------
     def _hash(self, text: str) -> str:

--- a/implementation_optimiser_bot.py
+++ b/implementation_optimiser_bot.py
@@ -41,11 +41,11 @@ class ImplementationOptimiserBot:
     the body in basic ``try``/``except`` blocks and emits log messages.
     """
 
-    manager: SelfCodingManager | None = None
+    manager: SelfCodingManager
 
     def __init__(
         self,
-        manager: SelfCodingManager | None = None,
+        manager: SelfCodingManager,
         *,
         context_builder: ContextBuilder,
     ) -> None:
@@ -54,30 +54,28 @@ class ImplementationOptimiserBot:
         self.history: List[TaskPackage] = []
         self.manager = manager
         self.context_builder = context_builder
-        if self.manager is not None:
-            try:
-                name = getattr(self, "name", getattr(self, "bot_name", self.__class__.__name__))
-                self.manager.register_bot(name)
-                orch = getattr(self.manager, "evolution_orchestrator", None)
-                if orch:
-                    orch.register_bot(name)
-            except Exception:  # pragma: no cover - best effort
-                logger.exception("bot registration failed")
+        try:
+            name = getattr(self, "name", getattr(self, "bot_name", self.__class__.__name__))
+            self.manager.register_bot(name)
+            orch = getattr(self.manager, "evolution_orchestrator", None)
+            if orch:
+                orch.register_bot(name)
+        except Exception:  # pragma: no cover - best effort
+            logger.exception("bot registration failed")
         try:
             self.context_builder.refresh_db_weights()
         except Exception as exc:
             logger.error("context builder refresh failed: %s", exc)
             raise RuntimeError("context builder refresh failed") from exc
-        if self.manager is not None:
-            try:
-                eng = getattr(self.manager, "engine", None)
-                if eng is not None:
-                    eng.context_builder = context_builder  # type: ignore[attr-defined]
-                    cb = getattr(eng, "context_builder", None)
-                    if cb and hasattr(cb, "refresh_db_weights"):
-                        cb.refresh_db_weights()  # type: ignore[attr-defined]
-            except Exception:
-                pass
+        try:
+            eng = getattr(self.manager, "engine", None)
+            if eng is not None:
+                eng.context_builder = context_builder  # type: ignore[attr-defined]
+                cb = getattr(eng, "context_builder", None)
+                if cb and hasattr(cb, "refresh_db_weights"):
+                    cb.refresh_db_weights()  # type: ignore[attr-defined]
+        except Exception:
+            pass
         self.name = getattr(self, "name", self.__class__.__name__)
         self.data_bot = data_bot
 

--- a/research_aggregator_bot.py
+++ b/research_aggregator_bot.py
@@ -767,23 +767,22 @@ class ResearchAggregatorBot:
         db_router: Optional[DBRouter] = None,
         enhancement_interval: float = 300.0,
         cache_ttl: float = 3600.0,
-        manager: SelfCodingManager | None = None,
         *,
+        manager: SelfCodingManager,
         context_builder: ContextBuilder,
     ) -> None:
         builder = context_builder
         if builder is None:
             raise ValueError("ContextBuilder is required")
         self.manager = manager
-        if self.manager is not None:
-            try:
-                name = getattr(self, "name", getattr(self, "bot_name", self.__class__.__name__))
-                self.manager.register_bot(name)
-                orch = getattr(self.manager, "evolution_orchestrator", None)
-                if orch:
-                    orch.register_bot(name)
-            except Exception:
-                logger.exception("bot registration failed")
+        try:
+            name = getattr(self, "name", getattr(self, "bot_name", self.__class__.__name__))
+            self.manager.register_bot(name)
+            orch = getattr(self.manager, "evolution_orchestrator", None)
+            if orch:
+                orch.register_bot(name)
+        except Exception:
+            logger.exception("bot registration failed")
         self.name = getattr(self, "name", self.__class__.__name__)
         self.data_bot = data_bot
         self.requirements = list(requirements)

--- a/structural_evolution_bot.py
+++ b/structural_evolution_bot.py
@@ -98,7 +98,7 @@ class StructuralEvolutionBot:
 
     def __init__(
         self,
-        manager: SelfCodingManager | None = None,
+        manager: SelfCodingManager,
         *,
         metrics_db: MetricsDB | None = None,
         db: EvolutionDB | None = None,
@@ -108,15 +108,14 @@ class StructuralEvolutionBot:
         self.metrics_db = metrics_db or MetricsDB()
         self.db = db or EvolutionDB()
         self.approval_policy = approval_policy or EvolutionApprovalPolicy()
-        if self.manager is not None:
-            try:
-                name = getattr(self, "name", getattr(self, "bot_name", self.__class__.__name__))
-                self.manager.register_bot(name)
-                orch = getattr(self.manager, "evolution_orchestrator", None)
-                if orch:
-                    orch.register_bot(name)
-            except Exception:
-                logger.exception("bot registration failed")
+        try:
+            name = getattr(self, "name", getattr(self, "bot_name", self.__class__.__name__))
+            self.manager.register_bot(name)
+            orch = getattr(self.manager, "evolution_orchestrator", None)
+            if orch:
+                orch.register_bot(name)
+        except Exception:
+            logger.exception("bot registration failed")
         logging.basicConfig(level=logging.INFO)
         self.logger = logging.getLogger("StructuralEvolution")
         self.name = getattr(self, "name", self.__class__.__name__)

--- a/workflow_evolution_bot.py
+++ b/workflow_evolution_bot.py
@@ -69,7 +69,7 @@ class WorkflowEvolutionBot:
 
     def __init__(
         self,
-        manager: SelfCodingManager | None = None,
+        manager: SelfCodingManager,
         *,
         pathway_db: PathwayDB | None = None,
         intent_clusterer: IntentClusterer | None = None,
@@ -77,15 +77,14 @@ class WorkflowEvolutionBot:
         self.manager = manager
         self.db = pathway_db or PathwayDB()
         self.intent_clusterer = intent_clusterer or IntentClusterer(UniversalRetriever())
-        if self.manager is not None:
-            try:
-                name = getattr(self, "name", getattr(self, "bot_name", self.__class__.__name__))
-                self.manager.register_bot(name)
-                orch = getattr(self.manager, "evolution_orchestrator", None)
-                if orch:
-                    orch.register_bot(name)
-            except Exception:
-                logger.exception("bot registration failed")
+        try:
+            name = getattr(self, "name", getattr(self, "bot_name", self.__class__.__name__))
+            self.manager.register_bot(name)
+            orch = getattr(self.manager, "evolution_orchestrator", None)
+            if orch:
+                orch.register_bot(name)
+        except Exception:
+            logger.exception("bot registration failed")
         self.name = getattr(self, "name", self.__class__.__name__)
         self.data_bot = data_bot
         # Track mutation events for rearranged sequences so benchmarking


### PR DESCRIPTION
## Summary
- enforce explicit `SelfCodingManager` requirement in `_resolve_helpers` and `self_coding_managed`
- require `SelfCodingManager` parameter in core bots and register via `manager`

## Testing
- `pytest tests/test_bot_creation_bot.py -q` *(fails: ModuleNotFoundError: No module named 'pylint')*


------
https://chatgpt.com/codex/tasks/task_e_68c55109a4f0832e9a7108db5cba3a82