### PR TITLE
Use internalize_coding_bot for self-coding managers

### DIFF
--- a/bot_planning_bot.py
+++ b/bot_planning_bot.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from .bot_registry import BotRegistry
 from .data_bot import DataBot
 from .coding_bot_interface import self_coding_managed
-from .self_coding_manager import SelfCodingManager
+from .self_coding_manager import SelfCodingManager, internalize_coding_bot
 from .self_coding_engine import SelfCodingEngine
 from .model_automation_pipeline import ModelAutomationPipeline
 from .threshold_service import ThresholdService
@@ -13,7 +13,10 @@ from .code_database import CodeDB
 from .gpt_memory import GPTMemoryManager
 from vector_service.context_builder import ContextBuilder
 from dataclasses import dataclass, field
-from typing import Iterable, List, Dict, Optional
+from typing import Iterable, List, Dict, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .evolution_orchestrator import EvolutionOrchestrator
 
 import networkx as nx
 try:
@@ -33,11 +36,14 @@ data_bot = DataBot(start_server=False)
 _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
-manager = SelfCodingManager(
+evolution_orchestrator: EvolutionOrchestrator | None = None
+manager = internalize_coding_bot(
+    "BotPlanningBot",
     engine,
     pipeline,
-    bot_registry=registry,
     data_bot=data_bot,
+    bot_registry=registry,
+    evolution_orchestrator=evolution_orchestrator,
     threshold_service=ThresholdService(),
 )
 

--- a/enhancement_bot.py
+++ b/enhancement_bot.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from .bot_registry import BotRegistry
 from .data_bot import DataBot
-from .self_coding_manager import SelfCodingManager
+from .self_coding_manager import SelfCodingManager, internalize_coding_bot
 from .self_coding_engine import SelfCodingEngine
 from .model_automation_pipeline import ModelAutomationPipeline
 from .threshold_service import ThresholdService
@@ -10,6 +10,10 @@ from .code_database import CodeDB
 from .gpt_memory import GPTMemoryManager
 from vector_service.context_builder import ContextBuilder
 from .coding_bot_interface import self_coding_managed
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .evolution_orchestrator import EvolutionOrchestrator
 
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
@@ -17,11 +21,14 @@ data_bot = DataBot(start_server=False)
 _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
-manager = SelfCodingManager(
+evolution_orchestrator: EvolutionOrchestrator | None = None
+manager = internalize_coding_bot(
+    "EnhancementBot",
     engine,
     pipeline,
-    bot_registry=registry,
     data_bot=data_bot,
+    bot_registry=registry,
+    evolution_orchestrator=evolution_orchestrator,
     threshold_service=ThresholdService(),
 )
 

--- a/research_aggregator_bot.py
+++ b/research_aggregator_bot.py
@@ -6,13 +6,17 @@ from .bot_registry import BotRegistry
 from .data_bot import DataBot
 
 from .coding_bot_interface import self_coding_managed
-from .self_coding_manager import SelfCodingManager
+from .self_coding_manager import SelfCodingManager, internalize_coding_bot
 from .self_coding_engine import SelfCodingEngine
 from .model_automation_pipeline import ModelAutomationPipeline
 from .threshold_service import ThresholdService
 from .code_database import CodeDB
 from .gpt_memory import GPTMemoryManager
 from vector_service.context_builder import ContextBuilder
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .evolution_orchestrator import EvolutionOrchestrator
 import sqlite3
 import time
 from dataclasses import dataclass, field
@@ -60,11 +64,14 @@ data_bot = DataBot(start_server=False)
 _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
-manager = SelfCodingManager(
+evolution_orchestrator: EvolutionOrchestrator | None = None
+manager = internalize_coding_bot(
+    "ResearchAggregatorBot",
     engine,
     pipeline,
-    bot_registry=registry,
     data_bot=data_bot,
+    bot_registry=registry,
+    evolution_orchestrator=evolution_orchestrator,
     threshold_service=ThresholdService(),
 )
 

--- a/structural_evolution_bot.py
+++ b/structural_evolution_bot.py
@@ -23,7 +23,7 @@ except Exception:  # pragma: no cover - optional dependency
 
 from .data_bot import MetricsDB, DataBot
 from .evolution_approval_policy import EvolutionApprovalPolicy
-from .self_coding_manager import SelfCodingManager
+from .self_coding_manager import SelfCodingManager, internalize_coding_bot
 from .bot_registry import BotRegistry
 from .self_coding_engine import SelfCodingEngine
 from .model_automation_pipeline import ModelAutomationPipeline
@@ -31,6 +31,10 @@ from .threshold_service import ThresholdService
 from .code_database import CodeDB
 from .gpt_memory import GPTMemoryManager
 from vector_service.context_builder import ContextBuilder
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .evolution_orchestrator import EvolutionOrchestrator
 
 logger = logging.getLogger(__name__)
 
@@ -40,11 +44,14 @@ data_bot = DataBot(start_server=False)
 _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
-manager = SelfCodingManager(
+evolution_orchestrator: EvolutionOrchestrator | None = None
+manager = internalize_coding_bot(
+    "StructuralEvolutionBot",
     engine,
     pipeline,
-    bot_registry=registry,
     data_bot=data_bot,
+    bot_registry=registry,
+    evolution_orchestrator=evolution_orchestrator,
     threshold_service=ThresholdService(),
 )
 

--- a/workflow_evolution_bot.py
+++ b/workflow_evolution_bot.py
@@ -11,13 +11,17 @@ from .neuroplasticity import PathwayDB
 from . import mutation_logger as MutationLogger
 from .bot_registry import BotRegistry
 from .data_bot import DataBot
-from .self_coding_manager import SelfCodingManager
+from .self_coding_manager import SelfCodingManager, internalize_coding_bot
 from .self_coding_engine import SelfCodingEngine
 from .model_automation_pipeline import ModelAutomationPipeline
 from .threshold_service import ThresholdService
 from .code_database import CodeDB
 from .gpt_memory import GPTMemoryManager
 from vector_service.context_builder import ContextBuilder
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .evolution_orchestrator import EvolutionOrchestrator
 try:  # pragma: no cover - allow flat imports
     from .intent_clusterer import IntentClusterer
     from .universal_retriever import UniversalRetriever
@@ -65,11 +69,14 @@ data_bot = DataBot(start_server=False)
 _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
-manager = SelfCodingManager(
+evolution_orchestrator: EvolutionOrchestrator | None = None
+manager = internalize_coding_bot(
+    "WorkflowEvolutionBot",
     engine,
     pipeline,
-    bot_registry=registry,
     data_bot=data_bot,
+    bot_registry=registry,
+    evolution_orchestrator=evolution_orchestrator,
     threshold_service=ThresholdService(),
 )
 


### PR DESCRIPTION
## Summary
- Replace direct `SelfCodingManager` instantiation with `internalize_coding_bot` across multiple bots
- Pass through `evolution_orchestrator` and ensure `self_coding_managed` decorator references returned manager

## Testing
- `pytest tests/test_coding_bot_interface.py tests/test_self_coding_managed_pipeline.py -q` *(fails: BotRegistry stub missing newer arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68c5951e1398832ebfa8e35d90ce0135