### PR TITLE
Inject shared EvolutionOrchestrator into bots

### DIFF
--- a/bot_creation_bot.py
+++ b/bot_creation_bot.py
@@ -39,6 +39,7 @@ from .trending_scraper import TrendingScraper
 from .admin_bot_base import AdminBotBase
 from .self_coding_manager import SelfCodingManager, internalize_coding_bot
 from .self_coding_thresholds import get_thresholds
+from .shared_evolution_orchestrator import get_orchestrator
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .evolution_orchestrator import EvolutionOrchestrator
@@ -69,7 +70,7 @@ data_bot = DataBot(start_server=False)
 _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), MenaceMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
-evolution_orchestrator: EvolutionOrchestrator | None = None
+evolution_orchestrator = get_orchestrator("BotCreationBot", data_bot, engine)
 _th = get_thresholds("BotCreationBot")
 persist_sc_thresholds(
     "BotCreationBot",

--- a/shared_evolution_orchestrator.py
+++ b/shared_evolution_orchestrator.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Provide a shared :class:`EvolutionOrchestrator` instance.
+
+This helper lazily constructs an :class:`EvolutionOrchestrator` with minimal
+dependencies and returns the same instance for all callers.  Bots retrieving
+the orchestrator can therefore coordinate through a common patch provenance
+token.
+"""
+
+from .data_bot import DataBot
+from .capital_management_bot import CapitalManagementBot
+from .system_evolution_manager import SystemEvolutionManager
+from .self_coding_engine import SelfCodingEngine
+from .evolution_orchestrator import EvolutionOrchestrator
+
+_shared_orchestrator: EvolutionOrchestrator | None = None
+
+
+def get_orchestrator(
+    bot_name: str, data_bot: DataBot, engine: SelfCodingEngine
+) -> EvolutionOrchestrator:
+    """Return a singleton ``EvolutionOrchestrator``.
+
+    Parameters
+    ----------
+    bot_name:
+        Name of the bot requesting orchestration. The first caller determines
+        the initial bot list for :class:`SystemEvolutionManager`.
+    data_bot:
+        Shared :class:`DataBot` instance.
+    engine:
+        :class:`SelfCodingEngine` powering self-improvement.
+    """
+    global _shared_orchestrator
+    if _shared_orchestrator is None:
+        capital_bot = CapitalManagementBot()
+        evolution_manager = SystemEvolutionManager(bots=[bot_name])
+        _shared_orchestrator = EvolutionOrchestrator(
+            data_bot, capital_bot, engine, evolution_manager
+        )
+    return _shared_orchestrator


### PR DESCRIPTION
## Summary
- add helper providing a singleton EvolutionOrchestrator
- wire enhancement, creation, planning and optimisation bots to use the shared orchestrator and provenance tokens
- update service supervisor to propagate orchestrator tokens through patch operations

## Testing
- `pre-commit run --files enhancement_bot.py bot_creation_bot.py bot_planning_bot.py service_supervisor.py implementation_optimiser_bot.py shared_evolution_orchestrator.py` *(fails: check-self-coding-decorator, self-coding-audit)*

------
https://chatgpt.com/codex/tasks/task_e_68c687757f48832eb5de046dc463a721