### PR TITLE
feat: improve anomaly detection

### DIFF
--- a/data_bot.py
+++ b/data_bot.py
@@ -2781,9 +2781,9 @@ class DataBot:
         """Return indices of rows considered anomalies.
 
         When PyTorch or scikit-learn are available this delegates to
-        :mod:`menace.anomaly_detection` and logs the produced anomaly scores
-        via ``metrics_db``.  It falls back to a simple standard deviation based
-        approach otherwise.
+        :mod:`menace.anomaly_detection`, which will log the produced anomaly
+        scores via ``metrics_db``.  It falls back to a simple standard deviation
+        based approach otherwise.
         """
         values: List[float]
         if pd is not None and hasattr(df, "empty") and not getattr(df, "empty", True):
@@ -2801,10 +2801,9 @@ class DataBot:
         try:
             from . import anomaly_detection
 
-            scores = anomaly_detection.anomaly_scores(values)
-            if metrics_db:
-                for score in scores:
-                    metrics_db.log_eval("anomaly", field, float(score))
+            scores = anomaly_detection.anomaly_scores(
+                values, metrics_db=metrics_db, field=field
+            )
             mean_s = sum(scores) / len(scores)
             std_s = (sum((s - mean_s) ** 2 for s in scores) / len(scores)) ** 0.5 or 1.0
             return [i for i, s in enumerate(scores) if s > mean_s + threshold * std_s]

--- a/tests/test_anomaly_detection.py
+++ b/tests/test_anomaly_detection.py
@@ -1,22 +1,47 @@
-import types
 import sys
 import types
+
 import pytest
 
 pytest.importorskip("pandas")
 import pandas as pd
 
 
-def _prepare(monkeypatch):
-    # stub heavy optional deps before importing menace
+class DummyMetricsDB:
+    def __init__(self) -> None:
+        self.records: list[tuple[str, str, float]] = []
+
+    def log_eval(self, cycle: str, metric: str, value: float) -> None:
+        self.records.append((cycle, metric, value))
+
+
+def _prepare(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in list(sys.modules):
+        if name.startswith("menace") or name in {"dynamic_path_router", "sandbox_runner"}:
+            sys.modules.pop(name, None)
     stub = types.ModuleType("stub")
     monkeypatch.setitem(sys.modules, "psutil", stub)
     monkeypatch.setitem(sys.modules, "sklearn", stub)
     monkeypatch.setitem(sys.modules, "sklearn.cluster", stub)
     stub.KMeans = object
+    si = types.ModuleType("menace.self_improvement")
+    bt = types.ModuleType("menace.self_improvement.baseline_tracker")
+    bt.BaselineTracker = object
+    si.baseline_tracker = bt
+    monkeypatch.setitem(sys.modules, "menace.self_improvement", si)
+    monkeypatch.setitem(sys.modules, "menace.self_improvement.baseline_tracker", bt)
+    monkeypatch.setitem(sys.modules, "sandbox_runner", types.ModuleType("sandbox_runner"))
+    monkeypatch.setitem(sys.modules, "sandbox_runner.bootstrap", types.ModuleType("sandbox_runner.bootstrap"))
+    monkeypatch.setitem(sys.modules, "sandbox_runner.cli", types.ModuleType("sandbox_runner.cli"))
+    monkeypatch.setitem(sys.modules, "menace.metrics_dashboard", types.ModuleType("menace.metrics_dashboard"))
+    monkeypatch.setitem(
+        sys.modules,
+        "menace.code_database",
+        types.SimpleNamespace(PatchHistoryDB=object),
+    )
 
 
-def test_anomaly_scores_fallback(monkeypatch):
+def test_anomaly_scores_mad(monkeypatch: pytest.MonkeyPatch) -> None:
     _prepare(monkeypatch)
     from menace import anomaly_detection as ad
 
@@ -24,16 +49,46 @@ def test_anomaly_scores_fallback(monkeypatch):
     monkeypatch.setattr(ad, "nn", None)
     monkeypatch.setattr(ad, "KMeans", None)
     monkeypatch.setattr(ad, "np", None)
-    scores = ad.anomaly_scores([1.0, 2.0, 50.0])
+    mdb = DummyMetricsDB()
+    scores = ad.anomaly_scores([1.0, 2.0, 50.0], metrics_db=mdb, field="cpu")
     assert len(scores) == 3
     assert scores[-1] > scores[0]
-    # cleanup imported modules
-    for m in list(sys.modules):
-        if m.startswith("menace"):
-            sys.modules.pop(m, None)
+    assert len(mdb.records) == 3
 
 
-def test_detect_anomalies_logging(tmp_path, monkeypatch):
+def test_anomaly_scores_empty() -> None:
+    from menace import anomaly_detection as ad
+
+    assert ad.anomaly_scores([]) == []
+
+
+def test_anomaly_scores_extreme_outlier(monkeypatch: pytest.MonkeyPatch) -> None:
+    _prepare(monkeypatch)
+    from menace import anomaly_detection as ad
+
+    monkeypatch.setattr(ad, "torch", None)
+    monkeypatch.setattr(ad, "nn", None)
+    monkeypatch.setattr(ad, "KMeans", None)
+    monkeypatch.setattr(ad, "np", None)
+    scores = ad.anomaly_scores([1.0, 2.0, 10 ** 9])
+    assert scores[-1] > scores[0] * 1_000_000
+
+
+def test_anomaly_scores_logs_metrics_advanced(monkeypatch: pytest.MonkeyPatch) -> None:
+    _prepare(monkeypatch)
+    from menace import anomaly_detection as ad
+
+    monkeypatch.setattr(ad, "torch", None)
+    monkeypatch.setattr(ad, "nn", None)
+    monkeypatch.setattr(ad, "_cluster_scores", lambda vals: [42.0 for _ in vals])
+    monkeypatch.setattr(ad, "np", object())
+    mdb = DummyMetricsDB()
+    scores = ad.anomaly_scores([1.0, 2.0], metrics_db=mdb, field="cpu")
+    assert scores == [42.0, 42.0]
+    assert mdb.records == [("anomaly", "cpu", 42.0), ("anomaly", "cpu", 42.0)]
+
+
+def test_detect_anomalies_logging(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     _prepare(monkeypatch)
     import menace.data_bot as db
 
@@ -43,18 +98,15 @@ def test_detect_anomalies_logging(tmp_path, monkeypatch):
     assert idxs == [2]
     rows = mdb.fetch_eval("anomaly")
     assert rows
-    for m in list(sys.modules):
-        if m.startswith("menace"):
-            sys.modules.pop(m, None)
 
 
-def test_detect_anomalies_logs_error(monkeypatch, caplog):
+def test_detect_anomalies_logs_error(monkeypatch: pytest.MonkeyPatch, caplog) -> None:
     _prepare(monkeypatch)
     import menace.data_bot as db
 
     boom_mod = types.ModuleType("menace.anomaly_detection")
 
-    def boom(*a, **k):
+    def boom(*a, **k):  # noqa: D401 - simple stub
         raise RuntimeError("fail")
 
     boom_mod.anomaly_scores = boom
@@ -66,6 +118,3 @@ def test_detect_anomalies_logs_error(monkeypatch, caplog):
     assert idxs == [2]
     assert "anomaly detection failed" in caplog.text
 
-    for m in list(sys.modules):
-        if m.startswith("menace"):
-            sys.modules.pop(m, None)


### PR DESCRIPTION
## Summary
- replace standard deviation fallback with median absolute deviation in anomaly detection
- log anomaly scores to MetricsDB in both advanced and fallback modes
- add tests for MAD scoring, metrics logging, and edge cases

## Testing
- `pytest tests/test_anomaly_detection.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c69ad7db18832e91c5f4e9b858e0ed