### PR TITLE
feat: refresh test command from thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,14 @@ manager.approval_policy = policy
 manager.run_patch(Path("sandbox_runner.py"), "tweak", clone_command=["git", "clone", "--depth", "1"])
 ```
 
-The default test command (`pytest -q`) can be overridden globally via the
-`SELF_CODING_TEST_COMMAND` environment variable or
-`SandboxSettings.self_coding_test_command`.  Per-bot commands are specified
-with a `test_command` entry in `config/self_coding_thresholds.yaml` or within
-`SandboxSettings.bot_thresholds`.
+If ``test_command`` is omitted, :class:`PatchApprovalPolicy` derives the value
+from the active ``threshold_service`` or per-bot configuration.  The default
+(`pytest -q`) can be overridden globally via the `SELF_CODING_TEST_COMMAND`
+environment variable or `SandboxSettings.self_coding_test_command`.  Per-bot
+commands are specified with a `test_command` entry in
+`config/self_coding_thresholds.yaml` or within `SandboxSettings.bot_thresholds`.
+The active command may be refreshed at runtime using
+``policy.update_test_command([...])``.
 
 ### SelfCodingEngine
 

--- a/docs/sandbox_self_improvement_configuration.md
+++ b/docs/sandbox_self_improvement_configuration.md
@@ -57,7 +57,12 @@ bots:
 
 The default test command is `pytest -q`.  Override it globally with the
 `SELF_CODING_TEST_COMMAND` environment variable or the corresponding
-`SandboxSettings.self_coding_test_command` field.
+`SandboxSettings.self_coding_test_command` field.  When
+``PatchApprovalPolicy`` is constructed without an explicit ``test_command``
+it queries the active ``threshold_service`` and falls back to
+``SandboxSettings.bot_thresholds`` for per-bot overrides.  The selected
+command can be changed on a running policy via
+``PatchApprovalPolicy.update_test_command``.
 
 ## Security considerations
 - Resource and network limits are controlled through environment variables.


### PR DESCRIPTION
## Summary
- derive test command from threshold service or per-bot settings when not explicitly provided
- allow updating the test command at runtime
- document new behaviour and add coverage for threshold and runtime overrides

## Testing
- `pre-commit run --files self_coding_manager.py README.md docs/sandbox_self_improvement_configuration.md tests/integration/test_custom_commands.py` *(fails: check-self-coding-decorator: DataBot missing @self_coding_managed; self-coding-audit: Found unmanaged bot classes)*
- `pytest tests/integration/test_custom_commands.py::test_patch_approval_policy_custom_test_command tests/integration/test_custom_commands.py::test_patch_approval_policy_env_var tests/integration/test_custom_commands.py::test_patch_approval_policy_config_override tests/integration/test_custom_commands.py::test_patch_approval_policy_handles_failure tests/integration/test_custom_commands.py::test_patch_approval_policy_threshold_service tests/integration/test_custom_commands.py::test_patch_approval_policy_bot_thresholds tests/integration/test_custom_commands.py::test_patch_approval_policy_update_runtime -q`


------
https://chatgpt.com/codex/tasks/task_e_68c66ce964ac832e9b80f0f01a899781