### PR TITLE
Ensure bot registrations pass manager and data bot references

### DIFF
--- a/bot_db_utils.py
+++ b/bot_db_utils.py
@@ -46,10 +46,17 @@ def wrap_bot_methods(
 
             if bot_registry:
                 try:
-                    bot_registry.register_bot(from_name)
+                    manager_obj = getattr(bot, "manager", None)
+                    d_bot = getattr(bot, "data_bot", None)
+                    bot_registry.register_bot(
+                        from_name, manager=manager_obj, data_bot=d_bot
+                    )
                 except Exception as exc:
                     logger.warning(
-                        "bot registration failed for %s: %s", from_name, exc, exc_info=True
+                        "bot registration failed for %s: %s",
+                        from_name,
+                        exc,
+                        exc_info=True,
                     )
 
             call_args = args[1:] if args and args[0] is bot else args
@@ -87,5 +94,9 @@ def wrap_bot_methods(
 
             return __f(*args, **kwargs)
 
-        bound = wrapper.__get__(bot, bot.__class__) if isinstance(attr, types.MethodType) else wrapper
+        bound = (
+            wrapper.__get__(bot, bot.__class__)
+            if isinstance(attr, types.MethodType)
+            else wrapper
+        )
         setattr(bot, name, bound)


### PR DESCRIPTION
## Summary
- pass manager and data bot when decorators register new bots
- propagate manager and data bot when SelfCodingManager registers bots
- include manager and data bot when wrapping bots with database utilities

## Testing
- `python tools/find_unmanaged_bots.py`


------
https://chatgpt.com/codex/tasks/task_e_68c57be80c28832eb2f6696eae48d767