### PR TITLE
Explicit coding bot registration

### DIFF
--- a/bot_registry.py
+++ b/bot_registry.py
@@ -106,7 +106,7 @@ class BotRegistry:
         test_failure_threshold: float | None = None,
         manager: "SelfCodingManager" | None = None,
         data_bot: "DataBot" | None = None,
-        is_coding_bot: bool | None = None,
+        is_coding_bot: bool = False,
     ) -> None:
         """Ensure *name* exists in the graph and persist metadata."""
         with self._lock:
@@ -114,11 +114,7 @@ class BotRegistry:
             node = self.graph.nodes[name]
             existing_mgr = node.get("selfcoding_manager") or node.get("manager")
             existing_data = node.get("data_bot")
-            is_coding_bot = (
-                bool(is_coding_bot)
-                if is_coding_bot is not None
-                else name.lower().endswith("bot")
-            )
+            is_coding_bot = bool(is_coding_bot)
             if is_coding_bot:
                 missing: list[str] = []
                 mgr = manager or existing_mgr

--- a/tests/integration/test_full_self_coding_flow.py
+++ b/tests/integration/test_full_self_coding_flow.py
@@ -195,7 +195,7 @@ def test_full_self_coding_flow(tmp_path, monkeypatch):
     # Decorator capturing registration and update
     def self_coding_decorator(cls):
         module_path = inspect.getfile(cls)
-        registry.register_bot(cls.name, manager=object(), data_bot=data_bot)
+        registry.register_bot(cls.name, manager=object(), data_bot=data_bot, is_coding_bot=True)
         registry.update_bot(cls.name, module_path)
         return cls
 

--- a/tests/test_bot_registry_degradation_orchestrator.py
+++ b/tests/test_bot_registry_degradation_orchestrator.py
@@ -49,7 +49,7 @@ def test_degradation_flows_through_orchestrator():
     manager.evolution_orchestrator = orchestrator
 
     registry = BotRegistry()
-    registry.register_bot("sample", manager=manager, data_bot=data_bot)
+    registry.register_bot("sample", manager=manager, data_bot=data_bot, is_coding_bot=True)
 
     data_bot.check_degradation("sample", roi=0.0, errors=5.0)
 


### PR DESCRIPTION
## Summary
- remove name-based heuristic from `register_bot`
- require explicit `is_coding_bot` flag and enforce manager/data bot presence
- update tests to register coding bots explicitly

## Testing
- `pytest` *(fails: 579 errors during collection)*
- `pytest tests/test_bot_registry_degradation_orchestrator.py tests/integration/test_full_self_coding_flow.py -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '')*

------
https://chatgpt.com/codex/tasks/task_e_68c636d29044832eb338aa299afa7f82