### PR TITLE
feat: auto-recalibrate data bot thresholds

### DIFF
--- a/docs/self_coding_engine.md
+++ b/docs/self_coding_engine.md
@@ -7,6 +7,10 @@ All coding bots interacting with the self‑coding system must be decorated with
 bot with `BotRegistry` and records ROI/error metrics in `DataBot` so new bots
 remain observable and improvable.
 
+`DataBot` also adapts its degradation thresholds over time. A rolling
+`BaselineTracker` recomputes ROI, error-rate and test-failure limits using
+recent statistics so sensitivity matches the bot's current performance.
+
 When a bot is registered the registry now verifies that both a
 `SelfCodingManager` and `DataBot` reference are supplied.  Missing references
 cause registration to fail and a `bot:unmanaged` event to be published, ensuring


### PR DESCRIPTION
## Summary
- add helper to compute adaptive ROI, error, and test-failure thresholds from BaselineTracker statistics
- refresh thresholds on each degradation check so limits track recent performance
- document adaptive thresholding behaviour in self-coding engine docs

## Testing
- `pre-commit run --files data_bot.py docs/self_coding_engine.md` *(fails: ungoverned embedding calls and static path checks across repo)*
- `pytest tests/test_data_bot_threshold_error_handling.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6aa4e0c3c832e8c54c91a7a060b12