### PR TITLE
Use context builder for prompt generation

### DIFF
--- a/chatgpt_idea_bot.py
+++ b/chatgpt_idea_bot.py
@@ -7,6 +7,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from typing import List, Dict, Iterable, Any, TYPE_CHECKING
+from vector_service.context_builder import build_prompt as cb_build_prompt
 from pathlib import Path
 from billing.prompt_notice import prepend_payment_notice
 try:  # pragma: no cover - optional billing dependency
@@ -452,9 +453,7 @@ class ChatGPTClient:
             )
         except Exception:
             logger.exception("failed to build prompt from context builder")
-            from prompt_types import Prompt  # type: ignore
-
-            prompt_obj = Prompt(user="", metadata=intent_meta)
+            prompt_obj = cb_build_prompt("", intent_metadata=intent_meta)
 
         parts: List[str] = [prompt_obj.user]
         if getattr(prompt_obj, "examples", None):

--- a/chunking.py
+++ b/chunking.py
@@ -273,7 +273,6 @@ def summarize_snippet(
         pass
 
     if not summary and llm is not None:
-        from prompt_types import Prompt
         context = ""
         try:
             ctx_res = context_builder.build(text)
@@ -299,13 +298,13 @@ def summarize_snippet(
                 )
         except Exception:
             context = ""
-        user_text = text
-        if context:
-            user_text += f"\n\nContext:\n{context}"
-        prompt = Prompt(
-            system="Summarise the following code snippet in one sentence.",
-            user=user_text,
+        intent_meta = {"retrieved_context": context} if context else {}
+        prompt = context_builder.build_prompt(
+            text,
+            intent_metadata=intent_meta,
+            top_k=0,
         )
+        prompt.system = "Summarise the following code snippet in one sentence."
         try:  # pragma: no cover - llm failures
             result = llm.generate(prompt, context_builder=context_builder)
             if getattr(result, "text", "").strip():


### PR DESCRIPTION
## Summary
- replace manual Prompt usage with context_builder.build_prompt and metadata
- funnel generative stub provider, enhancement and summarizer prompts through builder
- record prompt evolution via build_enriched_prompt to avoid raw Prompt creation

## Testing
- `pytest unit_tests/test_context_builder_build_prompt.py unit_tests/test_prompt_engine.py unit_tests/test_self_coding_engine.py -q` *(fails: ImportError: Self-coding engine is required for operation)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d3626d74832e949eb4457947210f