### PR TITLE
Ensure fresh ContextBuilder per helper call

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -1483,7 +1483,9 @@ class SelfCodingEngine:
         optional prompt strategy to the underlying :class:`PromptEngine`.
         """
         path = resolve_path(path)
-        from .coding_bot_interface import manager_generate_helper
+        from .self_coding_manager import (
+            _manager_generate_helper_with_builder as manager_generate_helper,
+        )
 
         manager = MANAGER_CONTEXT.get()
         try:
@@ -1728,7 +1730,9 @@ class SelfCodingEngine:
         # Snapshot of original file to merge patches into
         original_lines = path.read_text(encoding="utf-8").splitlines()
         code = "\n".join(original_lines)
-        from .coding_bot_interface import manager_generate_helper
+        from .self_coding_manager import (
+            _manager_generate_helper_with_builder as manager_generate_helper,
+        )
         manager = MANAGER_CONTEXT.get()
 
         def _verify(snippet: str) -> bool:

--- a/tests/test_helper_context_builder_instances.py
+++ b/tests/test_helper_context_builder_instances.py
@@ -1,0 +1,52 @@
+import ast
+import types
+from pathlib import Path
+
+
+def _load_helper_function():
+    src = Path(__file__).resolve().parents[1] / "self_coding_manager.py"
+    tree = ast.parse(src.read_text())
+    fn_node = next(
+        n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "_manager_generate_helper_with_builder"
+    )
+    ns: dict[str, object] = {}
+    exec("from typing import Any", ns)
+    code = compile(ast.Module([fn_node], []), str(src), "exec")
+    exec(code, ns)
+    return ns["_manager_generate_helper_with_builder"]
+
+
+def test_distinct_context_builders():
+    builders = []
+
+    class DummyBuilder:
+        def __init__(self) -> None:
+            self.refreshed = False
+
+        def refresh_db_weights(self) -> None:
+            self.refreshed = True
+
+    def ensure_fresh_weights(builder):  # pragma: no cover - simple stub
+        builder.refresh_db_weights()
+
+    def base_helper(manager, description, **kwargs):  # pragma: no cover - simple stub
+        builders.append(kwargs.get("context_builder"))
+        return "ok"
+
+    helper_fn = _load_helper_function()
+    # Inject dependencies into helper's global namespace
+    helper_fn.__globals__.update(
+        {
+            "ContextBuilder": DummyBuilder,
+            "ensure_fresh_weights": ensure_fresh_weights,
+            "_BASE_MANAGER_GENERATE_HELPER": base_helper,
+        }
+    )
+
+    dummy_manager = types.SimpleNamespace()
+    helper_fn(dummy_manager, "first")
+    helper_fn(dummy_manager, "second")
+
+    assert len(builders) == 2
+    assert builders[0] is not builders[1]
+    assert builders[0].refreshed and builders[1].refreshed


### PR DESCRIPTION
## Summary
- Use `_manager_generate_helper_with_builder` inside `SelfCodingEngine` so each helper request uses a fresh `ContextBuilder`
- Add regression test confirming new builders are created for separate helper invocations

## Testing
- `pytest tests/test_helper_context_builder_instances.py -q`
- `pytest tests/test_context_builder.py::test_manager_generate_helper -q` *(fails: FileNotFoundError: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c589e6a204832e9184ec2ca86c6c7d