### PR TITLE
Add evolution orchestrator compliance check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,6 +92,12 @@ repos:
         language: system
         pass_filenames: false
         files: '\.py$'
+      - id: check-evolution-orchestrator
+        name: Ensure internalized bots specify evolution orchestrator
+        entry: python tools/check_evolution_orchestrator.py
+        language: system
+        pass_filenames: false
+        files: '\.py$'
       - id: self-coding-audit
         name: Audit for unmanaged bot classes
         entry: python self_coding_audit.py

--- a/tests/test_self_coding_compliance.py
+++ b/tests/test_self_coding_compliance.py
@@ -9,3 +9,11 @@ def test_no_unmanaged_bots():
     script = repo_root / "tools" / "find_unmanaged_bots.py"
     result = subprocess.run([sys.executable, str(script)], capture_output=True, text=True)
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_internalized_bots_use_orchestrator():
+    """Fail if internalize_coding_bot lacks an evolution orchestrator."""
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "tools" / "check_evolution_orchestrator.py"
+    result = subprocess.run([sys.executable, str(script)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tools/check_evolution_orchestrator.py
+++ b/tools/check_evolution_orchestrator.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Ensure internalized bots specify an evolution orchestrator.
+
+This script scans all ``*_bot.py`` files for calls to
+``internalize_coding_bot``.  For every such call the
+``evolution_orchestrator`` keyword argument must be present and may not be
+set to ``None``.  Offending calls are printed and the script exits with a
+non-zero status so the check can be enforced via pre-commit/CI.
+"""
+
+import ast
+from pathlib import Path
+
+
+def _missing_orchestrator(path: Path) -> list[int]:
+    """Return line numbers of offending ``internalize_coding_bot`` calls."""
+
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+
+    offenders: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute):
+            func_name = func.attr
+        elif isinstance(func, ast.Name):
+            func_name = func.id
+        else:  # pragma: no cover - defensive
+            continue
+        if func_name != "internalize_coding_bot":
+            continue
+        has_kw = False
+        for kw in node.keywords:
+            if kw.arg == "evolution_orchestrator":
+                has_kw = True
+                if isinstance(kw.value, ast.Constant) and kw.value.value is None:
+                    offenders.append(node.lineno)
+                break
+        if not has_kw:
+            offenders.append(node.lineno)
+    return offenders
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    failures: list[tuple[Path, int]] = []
+    for path in root.rglob("*_bot.py"):
+        if "tests" in path.parts or "unit_tests" in path.parts:
+            continue
+        for line in _missing_orchestrator(path):
+            failures.append((path.relative_to(root), line))
+    if failures:
+        for p, line in failures:
+            print(f"{p}:{line} missing evolution_orchestrator")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- ensure internalized bots explicitly provide evolution orchestrators
- integrate new evolution orchestrator check into pre-commit
- enforce orchestrator check via unit tests

## Testing
- `pre-commit run check-evolution-orchestrator --files tools/check_evolution_orchestrator.py tests/test_self_coding_compliance.py .pre-commit-config.yaml`
- `pytest tests/test_self_coding_compliance.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6a4df5638832ea68a64f0de493eed