### PR TITLE
Enforce SelfCodingManager presence for debug services

### DIFF
--- a/debug_loop_service.py
+++ b/debug_loop_service.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import logging
 import threading
 import time
-from typing import Optional, Any
+from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 from pathlib import Path
 from .telemetry_feedback import TelemetryFeedback
@@ -13,11 +15,14 @@ from .error_logger import ErrorLogger
 from .self_coding_engine import SelfCodingEngine
 try:  # pragma: no cover - optional self-coding dependency
     from .self_coding_manager import SelfCodingManager, internalize_coding_bot
-except ImportError:  # pragma: no cover - self-coding unavailable
-    SelfCodingManager = Any  # type: ignore
-
-    def internalize_coding_bot(*args: Any, **kwargs: Any) -> Any:  # type: ignore
-        return SelfCodingManager(*args, **kwargs)
+except ImportError as exc:  # pragma: no cover - self-coding unavailable
+    logger.error(
+        "SelfCodingManager is required for DebugLoopService. "
+        "Install self-coding dependencies (e.g., `pip install menace-sandbox[self-coding]`).",
+    )
+    raise ImportError(
+        "DebugLoopService requires SelfCodingManager"
+    ) from exc
 from .model_automation_pipeline import ModelAutomationPipeline
 from .unified_event_bus import UnifiedEventBus
 from .code_database import CodeDB

--- a/stripe_watchdog.py
+++ b/stripe_watchdog.py
@@ -60,6 +60,17 @@ from snippet_compressor import compress_snippets
 
 logger = logging.getLogger(__name__)
 
+try:  # pragma: no cover - require self-coding manager
+    from self_coding_manager import SelfCodingManager, internalize_coding_bot
+except ImportError as exc:  # pragma: no cover - fail fast if missing
+    logger.error(
+        "SelfCodingManager is required for stripe_watchdog. "
+        "Install self-coding dependencies (e.g., `pip install menace-sandbox[self-coding]`).",
+    )
+    raise ImportError(
+        "stripe_watchdog requires SelfCodingManager"
+    ) from exc
+
 try:  # pragma: no cover - best effort to import sanity layer
     import menace_sanity_layer
     from menace_sanity_layer import (
@@ -180,10 +191,6 @@ try:  # Optional dependency – telemetry feedback loop
     from error_logger import ErrorLogger  # type: ignore
     from bot_registry import BotRegistry  # type: ignore
     from data_bot import DataBot  # type: ignore
-    from self_coding_manager import (
-        SelfCodingManager,
-        internalize_coding_bot,
-    )  # type: ignore
     from model_automation_pipeline import ModelAutomationPipeline  # type: ignore
     from shared_event_bus import event_bus as _SHARED_EVENT_BUS  # type: ignore
 except Exception:  # pragma: no cover - best effort
@@ -191,11 +198,6 @@ except Exception:  # pragma: no cover - best effort
     ErrorLogger = None  # type: ignore
     BotRegistry = None  # type: ignore
     DataBot = None  # type: ignore
-    SelfCodingManager = None  # type: ignore
-
-    def internalize_coding_bot(*args, **kwargs):  # type: ignore
-        return None
-
     ModelAutomationPipeline = None  # type: ignore
     _SHARED_EVENT_BUS = None  # type: ignore
 

--- a/tests/test_self_coding_manager_required.py
+++ b/tests/test_self_coding_manager_required.py
@@ -1,0 +1,35 @@
+import builtins
+import importlib
+import sys
+
+import pytest
+
+
+class _MissingSelfCoding:
+    def __init__(self, original_import):
+        self._original_import = original_import
+
+    def __call__(self, name, globals=None, locals=None, fromlist=(), level=0):
+        if name in {"menace_sandbox.self_coding_manager", "self_coding_manager"}:
+            raise ImportError("self_coding_manager is unavailable")
+        return self._original_import(name, globals, locals, fromlist, level)
+
+
+def _simulate_missing_self_coding(monkeypatch):
+    original = builtins.__import__
+    monkeypatch.setattr(builtins, "__import__", _MissingSelfCoding(original))
+    monkeypatch.delitem(sys.modules, "menace_sandbox.self_coding_manager", raising=False)
+
+
+def test_debug_loop_service_requires_self_coding_manager(monkeypatch):
+    _simulate_missing_self_coding(monkeypatch)
+    monkeypatch.delitem(sys.modules, "menace_sandbox.debug_loop_service", raising=False)
+    with pytest.raises(ImportError):
+        importlib.import_module("menace_sandbox.debug_loop_service")
+
+
+def test_stripe_watchdog_requires_self_coding_manager(monkeypatch):
+    _simulate_missing_self_coding(monkeypatch)
+    monkeypatch.delitem(sys.modules, "menace_sandbox.stripe_watchdog", raising=False)
+    with pytest.raises(ImportError):
+        importlib.import_module("menace_sandbox.stripe_watchdog")


### PR DESCRIPTION
## Summary
- require SelfCodingManager on import for debug_loop_service and stripe_watchdog
- remove fallback internalize_coding_bot stubs
- add tests ensuring modules fail fast without SelfCodingManager

## Testing
- `pytest tests/test_self_coding_manager_required.py -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68c63c920c54832e8f4ecc2449c0f5e6