### PR TITLE
Add manual prompt detection to ContextBuilder linter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,10 @@ implicit `ContextBuilder` usage is detected. The script also flags disallowed
 defaults for `context_builder` parameters (including sentinel objects), calls to
 helpers like `generate_candidates` that omit a `context_builder` keyword, or
 imports of `get_default_context_builder`, and CI fails when these patterns
-appear.
+appear.  Literal prompt strings passed directly to LLM clients are likewise
+rejected unless produced by `ContextBuilder.build_prompt` or
+`SelfCodingEngine.build_enriched_prompt`, and direct calls to
+`PromptEngine.build_prompt` are disallowed.
 
 ## Coding bot registration
 

--- a/tests/test_context_builder_static.py
+++ b/tests/test_context_builder_static.py
@@ -200,3 +200,56 @@ def test_allows_build_with_required_builder(tmp_path):
     path = tmp_path / "snippet.py"
     path.write_text(code)
     assert check_file(path) == []
+
+
+def test_flags_manual_string_prompt(tmp_path):
+    from scripts.check_context_builder_usage import check_file
+
+    code = (
+        "from vector_service.context_builder import ContextBuilder\n"
+        "def demo(llm):\n"
+        "    builder = ContextBuilder('bots.db', 'code.db', 'errors.db', 'workflows.db')\n"
+        "    llm.generate('hi', context_builder=builder)\n"
+    )
+    path = tmp_path / "snippet.py"
+    path.write_text(code)
+    assert check_file(path) == [
+        (
+            4,
+            "manual string prompt disallowed; use ContextBuilder.build_prompt or SelfCodingEngine.build_enriched_prompt",
+        )
+    ]
+
+
+def test_flags_string_concatenation_prompt(tmp_path):
+    from scripts.check_context_builder_usage import check_file
+
+    code = (
+        "from vector_service.context_builder import ContextBuilder\n"
+        "def demo(llm):\n"
+        "    builder = ContextBuilder('bots.db', 'code.db', 'errors.db', 'workflows.db')\n"
+        "    llm.generate('hi' + ' there', context_builder=builder)\n"
+    )
+    path = tmp_path / "snippet.py"
+    path.write_text(code)
+    assert check_file(path) == [
+        (
+            4,
+            "manual string prompt disallowed; use ContextBuilder.build_prompt or SelfCodingEngine.build_enriched_prompt",
+        )
+    ]
+
+
+def test_flags_prompt_engine_build_prompt(tmp_path):
+    from scripts.check_context_builder_usage import check_file
+
+    code = (
+        "from prompt_engine import PromptEngine\n"
+        "def demo():\n"
+        "    PromptEngine.build_prompt('x')\n"
+    )
+    path = tmp_path / "snippet.py"
+    path.write_text(code)
+    assert check_file(path) == [
+        (3, "PromptEngine.build_prompt disallowed; use ContextBuilder.build_prompt"),
+    ]


### PR DESCRIPTION
## Summary
- detect direct calls to `PromptEngine.build_prompt`
- flag manual string prompts passed to LLMs
- document new linter rules and add regression tests

## Testing
- `python scripts/check_context_builder_usage.py` *(fails: ContextBuilder missing in existing files)*
- `pytest tests/test_context_builder_static.py`

------
https://chatgpt.com/codex/tasks/task_e_68c6c178fc2c832e96b6ed1d0d6c9f96