### PR TITLE
chore: enforce self-coding decorator

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,8 @@ jobs:
         run: python tools/find_unmanaged_bots.py
       - name: Prevent unwrapped engine.generate_helper usage
         run: "python tools/check_engine_generate_helper_wrapping.py $(git ls-files '*.py')"
+      - name: Ensure helper callers use @self_coding_managed
+        run: python tools/check_self_coding_decorator.py
       - name: Verify patch provenance tags
         run: |
           git fetch --no-tags origin main
@@ -90,6 +92,8 @@ jobs:
         run: python tools/find_unmanaged_bots.py
       - name: Prevent unwrapped engine.generate_helper usage
         run: pre-commit run check-engine-generate-helper --all-files
+      - name: Ensure helper callers use @self_coding_managed
+        run: pre-commit run check-self-coding-decorator --all-files
       - name: Run flake8
         run: pre-commit run flake8 --all-files
       - name: Enforce DB router usage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,6 +192,19 @@ pre-commit run check-engine-generate-helper --all-files
 Run the hook before committing to ensure no direct `engine.generate_helper`
 calls slip into the codebase.
 
+## Helper caller decoration
+
+Any class that invokes `manager_generate_helper` or `generate_helper` must be
+decorated with `@self_coding_managed`.  The `check-self-coding-decorator` hook
+verifies this requirement:
+
+```bash
+pre-commit run check-self-coding-decorator --all-files
+```
+
+CI executes the same script, so missing decorators will cause the build to
+fail.
+
 ## Patch provenance
 
 Commits that modify self-coding infrastructure (`self_coding_manager.py`,


### PR DESCRIPTION
## Summary
- extend helper decorator check for both `manager_generate_helper` and `generate_helper`
- run helper caller check in CI and document pre-commit usage

## Testing
- `python tools/check_self_coding_decorator.py`
- `pre-commit run check-self-coding-decorator --files tools/check_self_coding_decorator.py`
- `pre-commit run forbid-stripe-keys --files CONTRIBUTING.md`
- `pre-commit run flake8 --files tools/check_self_coding_decorator.py`


------
https://chatgpt.com/codex/tasks/task_e_68c559d5a868832e9e35d7640e950d63