### PR TITLE
Persist per-bot test failure thresholds

### DIFF
--- a/automated_reviewer.py
+++ b/automated_reviewer.py
@@ -64,6 +64,7 @@ persist_sc_thresholds(
     "AutomatedReviewer",
     roi_drop=_th.roi_drop,
     error_increase=_th.error_increase,
+    test_failure_increase=_th.test_failure_increase,
 )
 manager = internalize_coding_bot(
     "AutomatedReviewer",
@@ -74,6 +75,7 @@ manager = internalize_coding_bot(
     evolution_orchestrator=evolution_orchestrator,
     roi_threshold=_th.roi_drop,
     error_threshold=_th.error_increase,
+    test_failure_threshold=_th.test_failure_increase,
     threshold_service=ThresholdService(),
 )
 

--- a/bot_creation_bot.py
+++ b/bot_creation_bot.py
@@ -75,6 +75,7 @@ persist_sc_thresholds(
     "BotCreationBot",
     roi_drop=_th.roi_drop,
     error_increase=_th.error_increase,
+    test_failure_increase=_th.test_failure_increase,
 )
 manager = internalize_coding_bot(
     "BotCreationBot",
@@ -85,6 +86,7 @@ manager = internalize_coding_bot(
     evolution_orchestrator=evolution_orchestrator,
     roi_threshold=_th.roi_drop,
     error_threshold=_th.error_increase,
+    test_failure_threshold=_th.test_failure_increase,
     threshold_service=ThresholdService(),
 )
 

--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -70,6 +70,7 @@ persist_sc_thresholds(
     "BotDevelopmentBot",
     roi_drop=_th.roi_drop,
     error_increase=_th.error_increase,
+    test_failure_increase=_th.test_failure_increase,
 )
 manager = internalize_coding_bot(
     "BotDevelopmentBot",
@@ -80,6 +81,7 @@ manager = internalize_coding_bot(
     evolution_orchestrator=evolution_orchestrator,
     roi_threshold=_th.roi_drop,
     error_threshold=_th.error_increase,
+    test_failure_threshold=_th.test_failure_increase,
     threshold_service=ThresholdService(),
 )
 
@@ -1055,19 +1057,23 @@ class BotDevelopmentBot:
                 if registry and d_bot and engine and pipeline:
                     bot_name = spec.name
                     module_path = str(file_path)
+                    _th = get_thresholds(bot_name)
                     registry.register_bot(
                         bot_name,
                         manager=self.manager,
                         data_bot=d_bot,
                         is_coding_bot=True,
+                        roi_threshold=_th.roi_drop,
+                        error_threshold=_th.error_increase,
+                        test_failure_threshold=_th.test_failure_increase,
                     )
                     registry.update_bot(bot_name, module_path)
                     d_bot.reload_thresholds(bot_name)
-                    _th = get_thresholds(bot_name)
                     persist_sc_thresholds(
                         bot_name,
                         roi_drop=_th.roi_drop,
                         error_increase=_th.error_increase,
+                        test_failure_increase=_th.test_failure_increase,
                     )
                     internalize_coding_bot(
                         bot_name,
@@ -1078,6 +1084,7 @@ class BotDevelopmentBot:
                         evolution_orchestrator=orchestrator,
                         roi_threshold=_th.roi_drop,
                         error_threshold=_th.error_increase,
+                        test_failure_threshold=_th.test_failure_increase,
                     )
             except Exception:  # pragma: no cover - best effort
                 self.logger.exception("dynamic bot registration failed for %s", spec.name)

--- a/bot_planning_bot.py
+++ b/bot_planning_bot.py
@@ -43,6 +43,7 @@ persist_sc_thresholds(
     "BotPlanningBot",
     roi_drop=_th.roi_drop,
     error_increase=_th.error_increase,
+    test_failure_increase=_th.test_failure_increase,
 )
 manager = internalize_coding_bot(
     "BotPlanningBot",
@@ -54,6 +55,7 @@ manager = internalize_coding_bot(
     threshold_service=ThresholdService(),
     roi_threshold=_th.roi_drop,
     error_threshold=_th.error_increase,
+    test_failure_threshold=_th.test_failure_increase,
 )
 
 

--- a/bot_registry.py
+++ b/bot_registry.py
@@ -102,6 +102,7 @@ class BotRegistry:
         *,
         roi_threshold: float | None = None,
         error_threshold: float | None = None,
+        test_failure_threshold: float | None = None,
         manager: "SelfCodingManager" | None = None,
         data_bot: "DataBot" | None = None,
         is_coding_bot: bool | None = None,
@@ -142,6 +143,8 @@ class BotRegistry:
                 node["roi_threshold"] = float(roi_threshold)
             if error_threshold is not None:
                 node["error_threshold"] = float(error_threshold)
+            if test_failure_threshold is not None:
+                node["test_failure_threshold"] = float(test_failure_threshold)
             node.setdefault("patch_history", [])
             if manager is not None:
                 node["selfcoding_manager"] = manager
@@ -289,17 +292,23 @@ class BotRegistry:
                                     name,
                                     exc,
                                 )
-            if roi_threshold is not None or error_threshold is not None:
+            if (
+                roi_threshold is not None
+                or error_threshold is not None
+                or test_failure_threshold is not None
+            ):
                 try:
                     threshold_service.update(
                         name,
                         roi_drop=roi_threshold,
                         error_threshold=error_threshold,
+                        test_failure_threshold=test_failure_threshold,
                     )
                     persist_sc_thresholds(
                         name,
                         roi_drop=roi_threshold,
                         error_increase=error_threshold,
+                        test_failure_increase=test_failure_threshold,
                         event_bus=self.event_bus,
                     )
                 except Exception as exc:  # pragma: no cover - best effort

--- a/bot_testing_bot.py
+++ b/bot_testing_bot.py
@@ -51,6 +51,7 @@ persist_sc_thresholds(
     "BotTestingBot",
     roi_drop=_th.roi_drop,
     error_increase=_th.error_increase,
+    test_failure_increase=_th.test_failure_increase,
 )
 manager = internalize_coding_bot(
     "BotTestingBot",
@@ -61,6 +62,7 @@ manager = internalize_coding_bot(
     evolution_orchestrator=evolution_orchestrator,
     roi_threshold=_th.roi_drop,
     error_threshold=_th.error_increase,
+    test_failure_threshold=_th.test_failure_increase,
     threshold_service=ThresholdService(),
 )
 

--- a/enhancement_bot.py
+++ b/enhancement_bot.py
@@ -28,6 +28,7 @@ persist_sc_thresholds(
     "EnhancementBot",
     roi_drop=_th.roi_drop,
     error_increase=_th.error_increase,
+    test_failure_increase=_th.test_failure_increase,
 )
 manager = internalize_coding_bot(
     "EnhancementBot",
@@ -39,6 +40,7 @@ manager = internalize_coding_bot(
     threshold_service=ThresholdService(),
     roi_threshold=_th.roi_drop,
     error_threshold=_th.error_increase,
+    test_failure_threshold=_th.test_failure_increase,
 )
 
 """Automatically validate and merge Codex refactors.

--- a/error_bot.py
+++ b/error_bot.py
@@ -117,6 +117,7 @@ persist_sc_thresholds(
     "ErrorBot",
     roi_drop=_th.roi_drop,
     error_increase=_th.error_increase,
+    test_failure_increase=_th.test_failure_increase,
 )
 manager = internalize_coding_bot(
     "ErrorBot",
@@ -128,6 +129,7 @@ manager = internalize_coding_bot(
     threshold_service=ThresholdService(),
     roi_threshold=_th.roi_drop,
     error_threshold=_th.error_increase,
+    test_failure_threshold=_th.test_failure_increase,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only

--- a/implementation_optimiser_bot.py
+++ b/implementation_optimiser_bot.py
@@ -40,6 +40,7 @@ persist_sc_thresholds(
     "ImplementationOptimiserBot",
     roi_drop=_th.roi_drop,
     error_increase=_th.error_increase,
+    test_failure_increase=_th.test_failure_increase,
 )
 manager = internalize_coding_bot(
     "ImplementationOptimiserBot",
@@ -50,6 +51,7 @@ manager = internalize_coding_bot(
     evolution_orchestrator=evolution_orchestrator,
     roi_threshold=_th.roi_drop,
     error_threshold=_th.error_increase,
+    test_failure_threshold=_th.test_failure_increase,
     threshold_service=ThresholdService(),
 )
 

--- a/research_aggregator_bot.py
+++ b/research_aggregator_bot.py
@@ -71,6 +71,7 @@ persist_sc_thresholds(
     "ResearchAggregatorBot",
     roi_drop=_th.roi_drop,
     error_increase=_th.error_increase,
+    test_failure_increase=_th.test_failure_increase,
 )
 manager = internalize_coding_bot(
     "ResearchAggregatorBot",
@@ -82,6 +83,7 @@ manager = internalize_coding_bot(
     threshold_service=ThresholdService(),
     roi_threshold=_th.roi_drop,
     error_threshold=_th.error_increase,
+    test_failure_threshold=_th.test_failure_increase,
 )
 
 @dataclass

--- a/self_coding_manager.py
+++ b/self_coding_manager.py
@@ -2002,17 +2002,18 @@ def internalize_coding_bot(
     evolution_orchestrator: "EvolutionOrchestrator | None" = None,
     roi_threshold: float | None = None,
     error_threshold: float | None = None,
+    test_failure_threshold: float | None = None,
     **manager_kwargs: Any,
 ) -> SelfCodingManager:
     """Wire ``bot_name`` into the self‑coding system.
 
-    The helper constructs a :class:`SelfCodingManager`, registers ROI/error
-    thresholds with :class:`BotRegistry` and ensures ``EvolutionOrchestrator``
-    reacts to ``degradation:detected`` events.
+    The helper constructs a :class:`SelfCodingManager`, registers ROI/error/test
+    failure thresholds with :class:`BotRegistry` and ensures
+    ``EvolutionOrchestrator`` reacts to ``degradation:detected`` events.
 
     Parameters mirror :class:`SelfCodingManager` while providing explicit
-    ``roi_threshold`` and ``error_threshold`` values.  Additional keyword
-    arguments are forwarded to ``SelfCodingManager``.
+    ``roi_threshold``, ``error_threshold`` and ``test_failure_threshold`` values.
+    Additional keyword arguments are forwarded to ``SelfCodingManager``.
     """
     manager = SelfCodingManager(
         engine,
@@ -2031,6 +2032,7 @@ def internalize_coding_bot(
         bot_name,
         roi_threshold=roi_threshold,
         error_threshold=error_threshold,
+        test_failure_threshold=test_failure_threshold,
         manager=manager,
         data_bot=data_bot,
         is_coding_bot=True,
@@ -2051,8 +2053,12 @@ def internalize_coding_bot(
                     if error_threshold is not None
                     else getattr(settings, "self_coding_error_increase", None)
                 ),
-                test_failure_increase=getattr(
-                    settings, "self_coding_test_failure_increase", None
+                test_failure_increase=(
+                    test_failure_threshold
+                    if test_failure_threshold is not None
+                    else getattr(
+                        settings, "self_coding_test_failure_increase", None
+                    )
                 ),
                 event_bus=getattr(data_bot, "event_bus", None),
             )

--- a/structural_evolution_bot.py
+++ b/structural_evolution_bot.py
@@ -51,6 +51,7 @@ persist_sc_thresholds(
     "StructuralEvolutionBot",
     roi_drop=_th.roi_drop,
     error_increase=_th.error_increase,
+    test_failure_increase=_th.test_failure_increase,
 )
 manager = internalize_coding_bot(
     "StructuralEvolutionBot",
@@ -62,6 +63,7 @@ manager = internalize_coding_bot(
     threshold_service=ThresholdService(),
     roi_threshold=_th.roi_drop,
     error_threshold=_th.error_increase,
+    test_failure_threshold=_th.test_failure_increase,
 )
 
 @dataclass

--- a/workflow_evolution_bot.py
+++ b/workflow_evolution_bot.py
@@ -76,6 +76,7 @@ persist_sc_thresholds(
     "WorkflowEvolutionBot",
     roi_drop=_th.roi_drop,
     error_increase=_th.error_increase,
+    test_failure_increase=_th.test_failure_increase,
 )
 manager = internalize_coding_bot(
     "WorkflowEvolutionBot",
@@ -87,6 +88,7 @@ manager = internalize_coding_bot(
     threshold_service=ThresholdService(),
     roi_threshold=_th.roi_drop,
     error_threshold=_th.error_increase,
+    test_failure_threshold=_th.test_failure_increase,
 )
 
 


### PR DESCRIPTION
## Summary
- track per-bot test failure thresholds via `internalize_coding_bot`
- propagate and store test failure limits in `BotRegistry`
- ensure DataBot emits breach events for bots with test failure thresholds

## Testing
- `pytest tests/test_data_bot_thresholds.py::test_internalize_records_thresholds_and_emits_test_failure tests/test_data_bot_thresholds.py::test_threshold_event_published tests/test_bot_registry_degradation_orchestrator.py::test_degradation_flows_through_orchestrator -q`

------
https://chatgpt.com/codex/tasks/task_e_68c61ca8c420832eb454fde497368dfd