### PR TITLE
Raise on SelfCodingManager init failure

### DIFF
--- a/auto_escalation_manager.py
+++ b/auto_escalation_manager.py
@@ -139,12 +139,12 @@ class AutoEscalationManager:
                     )
                     manager.register_bot(self.__class__.__name__)
                     self.manager = manager
-                except Exception:
-                    class _Mgr:
-                        def run_patch(self, *a, **k):
-                            return None
-
-                    manager = _Mgr()
+                except Exception as exc:
+                    logger = logging.getLogger(self.__class__.__name__)
+                    logger.exception("failed to initialize SelfCodingManager")
+                    raise RuntimeError(
+                        "SelfCodingManager initialization failed"
+                    ) from exc
                 debugger = AutomatedDebugger(
                     ErrorDB(), engine, self.context_builder, manager=manager
                 )


### PR DESCRIPTION
## Summary
- stop AutoEscalationManager from falling back to a stub manager when SelfCodingManager fails to initialize
- add a regression test verifying AutoEscalationManager initialization fails without SelfCodingManager

## Testing
- `pytest tests/test_auto_escalation_manager.py::test_publish_retry_and_log -q`
- `pytest tests/test_auto_escalation_manager.py::test_init_fails_without_self_coding_manager -q`


------
https://chatgpt.com/codex/tasks/task_e_68c638566e80832e83ed4b7261c081ab