### PR TITLE
Require real helpers for DataBot thresholds

### DIFF
--- a/data_bot.py
+++ b/data_bot.py
@@ -120,24 +120,6 @@ from .self_coding_thresholds import (
     get_thresholds as _load_sc_thresholds,
     _load_config as _load_sc_config,
 )
-from .coding_bot_interface import self_coding_managed
-
-
-class _StubRegistry:
-    def register_bot(self, *args, **kwargs) -> None:  # pragma: no cover - stub
-        return None
-
-    def update_bot(self, *args, **kwargs) -> None:  # pragma: no cover - stub
-        return None
-
-
-class _StubDataBot:
-    def reload_thresholds(self, _name: str):  # pragma: no cover - stub
-        return type("_T", (), {})()
-
-
-_REGISTRY_STUB = _StubRegistry()
-_DATA_BOT_STUB = _StubDataBot()
 
 logger = logging.getLogger(__name__)
 
@@ -165,6 +147,9 @@ def persist_sc_thresholds(
     the :class:`ROIThresholds` naming scheme. Forecast configuration can be
     supplied via ``forecast_model``, ``confidence`` and ``model_params``.
     """
+
+    if _save_sc_thresholds is None:  # pragma: no cover - dependency check
+        raise RuntimeError("update_thresholds helper is unavailable")
 
     bus = event_bus or _SHARED_EVENT_BUS
     try:
@@ -206,6 +191,9 @@ def load_sc_thresholds(
     is returned.  Otherwise a mapping of all stored bot thresholds is
     produced.  Any errors are logged and mirrored to the event bus.
     """
+
+    if _load_sc_thresholds is None or _load_sc_config is None:  # pragma: no cover
+        raise RuntimeError("threshold helpers are unavailable")
 
     bus = event_bus or _SHARED_EVENT_BUS
     try:
@@ -1154,7 +1142,6 @@ class MetricsDB:
             return pd.read_sql(query, conn, params=params)
 
 
-@self_coding_managed(bot_registry=_REGISTRY_STUB, data_bot=_DATA_BOT_STUB)
 class DataBot:
     """Collect metrics, expose them to Prometheus and detect anomalies.
 

--- a/tests/test_data_bot_degradation_patch_cycle.py
+++ b/tests/test_data_bot_degradation_patch_cycle.py
@@ -23,7 +23,7 @@ class DummySelfCodingManager:
         self.bot_registry = types.SimpleNamespace(graph={"dummy": {"module": str(module)}})
         self.calls: list[tuple[str, dict | None]] = []
 
-    def register_patch_cycle(self, desc: str, ctx=None):
+    def register_patch_cycle(self, desc: str, ctx=None, **_k):
         self.calls.append((desc, ctx))
 
 
@@ -40,9 +40,6 @@ class DummyHistoryDB:
 
 
 def test_threshold_breach_queues_patch_cycle(tmp_path, monkeypatch):
-    stub_cbi = types.ModuleType("menace.coding_bot_interface")
-    stub_cbi.self_coding_managed = lambda cls: cls
-    monkeypatch.setitem(sys.modules, "menace.coding_bot_interface", stub_cbi)
     stub_scm = types.ModuleType("menace.self_coding_manager")
     stub_scm.SelfCodingManager = DummySelfCodingManager
     stub_scm.HelperGenerationError = RuntimeError
@@ -60,6 +57,14 @@ def test_threshold_breach_queues_patch_cycle(tmp_path, monkeypatch):
     stub_ga_bot.GeneticAlgorithmBot = object
     stub_ga_bot.GARecord = stub_ga_bot.GAStore = object
     monkeypatch.setitem(sys.modules, "menace.genetic_algorithm_bot", stub_ga_bot)
+    stub_mut = types.ModuleType("menace.mutation_logger")
+    stub_mut.log_mutation = lambda *a, **k: None
+    stub_mut.record_mutation_outcome = lambda *a, **k: None
+    class _Ctx:
+        def __enter__(self): return None
+        def __exit__(self, *a): return False
+    stub_mut.log_context = _Ctx
+    monkeypatch.setitem(sys.modules, "menace.mutation_logger", stub_mut)
     stub = types.ModuleType("vector_metrics_db")
     monkeypatch.setitem(sys.modules, "menace.vector_metrics_db", stub)
     import menace.data_bot as db

--- a/tests/test_data_bot_thresholds.py
+++ b/tests/test_data_bot_thresholds.py
@@ -3,9 +3,10 @@ import types
 import yaml
 
 
-stub_cbi = types.ModuleType("menace.coding_bot_interface")
+stub_cbi = types.ModuleType("coding_bot_interface")
 stub_cbi.self_coding_managed = lambda *a, **k: (lambda cls: cls)
 stub_cbi.manager_generate_helper = lambda *_a, **_k: None
+sys.modules["coding_bot_interface"] = stub_cbi
 sys.modules["menace.coding_bot_interface"] = stub_cbi
 
 

--- a/tests/test_pending_patch_cycle_run.py
+++ b/tests/test_pending_patch_cycle_run.py
@@ -26,9 +26,6 @@ class DummyHistoryDB:
 
 
 def test_pending_patch_cycle_processed(monkeypatch):
-    stub_cbi = types.ModuleType("menace.coding_bot_interface")
-    stub_cbi.self_coding_managed = lambda cls: cls
-    monkeypatch.setitem(sys.modules, "menace.coding_bot_interface", stub_cbi)
     stub_scm = types.ModuleType("menace.self_coding_manager")
     stub_scm.SelfCodingManager = object
     stub_scm.HelperGenerationError = RuntimeError
@@ -46,6 +43,14 @@ def test_pending_patch_cycle_processed(monkeypatch):
     stub_ga_bot.GeneticAlgorithmBot = object
     stub_ga_bot.GARecord = stub_ga_bot.GAStore = object
     monkeypatch.setitem(sys.modules, "menace.genetic_algorithm_bot", stub_ga_bot)
+    stub_mut = types.ModuleType("menace.mutation_logger")
+    stub_mut.log_mutation = lambda *a, **k: None
+    stub_mut.record_mutation_outcome = lambda *a, **k: None
+    class _Ctx:
+        def __enter__(self): return None
+        def __exit__(self, *a): return False
+    stub_mut.log_context = _Ctx
+    monkeypatch.setitem(sys.modules, "menace.mutation_logger", stub_mut)
     stub = types.ModuleType("vector_metrics_db")
     monkeypatch.setitem(sys.modules, "menace.vector_metrics_db", stub)
     import menace.data_bot as db


### PR DESCRIPTION
## Summary
- drop stub BotRegistry/DataBot placeholders in data_bot
- raise clear errors when self-coding threshold helpers are missing
- update tests to use simple mocks for coding interface and mutation logger

## Testing
- `pytest tests/test_data_bot_thresholds.py tests/test_data_bot_degradation_patch_cycle.py tests/test_pending_patch_cycle_run.py tests/test_data_bot_threshold_error_handling.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c64f67b4c0832e963ca90ea60786e8