### PR TITLE
Use builder to fuse codex fallback prompts

### DIFF
--- a/tests/test_codex_fallback_context_builder.py
+++ b/tests/test_codex_fallback_context_builder.py
@@ -4,8 +4,8 @@ import codex_fallback_handler as cf
 
 
 class DummyBuilder:
-    def build_prompt(self, user: str, *, intent_metadata=None):
-        return Prompt(user, metadata=intent_metadata or {})
+    def build_prompt(self, user: str, *, intent=None, **kwargs):
+        return Prompt(user, metadata=intent or {})
 
 
 def test_fallback_generation_requires_context_builder(monkeypatch):


### PR DESCRIPTION
## Summary
- rely on `ContextBuilder.build_prompt` to enrich Codex fallback requests
- drop manual context stitching in fallback handler
- extend tests to assert vector-enriched prompts are used

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python - <<'PY'
import sys, types, pytest
sys.modules['sentence_transformers'] = types.ModuleType('sentence_transformers')
pytest.main(['tests/test_codex_fallback_context_builder.py', 'unit_tests/test_codex_fallback_handler.py::test_handle_reroutes', 'unit_tests/test_codex_fallback_handler.py::test_reroute_includes_retrieved_context', '-q'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c777fd5f40832e87edfd9ef71172cf