### PR TITLE
Add configurable patch success drop threshold

### DIFF
--- a/config/self_coding_thresholds.yaml
+++ b/config/self_coding_thresholds.yaml
@@ -2,6 +2,7 @@ default:
   roi_drop: -0.1
   error_increase: 1.0
   test_failure_increase: 0.0
+  patch_success_drop: -0.2
   model: exponential
   confidence: 0.95
 bots:
@@ -437,6 +438,10 @@ bots:
     roi_drop: -0.1
     error_increase: 1.0
     test_failure_increase: 0.0
+    patch_success_drop: -0.2
+    model: exponential
+    confidence: 0.95
+    model_params: {}
   finance_router:
     roi_drop: -0.05
     error_increase: 0.5
@@ -457,7 +462,19 @@ bots:
     roi_drop: -0.1
     error_increase: 1.0
     test_failure_increase: 0.0
+    patch_success_drop: -0.2
+    model: exponential
+    confidence: 0.95
+    model_params: {}
   auto_patch_cycle_bot:
     roi_drop: -0.1
     error_increase: 1.0
     test_failure_increase: 0.0
+  sample:
+    roi_drop: -0.1
+    error_increase: 1.0
+    test_failure_increase: 0.5
+    patch_success_drop: -0.2
+    model: exponential
+    confidence: 0.95
+    model_params: {}

--- a/roi_thresholds.py
+++ b/roi_thresholds.py
@@ -16,6 +16,7 @@ class ROIThresholds:
     roi_drop: float
     error_threshold: float
     test_failure_threshold: float = 0.0
+    patch_success_drop: float = -0.2
 
 
 def load_thresholds(
@@ -36,6 +37,7 @@ def load_thresholds(
     roi_drop = s.self_coding_roi_drop
     err_thresh = s.self_coding_error_increase
     fail_thresh = getattr(s, "self_coding_test_failure_increase", 0.0)
+    patch_drop = getattr(s, "self_coding_patch_success_drop", -0.2)
     if bot and bot in s.bot_thresholds:
         bt: BotThresholds = s.bot_thresholds[bot]
         if bt.roi_drop is not None:
@@ -44,8 +46,11 @@ def load_thresholds(
             err_thresh = bt.error_threshold
         if getattr(bt, "test_failure_threshold", None) is not None:
             fail_thresh = bt.test_failure_threshold
+        if getattr(bt, "patch_success_drop", None) is not None:
+            patch_drop = bt.patch_success_drop
     return ROIThresholds(
         roi_drop=roi_drop,
         error_threshold=err_thresh,
         test_failure_threshold=fail_thresh,
+        patch_success_drop=patch_drop,
     )

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -28,7 +28,7 @@ try:  # pragma: no cover - compatibility shim
     from pydantic import field_validator
 except Exception:  # pragma: no cover
     from pydantic import validator as field_validator  # type: ignore
- 
+
 SELF_CODING_ROI_DROP: float = float(os.getenv("SELF_CODING_ROI_DROP", "-0.1"))
 SELF_CODING_ERROR_INCREASE: float = float(
     os.getenv("SELF_CODING_ERROR_INCREASE", "1.0")
@@ -140,6 +140,7 @@ class BotThresholds(BaseModel):
     roi_drop: float | None = None
     error_threshold: float | None = None
     test_failure_threshold: float | None = None
+    patch_success_drop: float | None = None
     test_command: list[str] | None = None
 
 
@@ -1562,6 +1563,11 @@ class SandboxSettings(BaseSettings):
         1.0,
         env="SELF_CODING_ERROR_INCREASE",
         description="Error increase triggering self-coding.",
+    )
+    self_coding_patch_success_drop: float = Field(
+        -0.2,
+        env="SELF_CODING_PATCH_SUCCESS_DROP",
+        description="Patch success rate drop triggering self-coding.",
     )
     self_coding_test_command: list[str] | None = Field(
         None,

--- a/self_coding_thresholds.py
+++ b/self_coding_thresholds.py
@@ -74,6 +74,7 @@ class SelfCodingThresholds:
     roi_drop: float
     error_increase: float
     test_failure_increase: float = 0.0
+    patch_success_drop: float = -0.2
     roi_weight: float = 0.5
     error_weight: float = 0.3
     test_failure_weight: float = 0.2
@@ -118,6 +119,7 @@ def get_thresholds(
     roi_drop = getattr(s, "self_coding_roi_drop", -0.1)
     err_inc = getattr(s, "self_coding_error_increase", 1.0)
     fail_inc = getattr(s, "self_coding_test_failure_increase", 0.0)
+    patch_drop = getattr(s, "self_coding_patch_success_drop", -0.2)
     roi_weight = getattr(s, "self_coding_roi_weight", 0.5)
     err_weight = getattr(s, "self_coding_error_weight", 0.3)
     fail_weight = getattr(s, "self_coding_test_failure_weight", 0.2)
@@ -138,6 +140,7 @@ def get_thresholds(
     roi_drop = float(default.get("roi_drop", roi_drop))
     err_inc = float(default.get("error_increase", err_inc))
     fail_inc = float(default.get("test_failure_increase", fail_inc))
+    patch_drop = float(default.get("patch_success_drop", patch_drop))
     roi_weight = float(default.get("roi_weight", roi_weight))
     err_weight = float(default.get("error_weight", err_weight))
     fail_weight = float(default.get("test_failure_weight", fail_weight))
@@ -151,6 +154,7 @@ def get_thresholds(
         roi_drop = float(cfg.get("roi_drop", roi_drop))
         err_inc = float(cfg.get("error_increase", err_inc))
         fail_inc = float(cfg.get("test_failure_increase", fail_inc))
+        patch_drop = float(cfg.get("patch_success_drop", patch_drop))
         roi_weight = float(cfg.get("roi_weight", roi_weight))
         err_weight = float(cfg.get("error_weight", err_weight))
         fail_weight = float(cfg.get("test_failure_weight", fail_weight))
@@ -169,6 +173,7 @@ def get_thresholds(
         roi_drop=roi_drop,
         error_increase=err_inc,
         test_failure_increase=fail_inc,
+        patch_success_drop=patch_drop,
         roi_weight=roi_weight,
         error_weight=err_weight,
         test_failure_weight=fail_weight,
@@ -186,6 +191,7 @@ def update_thresholds(
     roi_drop: float | None = None,
     error_increase: float | None = None,
     test_failure_increase: float | None = None,
+    patch_success_drop: float | None = None,
     roi_weight: float | None = None,
     error_weight: float | None = None,
     test_failure_weight: float | None = None,
@@ -208,6 +214,8 @@ def update_thresholds(
         cfg["error_increase"] = float(error_increase)
     if test_failure_increase is not None:
         cfg["test_failure_increase"] = float(test_failure_increase)
+    if patch_success_drop is not None:
+        cfg["patch_success_drop"] = float(patch_success_drop)
     if roi_weight is not None:
         cfg["roi_weight"] = float(roi_weight)
     if error_weight is not None:
@@ -274,12 +282,14 @@ def adaptive_thresholds(
         roi_drop=roi_thresh,
         error_increase=err_thresh,
         test_failure_increase=fail_thresh,
+        patch_success_drop=current.patch_success_drop,
     )
 
     return ROIThresholds(
         roi_drop=roi_thresh,
         error_threshold=err_thresh,
         test_failure_threshold=fail_thresh,
+        patch_success_drop=current.patch_success_drop,
     )
 
 

--- a/threshold_service.py
+++ b/threshold_service.py
@@ -44,6 +44,7 @@ class ThresholdService:
             "roi_drop": rt.roi_drop,
             "error_threshold": rt.error_threshold,
             "test_failure_threshold": rt.test_failure_threshold,
+            "patch_success_drop": rt.patch_success_drop,
         }
         try:  # pragma: no cover - best effort
             self.event_bus.publish("thresholds:updated", payload)
@@ -71,6 +72,7 @@ class ThresholdService:
             roi_drop=raw.roi_drop,
             error_threshold=raw.error_increase,
             test_failure_threshold=raw.test_failure_increase,
+            patch_success_drop=raw.patch_success_drop,
         )
         key = bot or ""
         prev = self._thresholds.get(key)
@@ -84,6 +86,7 @@ class ThresholdService:
                     roi_drop=rt.roi_drop,
                     error_increase=rt.error_threshold,
                     test_failure_increase=rt.test_failure_threshold,
+                    patch_success_drop=rt.patch_success_drop,
                 )
         if bot and prev != rt:
             self._publish(bot, rt)
@@ -109,6 +112,7 @@ class ThresholdService:
         roi_drop: float | None = None,
         error_threshold: float | None = None,
         test_failure_threshold: float | None = None,
+        patch_success_drop: float | None = None,
     ) -> None:
         """Persist new thresholds for *bot* and broadcast changes."""
         update_thresholds(
@@ -116,16 +120,26 @@ class ThresholdService:
             roi_drop=roi_drop,
             error_increase=error_threshold,
             test_failure_increase=test_failure_threshold,
+            patch_success_drop=patch_success_drop,
         )
         current = self._thresholds.get(bot)
         if current is None:
             current = self.reload(bot)
         new_rt = ROIThresholds(
             roi_drop=roi_drop if roi_drop is not None else current.roi_drop,
-            error_threshold=
-                error_threshold if error_threshold is not None else current.error_threshold,
-            test_failure_threshold=
-                test_failure_threshold if test_failure_threshold is not None else current.test_failure_threshold,
+            error_threshold=(
+                error_threshold if error_threshold is not None else current.error_threshold
+            ),
+            test_failure_threshold=(
+                test_failure_threshold
+                if test_failure_threshold is not None
+                else current.test_failure_threshold
+            ),
+            patch_success_drop=(
+                patch_success_drop
+                if patch_success_drop is not None
+                else current.patch_success_drop
+            ),
         )
         prev = self._thresholds.get(bot)
         self._thresholds[bot] = new_rt


### PR DESCRIPTION
## Summary
- support configurable patch success drop in ROIThresholds and configuration
- load and persist patch success threshold across data bot and threshold service
- test patch success threshold loading and breach detection

## Testing
- `pre-commit run --files config/self_coding_thresholds.yaml data_bot.py roi_thresholds.py sandbox_settings.py self_coding_thresholds.py threshold_service.py tests/test_data_bot_thresholds.py`
- `pytest tests/test_data_bot_thresholds.py::test_reload_thresholds_includes_patch_success tests/test_data_bot_thresholds.py::test_patch_success_breach_detection -q`
- `pytest tests/test_data_bot_reload_thresholds.py -q`
- `pytest tests/test_data_bot_metric_deltas.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c694f2a948832ea4bb8bb675665ae1