### PR TITLE
Scan subpackages for unmanaged bots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,6 +172,7 @@ audits locally before committing:
 ```bash
 python tools/check_self_coding_registration.py
 python tools/find_unmanaged_bots.py
+python tools/check_self_coding_decorator.py
 ```
 
 These scripts exit with a non-zero status when unmanaged bots are present,

--- a/database_manager.py
+++ b/database_manager.py
@@ -17,7 +17,17 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints
     from .preliminary_research_bot import PreliminaryResearchBot
 else:  # pragma: no cover - lightweight fallback implementation
     from .preliminary_research_bot import BusinessData
+    from .bot_registry import BotRegistry
+    from .coding_bot_interface import self_coding_managed
+    from .data_bot import DataBot
+    from .self_coding_manager import SelfCodingManager
 
+    bot_registry = BotRegistry()
+    data_bot = DataBot(start_server=False)
+
+    @self_coding_managed(
+        bot_registry=bot_registry, data_bot=data_bot, manager=SelfCodingManager
+    )
     class PreliminaryResearchBot:
         """Minimal fallback that attempts a basic scrape for metrics."""
 

--- a/docs/internalize_coding_bot.md
+++ b/docs/internalize_coding_bot.md
@@ -49,6 +49,11 @@ non-zero status.
 To satisfy the hook:
 
 1. Call `internalize_coding_bot` during module initialisation, **or**
-2. Decorate the bot with `@self_coding_managed`.
+2. Decorate the bot with `@self_coding_managed` providing
+   `bot_registry`, `data_bot`, and `SelfCodingManager`.
 
 This ensures all exported bots participate in the self-coding lifecycle.
+
+For a comprehensive audit of the repository, run
+`tools/check_self_coding_decorator.py` which walks all subpackages and fails
+when any class ending in `Bot` lacks the `@self_coding_managed` decorator.


### PR DESCRIPTION
## Summary
- extend self-coding decorator audit to walk all subpackages and flag any bot classes lacking `@self_coding_managed`
- decorate `PreliminaryResearchBot` fallback stub with registry, data bot, and `SelfCodingManager`
- document the audit requirement and link the check script in onboarding docs

## Testing
- `python tools/check_self_coding_decorator.py`
- `python -m py_compile tools/check_self_coding_decorator.py database_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c64a7cd79c832ea89eb41244426128