### PR TITLE
feat: allow explicit coding bot flag

### DIFF
--- a/bot_db_utils.py
+++ b/bot_db_utils.py
@@ -49,7 +49,10 @@ def wrap_bot_methods(
                     manager_obj = getattr(bot, "manager", None)
                     d_bot = getattr(bot, "data_bot", None)
                     bot_registry.register_bot(
-                        from_name, manager=manager_obj, data_bot=d_bot
+                        from_name,
+                        manager=manager_obj,
+                        data_bot=d_bot,
+                        is_coding_bot=bool(manager_obj and d_bot),
                     )
                 except Exception as exc:
                     logger.warning(

--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -1040,7 +1040,10 @@ class BotDevelopmentBot:
                     bot_name = spec.name
                     module_path = str(file_path)
                     registry.register_bot(
-                        bot_name, manager=self.manager, data_bot=d_bot
+                        bot_name,
+                        manager=self.manager,
+                        data_bot=d_bot,
+                        is_coding_bot=True,
                     )
                     registry.update_bot(bot_name, module_path)
                     d_bot.reload_thresholds(bot_name)

--- a/coding_bot_interface.py
+++ b/coding_bot_interface.py
@@ -177,12 +177,15 @@ def self_coding_managed(
                 error_threshold=err_t,
                 manager=manager,
                 data_bot=data_bot,
+                is_coding_bot=True,
             )
         except TypeError:  # pragma: no cover - legacy registries
             try:
-                bot_registry.register_bot(name, manager=manager, data_bot=data_bot)
+                bot_registry.register_bot(
+                    name, manager=manager, data_bot=data_bot, is_coding_bot=True
+                )
             except TypeError:
-                bot_registry.register_bot(name)
+                bot_registry.register_bot(name, is_coding_bot=True)
         try:
             bot_registry.update_bot(name, module_path)
         except Exception:  # pragma: no cover - best effort
@@ -312,6 +315,7 @@ def self_coding_managed(
                     error_threshold=getattr(thresholds, "error_threshold", None),
                     manager=manager_local,
                     data_bot=d_bot,
+                    is_coding_bot=True,
                 )
             except Exception:  # pragma: no cover - best effort
                 logger.exception("bot registration failed for %s", name_local)

--- a/self_coding_manager.py
+++ b/self_coding_manager.py
@@ -279,7 +279,10 @@ class SelfCodingManager:
         if self.bot_registry:
             try:
                 self.bot_registry.register_bot(
-                    self.bot_name, manager=self, data_bot=self.data_bot
+                    self.bot_name,
+                    manager=self,
+                    data_bot=self.data_bot,
+                    is_coding_bot=True,
                 )
             except Exception:  # pragma: no cover - best effort
                 self.logger.exception("failed to register bot in registry")
@@ -336,7 +339,12 @@ class SelfCodingManager:
         if not self.bot_registry:
             return
         try:
-            self.bot_registry.register_bot(name, manager=self, data_bot=self.data_bot)
+            self.bot_registry.register_bot(
+                name,
+                manager=self,
+                data_bot=self.data_bot,
+                is_coding_bot=True,
+            )
             if self.data_bot:
                 try:
                     self.threshold_service.reload(name)
@@ -1647,7 +1655,10 @@ class SelfCodingManager:
                     resources=(f"hot_swap:{int(time.time())},patch_id:{patch_id}"),
                 )
                 self.bot_registry.register_bot(
-                    self.bot_name, manager=self, data_bot=self.data_bot
+                    self.bot_name,
+                    manager=self,
+                    data_bot=self.data_bot,
+                    is_coding_bot=True,
                 )
                 self.bot_registry.record_interaction_metadata(
                     self.bot_name,
@@ -1881,6 +1892,7 @@ def internalize_coding_bot(
         error_threshold=error_threshold,
         manager=manager,
         data_bot=data_bot,
+        is_coding_bot=True,
     )
     if evolution_orchestrator is not None:
         evolution_orchestrator.selfcoding_manager = manager

--- a/tests/test_coding_bot_interface.py
+++ b/tests/test_coding_bot_interface.py
@@ -78,7 +78,7 @@ class DummyRegistry:
         self.registered = []
         self.updated = []
 
-    def register_bot(self, name):
+    def register_bot(self, name, **kwargs):
         self.registered.append(name)
 
     def update_bot(self, name, module_path):


### PR DESCRIPTION
## Summary
- allow explicitly marking bots as coding to bypass name heuristics
- ensure coding bots are registered with `is_coding_bot=True`
- avoid false positives for non-coding bots when auto-registering

## Testing
- `pytest tests/test_coding_bot_interface.py::test_auto_instantiates_orchestrator -q` *(fails: SelfCodingManager is required but was not provided)*
- `pytest tests/test_bot_registry_save.py::test_registry_save_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5839f4844832e97788a9f5b0773c7