### PR TITLE
Persist self-coding thresholds for uncapped bots

### DIFF
--- a/debug_loop_service.py
+++ b/debug_loop_service.py
@@ -25,7 +25,8 @@ from .code_database import CodeDB
 from .menace_memory_manager import MenaceMemoryManager
 from .knowledge_graph import KnowledgeGraph
 from .bot_registry import BotRegistry
-from .data_bot import DataBot
+from .data_bot import DataBot, persist_sc_thresholds
+from .self_coding_thresholds import get_thresholds
 
 try:  # pragma: no cover - optional vector service dependency
     from vector_service.context_builder import ContextBuilder
@@ -71,6 +72,13 @@ class DebugLoopService:
             pipeline = ModelAutomationPipeline(
                 context_builder=context_builder, event_bus=bus, bot_registry=registry
             )
+            _th = get_thresholds("DebugLoopService")
+            persist_sc_thresholds(
+                "DebugLoopService",
+                roi_drop=_th.roi_drop,
+                error_increase=_th.error_increase,
+                test_failure_increase=_th.test_failure_increase,
+            )
             manager = internalize_coding_bot(
                 "DebugLoopService",
                 engine,
@@ -78,6 +86,9 @@ class DebugLoopService:
                 data_bot=data_bot,
                 bot_registry=registry,
                 event_bus=bus,
+                roi_threshold=_th.roi_drop,
+                error_threshold=_th.error_increase,
+                test_failure_threshold=_th.test_failure_increase,
             )
             if not isinstance(manager, SelfCodingManager):  # pragma: no cover - safety
                 raise RuntimeError(

--- a/menace_master.py
+++ b/menace_master.py
@@ -62,7 +62,8 @@ from menace.self_coding_manager import (  # noqa: E402
     PatchApprovalPolicy,
     internalize_coding_bot,
 )
-from menace.data_bot import DataBot  # noqa: E402
+from menace.data_bot import DataBot, persist_sc_thresholds  # noqa: E402
+from menace.self_coding_thresholds import get_thresholds  # noqa: E402
 from menace.advanced_error_management import AutomatedRollbackManager  # noqa: E402
 from menace.environment_bootstrap import EnvironmentBootstrapper  # noqa: E402
 from menace.auto_env_setup import ensure_env, interactive_setup  # noqa: E402
@@ -539,6 +540,14 @@ def deploy_patch(
     pipeline = ModelAutomationPipeline(
         context_builder=builder, event_bus=bus, bot_registry=registry
     )
+    _th = get_thresholds("MenaceMaster")
+    persist_sc_thresholds(
+        "MenaceMaster",
+        roi_drop=_th.roi_drop,
+        error_increase=_th.error_increase,
+        test_failure_increase=_th.test_failure_increase,
+        event_bus=bus,
+    )
     manager = internalize_coding_bot(
         "MenaceMaster",
         engine,
@@ -547,6 +556,9 @@ def deploy_patch(
         bot_registry=registry,
         approval_policy=policy,
         event_bus=bus,
+        roi_threshold=_th.roi_drop,
+        error_threshold=_th.error_increase,
+        test_failure_threshold=_th.test_failure_increase,
     )
     manager.context_builder = builder
     try:

--- a/sandbox_runner.py
+++ b/sandbox_runner.py
@@ -193,7 +193,8 @@ except Exception:  # pragma: no cover - fallback for test stubs
     from patch_suggestion_db import PatchSuggestionDB
 from menace.audit_trail import AuditTrail
 from menace.error_bot import ErrorBot, ErrorDB
-from menace.data_bot import MetricsDB, DataBot
+from menace.data_bot import MetricsDB, DataBot, persist_sc_thresholds
+from menace.self_coding_thresholds import get_thresholds
 from menace.composite_workflow_scorer import CompositeWorkflowScorer
 from menace.neuroplasticity import PathwayDB
 from sandbox_runner.metrics_plugins import (
@@ -965,6 +966,13 @@ def _sandbox_init(
 
     bus = UnifiedEventBus()
     registry = BotRegistry(event_bus=bus)
+    _th = get_thresholds("menace")
+    persist_sc_thresholds(
+        "menace",
+        roi_drop=_th.roi_drop,
+        error_increase=_th.error_increase,
+        test_failure_increase=_th.test_failure_increase,
+    )
     quick_manager = internalize_coding_bot(
         "menace",
         engine,
@@ -974,6 +982,9 @@ def _sandbox_init(
         data_bot=data_bot,
         bot_registry=registry,
         event_bus=bus,
+        roi_threshold=_th.roi_drop,
+        error_threshold=_th.error_increase,
+        test_failure_threshold=_th.test_failure_increase,
     )
     quick_fix_engine = QuickFixEngine(
         telem_db,

--- a/service_supervisor.py
+++ b/service_supervisor.py
@@ -68,7 +68,8 @@ from vector_service.context_builder import ContextBuilder  # noqa: E402
 from context_builder_util import create_context_builder  # noqa: E402
 from .shared_event_bus import event_bus as bus  # noqa: E402
 from .bot_registry import BotRegistry  # noqa: E402
-from .data_bot import DataBot  # noqa: E402
+from .data_bot import DataBot, persist_sc_thresholds  # noqa: E402
+from .self_coding_thresholds import get_thresholds  # noqa: E402
 from .coding_bot_interface import self_coding_managed  # noqa: E402
 
 try:  # optional dependency
@@ -394,6 +395,14 @@ class ServiceSupervisor:
             event_bus=bus,
             bot_registry=registry,
         )
+        _th = get_thresholds(self.__class__.__name__)
+        persist_sc_thresholds(
+            self.__class__.__name__,
+            roi_drop=_th.roi_drop,
+            error_increase=_th.error_increase,
+            test_failure_increase=_th.test_failure_increase,
+            event_bus=bus,
+        )
         manager = internalize_coding_bot(
             self.__class__.__name__,
             engine,
@@ -402,6 +411,9 @@ class ServiceSupervisor:
             bot_registry=registry,
             approval_policy=self.approval_policy,
             event_bus=bus,
+            roi_threshold=_th.roi_drop,
+            error_threshold=_th.error_increase,
+            test_failure_threshold=_th.test_failure_increase,
         )
         manager.context_builder = self.context_builder
         self.manager = manager
@@ -440,6 +452,14 @@ class ServiceSupervisor:
                 event_bus=bus,
                 bot_registry=registry,
             )
+            _th = get_thresholds(self.__class__.__name__)
+            persist_sc_thresholds(
+                self.__class__.__name__,
+                roi_drop=_th.roi_drop,
+                error_increase=_th.error_increase,
+                test_failure_increase=_th.test_failure_increase,
+                event_bus=bus,
+            )
             manager = internalize_coding_bot(
                 self.__class__.__name__,
                 engine,
@@ -448,6 +468,9 @@ class ServiceSupervisor:
                 bot_registry=registry,
                 approval_policy=self.approval_policy,
                 event_bus=bus,
+                roi_threshold=_th.roi_drop,
+                error_threshold=_th.error_increase,
+                test_failure_threshold=_th.test_failure_increase,
             )
             manager.context_builder = self.context_builder
             manager.run_patch(path, description)

--- a/watchdog.py
+++ b/watchdog.py
@@ -90,7 +90,7 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - gracefully degrade in tests
     UnifiedEventBus = None  # type: ignore
 from .coding_bot_interface import self_coding_managed
-from .data_bot import DataBot
+from .data_bot import DataBot, persist_sc_thresholds
 from .self_coding_engine import SelfCodingEngine
 from .self_coding_manager import internalize_coding_bot
 from .model_automation_pipeline import ModelAutomationPipeline
@@ -298,6 +298,12 @@ class Watchdog:
             context_builder=self.context_builder,
             event_bus=bus_local,
             bot_registry=self.registry,
+        )
+        persist_sc_thresholds(
+            self.__class__.__name__,
+            roi_drop=self.thresholds.roi_loss_percent,
+            error_increase=self.thresholds.error_trend,
+            event_bus=bus_local,
         )
         self.manager = internalize_coding_bot(
             self.__class__.__name__,


### PR DESCRIPTION
## Summary
- load self-coding thresholds from configuration when bootstrapping bots that lacked explicit values
- persist thresholds via `persist_sc_thresholds` so DataBot and BotRegistry share limits
- wire retrieved thresholds into `internalize_coding_bot` calls

## Testing
- `pre-commit run --files sandbox_runner.py debug_loop_service.py service_supervisor.py menace_master.py stripe_watchdog.py watchdog.py` *(fails: ModuleNotFoundError: dynamic_path_router)*
- `pytest tests/test_data_bot_thresholds.py tests/test_sc_threshold_persistence.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c63fa2d940832e89a560d74f783519