### PR TITLE
Use ContextBuilder.build_prompt in fallback

### DIFF
--- a/codex_fallback_handler.py
+++ b/codex_fallback_handler.py
@@ -70,21 +70,12 @@ class _ContextClient:
         self._builder = context_builder
 
     def generate(self, prompt: Prompt) -> LLMResult:
-        context = ""
         try:
-            ctx_res = self._builder.build(prompt.user)
-            context = ctx_res[0] if isinstance(ctx_res, tuple) else ctx_res
-        except Exception:
-            context = ""
-        if context:
-            prompt = Prompt(
-                f"{context}\n\n{prompt.user}",
-                system=prompt.system,
-                examples=prompt.examples,
-                vector_confidence=prompt.vector_confidence,
-                tags=prompt.tags,
-                metadata=prompt.metadata,
+            prompt = self._builder.build_prompt(
+                prompt.user, intent_metadata=prompt.metadata
             )
+        except Exception:
+            pass
         return self._client.generate(prompt, context_builder=self._builder)
 
 

--- a/tests/test_codex_fallback_context_builder.py
+++ b/tests/test_codex_fallback_context_builder.py
@@ -4,8 +4,8 @@ import codex_fallback_handler as cf
 
 
 class DummyBuilder:
-    def build(self, *_):
-        return ""
+    def build_prompt(self, user: str, *, intent_metadata=None):
+        return Prompt(user, metadata=intent_metadata or {})
 
 
 def test_fallback_generation_requires_context_builder(monkeypatch):


### PR DESCRIPTION
## Summary
- build context-aware prompt via ContextBuilder in Codex fallback client
- update tests for new ContextBuilder API usage

## Testing
- `pre-commit run --files codex_fallback_handler.py tests/test_codex_fallback_context_builder.py` *(fails: ModuleNotFoundError: No module named 'dynamic_path_router')*
- `pytest tests/test_codex_fallback_context_builder.py -q` *(fails: KeyboardInterrupt during heavy imports)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d0841894832ea8312c776df53f4e