### PR TITLE
Add diff risk scoring and patch escalation

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -1302,6 +1302,11 @@ class SandboxSettings(BaseSettings):
         env="SANDBOX_PATCH_RETRY_DELAY",
         description="Delay in seconds between patch generation attempts.",
     )
+    diff_risk_threshold: float = Field(
+        0.5,
+        env="DIFF_RISK_THRESHOLD",
+        description="Abort patches whose diff risk exceeds this score.",
+    )
     flakiness_runs: int = Field(
         5,
         env="FLAKINESS_RUNS",

--- a/vector_service/patch_logger.py
+++ b/vector_service/patch_logger.py
@@ -328,6 +328,8 @@ class PatchLogger:
         error_traces: Sequence[Mapping[str, Any]] | None = None,
         roi_tag: RoiTag | str | None = None,
         effort_estimate: float | None = None,
+        risk_flags: Sequence[str] | None = None,
+        diff_risk_score: float | None = None,
     ) -> dict[str, float]:
         """Log patch outcome for vectors contributing to a patch.
 
@@ -845,6 +847,10 @@ class PatchLogger:
         }
         if patch_id:
             payload["patch_id"] = patch_id
+        if risk_flags:
+            payload["risk_flags"] = list(risk_flags)
+        if diff_risk_score is not None:
+            payload["diff_risk_score"] = float(diff_risk_score)
 
         # Persist risk summaries for audit
         try:
@@ -899,6 +905,10 @@ class PatchLogger:
             "roi_tag": roi_tag_val.value,
             "enhancement_score": enhancement_score,
         }
+        if risk_flags:
+            summary_payload["risk_flags"] = list(risk_flags)
+        if diff_risk_score is not None:
+            summary_payload["diff_risk_score"] = float(diff_risk_score)
         if error_summary is not None:
             summary_payload["error_summary"] = error_summary
         if self.event_bus is not None:


### PR DESCRIPTION
## Summary
- compute diff-based risk score in quick fix engine and abort risky patches
- expose configurable diff risk threshold in `SandboxSettings`
- log diff risk flags and scores via `PatchLogger`

## Testing
- `pytest unit_tests/test_quick_fix_engine.py -q`
- `pytest tests/test_patch_logger_metrics.py -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '')*


------
https://chatgpt.com/codex/tasks/task_e_68c6693d52b0832eb0034bf7a70976f2