### PR TITLE
Persist threshold updates across components

### DIFF
--- a/self_coding_manager.py
+++ b/self_coding_manager.py
@@ -36,7 +36,7 @@ from .sandbox_runner.test_harness import run_tests, TestHarnessResult
 
 from .self_coding_engine import SelfCodingEngine
 from .model_automation_pipeline import ModelAutomationPipeline, AutomationResult
-from .data_bot import DataBot
+from .data_bot import DataBot, persist_sc_thresholds
 from .error_bot import ErrorDB
 from .advanced_error_management import FormalVerifier, AutomatedRollbackManager
 from . import mutation_logger as MutationLogger
@@ -411,6 +411,19 @@ class SelfCodingManager:
                             error_threshold=
                                 new_err if new_err != t.error_threshold else None,
                         )
+                        try:  # pragma: no cover - best effort persistence
+                            persist_sc_thresholds(
+                                self.bot_name,
+                                roi_drop=new_roi if new_roi != t.roi_drop else None,
+                                error_increase=
+                                    new_err if new_err != t.error_threshold else None,
+                                event_bus=self.event_bus,
+                            )
+                        except Exception:
+                            self.logger.exception(
+                                "failed to persist thresholds for %s",
+                                self.bot_name,
+                            )
                         t = self.threshold_service.reload(self.bot_name)
                 except Exception:  # pragma: no cover - adaptive failures
                     self.logger.exception("adaptive threshold update failed")


### PR DESCRIPTION
## Summary
- Persist adaptive self-coding thresholds when `SelfCodingManager` adjusts limits
- Ensure `BotRegistry` writes new ROI/error thresholds to durable config and records patch history without a full patch run
- Make `EvolutionOrchestrator` use shared event bus at runtime and gracefully call `register_patch_cycle` on managers that lack `provenance_token`

## Testing
- `pytest tests/test_data_bot_threshold_error_handling.py tests/test_threshold_adaptation.py tests/integration/test_auto_registration_patch_hot_swap.py tests/test_data_bot_degradation_patch_cycle.py::test_threshold_breach_queues_patch_cycle tests/test_pending_patch_cycle_run.py::test_pending_patch_cycle_processed -q`


------
https://chatgpt.com/codex/tasks/task_e_68c56f054090832e999a5974a0eaaf72