### PR TITLE
refactor: centralize prompt enrichment

### DIFF
--- a/tests/test_build_enriched_prompt.py
+++ b/tests/test_build_enriched_prompt.py
@@ -139,7 +139,7 @@ def test_enriched_prompt_merges_metadata():
         intent_metadata={"intent": "meta"},
     )
     assert prompt.metadata["intent"] == "meta"
-    assert prompt.metadata["error_trace"] == "trace"
+    assert prompt.metadata["error_log"] == "trace"
     assert "vectors" in prompt.metadata
     assert engine._last_prompt is prompt
 


### PR DESCRIPTION
## Summary
- add build_enriched_prompt that merges metadata, snippets, and optional error logs
- redirect generate_helper to build_enriched_prompt with error logs
- adjust unit tests for new prompt enrichment API

## Testing
- `python -m pytest tests/test_build_enriched_prompt.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6c6900a64832ea55b48bd0e49d22d