### PR TITLE
Schedule monitoring for internalized bots

### DIFF
--- a/self_coding_manager.py
+++ b/self_coding_manager.py
@@ -2213,6 +2213,12 @@ def internalize_coding_bot(
         data_bot=data_bot,
         is_coding_bot=True,
     )
+    try:
+        data_bot.schedule_monitoring(bot_name)
+    except Exception:  # pragma: no cover - best effort
+        manager.logger.exception(
+            "failed to schedule monitoring for %s", bot_name
+        )
     settings = getattr(data_bot, "settings", None)
     thresholds = getattr(settings, "bot_thresholds", {}) if settings else {}
     if bot_name not in thresholds:

--- a/tests/test_internalize_schedule_monitoring.py
+++ b/tests/test_internalize_schedule_monitoring.py
@@ -1,0 +1,80 @@
+import types
+import sys
+from pathlib import Path
+
+stub_dpr = types.SimpleNamespace(
+    resolve_path=lambda p: Path(p),
+    path_for_prompt=lambda p: p,
+    repo_root=lambda: Path("."),
+    resolve_dir=lambda p: Path(p),
+    get_project_root=lambda: Path("."),
+    resolve_module_path=lambda m: Path(m),
+)
+sys.modules["dynamic_path_router"] = stub_dpr
+sys.modules["menace.dynamic_path_router"] = stub_dpr
+
+stub_cbi = types.ModuleType("coding_bot_interface")
+stub_cbi.self_coding_managed = lambda *a, **k: (lambda cls: cls)
+stub_cbi.manager_generate_helper = lambda *_a, **_k: None
+sys.modules["coding_bot_interface"] = stub_cbi
+sys.modules["menace.coding_bot_interface"] = stub_cbi
+
+stub_engine = types.ModuleType("self_coding_engine")
+class _DummyEngine:  # noqa: WPS431 - simple placeholder
+    pass
+stub_engine.SelfCodingEngine = _DummyEngine
+sys.modules["self_coding_engine"] = stub_engine
+sys.modules["menace.self_coding_engine"] = stub_engine
+
+stub_harness = types.ModuleType("sandbox_runner.test_harness")
+stub_harness.run_tests = lambda *a, **k: None
+class _DummyResult:  # noqa: WPS431 - simple placeholder
+    pass
+stub_harness.TestHarnessResult = _DummyResult
+sandbox_runner_pkg = types.ModuleType("sandbox_runner")
+sandbox_runner_pkg.test_harness = stub_harness
+sys.modules["sandbox_runner"] = sandbox_runner_pkg
+sys.modules["sandbox_runner.test_harness"] = stub_harness
+menace_sandbox_runner_pkg = types.ModuleType("menace.sandbox_runner")
+menace_sandbox_runner_pkg.test_harness = stub_harness
+sys.modules["menace.sandbox_runner"] = menace_sandbox_runner_pkg
+sys.modules["menace.sandbox_runner.test_harness"] = stub_harness
+
+import menace.self_coding_manager as scm
+
+
+def test_schedule_monitoring_invoked_without_event_bus(monkeypatch):
+    calls = []
+
+    class DummyDataBot:
+        def __init__(self):
+            self.settings = types.SimpleNamespace(bot_thresholds={})
+            self.event_bus = None
+
+        def schedule_monitoring(self, bot: str) -> None:
+            calls.append(bot)
+
+    class DummyManager:
+        def __init__(self, *_a, **_k):
+            self.quick_fix = object()
+            self.logger = types.SimpleNamespace(
+                exception=lambda *a, **k: None
+            )
+
+    class DummyRegistry:
+        def register_bot(self, *_a, **_k):
+            return None
+
+    monkeypatch.setattr(scm, "SelfCodingManager", DummyManager)
+    monkeypatch.setattr(scm, "persist_sc_thresholds", lambda *a, **k: None)
+
+    data_bot = DummyDataBot()
+    scm.internalize_coding_bot(
+        "bot",
+        engine=object(),
+        pipeline=object(),
+        data_bot=data_bot,
+        bot_registry=DummyRegistry(),
+    )
+
+    assert calls == ["bot"]


### PR DESCRIPTION
## Summary
- schedule monitoring for internalized coding bots via DataBot
- cover no-event-bus path with schedule_monitoring unit test

## Testing
- `pytest tests/test_internalize_schedule_monitoring.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6a62a30b8832e9c2b20a12753144c