### PR TITLE
feat: enforce internalized coding bots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,16 +179,16 @@ These scripts exit with a non-zero status when unmanaged bots are present,
 causing CI to fail.
 
 The `check-coding-bot-decorators` hook (`tools/check_coding_bot_decorators.py`)
-adds an extra safeguard by scanning for modules that import
-`SelfCodingEngine` and flagging any bot classes that lack the
-`@self_coding_managed` decorator. Run it locally when adding new bots:
+scans every bot module and fails if a bot class lacks the
+`@self_coding_managed` decorator or the module omits an
+`internalize_coding_bot` call. Run it locally when adding new bots:
 
 ```bash
 pre-commit run check-coding-bot-decorators --all-files
 ```
 
-CI runs the same script directly via `python tools/check_coding_bot_decorators.py`
-to ensure the build fails if any `*_bot.py` misses the decorator.
+CI invokes the same script via `make self-coding-check` so the build fails when
+an unmanaged bot is introduced.
 
 The repository also ships `self_coding_audit.py`, which scans all Python files
 for classes ending in `Bot` without `@self_coding_managed`. The audit runs as a

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,4 @@ check-context-builder:
 self-coding-check:
 	python tools/check_self_coding_usage.py
 	python tools/find_unmanaged_bots.py
+	python tools/check_coding_bot_decorators.py


### PR DESCRIPTION
## Summary
- extend coding bot decorator check to cover all modules importing SelfCodingEngine or calling `internalize_coding_bot`
- integrate the new check into `self-coding-check` make target
- document internalization requirement for coding bots

## Testing
- `make self-coding-check`


------
https://chatgpt.com/codex/tasks/task_e_68c6704278ec832e929a3487af5d6eb4