### PR TITLE
feat: auto recalibrate thresholds

### DIFF
--- a/self_coding_thresholds.py
+++ b/self_coding_thresholds.py
@@ -79,6 +79,7 @@ class SelfCodingThresholds:
     error_weight: float = 0.3
     test_failure_weight: float = 0.2
     patch_success_weight: float = 0.1
+    auto_recalibrate: bool = True
     test_command: list[str] | None = None
     model: str = "exponential"
     confidence: float = 0.95
@@ -124,6 +125,7 @@ def get_thresholds(
     err_weight = getattr(s, "self_coding_error_weight", 0.3)
     fail_weight = getattr(s, "self_coding_test_failure_weight", 0.2)
     patch_weight = getattr(s, "self_coding_patch_success_weight", 0.1)
+    auto_recal = getattr(s, "self_coding_auto_recalibrate", True)
     cmd: list[str] | None
     env_cmd = os.getenv("SELF_CODING_TEST_COMMAND")
     if env_cmd:
@@ -145,6 +147,7 @@ def get_thresholds(
     err_weight = float(default.get("error_weight", err_weight))
     fail_weight = float(default.get("test_failure_weight", fail_weight))
     patch_weight = float(default.get("patch_success_weight", patch_weight))
+    auto_recal = bool(default.get("auto_recalibrate", auto_recal))
     model = default.get("model", "exponential")
     conf = float(default.get("confidence", 0.95))
     params = default.get("model_params", {})
@@ -159,6 +162,7 @@ def get_thresholds(
         err_weight = float(cfg.get("error_weight", err_weight))
         fail_weight = float(cfg.get("test_failure_weight", fail_weight))
         patch_weight = float(cfg.get("patch_success_weight", patch_weight))
+        auto_recal = bool(cfg.get("auto_recalibrate", auto_recal))
         model = cfg.get("model", model)
         conf = float(cfg.get("confidence", conf))
         params = cfg.get("model_params", params)
@@ -178,6 +182,7 @@ def get_thresholds(
         error_weight=err_weight,
         test_failure_weight=fail_weight,
         patch_success_weight=patch_weight,
+        auto_recalibrate=auto_recal,
         test_command=cmd_cfg,
         model=model,
         confidence=conf,
@@ -196,6 +201,7 @@ def update_thresholds(
     error_weight: float | None = None,
     test_failure_weight: float | None = None,
     patch_success_weight: float | None = None,
+    auto_recalibrate: bool | None = None,
     test_command: list[str] | None = None,
     forecast_model: str | None = None,
     confidence: float | None = None,
@@ -224,6 +230,8 @@ def update_thresholds(
         cfg["test_failure_weight"] = float(test_failure_weight)
     if patch_success_weight is not None:
         cfg["patch_success_weight"] = float(patch_success_weight)
+    if auto_recalibrate is not None:
+        cfg["auto_recalibrate"] = bool(auto_recalibrate)
     if test_command is not None:
         cfg["test_command"] = list(test_command)
     if forecast_model is not None:

--- a/tests/test_threshold_recalibration.py
+++ b/tests/test_threshold_recalibration.py
@@ -1,0 +1,81 @@
+import types
+import sys
+
+# provide stubs for optional dependencies
+stub_cbi = types.ModuleType("coding_bot_interface")
+stub_cbi.self_coding_managed = lambda *a, **k: (lambda cls: cls)
+stub_cbi.manager_generate_helper = lambda *_a, **_k: None
+sys.modules["coding_bot_interface"] = stub_cbi
+sys.modules["menace.coding_bot_interface"] = stub_cbi
+
+class UnifiedEventBus:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+
+    def publish(self, topic: str, payload: dict) -> None:
+        self.events.append((topic, payload))
+
+    def subscribe(self, topic: str, handler):
+        pass
+
+
+def _setup(monkeypatch, tmp_path):
+    stub = types.ModuleType("vector_metrics_db")
+    monkeypatch.setitem(sys.modules, "menace.vector_metrics_db", stub)
+    sys.modules.setdefault("sandbox_settings", sys.modules["menace.sandbox_settings"])
+    import menace.data_bot as db  # noqa: WPS433
+    monkeypatch.setattr(db, "psutil", None)
+    settings = types.SimpleNamespace(
+        self_coding_roi_drop=-0.1,
+        self_coding_error_increase=1.0,
+        self_coding_test_failure_increase=0.0,
+        bot_thresholds={},
+    )
+    mdb = db.MetricsDB(tmp_path / "m.db")
+    bus = UnifiedEventBus()
+    bot = db.DataBot(mdb, event_bus=bus, settings=settings)
+    return db, bot, bus
+
+
+def test_reload_thresholds_recalibrates(monkeypatch, tmp_path):
+    db, bot, bus = _setup(monkeypatch, tmp_path)
+    tracker = db.BaselineTracker(window=5)
+    for roi, err, fail in zip([1, 0, 1, 0, 1], [0, 3, 0, 3, 0], [0, 1, 0, 1, 0]):
+        tracker.update(roi=roi, errors=err, tests_failed=fail)
+    bot._baseline["bot"] = tracker
+    raw = db.SelfCodingThresholds(
+        roi_drop=-0.1,
+        error_increase=1.0,
+        test_failure_increase=0.0,
+        auto_recalibrate=True,
+    )
+    monkeypatch.setattr(db, "load_sc_thresholds", lambda *a, **k: raw)
+    monkeypatch.setattr(db, "_load_sc_thresholds", lambda *a, **k: raw)
+    calls: list[tuple] = []
+    monkeypatch.setattr(db, "persist_sc_thresholds", lambda *a, **k: calls.append((a, k)))
+    rt = bot.reload_thresholds("bot")
+    assert rt.roi_drop < -0.1
+    assert rt.error_threshold > 1.0
+    assert rt.test_failure_threshold > 0.0
+    assert calls
+    recal = [e for t, e in bus.events if t == "data:thresholds_recalibrated"]
+    assert recal and recal[0]["bot"] == "bot"
+
+
+def test_reload_thresholds_respects_toggle(monkeypatch, tmp_path):
+    db, bot, bus = _setup(monkeypatch, tmp_path)
+    tracker = db.BaselineTracker(window=5)
+    for roi, err, fail in zip([1, 0, 1, 0, 1], [0, 3, 0, 3, 0], [0, 1, 0, 1, 0]):
+        tracker.update(roi=roi, errors=err, tests_failed=fail)
+    bot._baseline["bot"] = tracker
+    raw = db.SelfCodingThresholds(
+        roi_drop=-0.1,
+        error_increase=1.0,
+        test_failure_increase=0.0,
+        auto_recalibrate=False,
+    )
+    monkeypatch.setattr(db, "load_sc_thresholds", lambda *a, **k: raw)
+    monkeypatch.setattr(db, "_load_sc_thresholds", lambda *a, **k: raw)
+    bot.reload_thresholds("bot")
+    recal = [e for t, e in bus.events if t == "data:thresholds_recalibrated"]
+    assert not recal


### PR DESCRIPTION
## Summary
- allow per-bot auto recalibration of thresholds using BaselineTracker stats
- broadcast and persist updated thresholds
- add tests covering recalibration behaviour and toggle

## Testing
- `pytest tests/test_threshold_recalibration.py -q`
- `pytest tests/test_data_bot_thresholds.py -q`
- `pytest tests/test_data_bot_metric_deltas.py -q`
- `pytest tests/test_data_bot_threshold_error_handling.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c69d53a894832eab14ea4ded3ed7ae