### PR TITLE
Use metadata for refactor prompts

### DIFF
--- a/enhancement_bot.py
+++ b/enhancement_bot.py
@@ -194,15 +194,17 @@ class EnhancementBot:
             except Exception:
                 context = ""
 
-        intent_text = "Summarize the code change."
+        intent_meta: Dict[str, Any] = {
+            "before_hash": self._hash(before),
+            "after_hash": self._hash(after),
+        }
         if hint:
-            intent_text = f"Diff summary hint: {hint}\n\n{intent_text}"
-        intent_meta: Dict[str, Any] = {"before": before, "after": after}
+            intent_meta["refactor_summary"] = hint
         if context:
             intent_meta["retrieved_context"] = context
         prompt = self.context_builder.build_prompt(
-            intent_text,
-            intent_metadata=intent_meta,
+            "Summarize the code change.",
+            intent=intent_meta,
             top_k=0,
         )
         notice = prepend_payment_notice([])[0]["content"]

--- a/tests/test_enhancement_bot.py
+++ b/tests/test_enhancement_bot.py
@@ -34,8 +34,15 @@ sys.modules.setdefault("snippet_compressor", sc_mod)
 vector_service_pkg = types.ModuleType("vector_service")
 context_builder_mod = types.SimpleNamespace(ContextBuilder=object)
 vector_service_pkg.context_builder = context_builder_mod
+embedding_stub = types.SimpleNamespace(
+    EmbeddingBackfill=types.SimpleNamespace(watch_events=lambda *a, **k: None)
+)
+vector_service_pkg.embedding_backfill = embedding_stub
+vector_service_pkg.EmbeddingBackfill = embedding_stub.EmbeddingBackfill
+vector_service_pkg.EmbeddableDBMixin = object
 sys.modules.setdefault("vector_service", vector_service_pkg)
 sys.modules.setdefault("vector_service.context_builder", context_builder_mod)
+sys.modules.setdefault("vector_service.embedding_backfill", embedding_stub)
 
 # Micro model stubs
 diff_stub = types.SimpleNamespace(summarize_diff=lambda *a, **k: "")
@@ -44,11 +51,13 @@ sys.modules.setdefault("menace_sandbox.micro_models", micro_pkg)
 sys.modules.setdefault("menace_sandbox.micro_models.diff_summarizer", diff_stub)
 
 from menace_sandbox.enhancement_bot import EnhancementBot  # noqa: E402
-from llm_interface import LLMClient, LLMResult  # noqa: E402
+from llm_interface import LLMClient, LLMResult, Prompt  # noqa: E402
 
 
 def test_codex_summarize_injects_context():
     calls: dict[str, str | int] = {}
+
+    prompts: dict[str, object] = {}
 
     class DummyBuilder:
         def refresh_db_weights(self):
@@ -58,6 +67,11 @@ def test_codex_summarize_injects_context():
             calls["desc"] = desc
             calls["top_k"] = top_k
             return "CTX"
+
+        def build_prompt(self, query, *, intent=None, intent_metadata=None, top_k=0):
+            meta = intent or intent_metadata or {}
+            prompts["built"] = Prompt(query, metadata={"intent": meta})
+            return prompts["built"]
 
     class DummyLLM(LLMClient):
         def __init__(self) -> None:
@@ -77,7 +91,11 @@ def test_codex_summarize_injects_context():
     assert res == "summary"
     assert calls["desc"] == "diff"
     assert calls["top_k"] == 5
-    assert llm.prompt and "CTX" in llm.prompt.user
+    assert llm.prompt is prompts["built"]
+    meta = prompts["built"].metadata["intent"]
+    assert meta["retrieved_context"] == "CTX"
+    assert meta["refactor_summary"] == "diff"
+    assert "before_hash" in meta and "after_hash" in meta
     assert llm.ctx is builder
 
 
@@ -86,12 +104,19 @@ def test_codex_summarize_compresses_context():
     from snippet_compressor import compress_snippets
     expected = compress_snippets({"snippet": long_ctx})["snippet"]
 
+    prompts: dict[str, Prompt] = {}
+
     class DummyBuilder:
         def refresh_db_weights(self):
             return {}
 
         def build(self, desc: str, *, top_k: int = 5) -> str:  # noqa: D401 - simple stub
             return long_ctx
+
+        def build_prompt(self, query, *, intent=None, intent_metadata=None, top_k=0):
+            meta = intent or intent_metadata or {}
+            prompts["built"] = Prompt(query, metadata={"intent": meta})
+            return prompts["built"]
 
     class DummyLLM(LLMClient):
         def __init__(self) -> None:
@@ -107,9 +132,39 @@ def test_codex_summarize_compresses_context():
     bot = EnhancementBot(context_builder=DummyBuilder(), llm_client=DummyLLM())
     bot._codex_summarize("before", "after", hint="diff", confidence=1.0)
     assert bot.llm_client and bot.llm_client.prompt  # type: ignore[attr-defined]
-    user = bot.llm_client.prompt.user  # type: ignore[union-attr]
-    assert expected in user
-    assert long_ctx not in user
+    meta = prompts["built"].metadata["intent"]
+    assert meta["retrieved_context"] == expected
+    assert meta["retrieved_context"] != long_ctx
+
+
+def test_codex_summarize_builds_prompt():
+    prompts: dict[str, Prompt] = {}
+
+    class DummyBuilder:
+        def refresh_db_weights(self):
+            return {}
+
+        def build(self, *_a, **_k):  # pragma: no cover - simple stub
+            return ""
+
+        def build_prompt(self, query, *, intent=None, intent_metadata=None, top_k=0):
+            prompts["built"] = Prompt(query, metadata={"intent": intent or intent_metadata or {}})
+            return prompts["built"]
+
+    called: dict[str, object] = {}
+
+    class DummyLLM(LLMClient):
+        def __init__(self) -> None:
+            super().__init__(model="dummy", backends=[])
+
+        def generate(self, prompt, *, context_builder=None):  # type: ignore[override]
+            called["prompt"] = prompt
+            return LLMResult(text="ok")
+
+    bot = EnhancementBot(context_builder=DummyBuilder(), llm_client=DummyLLM())
+    bot._codex_summarize("before", "after", hint="diff")
+    assert "built" in prompts, "context_builder.build_prompt was not invoked"
+    assert called["prompt"] is prompts["built"], "llm_client.generate did not receive built prompt"
 
 
 def test_requires_context_builder():


### PR DESCRIPTION
## Summary
- Build intent metadata with before/after hashes and refactor summary
- Generate Prompt via context builder and forward to LLM client
- Test ensures enhancement bot passes built Prompt to LLM

## Testing
- `pre-commit run --files enhancement_bot.py tests/test_enhancement_bot.py` *(fails: data_bot.py unmanaged exported bots)*
- `pytest tests/test_enhancement_bot.py -k codex_summarize_builds_prompt -q` *(fails: AttributeError: '_Stub' object has no attribute 'watch_events')*


------
https://chatgpt.com/codex/tasks/task_e_68c766ca69c0832e8b970653c1956504