### PR TITLE
Run self-coding audit scripts in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,10 @@ jobs:
         run: "python tools/check_self_coding_integrity.py $(git ls-files '*.py')"
       - name: ensure all bots are self-coding managed
         run: pre-commit run self-coding-registration --all-files
+      - name: Verify self-coding registration
+        run: python tools/check_self_coding_registration.py
+      - name: Scan for unmanaged bots
+        run: python tools/find_unmanaged_bots.py
       - name: Run self-coding checks
         run: make self-coding-check
       - name: Prevent unwrapped engine.generate_helper usage
@@ -101,6 +105,10 @@ jobs:
         run: pre-commit run check-self-coding-integrity --all-files
       - name: ensure all bots are self-coding managed
         run: pre-commit run self-coding-registration --all-files
+      - name: Verify self-coding registration
+        run: python tools/check_self_coding_registration.py
+      - name: Scan for unmanaged bots
+        run: python tools/find_unmanaged_bots.py
       - name: Ensure SelfCodingEngine bots are decorated and registered
         run: python tools/check_coding_bot_decorators.py
       - name: Run self-coding checks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,6 +164,19 @@ pre-commit run find-unmanaged-bots --all-files
 
 CI fails if unmanaged bots are detected.
 
+The pipeline also runs `tools/check_self_coding_registration.py` and
+`tools/find_unmanaged_bots.py` to ensure every `*Bot` class is either decorated
+with `@self_coding_managed` or registered via `internalize_coding_bot`. Run the
+audits locally before committing:
+
+```bash
+python tools/check_self_coding_registration.py
+python tools/find_unmanaged_bots.py
+```
+
+These scripts exit with a non-zero status when unmanaged bots are present,
+causing CI to fail.
+
 The `check-coding-bot-decorators` hook (`tools/check_coding_bot_decorators.py`)
 adds an extra safeguard by scanning for modules that import
 `SelfCodingEngine` and flagging any bot classes that lack the


### PR DESCRIPTION
## Summary
- run check_self_coding_registration and find_unmanaged_bots in workflow
- note self-coding audits in CONTRIBUTING

## Testing
- `pre-commit run --files .github/workflows/tests.yml CONTRIBUTING.md` *(fails: check-static-paths, forbid-stripe-keys)*
- `python tools/check_self_coding_registration.py`
- `python tools/find_unmanaged_bots.py`


------
https://chatgpt.com/codex/tasks/task_e_68c63ea1a194832e887fdfadf6a4596f