### PR TITLE
Persist self-coding thresholds for internalized bots

### DIFF
--- a/automated_reviewer.py
+++ b/automated_reviewer.py
@@ -8,7 +8,7 @@ from typing import Optional
 from typing import TYPE_CHECKING
 
 from .bot_registry import BotRegistry
-from .data_bot import DataBot
+from .data_bot import DataBot, persist_sc_thresholds
 from .coding_bot_interface import self_coding_managed
 from .self_coding_engine import SelfCodingEngine
 from .model_automation_pipeline import ModelAutomationPipeline
@@ -16,6 +16,7 @@ from .code_database import CodeDB
 from .menace_memory_manager import MenaceMemoryManager
 from .threshold_service import ThresholdService
 from .self_coding_manager import SelfCodingManager, internalize_coding_bot
+from .self_coding_thresholds import get_thresholds
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
     from .auto_escalation_manager import AutoEscalationManager
@@ -54,6 +55,12 @@ _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), MenaceMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 evolution_orchestrator: EvolutionOrchestrator | None = None
+_th = get_thresholds("AutomatedReviewer")
+persist_sc_thresholds(
+    "AutomatedReviewer",
+    roi_drop=_th.roi_drop,
+    error_increase=_th.error_increase,
+)
 manager = internalize_coding_bot(
     "AutomatedReviewer",
     engine,
@@ -61,8 +68,8 @@ manager = internalize_coding_bot(
     data_bot=data_bot,
     bot_registry=registry,
     evolution_orchestrator=evolution_orchestrator,
-    roi_threshold=-0.1,
-    error_threshold=0.2,
+    roi_threshold=_th.roi_drop,
+    error_threshold=_th.error_increase,
     threshold_service=ThresholdService(),
 )
 

--- a/bot_creation_bot.py
+++ b/bot_creation_bot.py
@@ -16,7 +16,7 @@ from collections import deque
 import re
 import time
 
-from .data_bot import DataBot, MetricsDB
+from .data_bot import DataBot, MetricsDB, persist_sc_thresholds
 from .bot_registry import BotRegistry
 from .bot_planning_bot import BotPlanningBot, PlanningTask
 from .bot_development_bot import BotDevelopmentBot, BotSpec
@@ -38,6 +38,7 @@ from .workflow_evolution_bot import WorkflowEvolutionBot
 from .trending_scraper import TrendingScraper
 from .admin_bot_base import AdminBotBase
 from .self_coding_manager import SelfCodingManager, internalize_coding_bot
+from .self_coding_thresholds import get_thresholds
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .evolution_orchestrator import EvolutionOrchestrator
@@ -69,6 +70,12 @@ _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), MenaceMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 evolution_orchestrator: EvolutionOrchestrator | None = None
+_th = get_thresholds("BotCreationBot")
+persist_sc_thresholds(
+    "BotCreationBot",
+    roi_drop=_th.roi_drop,
+    error_increase=_th.error_increase,
+)
 manager = internalize_coding_bot(
     "BotCreationBot",
     engine,
@@ -76,8 +83,8 @@ manager = internalize_coding_bot(
     data_bot=data_bot,
     bot_registry=registry,
     evolution_orchestrator=evolution_orchestrator,
-    roi_threshold=-0.1,
-    error_threshold=0.2,
+    roi_threshold=_th.roi_drop,
+    error_threshold=_th.error_increase,
     threshold_service=ThresholdService(),
 )
 

--- a/bot_planning_bot.py
+++ b/bot_planning_bot.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from .bot_registry import BotRegistry
-from .data_bot import DataBot
+from .data_bot import DataBot, persist_sc_thresholds
 from .coding_bot_interface import self_coding_managed
 from .self_coding_manager import SelfCodingManager, internalize_coding_bot
 from .self_coding_engine import SelfCodingEngine
@@ -11,6 +11,7 @@ from .model_automation_pipeline import ModelAutomationPipeline
 from .threshold_service import ThresholdService
 from .code_database import CodeDB
 from .gpt_memory import GPTMemoryManager
+from .self_coding_thresholds import get_thresholds
 from vector_service.context_builder import ContextBuilder
 from dataclasses import dataclass, field
 from typing import Iterable, List, Dict, Optional, TYPE_CHECKING
@@ -37,6 +38,12 @@ _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 evolution_orchestrator: EvolutionOrchestrator | None = None
+_th = get_thresholds("BotPlanningBot")
+persist_sc_thresholds(
+    "BotPlanningBot",
+    roi_drop=_th.roi_drop,
+    error_increase=_th.error_increase,
+)
 manager = internalize_coding_bot(
     "BotPlanningBot",
     engine,
@@ -45,6 +52,8 @@ manager = internalize_coding_bot(
     bot_registry=registry,
     evolution_orchestrator=evolution_orchestrator,
     threshold_service=ThresholdService(),
+    roi_threshold=_th.roi_drop,
+    error_threshold=_th.error_increase,
 )
 
 

--- a/bot_testing_bot.py
+++ b/bot_testing_bot.py
@@ -23,13 +23,14 @@ import time
 from .bot_testing_config import BotTestingSettings
 from .db_router import DBRouter, GLOBAL_ROUTER, init_db_router
 from .bot_registry import BotRegistry
-from .data_bot import DataBot
+from .data_bot import DataBot, persist_sc_thresholds
 from .self_coding_manager import SelfCodingManager, internalize_coding_bot
 from .self_coding_engine import SelfCodingEngine
 from .model_automation_pipeline import ModelAutomationPipeline
 from .threshold_service import ThresholdService
 from .code_database import CodeDB
 from .gpt_memory import GPTMemoryManager
+from .self_coding_thresholds import get_thresholds
 from vector_service.context_builder import ContextBuilder
 from typing import TYPE_CHECKING
 
@@ -45,6 +46,12 @@ _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 evolution_orchestrator: EvolutionOrchestrator | None = None
+_th = get_thresholds("BotTestingBot")
+persist_sc_thresholds(
+    "BotTestingBot",
+    roi_drop=_th.roi_drop,
+    error_increase=_th.error_increase,
+)
 manager = internalize_coding_bot(
     "BotTestingBot",
     engine,
@@ -52,8 +59,8 @@ manager = internalize_coding_bot(
     data_bot=data_bot,
     bot_registry=registry,
     evolution_orchestrator=evolution_orchestrator,
-    roi_threshold=-0.1,
-    error_threshold=0.2,
+    roi_threshold=_th.roi_drop,
+    error_threshold=_th.error_increase,
     threshold_service=ThresholdService(),
 )
 

--- a/config/self_coding_thresholds.yaml
+++ b/config/self_coding_thresholds.yaml
@@ -19,7 +19,7 @@ bots:
     test_failure_increase: 0.0
   AutomatedReviewer:
     roi_drop: -0.1
-    error_increase: 1.0
+    error_increase: 0.2
     test_failure_increase: 0.0
   AverageMetricBot:
     roi_drop: -0.1
@@ -35,11 +35,11 @@ bots:
     test_failure_increase: 0.0
   BotCreationBot:
     roi_drop: -0.1
-    error_increase: 1.0
+    error_increase: 0.2
     test_failure_increase: 0.0
   BotDevelopmentBot:
     roi_drop: -0.1
-    error_increase: 1.0
+    error_increase: 0.2
     test_failure_increase: 0.0
   BotPlanningBot:
     roi_drop: -0.1
@@ -47,7 +47,7 @@ bots:
     test_failure_increase: 0.0
   BotTestingBot:
     roi_drop: -0.1
-    error_increase: 1.0
+    error_increase: 0.2
     test_failure_increase: 0.0
   CapitalManagementBot:
     roi_drop: -0.05
@@ -267,7 +267,7 @@ bots:
     test_failure_increase: 0.0
   ImplementationOptimiserBot:
     roi_drop: -0.1
-    error_increase: 1.0
+    error_increase: 0.2
     test_failure_increase: 0.0
   InformationSynthesisBot:
     roi_drop: -0.1

--- a/enhancement_bot.py
+++ b/enhancement_bot.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from .bot_registry import BotRegistry
-from .data_bot import DataBot
+from .data_bot import DataBot, persist_sc_thresholds
 from .self_coding_manager import SelfCodingManager, internalize_coding_bot
 from .self_coding_engine import SelfCodingEngine
 from .model_automation_pipeline import ModelAutomationPipeline
 from .threshold_service import ThresholdService
 from .code_database import CodeDB
 from .gpt_memory import GPTMemoryManager
+from .self_coding_thresholds import get_thresholds
 from vector_service.context_builder import ContextBuilder
 from .coding_bot_interface import self_coding_managed
 from typing import TYPE_CHECKING
@@ -22,6 +23,12 @@ _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 evolution_orchestrator: EvolutionOrchestrator | None = None
+_th = get_thresholds("EnhancementBot")
+persist_sc_thresholds(
+    "EnhancementBot",
+    roi_drop=_th.roi_drop,
+    error_increase=_th.error_increase,
+)
 manager = internalize_coding_bot(
     "EnhancementBot",
     engine,
@@ -30,6 +37,8 @@ manager = internalize_coding_bot(
     bot_registry=registry,
     evolution_orchestrator=evolution_orchestrator,
     threshold_service=ThresholdService(),
+    roi_threshold=_th.roi_drop,
+    error_threshold=_th.error_increase,
 )
 
 """Automatically validate and merge Codex refactors.

--- a/error_bot.py
+++ b/error_bot.py
@@ -90,13 +90,14 @@ from .metrics_exporter import error_bot_exceptions
 from .scope_utils import build_scope_clause, Scope, apply_scope
 from .coding_bot_interface import self_coding_managed
 from .bot_registry import BotRegistry
-from .data_bot import DataBot
+from .data_bot import DataBot, persist_sc_thresholds
 from .self_coding_manager import SelfCodingManager, internalize_coding_bot
 from .self_coding_engine import SelfCodingEngine
 from .model_automation_pipeline import ModelAutomationPipeline
 from .threshold_service import ThresholdService
 from .code_database import CodeDB
 from .gpt_memory import GPTMemoryManager
+from .self_coding_thresholds import get_thresholds
 from vector_service.context_builder import ContextBuilder
 from db_dedup import insert_if_unique, ensure_content_hash_column
 
@@ -111,6 +112,12 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     from .evolution_orchestrator import EvolutionOrchestrator
 
 evolution_orchestrator: EvolutionOrchestrator | None = None
+_th = get_thresholds("ErrorBot")
+persist_sc_thresholds(
+    "ErrorBot",
+    roi_drop=_th.roi_drop,
+    error_increase=_th.error_increase,
+)
 manager = internalize_coding_bot(
     "ErrorBot",
     engine,
@@ -119,6 +126,8 @@ manager = internalize_coding_bot(
     bot_registry=registry,
     evolution_orchestrator=evolution_orchestrator,
     threshold_service=ThresholdService(),
+    roi_threshold=_th.roi_drop,
+    error_threshold=_th.error_increase,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only

--- a/implementation_optimiser_bot.py
+++ b/implementation_optimiser_bot.py
@@ -12,12 +12,13 @@ from .model_automation_pipeline import ModelAutomationPipeline
 from .threshold_service import ThresholdService
 from .code_database import CodeDB
 from .gpt_memory import GPTMemoryManager
+from .self_coding_thresholds import get_thresholds
 import ast
 import logging
 import time
 from vector_service.context_builder import ContextBuilder
 from .bot_registry import BotRegistry
-from .data_bot import DataBot
+from .data_bot import DataBot, persist_sc_thresholds
 from .coding_bot_interface import self_coding_managed
 from .task_handoff_bot import TaskPackage, TaskInfo
 from typing import TYPE_CHECKING
@@ -34,6 +35,12 @@ _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 evolution_orchestrator: EvolutionOrchestrator | None = None
+_th = get_thresholds("ImplementationOptimiserBot")
+persist_sc_thresholds(
+    "ImplementationOptimiserBot",
+    roi_drop=_th.roi_drop,
+    error_increase=_th.error_increase,
+)
 manager = internalize_coding_bot(
     "ImplementationOptimiserBot",
     engine,
@@ -41,8 +48,8 @@ manager = internalize_coding_bot(
     data_bot=data_bot,
     bot_registry=registry,
     evolution_orchestrator=evolution_orchestrator,
-    roi_threshold=-0.1,
-    error_threshold=0.2,
+    roi_threshold=_th.roi_drop,
+    error_threshold=_th.error_increase,
     threshold_service=ThresholdService(),
 )
 

--- a/research_aggregator_bot.py
+++ b/research_aggregator_bot.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from .bot_registry import BotRegistry
-from .data_bot import DataBot
+from .data_bot import DataBot, persist_sc_thresholds
 
 from .coding_bot_interface import self_coding_managed
 from .self_coding_manager import SelfCodingManager, internalize_coding_bot
@@ -12,6 +12,7 @@ from .model_automation_pipeline import ModelAutomationPipeline
 from .threshold_service import ThresholdService
 from .code_database import CodeDB
 from .gpt_memory import GPTMemoryManager
+from .self_coding_thresholds import get_thresholds
 from vector_service.context_builder import ContextBuilder
 from typing import TYPE_CHECKING
 
@@ -65,6 +66,12 @@ _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 evolution_orchestrator: EvolutionOrchestrator | None = None
+_th = get_thresholds("ResearchAggregatorBot")
+persist_sc_thresholds(
+    "ResearchAggregatorBot",
+    roi_drop=_th.roi_drop,
+    error_increase=_th.error_increase,
+)
 manager = internalize_coding_bot(
     "ResearchAggregatorBot",
     engine,
@@ -73,6 +80,8 @@ manager = internalize_coding_bot(
     bot_registry=registry,
     evolution_orchestrator=evolution_orchestrator,
     threshold_service=ThresholdService(),
+    roi_threshold=_th.roi_drop,
+    error_threshold=_th.error_increase,
 )
 
 @dataclass

--- a/structural_evolution_bot.py
+++ b/structural_evolution_bot.py
@@ -21,7 +21,7 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     pd = None  # type: ignore
 
-from .data_bot import MetricsDB, DataBot
+from .data_bot import MetricsDB, DataBot, persist_sc_thresholds
 from .evolution_approval_policy import EvolutionApprovalPolicy
 from .self_coding_manager import SelfCodingManager, internalize_coding_bot
 from .bot_registry import BotRegistry
@@ -30,6 +30,7 @@ from .model_automation_pipeline import ModelAutomationPipeline
 from .threshold_service import ThresholdService
 from .code_database import CodeDB
 from .gpt_memory import GPTMemoryManager
+from .self_coding_thresholds import get_thresholds
 from vector_service.context_builder import ContextBuilder
 from typing import TYPE_CHECKING
 
@@ -45,6 +46,12 @@ _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 evolution_orchestrator: EvolutionOrchestrator | None = None
+_th = get_thresholds("StructuralEvolutionBot")
+persist_sc_thresholds(
+    "StructuralEvolutionBot",
+    roi_drop=_th.roi_drop,
+    error_increase=_th.error_increase,
+)
 manager = internalize_coding_bot(
     "StructuralEvolutionBot",
     engine,
@@ -53,6 +60,8 @@ manager = internalize_coding_bot(
     bot_registry=registry,
     evolution_orchestrator=evolution_orchestrator,
     threshold_service=ThresholdService(),
+    roi_threshold=_th.roi_drop,
+    error_threshold=_th.error_increase,
 )
 
 @dataclass

--- a/workflow_evolution_bot.py
+++ b/workflow_evolution_bot.py
@@ -10,13 +10,14 @@ import logging
 from .neuroplasticity import PathwayDB
 from . import mutation_logger as MutationLogger
 from .bot_registry import BotRegistry
-from .data_bot import DataBot
+from .data_bot import DataBot, persist_sc_thresholds
 from .self_coding_manager import SelfCodingManager, internalize_coding_bot
 from .self_coding_engine import SelfCodingEngine
 from .model_automation_pipeline import ModelAutomationPipeline
 from .threshold_service import ThresholdService
 from .code_database import CodeDB
 from .gpt_memory import GPTMemoryManager
+from .self_coding_thresholds import get_thresholds
 from vector_service.context_builder import ContextBuilder
 from typing import TYPE_CHECKING
 
@@ -70,6 +71,12 @@ _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 evolution_orchestrator: EvolutionOrchestrator | None = None
+_th = get_thresholds("WorkflowEvolutionBot")
+persist_sc_thresholds(
+    "WorkflowEvolutionBot",
+    roi_drop=_th.roi_drop,
+    error_increase=_th.error_increase,
+)
 manager = internalize_coding_bot(
     "WorkflowEvolutionBot",
     engine,
@@ -78,6 +85,8 @@ manager = internalize_coding_bot(
     bot_registry=registry,
     evolution_orchestrator=evolution_orchestrator,
     threshold_service=ThresholdService(),
+    roi_threshold=_th.roi_drop,
+    error_threshold=_th.error_increase,
 )
 
 


### PR DESCRIPTION
## Summary
- ensure each internalized bot saves and uses ROI/error thresholds via `persist_sc_thresholds`
- load thresholds from configuration and forward them to `internalize_coding_bot`
- record stricter `error_increase` limits in `config/self_coding_thresholds.yaml`

## Testing
- `pytest tests/test_sc_threshold_persistence.py -q`
- `pre-commit run --files automated_reviewer.py bot_creation_bot.py bot_development_bot.py bot_planning_bot.py bot_testing_bot.py config/self_coding_thresholds.yaml enhancement_bot.py error_bot.py implementation_optimiser_bot.py research_aggregator_bot.py structural_evolution_bot.py workflow_evolution_bot.py` *(failed: Interrupted (^C))*

------
https://chatgpt.com/codex/tasks/task_e_68c59719ea10832e8634e93da99c75b2