### PR TITLE
Use context builder prompt for summaries

### DIFF
--- a/tests/test_chunk_workflow.py
+++ b/tests/test_chunk_workflow.py
@@ -138,7 +138,7 @@ def test_prompt_from_summaries_under_limit(tmp_path, monkeypatch):
         confidence_threshold=-1.0,
         token_threshold=50,
         chunk_token_threshold=20,
-        context_builder=object(),
+        context_builder=DummyBuilder(),
     )
 
     if pc._count_tokens(code) > engine.token_threshold:

--- a/tests/test_chunking_enriched_prompt.py
+++ b/tests/test_chunking_enriched_prompt.py
@@ -1,8 +1,5 @@
 import types
 import chunking
-import snippet_compressor
-
-
 class StubLLM:
     def __init__(self):
         self.last_prompt = None
@@ -16,32 +13,30 @@ class StubBuilder:
     def __init__(self):
         self.prompt_calls = []
 
-    def build(self, text, include_vectors=False, return_metadata=False):
-        assert include_vectors and return_metadata
-        vectors = [("code", "v1", 0.6)]
-        meta = {"code": [{"desc": "ctx1", "score": 0.6}]}
-        return ("CTX", "SID", vectors, meta)
-
-    def build_prompt(self, text, *, intent=None, top_k=0, **kwargs):
+    def build_prompt(self, text, *, intent=None, top_k=5, **kwargs):
         self.prompt_calls.append((text, intent, top_k))
         from prompt_types import Prompt
-        return Prompt(user=text, metadata={})
+
+        meta = {
+            "vector_confidences": [0.6],
+            "vectors": [("code", "v1", 0.6)],
+            "retrieval_metadata": {"code": [{"desc": "ctx1", "score": 0.6}]},
+        }
+        prompt = Prompt(user=text, metadata=meta)
+        prompt.vector_confidence = 0.6
+        return prompt
 
 
 def test_summarize_snippet_enriched_prompt(tmp_path, monkeypatch):
     monkeypatch.setattr(chunking, "SNIPPET_CACHE_DIR", tmp_path)
-    monkeypatch.setattr(
-        snippet_compressor,
-        "compress_snippets",
-        lambda meta, max_length=200: {"snippet": meta.get("snippet", "")},
-    )
     llm = StubLLM()
     builder = StubBuilder()
     result = chunking.summarize_code("print('x')", llm, context_builder=builder)
     assert result == "summary"
     assert builder.prompt_calls[0][0] == "print('x')"
+    assert builder.prompt_calls[0][2] == 5
     intent = builder.prompt_calls[0][1]
-    assert intent["retrieved_context"] == "CTX"
+    assert intent["instruction"].startswith("Summarise")
     prompt = llm.last_prompt
     assert prompt.vector_confidence == 0.6
     assert prompt.metadata["vector_confidences"] == [0.6]

--- a/tests/test_chunking_summarize_cache.py
+++ b/tests/test_chunking_summarize_cache.py
@@ -16,8 +16,10 @@ class DummyLLM(LLMClient):
 
 
 class DummyBuilder:
-    def build(self, text: str):  # pragma: no cover - simple stub
-        return ""
+    def build_prompt(self, text: str, *, intent=None, top_k=5, **kwargs):  # pragma: no cover - simple stub
+        from prompt_types import Prompt
+
+        return Prompt(user=text, metadata={})
 
 
 def test_summarize_code_uses_cache(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Build code and snippet summaries via `context_builder.build_prompt` to automatically include vector context and metadata
- Gracefully fall back to heuristics when a context builder is unavailable
- Extend summariser tests to exercise enriched-context prompts and missing-builder scenarios

## Testing
- `pytest tests/test_code_summarizer.py tests/test_chunking_enriched_prompt.py tests/test_chunking_summarize_cache.py tests/test_chunk_workflow.py unit_tests/test_chunking.py`

------
https://chatgpt.com/codex/tasks/task_e_68c77d58f3d4832ea5df61097c4c2765