### PR TITLE
Persist threshold updates to self-coding config

### DIFF
--- a/data_bot.py
+++ b/data_bot.py
@@ -2251,6 +2251,19 @@ class DataBot:
             error_threshold=error_threshold,
             test_failure_threshold=test_failure_threshold,
         )
+        # mirror updates in the self-coding configuration so future
+        # processes see the new limits without relying solely on the
+        # :class:`ThresholdService` cache
+        try:
+            persist_sc_thresholds(
+                bot,
+                roi_drop=roi_drop,
+                error_increase=error_threshold,
+                test_failure_increase=test_failure_threshold,
+                event_bus=self.event_bus,
+            )
+        except Exception:  # pragma: no cover - best effort persistence
+            self.logger.exception("failed to persist thresholds for %s", bot)
         if forecast is not None:
             hist = self._forecast_history.setdefault(
                 bot, {"roi": [], "errors": [], "tests_failed": []}

--- a/tests/test_sc_threshold_persistence.py
+++ b/tests/test_sc_threshold_persistence.py
@@ -1,0 +1,52 @@
+import yaml
+
+import menace.data_bot as db
+import menace.self_coding_thresholds as sct
+
+
+def test_update_thresholds_persists_and_reloads(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "self_coding_thresholds.yaml"
+    monkeypatch.setattr(sct, "_CONFIG_PATH", cfg_path)
+    metrics = db.MetricsDB(path=tmp_path / "metrics.db")
+
+    class DummyService:
+        def __init__(self):
+            self._thresholds = {}
+
+        def update(
+            self,
+            bot,
+            *,
+            roi_drop=None,
+            error_threshold=None,
+            test_failure_threshold=None,
+        ):
+            pass
+
+        def _publish(self, bot, rt):
+            pass
+
+    bot = db.DataBot(
+        db=metrics,
+        threshold_update_interval=0,
+        threshold_service=DummyService(),
+    )
+
+    bot.update_thresholds(
+        "alpha",
+        roi_drop=-0.2,
+        error_threshold=1.5,
+        test_failure_threshold=0.3,
+    )
+
+    assert cfg_path.exists(), "thresholds should be written to config file"
+    data = yaml.safe_load(cfg_path.read_text())
+    assert data["bots"]["alpha"]["roi_drop"] == -0.2
+    assert data["bots"]["alpha"]["error_increase"] == 1.5
+    assert data["bots"]["alpha"]["test_failure_increase"] == 0.3
+
+    bot.reload_thresholds("alpha")
+    rt = bot.get_thresholds("alpha")
+    assert rt.roi_drop == -0.2
+    assert rt.error_threshold == 1.5
+    assert rt.test_failure_threshold == 0.3


### PR DESCRIPTION
## Summary
- Ensure `DataBot.update_thresholds` writes new self-coding limits to `self_coding_thresholds.yaml`
- Add regression test confirming threshold updates persist and can be reloaded

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_threshold_adaptation.py tests/test_sc_threshold_persistence.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5686797cc832e910a1563de0e5409