### PR TITLE
Refactor code summarizer to use context builder prompt

### DIFF
--- a/code_summarizer.py
+++ b/code_summarizer.py
@@ -127,15 +127,13 @@ def summarize_code(
             except Exception:
                 vec_ctx = ""
             client = OllamaClient()  # type: ignore[call-arg]
-            text = f"Summarize the following code:\n{code}\nSummary:"
-            meta = {"small_task": True}
+            prompt_kwargs = {
+                "intent": {"task": "summarize_code", "small_task": True},
+                "top_k": 0,
+            }
             if vec_ctx:
-                meta["retrieved_context"] = vec_ctx
-            prompt = context_builder.build_prompt(
-                text,
-                intent_metadata=meta,
-                top_k=0,
-            )
+                prompt_kwargs["retrieval_context"] = vec_ctx
+            prompt = context_builder.build_prompt(code, **prompt_kwargs)
             result = client.generate(prompt, context_builder=context_builder)
             summary = getattr(result, "text", "").strip()
             if summary:

--- a/tests/test_code_summarizer.py
+++ b/tests/test_code_summarizer.py
@@ -10,6 +10,9 @@ class DummyBuilder:
         self.calls += 1
         return ""
 
+    def build_prompt(self, text, **kwargs):  # pragma: no cover - simple stub
+        return types.SimpleNamespace(user=text, metadata={}, examples=[])
+
 
 def test_summarize_code_micro_model(monkeypatch):
     """Ensure the micro-model path is used and honours token limits."""


### PR DESCRIPTION
## Summary
- replace manual prompt construction with `context_builder.build_prompt` using summarization intent
- pass retrieved context to `build_prompt` and feed enriched prompt to `OllamaClient`
- update tests to provide `build_prompt`

## Testing
- `pytest tests/test_code_summarizer.py -q`
- `pre-commit run --files code_summarizer.py tests/test_code_summarizer.py` *(fails: embedding watcher AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_68c760bca2a8832eb744e5e0e94138fd