### PR TITLE
Wire real self-coding engine into remaining bots

### DIFF
--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -44,10 +44,7 @@ from vector_service.context_builder import ContextBuilder, FallbackResult, Error
 from .codex_output_analyzer import (
     validate_stripe_usage,
 )
-try:  # pragma: no cover - optional self-coding dependency
-    from .self_coding_manager import SelfCodingManager
-except ImportError:  # pragma: no cover - self-coding unavailable
-    SelfCodingManager = Any  # type: ignore
+from .self_coding_manager import SelfCodingManager
 from .self_coding_engine import SelfCodingEngine
 from .model_automation_pipeline import ModelAutomationPipeline
 from .data_bot import DataBot
@@ -55,30 +52,20 @@ from .code_database import CodeDB
 from .menace_memory_manager import MenaceMemoryManager
 from .unified_event_bus import UnifiedEventBus
 from .bot_registry import BotRegistry
+from .threshold_service import ThresholdService
 
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-
-class _StubThresholds:
-    roi_drop = 0.0
-    error_threshold = 0.0
-    test_failure_threshold = 0.0
-
-
-class _StubThresholdService:
-    def get(self, name: str) -> _StubThresholds:  # pragma: no cover - simple stub
-        return _StubThresholds()
-
-
-engine = object()
-pipeline = object()
+_context_builder = ContextBuilder()
+engine = SelfCodingEngine(CodeDB(), MenaceMemoryManager(), context_builder=_context_builder)
+pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 manager = SelfCodingManager(
     engine,
     pipeline,
     bot_registry=registry,
     data_bot=data_bot,
-    threshold_service=_StubThresholdService(),
+    threshold_service=ThresholdService(),
 )
 
 try:  # pragma: no cover - optional dependency

--- a/bot_planning_bot.py
+++ b/bot_planning_bot.py
@@ -6,6 +6,12 @@ from .bot_registry import BotRegistry
 from .data_bot import DataBot
 from .coding_bot_interface import self_coding_managed
 from .self_coding_manager import SelfCodingManager
+from .self_coding_engine import SelfCodingEngine
+from .model_automation_pipeline import ModelAutomationPipeline
+from .threshold_service import ThresholdService
+from .code_database import CodeDB
+from .gpt_memory import GPTMemoryManager
+from vector_service.context_builder import ContextBuilder
 from dataclasses import dataclass, field
 from typing import Iterable, List, Dict, Optional
 
@@ -24,26 +30,15 @@ import pulp
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-
-class _StubThresholds:
-    roi_drop = 0.0
-    error_threshold = 0.0
-    test_failure_threshold = 0.0
-
-
-class _StubThresholdService:
-    def get(self, name: str) -> _StubThresholds:  # pragma: no cover - simple stub
-        return _StubThresholds()
-
-
-engine = object()
-pipeline = object()
+_context_builder = ContextBuilder()
+engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
+pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 manager = SelfCodingManager(
     engine,
     pipeline,
     bot_registry=registry,
     data_bot=data_bot,
-    threshold_service=_StubThresholdService(),
+    threshold_service=ThresholdService(),
 )
 
 

--- a/bot_testing_bot.py
+++ b/bot_testing_bot.py
@@ -26,32 +26,27 @@ from .db_router import DBRouter, GLOBAL_ROUTER, init_db_router
 from .bot_registry import BotRegistry
 from .data_bot import DataBot
 from .self_coding_manager import SelfCodingManager
+from .self_coding_engine import SelfCodingEngine
+from .model_automation_pipeline import ModelAutomationPipeline
+from .threshold_service import ThresholdService
+from .code_database import CodeDB
+from .gpt_memory import GPTMemoryManager
+from vector_service.context_builder import ContextBuilder
 
 logger = logging.getLogger("BotTester")
 
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-
-class _StubThresholds:
-    roi_drop = 0.0
-    error_threshold = 0.0
-    test_failure_threshold = 0.0
-
-
-class _StubThresholdService:
-    def get(self, name: str) -> _StubThresholds:  # pragma: no cover - simple stub
-        return _StubThresholds()
-
-
-engine = object()
-pipeline = object()
+_context_builder = ContextBuilder()
+engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
+pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 manager = SelfCodingManager(
     engine,
     pipeline,
     bot_registry=registry,
     data_bot=data_bot,
-    threshold_service=_StubThresholdService(),
+    threshold_service=ThresholdService(),
 )
 
 # Allow users to register custom randomizers for specific types

--- a/enhancement_bot.py
+++ b/enhancement_bot.py
@@ -2,30 +2,27 @@ from __future__ import annotations
 
 from .bot_registry import BotRegistry
 from .data_bot import DataBot
+from .self_coding_manager import SelfCodingManager
+from .self_coding_engine import SelfCodingEngine
+from .model_automation_pipeline import ModelAutomationPipeline
+from .threshold_service import ThresholdService
+from .code_database import CodeDB
+from .gpt_memory import GPTMemoryManager
+from vector_service.context_builder import ContextBuilder
+from .coding_bot_interface import self_coding_managed
 
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-
-class _StubThresholds:
-    roi_drop = 0.0
-    error_threshold = 0.0
-    test_failure_threshold = 0.0
-
-
-class _StubThresholdService:
-    def get(self, name: str) -> _StubThresholds:  # pragma: no cover - simple stub
-        return _StubThresholds()
-
-
-engine = object()
-pipeline = object()
+_context_builder = ContextBuilder()
+engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
+pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 manager = SelfCodingManager(
     engine,
     pipeline,
     bot_registry=registry,
     data_bot=data_bot,
-    threshold_service=_StubThresholdService(),
+    threshold_service=ThresholdService(),
 )
 
 """Automatically validate and merge Codex refactors.
@@ -58,11 +55,6 @@ from snippet_compressor import compress_snippets
 
 from billing.prompt_notice import prepend_payment_notice
 from llm_interface import LLMClient, Prompt
-try:  # pragma: no cover - optional self-coding dependency
-    from .self_coding_manager import SelfCodingManager
-except ImportError:  # pragma: no cover - self-coding unavailable
-    SelfCodingManager = Any  # type: ignore
-from .coding_bot_interface import self_coding_managed
 
 try:
     from vector_service.context_builder import ContextBuilder

--- a/error_bot.py
+++ b/error_bot.py
@@ -91,35 +91,27 @@ from .scope_utils import build_scope_clause, Scope, apply_scope
 from .coding_bot_interface import self_coding_managed
 from .bot_registry import BotRegistry
 from .data_bot import DataBot
-try:  # pragma: no cover - optional self-coding dependency
-    from .self_coding_manager import SelfCodingManager
-except ImportError:  # pragma: no cover - self-coding unavailable
-    SelfCodingManager = Any  # type: ignore
+from .self_coding_manager import SelfCodingManager
+from .self_coding_engine import SelfCodingEngine
+from .model_automation_pipeline import ModelAutomationPipeline
+from .threshold_service import ThresholdService
+from .code_database import CodeDB
+from .gpt_memory import GPTMemoryManager
+from vector_service.context_builder import ContextBuilder
 from db_dedup import insert_if_unique, ensure_content_hash_column
 
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-
-class _StubThresholds:
-    roi_drop = 0.0
-    error_threshold = 0.0
-    test_failure_threshold = 0.0
-
-
-class _StubThresholdService:
-    def get(self, name: str) -> _StubThresholds:  # pragma: no cover - simple stub
-        return _StubThresholds()
-
-
-engine = object()
-pipeline = object()
+_context_builder = ContextBuilder()
+engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
+pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 manager = SelfCodingManager(
     engine,
     pipeline,
     bot_registry=registry,
     data_bot=data_bot,
-    threshold_service=_StubThresholdService(),
+    threshold_service=ThresholdService(),
 )
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only

--- a/implementation_optimiser_bot.py
+++ b/implementation_optimiser_bot.py
@@ -7,6 +7,11 @@ from pathlib import Path
 from typing import List
 
 from .self_coding_manager import SelfCodingManager
+from .self_coding_engine import SelfCodingEngine
+from .model_automation_pipeline import ModelAutomationPipeline
+from .threshold_service import ThresholdService
+from .code_database import CodeDB
+from .gpt_memory import GPTMemoryManager
 import ast
 import logging
 import time
@@ -22,26 +27,15 @@ from .task_handoff_bot import TaskPackage, TaskInfo
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-
-class _StubThresholds:
-    roi_drop = 0.0
-    error_threshold = 0.0
-    test_failure_threshold = 0.0
-
-
-class _StubThresholdService:
-    def get(self, name: str) -> _StubThresholds:  # pragma: no cover - simple stub
-        return _StubThresholds()
-
-
-engine = object()
-pipeline = object()
+_context_builder = ContextBuilder()
+engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
+pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 manager = SelfCodingManager(
     engine,
     pipeline,
     bot_registry=registry,
     data_bot=data_bot,
-    threshold_service=_StubThresholdService(),
+    threshold_service=ThresholdService(),
 )
 
 

--- a/research_aggregator_bot.py
+++ b/research_aggregator_bot.py
@@ -7,6 +7,12 @@ from .data_bot import DataBot
 
 from .coding_bot_interface import self_coding_managed
 from .self_coding_manager import SelfCodingManager
+from .self_coding_engine import SelfCodingEngine
+from .model_automation_pipeline import ModelAutomationPipeline
+from .threshold_service import ThresholdService
+from .code_database import CodeDB
+from .gpt_memory import GPTMemoryManager
+from vector_service.context_builder import ContextBuilder
 import sqlite3
 import time
 from dataclasses import dataclass, field
@@ -51,26 +57,15 @@ logger = logging.getLogger(__name__)
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-
-class _StubThresholds:
-    roi_drop = 0.0
-    error_threshold = 0.0
-    test_failure_threshold = 0.0
-
-
-class _StubThresholdService:
-    def get(self, name: str) -> _StubThresholds:  # pragma: no cover - simple stub
-        return _StubThresholds()
-
-
-engine = object()
-pipeline = object()
+_context_builder = ContextBuilder()
+engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
+pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 manager = SelfCodingManager(
     engine,
     pipeline,
     bot_registry=registry,
     data_bot=data_bot,
-    threshold_service=_StubThresholdService(),
+    threshold_service=ThresholdService(),
 )
 
 @dataclass

--- a/structural_evolution_bot.py
+++ b/structural_evolution_bot.py
@@ -25,32 +25,27 @@ from .data_bot import MetricsDB, DataBot
 from .evolution_approval_policy import EvolutionApprovalPolicy
 from .self_coding_manager import SelfCodingManager
 from .bot_registry import BotRegistry
+from .self_coding_engine import SelfCodingEngine
+from .model_automation_pipeline import ModelAutomationPipeline
+from .threshold_service import ThresholdService
+from .code_database import CodeDB
+from .gpt_memory import GPTMemoryManager
+from vector_service.context_builder import ContextBuilder
 
 logger = logging.getLogger(__name__)
 
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-
-class _StubThresholds:
-    roi_drop = 0.0
-    error_threshold = 0.0
-    test_failure_threshold = 0.0
-
-
-class _StubThresholdService:
-    def get(self, name: str) -> _StubThresholds:  # pragma: no cover - simple stub
-        return _StubThresholds()
-
-
-engine = object()
-pipeline = object()
+_context_builder = ContextBuilder()
+engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
+pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 manager = SelfCodingManager(
     engine,
     pipeline,
     bot_registry=registry,
     data_bot=data_bot,
-    threshold_service=_StubThresholdService(),
+    threshold_service=ThresholdService(),
 )
 
 @dataclass

--- a/workflow_evolution_bot.py
+++ b/workflow_evolution_bot.py
@@ -12,6 +12,12 @@ from . import mutation_logger as MutationLogger
 from .bot_registry import BotRegistry
 from .data_bot import DataBot
 from .self_coding_manager import SelfCodingManager
+from .self_coding_engine import SelfCodingEngine
+from .model_automation_pipeline import ModelAutomationPipeline
+from .threshold_service import ThresholdService
+from .code_database import CodeDB
+from .gpt_memory import GPTMemoryManager
+from vector_service.context_builder import ContextBuilder
 try:  # pragma: no cover - allow flat imports
     from .intent_clusterer import IntentClusterer
     from .universal_retriever import UniversalRetriever
@@ -56,26 +62,15 @@ logger = logging.getLogger(__name__)
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-
-class _StubThresholds:
-    roi_drop = 0.0
-    error_threshold = 0.0
-    test_failure_threshold = 0.0
-
-
-class _StubThresholdService:
-    def get(self, name: str) -> _StubThresholds:  # pragma: no cover - simple stub
-        return _StubThresholds()
-
-
-engine = object()
-pipeline = object()
+_context_builder = ContextBuilder()
+engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
+pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 manager = SelfCodingManager(
     engine,
     pipeline,
     bot_registry=registry,
     data_bot=data_bot,
-    threshold_service=_StubThresholdService(),
+    threshold_service=ThresholdService(),
 )
 
 


### PR DESCRIPTION
## Summary
- replace stub self-coding blocks with real `SelfCodingEngine` and `ModelAutomationPipeline`
- use `ThresholdService` instead of `_StubThresholdService`
- ensure bots remain decorated with `@self_coding_managed`

## Testing
- `pytest -q` *(fails: missing modules/import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c581d65de4832eb69c756542a5af42