### PR TITLE
Extend self-coding registration check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
         pass_filenames: true
         files: '\.py$'
       - id: self-coding-registration
-        name: ensure all bots are self-coding managed
+        name: Ensure bots are internalized or self-coding managed
         entry: python tools/check_self_coding_registration.py
         language: system
         pass_filenames: false

--- a/docs/internalize_coding_bot.md
+++ b/docs/internalize_coding_bot.md
@@ -36,3 +36,18 @@ manager = internalize_coding_bot(
 
 Each coding bot should invoke this helper during initialisation to ensure
 recursive integrity and automatic patch cycles.
+
+## Pre-commit check
+
+Repositories using the provided pre-commit configuration run
+`tools/check_self_coding_registration.py` to ensure every module that exports a
+class or function ending in `Bot` either calls `internalize_coding_bot` or uses
+the `@self_coding_managed` decorator.  If a bot fails these requirements the
+hook exits with a non-zero status and the commit is rejected.
+
+To pass the check:
+
+1. Call `internalize_coding_bot` during module initialisation, **or**
+2. Decorate the bot with `@self_coding_managed`.
+
+This guarantees all exported bots participate in the self-coding lifecycle.

--- a/tools/check_self_coding_registration.py
+++ b/tools/check_self_coding_registration.py
@@ -1,18 +1,32 @@
 #!/usr/bin/env python3
-"""Check that ``SelfCodingManager`` usage is properly registered.
+"""Check that coding bots are properly registered.
 
-The script scans all Python modules in the repository looking for
-instantiations of :class:`SelfCodingManager`.  Any module (excluding test
-modules and ``self_coding_manager.py`` itself) that constructs a manager must
-either call ``internalize_coding_bot`` or decorate a class with
-``@self_coding_managed``.  Offending modules are printed and the script exits
-with a non-zero status so the check can be enforced in pre-commit/CI.
+The script scans all Python modules in the repository looking for either
+instantiations of :class:`SelfCodingManager` *or* modules that export classes or
+functions whose names end with ``Bot``.  Any such module (excluding test modules
+and ``self_coding_manager.py`` itself) must either call
+``internalize_coding_bot`` or decorate the bot with ``@self_coding_managed``.
+Offending modules are printed and the script exits with a non-zero status so
+the check can be enforced in pre-commit/CI.
 """
 
 from __future__ import annotations
 
 import ast
 from pathlib import Path
+
+
+def _has_self_coding_decorator(node: ast.AST) -> bool:
+    """Return ``True`` if ``node`` has the ``self_coding_managed`` decorator."""
+
+    for dec in getattr(node, "decorator_list", []):
+        if isinstance(dec, ast.Call):
+            dec = dec.func
+        if isinstance(dec, ast.Name) and dec.id == "self_coding_managed":
+            return True
+        if isinstance(dec, ast.Attribute) and dec.attr == "self_coding_managed":
+            return True
+    return False
 
 
 def _instantiates_manager(tree: ast.AST) -> bool:
@@ -41,24 +55,39 @@ def _calls_internalize(tree: ast.AST) -> bool:
     return False
 
 
-def _has_managed_class(tree: ast.AST) -> bool:
-    """Return ``True`` if any class uses the ``self_coding_managed`` decorator."""
+def _has_managed_entity(tree: ast.AST) -> bool:
+    """Return ``True`` if any top-level class or function uses the decorator."""
 
     for node in getattr(tree, "body", []):
-        if isinstance(node, ast.ClassDef):
-            for dec in node.decorator_list:
-                if isinstance(dec, ast.Call):
-                    dec = dec.func
-                if isinstance(dec, ast.Name) and dec.id == "self_coding_managed":
-                    return True
-                if isinstance(dec, ast.Attribute) and dec.attr == "self_coding_managed":
-                    return True
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            if _has_self_coding_decorator(node):
+                return True
     return False
+
+
+def _exported_bots(tree: ast.AST) -> list[ast.AST]:
+    """Return top-level bot definitions exported by the module."""
+
+    bots = []
+    for node in getattr(tree, "body", []):
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name.endswith("Bot") and not node.name.startswith("_"):
+                bots.append(node)
+    return bots
+
+
+def _unmanaged_exports(tree: ast.AST, calls_internalize: bool) -> list[str]:
+    """Return names of exported bots lacking registration or decoration."""
+
+    if calls_internalize:
+        return []
+    return [node.name for node in _exported_bots(tree) if not _has_self_coding_decorator(node)]
 
 
 def main() -> int:
     root = Path(__file__).resolve().parents[1]
-    offenders: list[Path] = []
+    manager_offenders: list[Path] = []
+    export_offenders: list[tuple[Path, list[str]]] = []
     for path in root.rglob("*.py"):
         if "tests" in path.parts or "unit_tests" in path.parts:
             continue
@@ -68,16 +97,21 @@ def main() -> int:
             tree = ast.parse(path.read_text(encoding="utf-8"))
         except Exception:
             continue
-        if not _instantiates_manager(tree):
-            continue
-        if _calls_internalize(tree) or _has_managed_class(tree):
-            continue
-        offenders.append(path.relative_to(root))
-    if offenders:
-        for p in offenders:
+        calls_internalize = _calls_internalize(tree)
+        unmanaged = _unmanaged_exports(tree, calls_internalize)
+        has_manager = _instantiates_manager(tree)
+        if has_manager and not (calls_internalize or _has_managed_entity(tree)):
+            manager_offenders.append(path.relative_to(root))
+        if unmanaged:
+            export_offenders.append((path.relative_to(root), unmanaged))
+    if manager_offenders or export_offenders:
+        for p in manager_offenders:
             print(
-                f"{p}: SelfCodingManager instantiated without internalize_coding_bot or @self_coding_managed"
+                f"{p}: SelfCodingManager instantiated without "
+                "internalize_coding_bot or @self_coding_managed",
             )
+        for p, bots in export_offenders:
+            print(f"{p}: unmanaged exported bots: {', '.join(bots)}")
         return 1
     return 0
 


### PR DESCRIPTION
## Summary
- extend self-coding registration script to flag exported bot classes and functions missing `internalize_coding_bot` or `@self_coding_managed`
- update pre-commit hook description and documentation on how to satisfy the check

## Testing
- `pre-commit run --files tools/check_self_coding_registration.py docs/internalize_coding_bot.md .pre-commit-config.yaml` *(fails: SelfCodingManager instantiated without internalize_coding_bot or @self_coding_managed; unmanaged exported bots)*

------
https://chatgpt.com/codex/tasks/task_e_68c5af5900e4832eac5202b782e6f377