### PR TITLE
Add helper for coding bot internalization

### DIFF
--- a/docs/internalize_coding_bot.md
+++ b/docs/internalize_coding_bot.md
@@ -1,0 +1,38 @@
+# internalize_coding_bot
+
+`internalize_coding_bot` wires a coding bot into the self‑coding system by:
+
+- creating a `SelfCodingManager` for the bot,
+- registering ROI/error thresholds with `BotRegistry`,
+- registering the bot with `EvolutionOrchestrator` and subscribing to `degradation:detected` events.
+
+## Example
+
+```python
+from menace.self_coding_manager import internalize_coding_bot
+from menace.self_coding_engine import SelfCodingEngine
+from menace.model_automation_pipeline import ModelAutomationPipeline
+from menace.data_bot import DataBot
+from menace.bot_registry import BotRegistry
+from menace.evolution_orchestrator import EvolutionOrchestrator
+
+engine = SelfCodingEngine(...)
+pipeline = ModelAutomationPipeline(...)
+data_bot = DataBot()
+registry = BotRegistry()
+orchestrator = EvolutionOrchestrator(data_bot, ...)
+
+manager = internalize_coding_bot(
+    "example-bot",
+    engine,
+    pipeline,
+    data_bot=data_bot,
+    bot_registry=registry,
+    evolution_orchestrator=orchestrator,
+    roi_threshold=-0.1,
+    error_threshold=0.2,
+)
+```
+
+Each coding bot should invoke this helper during initialisation to ensure
+recursive integrity and automatic patch cycles.

--- a/docs/self_coding_engine.md
+++ b/docs/self_coding_engine.md
@@ -7,6 +7,13 @@ All coding bots interacting with the self‑coding system must be decorated with
 bot with `BotRegistry` and records ROI/error metrics in `DataBot` so new bots
 remain observable and improvable.
 
+For new coding bots use ``internalize_coding_bot`` to instantiate a
+``SelfCodingManager`` and wire the bot into ``BotRegistry`` and
+``EvolutionOrchestrator``. The helper subscribes the manager to
+``degradation:detected`` events so regression automatically triggers a patch
+cycle. See [internalize_coding_bot.md](internalize_coding_bot.md) for an
+example.
+
 ## Usage
 
 ```python


### PR DESCRIPTION
## Summary
- add `internalize_coding_bot` helper to wire SelfCodingManager, BotRegistry and EvolutionOrchestrator
- document how to wire coding bots via `internalize_coding_bot`

## Testing
- `pytest tests/test_coding_bot_registration.py -q` *(fails: BotPlanningBot missing manager attribute)*

------
https://chatgpt.com/codex/tasks/task_e_68c5615f15f0832e9a31e97a3c28fa76