### PR TITLE
Ensure shared event bus and provenance usage

### DIFF
--- a/quick_fix_engine.py
+++ b/quick_fix_engine.py
@@ -397,7 +397,12 @@ def generate_patch(
     try:
         meta = dict(context_meta)
         meta.setdefault("trigger", "quick_fix_engine")
-        manager.register_patch_cycle(description, meta)
+        token = getattr(
+            getattr(manager, "evolution_orchestrator", None),
+            "provenance_token",
+            None,
+        )
+        manager.register_patch_cycle(description, meta, provenance_token=token)
     except Exception:
         logger.exception("failed to register patch cycle")
 

--- a/self_coding_manager.py
+++ b/self_coding_manager.py
@@ -375,12 +375,17 @@ class SelfCodingManager:
                         "failed to register bot with evolution orchestrator"
                     )
             if self.data_bot and self.evolution_orchestrator:
-                try:
-                    self.data_bot.subscribe_degradation(
-                        lambda e: self.evolution_orchestrator.register_patch_cycle(e)
-                    )
-                except Exception:  # pragma: no cover - best effort
-                    self.logger.exception("failed to subscribe to degradation events")
+                bus = getattr(self.data_bot, "event_bus", None)
+                if bus:
+                    try:
+                        bus.subscribe(
+                            "degradation:detected",
+                            lambda _t, e: self.evolution_orchestrator.register_patch_cycle(e),
+                        )
+                    except Exception:  # pragma: no cover - best effort
+                        self.logger.exception(
+                            "failed to subscribe to degradation events"
+                        )
         except Exception:  # pragma: no cover - best effort
             self.logger.exception("failed to register bot in registry")
 

--- a/service_supervisor.py
+++ b/service_supervisor.py
@@ -66,7 +66,7 @@ from .model_automation_pipeline import ModelAutomationPipeline  # noqa: E402
 from .quick_fix_engine import QuickFixEngine  # noqa: E402
 from vector_service.context_builder import ContextBuilder  # noqa: E402
 from context_builder_util import create_context_builder  # noqa: E402
-from .unified_event_bus import UnifiedEventBus  # noqa: E402
+from .shared_event_bus import event_bus as bus  # noqa: E402
 from .bot_registry import BotRegistry  # noqa: E402
 from .data_bot import DataBot  # noqa: E402
 from .coding_bot_interface import self_coding_managed  # noqa: E402
@@ -76,7 +76,9 @@ try:  # optional dependency
 except Exception:  # pragma: no cover - optional
     psutil = None  # type: ignore
 
-bus = UnifiedEventBus()
+# ``bus`` is the shared :class:`UnifiedEventBus` instance so all services
+# exchange events via a common channel.  Creating separate buses would isolate
+# degradation notifications and break global coordination.
 registry = BotRegistry(event_bus=bus)
 data_bot = DataBot(event_bus=bus)
 

--- a/stripe_watchdog.py
+++ b/stripe_watchdog.py
@@ -182,7 +182,7 @@ try:  # Optional dependency – telemetry feedback loop
     from data_bot import DataBot  # type: ignore
     from self_coding_manager import SelfCodingManager  # type: ignore
     from model_automation_pipeline import ModelAutomationPipeline  # type: ignore
-    from unified_event_bus import UnifiedEventBus  # type: ignore
+    from shared_event_bus import event_bus as _SHARED_EVENT_BUS  # type: ignore
 except Exception:  # pragma: no cover - best effort
     TelemetryFeedback = None  # type: ignore
     ErrorLogger = None  # type: ignore
@@ -190,7 +190,7 @@ except Exception:  # pragma: no cover - best effort
     DataBot = None  # type: ignore
     SelfCodingManager = None  # type: ignore
     ModelAutomationPipeline = None  # type: ignore
-    UnifiedEventBus = None  # type: ignore
+    _SHARED_EVENT_BUS = None  # type: ignore
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -1925,10 +1925,10 @@ def main(
             and engine is not None
             and SelfCodingManager
             and ModelAutomationPipeline
-            and UnifiedEventBus
+            and _SHARED_EVENT_BUS
         ):
             try:
-                bus = UnifiedEventBus()
+                bus = _SHARED_EVENT_BUS
                 registry = BotRegistry(event_bus=bus) if BotRegistry else None
                 data_bot = DataBot(event_bus=bus) if DataBot else None
                 pipeline = ModelAutomationPipeline(


### PR DESCRIPTION
## Summary
- Route supervisor and Stripe watchdog through the shared UnifiedEventBus
- Subscribe to degradation events via the global bus
- Propagate EvolutionOrchestrator provenance token when registering patch cycles

## Testing
- `pytest tests/test_bot_registry_degradation_orchestrator.py`
- `pytest tests/test_quick_fix_engine.py tests/test_metrics_event_bus_integration.py` *(fails: FileNotFoundError, ImportError)*


------
https://chatgpt.com/codex/tasks/task_e_68c598c6341c832e9ba2cd62baf0a458