### PR TITLE
docs: clarify prompt building

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,39 @@ from vector_service.context_builder import ContextBuilder
 builder = ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
 ```
 
+### Prompt building
+
+``ContextBuilder.build_prompt`` converts a free-form goal and optional intent
+metadata into a ``Prompt``. ``SelfCodingEngine.build_enriched_prompt`` then
+fuses intent tags and recent error traces with the retrieved vector context.
+
+```python
+from vector_service.context_builder import ContextBuilder
+from self_coding_engine import SelfCodingEngine
+from menace_memory_manager import MenaceMemoryManager
+from code_database import CodeDB
+
+builder = ContextBuilder("bots.db", "code.db", "errors.db", "workflows.db")
+prompt = builder.build_prompt(
+    "optimise database",
+    intent={"intent_tags": ["perf"], "ticket": 7},
+)
+
+engine = SelfCodingEngine(CodeDB("code.db"), MenaceMemoryManager("mem.db"), context_builder=builder)
+enriched = engine.build_enriched_prompt(
+    "optimise database",
+    intent={"intent_tags": ["perf"]},
+    error_log="timeout stack",
+    context_builder=builder,
+)
+print(enriched.metadata["intent_tags"])
+print(enriched.metadata["vectors"][:1])
+```
+
+Avoid inline ``Prompt(...)`` strings; run
+``python scripts/check_context_builder_usage.py`` to statically flag missing
+``context_builder`` wiring.
+
 ### BotDevelopmentBot
 
 ```python

--- a/docs/context_builder.md
+++ b/docs/context_builder.md
@@ -98,12 +98,12 @@ from vector_service.context_builder import ContextBuilder, build_prompt
 builder = ContextBuilder()
 prompt = builder.build_prompt(
     "optimise database",
-    latent_queries=["speed up queries"],
+    intent={"ticket": 123, "intent_tags": ["perf"]},
     error_log="timeout",
-    intent_metadata={"ticket": 123},
+    latent_queries=["speed up queries"],
 )
-print(prompt.user)
-print(prompt.examples)
+print(prompt.metadata["intent"])
+print(prompt.metadata["vectors"][:1])
 
 # or use the module level helper
 prompt2 = build_prompt("optimise database")
@@ -112,8 +112,17 @@ prompt2 = build_prompt("optimise database")
 Example output::
 
 ```
-Prompt(user='optimise database', examples=['index existing tables', 'cache results'])
+{'ticket': 123, 'intent_tags': ['perf']}
+[('errors:17', 0.8)]
 ```
+
+Intent metadata and retrieved vector identifiers are merged into the returned
+prompt's ``metadata`` so downstream components can reason about both the user's
+intent and the surrounding context.
+
+Avoid constructing prompt strings inline; always call ``build_prompt`` and run
+``python scripts/check_context_builder_usage.py`` to statically flag any missing
+``context_builder`` wiring.
 
 Configuration knobs controlling this method live under ``context_builder`` in the
 main settings file:


### PR DESCRIPTION
## Summary
- document how `ContextBuilder.build_prompt` merges intent metadata with vector context
- show `SelfCodingEngine.build_enriched_prompt` enrichment and deduplication
- add README guidance to avoid inline prompts and run static checker

## Testing
- `pytest -q` *(fails: interrupted, 551 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c78a3f9584832ea53c208b99a71db3