### PR TITLE
Use shared orchestrator across bots

### DIFF
--- a/automated_reviewer.py
+++ b/automated_reviewer.py
@@ -21,6 +21,7 @@ from .self_coding_manager import (
     _manager_generate_helper_with_builder as manager_generate_helper,
 )
 from .self_coding_thresholds import get_thresholds
+from .shared_evolution_orchestrator import get_orchestrator
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
     from .auto_escalation_manager import AutoEscalationManager
@@ -58,7 +59,7 @@ data_bot = DataBot(start_server=False)
 _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), MenaceMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
-evolution_orchestrator: EvolutionOrchestrator | None = None
+evolution_orchestrator = get_orchestrator("AutomatedReviewer", data_bot, engine)
 _th = get_thresholds("AutomatedReviewer")
 persist_sc_thresholds(
     "AutomatedReviewer",

--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -57,6 +57,7 @@ from .menace_memory_manager import MenaceMemoryManager
 from .bot_registry import BotRegistry
 from .threshold_service import ThresholdService
 from .self_coding_thresholds import get_thresholds
+from .shared_evolution_orchestrator import get_orchestrator
 
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
@@ -64,7 +65,7 @@ data_bot = DataBot(start_server=False)
 _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), MenaceMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
-evolution_orchestrator: EvolutionOrchestrator | None = None
+evolution_orchestrator = get_orchestrator("BotDevelopmentBot", data_bot, engine)
 _th = get_thresholds("BotDevelopmentBot")
 persist_sc_thresholds(
     "BotDevelopmentBot",

--- a/bot_testing_bot.py
+++ b/bot_testing_bot.py
@@ -33,6 +33,7 @@ from .gpt_memory import GPTMemoryManager
 from .self_coding_thresholds import get_thresholds
 from vector_service.context_builder import ContextBuilder
 from typing import TYPE_CHECKING
+from .shared_evolution_orchestrator import get_orchestrator
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .evolution_orchestrator import EvolutionOrchestrator
@@ -45,7 +46,7 @@ data_bot = DataBot(start_server=False)
 _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
-evolution_orchestrator: EvolutionOrchestrator | None = None
+evolution_orchestrator = get_orchestrator("BotTestingBot", data_bot, engine)
 _th = get_thresholds("BotTestingBot")
 persist_sc_thresholds(
     "BotTestingBot",

--- a/error_bot.py
+++ b/error_bot.py
@@ -99,6 +99,7 @@ from .code_database import CodeDB
 from .gpt_memory import GPTMemoryManager
 from .self_coding_thresholds import get_thresholds
 from vector_service.context_builder import ContextBuilder
+from .shared_evolution_orchestrator import get_orchestrator
 from db_dedup import insert_if_unique, ensure_content_hash_column
 
 registry = BotRegistry()
@@ -111,7 +112,7 @@ pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .evolution_orchestrator import EvolutionOrchestrator
 
-evolution_orchestrator: EvolutionOrchestrator | None = None
+evolution_orchestrator = get_orchestrator("ErrorBot", data_bot, engine)
 _th = get_thresholds("ErrorBot")
 persist_sc_thresholds(
     "ErrorBot",

--- a/research_aggregator_bot.py
+++ b/research_aggregator_bot.py
@@ -15,6 +15,7 @@ from .gpt_memory import GPTMemoryManager
 from .self_coding_thresholds import get_thresholds
 from vector_service.context_builder import ContextBuilder
 from typing import TYPE_CHECKING
+from .shared_evolution_orchestrator import get_orchestrator
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .evolution_orchestrator import EvolutionOrchestrator
@@ -65,7 +66,7 @@ data_bot = DataBot(start_server=False)
 _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
-evolution_orchestrator: EvolutionOrchestrator | None = None
+evolution_orchestrator = get_orchestrator("ResearchAggregatorBot", data_bot, engine)
 _th = get_thresholds("ResearchAggregatorBot")
 persist_sc_thresholds(
     "ResearchAggregatorBot",

--- a/structural_evolution_bot.py
+++ b/structural_evolution_bot.py
@@ -33,6 +33,7 @@ from .gpt_memory import GPTMemoryManager
 from .self_coding_thresholds import get_thresholds
 from vector_service.context_builder import ContextBuilder
 from typing import TYPE_CHECKING
+from .shared_evolution_orchestrator import get_orchestrator
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .evolution_orchestrator import EvolutionOrchestrator
@@ -45,7 +46,7 @@ data_bot = DataBot(start_server=False)
 _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
-evolution_orchestrator: EvolutionOrchestrator | None = None
+evolution_orchestrator = get_orchestrator("StructuralEvolutionBot", data_bot, engine)
 _th = get_thresholds("StructuralEvolutionBot")
 persist_sc_thresholds(
     "StructuralEvolutionBot",

--- a/workflow_evolution_bot.py
+++ b/workflow_evolution_bot.py
@@ -20,6 +20,7 @@ from .gpt_memory import GPTMemoryManager
 from .self_coding_thresholds import get_thresholds
 from vector_service.context_builder import ContextBuilder
 from typing import TYPE_CHECKING
+from .shared_evolution_orchestrator import get_orchestrator
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .evolution_orchestrator import EvolutionOrchestrator
@@ -70,7 +71,7 @@ data_bot = DataBot(start_server=False)
 _context_builder = ContextBuilder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
-evolution_orchestrator: EvolutionOrchestrator | None = None
+evolution_orchestrator = get_orchestrator("WorkflowEvolutionBot", data_bot, engine)
 _th = get_thresholds("WorkflowEvolutionBot")
 persist_sc_thresholds(
     "WorkflowEvolutionBot",


### PR DESCRIPTION
## Summary
- initialize ResearchAggregatorBot, AutomatedReviewer, StructuralEvolutionBot, ErrorBot, WorkflowEvolutionBot, BotTestingBot, and BotDevelopmentBot with a shared evolution orchestrator
- route internalize_coding_bot through this orchestrator for consistent bot registration

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'reset_history'...)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a133b7d4832e903cccf47a24be77