### PR TITLE
Emit patch applied events on degradation

### DIFF
--- a/tests/integration/test_auto_registration_patch_hot_swap.py
+++ b/tests/integration/test_auto_registration_patch_hot_swap.py
@@ -48,6 +48,7 @@ def test_auto_registration_patch_hot_swap(tmp_path, monkeypatch):
             self.register_calls.append((desc, ctx))
             self._last_patch_id = 1
             self._last_commit_hash = "deadbeef"
+            return 1, "deadbeef"
 
         def run_patch(self, path: Path, desc: str, *, context_meta=None, context_builder=None):
             self.patch_calls.append((path, desc))

--- a/tests/integration/test_degradation_patch_cycle.py
+++ b/tests/integration/test_degradation_patch_cycle.py
@@ -70,6 +70,9 @@ class SelfCodingManager:
                 "self_coding:cycle_registered",
                 {"bot": self.bot_name, "description": description},
             )
+        self._last_patch_id = 123
+        self._last_commit_hash = "deadbeef"
+        return 123, "deadbeef"
 
     def should_refactor(self) -> bool:  # noqa: D401 - simple always-true stub
         return True
@@ -207,6 +210,7 @@ def test_degradation_triggers_patch(tmp_path, monkeypatch):
     topics = [t for t, _ in bus.events]
     assert "self_coding:cycle_registered" in topics
     assert "bot:patched" in topics
+    assert "bot:patch_applied" in topics
 
 
 def test_bot_degraded_event_triggers_patch(tmp_path, monkeypatch):
@@ -264,6 +268,7 @@ def test_bot_degraded_event_triggers_patch(tmp_path, monkeypatch):
     topics = [t for t, _ in bus.events]
     assert "self_coding:cycle_registered" in topics
     assert "bot:patched" in topics
+    assert "bot:patch_applied" in topics
 
 
 def test_decorated_bot_triggers_degradation(tmp_path, monkeypatch):
@@ -338,3 +343,4 @@ def test_decorated_bot_triggers_degradation(tmp_path, monkeypatch):
     topics = [t for t, _ in bus.events]
     assert "self_coding:cycle_registered" in topics
     assert "bot:patched" in topics
+    assert "bot:patch_applied" in topics

--- a/tests/integration/test_degradation_quick_fix_rollback.py
+++ b/tests/integration/test_degradation_quick_fix_rollback.py
@@ -53,6 +53,9 @@ class SelfCodingManager:
                 "self_coding:cycle_registered",
                 {"bot": self.bot_name, "description": description},
             )
+        self._last_patch_id = 100
+        self._last_commit_hash = "deadbeef"
+        return 100, "deadbeef"
 
     def run_patch(self, path: Path, description: str, *, context_meta=None, context_builder=None):
         passed, pid, _ = self.quick_fix.apply_validated_patch(
@@ -210,6 +213,7 @@ def test_degradation_applies_patch_and_improves_roi(tmp_path, monkeypatch):
     patched_event = next(p for t, p in bus.events if t == "bot:patched")
     assert patched_event["roi_delta"] > 0
     assert any(t == "self_coding:patch_applied" for t, _ in bus.events)
+    assert any(t == "bot:patch_applied" for t, _ in bus.events)
 
 
 def test_failed_validation_triggers_rollback(tmp_path, monkeypatch):
@@ -233,3 +237,4 @@ def test_failed_validation_triggers_rollback(tmp_path, monkeypatch):
     topics = [t for t, _ in bus.events]
     assert "bot:patch_failed" in topics
     assert "bot:patched" not in topics
+    assert "bot:patch_applied" not in topics

--- a/tests/integration/test_full_self_coding_flow.py
+++ b/tests/integration/test_full_self_coding_flow.py
@@ -116,6 +116,9 @@ class SelfCodingManager:
             self.event_bus.publish(
                 "self_coding:cycle_registered", {"bot": self.bot_name, "description": description}
             )
+        self._last_patch_id = 123
+        self._last_commit_hash = "deadbeef"
+        return 123, "deadbeef"
 
     def run_patch(self, path: Path, description: str, *, context_meta=None, context_builder=None):
         manager_generate_helper(self, description, path=str(path))
@@ -251,4 +254,5 @@ def test_full_self_coding_flow(tmp_path, monkeypatch):
     assert engine.calls, "generate_helper not invoked"
     topics = [t for t, _ in bus.events]
     assert "self_coding:cycle_registered" in topics, "patch cycle not registered"
+    assert "bot:patch_applied" in topics
     assert update_calls and update_calls[-1][0] == "dummy_bot", "update_bot not called"

--- a/tests/integration/test_full_self_coding_pipeline.py
+++ b/tests/integration/test_full_self_coding_pipeline.py
@@ -65,6 +65,8 @@ class SelfCodingManager:
             if context_meta:
                 payload.update(context_meta)
             self.event_bus.publish("self_coding:cycle_registered", payload)
+        self._last_commit_hash = "deadbeef"
+        return self._last_patch_id, "deadbeef"
 
     def run_patch(
         self, path: Path, description: str, *, context_meta=None, context_builder=None
@@ -241,6 +243,9 @@ def test_full_self_coding_pipeline(tmp_path, monkeypatch):
 
     patch_event = next(p for t, p in bus.published if t == "self_coding:patch_applied")
     assert patch_event["patch_id"] == 42
+
+    bot_patch_event = next(p for t, p in bus.published if t == "bot:patch_applied")
+    assert bot_patch_event["patch_id"] == cycle_event["patch_id"]
 
     patched = next(p for t, p in bus.published if t == "bot:patched")
     assert patched["bot"] == "dummy_module"

--- a/tests/test_metrics_event_bus_integration.py
+++ b/tests/test_metrics_event_bus_integration.py
@@ -74,8 +74,9 @@ def test_event_bus_propagates_degradation(tmp_path, monkeypatch):
             self.bot_name = "b1"
             self.events: list[dict] = []
 
-        def register_patch_cycle(self, event: dict) -> None:
+        def register_patch_cycle(self, event: dict) -> tuple[int, str]:
             self.events.append(event)
+            return 1, "deadbeef"
 
     scm = DummySelfCodingManager()
 

--- a/tests/test_self_improvement_pipeline.py
+++ b/tests/test_self_improvement_pipeline.py
@@ -84,9 +84,10 @@ class FakeSelfCodingManager:
         self.quick_fix = quick_fix
         self.bot_name = bot_name
 
-    def register_patch_cycle(self, desc: str, event: dict | None = None) -> None:
+    def register_patch_cycle(self, desc: str, event: dict | None = None) -> tuple[int, str]:
         self.quick_fix.apply_patch(desc)
         self.bot_registry.update_bot(self.bot_name, f"{self.bot_name}_patched")
+        return 1, "deadbeef"
 
 
 class FakeEvolutionOrchestrator:


### PR DESCRIPTION
## Summary
- call generate_and_patch on degradation and publish bot:patch_applied events
- log patch ids and commit hashes in bot patch history
- add tests for bot:patch_applied event

## Testing
- `MENACE_ID=test pytest tests/test_metrics_event_bus_integration.py tests/test_self_improvement_pipeline.py -q`
- `pytest tests/integration/test_degradation_patch_cycle.py tests/integration/test_degradation_quick_fix_rollback.py tests/integration/test_full_self_coding_pipeline.py tests/integration/test_full_self_coding_flow.py tests/integration/test_auto_registration_patch_hot_swap.py -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '')*


------
https://chatgpt.com/codex/tasks/task_e_68c55474e54c832eacad937bef62ec05