### PR TITLE
Use ContextBuilder for snippet summaries

### DIFF
--- a/chunking.py
+++ b/chunking.py
@@ -298,13 +298,16 @@ def summarize_snippet(
                 )
         except Exception:
             context = ""
-        intent_meta = {"retrieved_context": context} if context else {}
+        intent_meta = {
+            "instruction": "Summarise the following code snippet in one sentence.",
+        }
+        if context:
+            intent_meta["retrieved_context"] = context
         prompt = context_builder.build_prompt(
             text,
-            intent_metadata=intent_meta,
+            intent=intent_meta,
             top_k=0,
         )
-        prompt.system = "Summarise the following code snippet in one sentence."
         try:  # pragma: no cover - llm failures
             result = llm.generate(prompt, context_builder=context_builder)
             if getattr(result, "text", "").strip():

--- a/tests/test_chunking_prompt_builder.py
+++ b/tests/test_chunking_prompt_builder.py
@@ -1,0 +1,40 @@
+import types
+import sys
+import chunking as pc
+
+
+def test_summarize_snippet_invokes_build_prompt(monkeypatch):
+    # Ensure micro-model summariser does not short-circuit
+    monkeypatch.setitem(
+        sys.modules,
+        "micro_models.diff_summarizer",
+        types.SimpleNamespace(summarize_diff=lambda a, b: ""),
+    )
+    # Bypass cache interactions
+    monkeypatch.setattr(pc, "_load_snippet_summary", lambda digest: None)
+    monkeypatch.setattr(pc, "_store_snippet_summary", lambda digest, summary: None)
+
+    prompts = {}
+
+    class DummyBuilder:
+        def build(self, text: str) -> str:  # pragma: no cover - simple stub
+            return ""
+
+        def build_prompt(self, text, *, intent=None, intent_metadata=None, top_k=0):
+            prompts["built"] = types.SimpleNamespace(user=text, metadata={})
+            return prompts["built"]
+
+    called = {}
+
+    def fake_generate(prompt, *, context_builder):  # pragma: no cover - simple stub
+        called["prompt"] = prompt
+        return types.SimpleNamespace(text="summary")
+
+    builder = DummyBuilder()
+    llm = types.SimpleNamespace(generate=fake_generate)
+
+    result = pc.summarize_snippet("example", llm, context_builder=builder)
+
+    assert result == "summary"
+    assert "built" in prompts, "context_builder.build_prompt was not invoked"
+    assert called["prompt"] is prompts["built"], "llm.generate did not receive built prompt"


### PR DESCRIPTION
## Summary
- encode snippet summarisation instructions via ContextBuilder intent metadata
- drop manual system prompt and pass prompt object to llm
- add unit test ensuring ContextBuilder.build_prompt is invoked

## Testing
- `pre-commit run --files chunking.py tests/test_chunking_prompt_builder.py` (fails: data_bot.py:DataBot missing @self_coding_managed)
- `pytest tests/test_chunking_prompt_builder.py`


------
https://chatgpt.com/codex/tasks/task_e_68c75f5a487c832e94a79e75a02b950a