### PR TITLE
Ensure self-coding manager is mandatory for critical bots

### DIFF
--- a/bot_planning_bot.py
+++ b/bot_planning_bot.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 from .bot_registry import BotRegistry
 from .data_bot import DataBot, persist_sc_thresholds
 from .coding_bot_interface import self_coding_managed
-try:  # pragma: no cover - optional to avoid circular imports in tests
+try:  # pragma: no cover - fail fast if self-coding manager missing
     from .self_coding_manager import SelfCodingManager, internalize_coding_bot
-except Exception:  # pragma: no cover - provide stubs when unavailable
-    SelfCodingManager = None  # type: ignore
-
-    def internalize_coding_bot(*_a, **_k):  # type: ignore
-        return None
+except Exception as exc:  # pragma: no cover - critical dependency
+    raise RuntimeError(
+        "BotPlanningBot requires SelfCodingManager; install self-coding dependencies."
+    ) from exc
 from .self_coding_engine import SelfCodingEngine
 try:  # pragma: no cover - optional to avoid circular imports in tests
     from .model_automation_pipeline import ModelAutomationPipeline
@@ -67,6 +66,8 @@ manager = internalize_coding_bot(
     error_threshold=_th.error_increase,
     test_failure_threshold=_th.test_failure_increase,
 )
+if not isinstance(manager, SelfCodingManager):  # pragma: no cover - safety check
+    raise RuntimeError("internalize_coding_bot failed to return a SelfCodingManager")
 
 
 class TemplateManager:

--- a/debug_loop_service.py
+++ b/debug_loop_service.py
@@ -13,15 +13,11 @@ from pathlib import Path
 from .telemetry_feedback import TelemetryFeedback
 from .error_logger import ErrorLogger
 from .self_coding_engine import SelfCodingEngine
-try:  # pragma: no cover - optional self-coding dependency
+try:  # pragma: no cover - fail fast if self-coding manager missing
     from .self_coding_manager import SelfCodingManager, internalize_coding_bot
-except ImportError as exc:  # pragma: no cover - self-coding unavailable
-    logger.error(
-        "SelfCodingManager is required for DebugLoopService. "
-        "Install self-coding dependencies (e.g., `pip install menace-sandbox[self-coding]`).",
-    )
-    raise ImportError(
-        "DebugLoopService requires SelfCodingManager"
+except Exception as exc:  # pragma: no cover - critical dependency
+    raise RuntimeError(
+        "DebugLoopService requires SelfCodingManager; install self-coding dependencies."
     ) from exc
 from .model_automation_pipeline import ModelAutomationPipeline
 from .unified_event_bus import UnifiedEventBus
@@ -83,6 +79,10 @@ class DebugLoopService:
                 bot_registry=registry,
                 event_bus=bus,
             )
+            if not isinstance(manager, SelfCodingManager):  # pragma: no cover - safety
+                raise RuntimeError(
+                    "internalize_coding_bot failed to return a SelfCodingManager"
+                )
             feedback = TelemetryFeedback(
                 logger,
                 manager,

--- a/stripe_watchdog.py
+++ b/stripe_watchdog.py
@@ -60,15 +60,11 @@ from snippet_compressor import compress_snippets
 
 logger = logging.getLogger(__name__)
 
-try:  # pragma: no cover - require self-coding manager
+try:  # pragma: no cover - fail fast if self-coding manager missing
     from self_coding_manager import SelfCodingManager, internalize_coding_bot
-except ImportError as exc:  # pragma: no cover - fail fast if missing
-    logger.error(
-        "SelfCodingManager is required for stripe_watchdog. "
-        "Install self-coding dependencies (e.g., `pip install menace-sandbox[self-coding]`).",
-    )
-    raise ImportError(
-        "stripe_watchdog requires SelfCodingManager"
+except Exception as exc:  # pragma: no cover - critical dependency
+    raise RuntimeError(
+        "stripe_watchdog requires SelfCodingManager; install self-coding dependencies."
     ) from exc
 
 try:  # pragma: no cover - best effort to import sanity layer
@@ -1951,6 +1947,10 @@ def main(
                     bot_registry=registry,
                     event_bus=bus,
                 )
+                if not isinstance(manager, SelfCodingManager):  # pragma: no cover
+                    raise RuntimeError(
+                        "internalize_coding_bot failed to return a SelfCodingManager"
+                    )
                 telemetry = TelemetryFeedback(
                     ErrorLogger(context_builder=builder),
                     manager,


### PR DESCRIPTION
## Summary
- Import `SelfCodingManager` and `internalize_coding_bot` directly without stubs
- Raise explicit runtime errors if self-coding manager is unavailable
- Verify self-coding manager creation for BotPlanningBot, DebugLoopService, and stripe_watchdog

## Testing
- `python -m py_compile bot_planning_bot.py debug_loop_service.py stripe_watchdog.py`
- `pytest bot_planning_bot.py debug_loop_service.py stripe_watchdog.py -q` *(fails: ModuleNotFoundError: No module named 'db_router')*


------
https://chatgpt.com/codex/tasks/task_e_68c63ddedf70832ea33983553ab92187