### PR TITLE
feat: enrich prompt building

### DIFF
--- a/tests/test_build_enriched_prompt.py
+++ b/tests/test_build_enriched_prompt.py
@@ -133,12 +133,12 @@ def test_enriched_prompt_merges_metadata():
     engine.context_builder = DummyBuilder()
     engine._last_retry_trace = "trace"
     engine._last_prompt_metadata = {}
+    intent = {"query": "do things", "intent": "meta"}
     prompt = engine.build_enriched_prompt(
-        "do things",
+        intent,
         context_builder=engine.context_builder,
-        intent_metadata={"intent": "meta"},
     )
-    assert prompt.metadata["intent"] == "meta"
+    assert prompt.metadata["intent"]["intent"] == "meta"
     assert prompt.metadata["error_log"] == "trace"
     assert "vectors" in prompt.metadata
     assert engine._last_prompt is prompt


### PR DESCRIPTION
## Summary
- add `SelfCodingEngine.build_enriched_prompt` that fuses failure logs, patch history, vectors and ROI tags into prompts
- use new helper in internal call paths to avoid direct `Prompt` instantiation
- adjust tests for new intent-based API

## Testing
- `pytest tests/test_build_enriched_prompt.py -q`
- `pytest tests/test_context_builder_static.py::test_no_manual_string_prompt -q` *(test not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6dc73002c832e8e1a5ece6f8c6022