### PR TITLE
Integrate self-coding manager into error logging

### DIFF
--- a/tests/test_error_logger_builder_validation.py
+++ b/tests/test_error_logger_builder_validation.py
@@ -6,6 +6,7 @@ os.environ.setdefault("MENACE_LIGHT_IMPORTS", "1")
 
 import menace.error_logger as elog  # noqa: E402
 from menace.error_logger import ErrorLogger  # noqa: E402
+import types
 
 
 class DummyBuilder:
@@ -16,10 +17,18 @@ class DummyBuilder:
         self.refresh_calls += 1
 
 
+class DummyManager:
+    def __init__(self):
+        self.evolution_orchestrator = types.SimpleNamespace(provenance_token="tok", event_bus=None)
+
+    def generate_patch(self, module, description="", context_builder=None, provenance_token="", **kwargs):  # pragma: no cover - stub
+        return 1
+
+
 def test_refresh_called_during_init(monkeypatch, tmp_path):
     builder = DummyBuilder()
     db = types.SimpleNamespace(add_telemetry=lambda *a, **k: None)
-    logger = ErrorLogger(db=db, context_builder=builder)
+    logger = ErrorLogger(db=db, context_builder=builder, manager=DummyManager())
     called: list[bool] = []
 
     def fake_generate_patch(module, manager, *, context_builder):

--- a/tests/test_error_logger_replicator.py
+++ b/tests/test_error_logger_replicator.py
@@ -1,11 +1,20 @@
 import types
 import menace.error_logger as elog
+import types
 from db_dedup import compute_content_hash
 
 
 class DummyBuilder:
     def refresh_db_weights(self):
         pass
+
+
+class DummyManager:
+    def __init__(self):
+        self.evolution_orchestrator = types.SimpleNamespace(provenance_token="tok", event_bus=None)
+
+    def generate_patch(self, module, description="", context_builder=None, provenance_token="", **kwargs):  # pragma: no cover - stub
+        return 1
 
 
 class StubReplicator:
@@ -55,7 +64,7 @@ def test_error_logger_telemetry_replication(monkeypatch):
     events = []
     db = types.SimpleNamespace(add_telemetry=lambda e: events.append(e))
     monkeypatch.setattr(elog, "get_embedder", lambda: None)
-    logger = elog.ErrorLogger(db, context_builder=DummyBuilder())
+    logger = elog.ErrorLogger(db, context_builder=DummyBuilder(), manager=DummyManager())
     try:
         raise RuntimeError("boom")
     except Exception as exc:
@@ -77,7 +86,7 @@ def test_replicator_flush_after_failure(monkeypatch):
     events = []
     db = types.SimpleNamespace(add_telemetry=lambda e: events.append(e))
     monkeypatch.setattr(elog, "get_embedder", lambda: None)
-    logger = elog.ErrorLogger(db, context_builder=DummyBuilder())
+    logger = elog.ErrorLogger(db, context_builder=DummyBuilder(), manager=DummyManager())
     inst = StubReplicator.instances[-1]
     inst.fail = True
     try:
@@ -98,7 +107,7 @@ def test_event_checksum_and_validation(monkeypatch):
     events = []
     db = types.SimpleNamespace(add_telemetry=lambda e: events.append(e))
     monkeypatch.setattr(elog, "get_embedder", lambda: None)
-    logger = elog.ErrorLogger(db, context_builder=DummyBuilder())
+    logger = elog.ErrorLogger(db, context_builder=DummyBuilder(), manager=DummyManager())
     try:
         raise RuntimeError("boom3")
     except Exception as exc:

--- a/tests/test_error_logger_update_trigger.py
+++ b/tests/test_error_logger_update_trigger.py
@@ -9,6 +9,7 @@ sys.modules.setdefault(
 
 import menace.error_logger as elog  # noqa: E402
 from menace.error_logger import ErrorLogger  # noqa: E402
+import types
 from menace.error_bot import ErrorDB  # noqa: E402
 
 
@@ -17,10 +18,18 @@ class DummyBuilder:
         pass
 
 
+class DummyManager:
+    def __init__(self):
+        self.evolution_orchestrator = types.SimpleNamespace(provenance_token="tok", event_bus=None)
+
+    def generate_patch(self, module, description="", context_builder=None, provenance_token="", **kwargs):  # pragma: no cover - stub
+        return 1
+
+
 def test_error_logger_triggers_rule_update(monkeypatch, tmp_path):
     monkeypatch.setattr(elog, "get_embedder", lambda: None)
     db = ErrorDB(path=tmp_path / "errors.db")
-    logger = ErrorLogger(db=db, context_builder=DummyBuilder())
+    logger = ErrorLogger(db=db, context_builder=DummyBuilder(), manager=DummyManager())
 
     called: list[bool] = []
 

--- a/tests/test_knowledge_graph_error_causes.py
+++ b/tests/test_knowledge_graph_error_causes.py
@@ -3,6 +3,7 @@ import sys
 import pytest
 import menace.error_bot as eb
 import menace.error_logger as elog
+import types
 import menace.knowledge_graph as kg
 
 pytest.importorskip("networkx")
@@ -13,10 +14,18 @@ class DummyBuilder:
         pass
 
 
+class DummyManager:
+    def __init__(self):
+        self.evolution_orchestrator = types.SimpleNamespace(provenance_token="tok", event_bus=None)
+
+    def generate_patch(self, module, description="", context_builder=None, provenance_token="", **kwargs):  # pragma: no cover - stub
+        return 1
+
+
 def test_update_error_stats_records_causes(tmp_path, monkeypatch):
     monkeypatch.setattr(elog, "get_embedder", lambda: None)
     db = eb.ErrorDB(tmp_path / "e.db")
-    logger = elog.ErrorLogger(db, context_builder=DummyBuilder())
+    logger = elog.ErrorLogger(db, context_builder=DummyBuilder(), manager=DummyManager())
 
     mod = tmp_path / "m.py"  # path-ignore
     mod.write_text("def boom():\n    raise ValueError('bad')\n")

--- a/tests/test_log_roi_cap.py
+++ b/tests/test_log_roi_cap.py
@@ -1,11 +1,20 @@
 import json
 import types
 import menace.error_logger as elog
+import types
 
 
 class DummyBuilder:
     def refresh_db_weights(self):
         pass
+
+
+class DummyManager:
+    def __init__(self):
+        self.evolution_orchestrator = types.SimpleNamespace(provenance_token="tok", event_bus=None)
+
+    def generate_patch(self, module, description="", context_builder=None, provenance_token="", **kwargs):  # pragma: no cover - stub
+        return 1
 
 
 class StubReplicator:
@@ -29,7 +38,7 @@ def test_log_roi_cap_emits_roibottleneck_event(monkeypatch):
     monkeypatch.setattr(elog, "TelemetryReplicator", StubReplicator)
     monkeypatch.setattr(elog, "get_embedder", lambda: None)
     db = types.SimpleNamespace(add_telemetry=lambda e: None)
-    logger = elog.ErrorLogger(db, context_builder=DummyBuilder())
+    logger = elog.ErrorLogger(db, context_builder=DummyBuilder(), manager=DummyManager())
     profile = {
         "weights": {
             "profitability": 0.25,
@@ -69,7 +78,7 @@ def test_log_roi_cap_logs_when_no_replicator(monkeypatch):
     monkeypatch.delenv("KAFKA_HOSTS", raising=False)
     monkeypatch.setattr(elog, "get_embedder", lambda: None)
     db = types.SimpleNamespace(add_telemetry=lambda e: None)
-    logger = elog.ErrorLogger(db, context_builder=DummyBuilder())
+    logger = elog.ErrorLogger(db, context_builder=DummyBuilder(), manager=DummyManager())
 
     class StubLogger:
         def __init__(self):

--- a/tests/test_path_resolution_cache.py
+++ b/tests/test_path_resolution_cache.py
@@ -1,9 +1,21 @@
 import importlib
 
 
+import importlib
+import types
+
+
 class DummyBuilder:
     def refresh_db_weights(self):
         pass
+
+
+class DummyManager:
+    def __init__(self):
+        self.evolution_orchestrator = types.SimpleNamespace(provenance_token="tok", event_bus=None)
+
+    def generate_patch(self, module, description="", context_builder=None, provenance_token="", **kwargs):  # pragma: no cover - stub
+        return 1
 
 
 def test_resolve_path_updates_after_repo_move(monkeypatch, tmp_path):
@@ -65,7 +77,7 @@ def test_error_logger_path_for_prompt_cache(monkeypatch, tmp_path):
         def add_telemetry(self, event):
             self.events.append(event)
 
-    logger = el.ErrorLogger(db=DummyDB(), context_builder=DummyBuilder())
+    logger = el.ErrorLogger(db=DummyDB(), context_builder=DummyBuilder(), manager=DummyManager())
     events1 = logger.log_fix_suggestions({}, {})
     assert events1 and events1[0].module == file_a.resolve().as_posix()
 

--- a/tests/test_sentry_client.py
+++ b/tests/test_sentry_client.py
@@ -2,12 +2,21 @@ import sys
 import types
 import importlib
 import menace.error_logger as elog
+import types
 import menace.sentry_client as sc
 
 
 class DummyBuilder:
     def refresh_db_weights(self):
         pass
+
+
+class DummyManager:
+    def __init__(self):
+        self.evolution_orchestrator = types.SimpleNamespace(provenance_token="tok", event_bus=None)
+
+    def generate_patch(self, module, description="", context_builder=None, provenance_token="", **kwargs):  # pragma: no cover - stub
+        return 1
 
 
 class StubSDK:
@@ -31,7 +40,7 @@ def test_error_logger_with_sentry(monkeypatch):
     sentry = sc.SentryClient("http://dsn")
     events = []
     db = types.SimpleNamespace(add_telemetry=lambda e: events.append(e))
-    logger = elog.ErrorLogger(db, sentry=sentry, context_builder=DummyBuilder())
+    logger = elog.ErrorLogger(db, sentry=sentry, context_builder=DummyBuilder(), manager=DummyManager())
     try:
         raise RuntimeError("boom")
     except Exception as exc:

--- a/tests/test_telemetry_feedback.py
+++ b/tests/test_telemetry_feedback.py
@@ -82,6 +82,14 @@ class DummyBuilder:
         pass
 
 
+class LoggerManager:
+    def __init__(self):
+        self.evolution_orchestrator = types.SimpleNamespace(provenance_token="tok", event_bus=None)
+
+    def generate_patch(self, module, description="", context_builder=None, provenance_token="", **kwargs):  # pragma: no cover - stub
+        return 1
+
+
 class DummyEngine:
     def __init__(self):
         self.calls = []
@@ -150,7 +158,7 @@ def _setup(tmp_path, monkeypatch):
         "category TEXT, module TEXT, count INTEGER, PRIMARY KEY(category, module)"
         ")"
     )
-    logger = elog.ErrorLogger(db, context_builder=DummyBuilder())
+    logger = elog.ErrorLogger(db, context_builder=DummyBuilder(), manager=LoggerManager())
     engine = DummyEngine()
     mod = tmp_path / "bot.py"  # path-ignore
     mod.write_text("def x():\n    pass\n")


### PR DESCRIPTION
## Summary
- Require `SelfCodingManager` when creating `ErrorLogger`
- Trigger self-coding patch generation with provenance tokens when errors are logged
- Remove Codex prompt fallback for metric bottlenecks and publish patch failure events

## Testing
- `pytest tests/test_error_logger_fix_suggestions.py tests/test_error_logger_replicator.py tests/test_path_resolution_cache.py tests/test_log_roi_cap.py tests/test_sentry_client.py tests/test_error_logger_builder_validation.py -q`
- `pytest tests/test_error_logger_update_trigger.py tests/test_fix_suggestions.py tests/test_telemetry_feedback.py -q` *(fails: ImportError: Self-coding engine is required for operation)*
- `pytest tests/test_knowledge_graph_error_causes.py tests/test_roi_fix_edge_cases.py -q` *(fails: ImportError: Self-coding engine is required for operation)*

------
https://chatgpt.com/codex/tasks/task_e_68c6483c7098832e8750326c0bf3c57e