### PR TITLE
Use ContextBuilder for stub generation prompts

### DIFF
--- a/sandbox_runner/tests/test_generative_stub_context_builder.py
+++ b/sandbox_runner/tests/test_generative_stub_context_builder.py
@@ -79,7 +79,10 @@ def test_context_builder_used_for_retries(monkeypatch, tmp_path):
     cfg.retry_max = 0.0
     cfg.cache_path = tmp_path / "cache.json"
 
-    result = gsp.generate_stubs([{"x": 1}], {"context_builder": builder, "target": None}, cfg)
+    result = gsp.generate_stubs(
+        [{"x": 1}], {"target": None}, context_builder=builder, config=cfg
+    )
 
     assert result == [{"a": 1}]
     assert builder.calls == 2
+    assert builder.last_query and "x=1" in builder.last_query


### PR DESCRIPTION
## Summary
- Accept `ContextBuilder` as dependency in generative stub provider
- Build stub generation prompts via `context_builder.build_prompt`
- Update tests to exercise enriched prompt stub generation

## Testing
- `pytest sandbox_runner/tests/test_generative_stub_context_builder.py -q`
- `pre-commit run --files sandbox_runner/generative_stub_provider.py sandbox_runner/tests/test_generative_stub_context_builder.py` *(fails: ModuleNotFoundError: dynamic_path_router, check-context-builder-usage, self-coding-audit, others)*

------
https://chatgpt.com/codex/tasks/task_e_68c784e75190832e89c1965dbb061a83