### PR TITLE
Refactor ask_with_memory to use prompt builder

### DIFF
--- a/chatgpt_enhancement_bot.py
+++ b/chatgpt_enhancement_bot.py
@@ -1008,9 +1008,12 @@ def summarise_text(text: str, ratio: float = DEFAULT_SUMMARY_RATIO) -> str:
     return ". ".join(sentences[:count]) + "."
 
 
-def parse_enhancements(data: dict[str, object]) -> List[Enhancement]:
+def parse_enhancements(data: dict[str, object] | str) -> List[Enhancement]:
     """Parse enhancements from ChatGPT JSON response."""
-    text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+    if isinstance(data, str):
+        text = data
+    else:
+        text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
     try:
         items = json.loads(text)
         if not isinstance(items, list):

--- a/conversation_manager_bot.py
+++ b/conversation_manager_bot.py
@@ -144,18 +144,13 @@ class ConversationManagerBot:
     def _chatgpt(self, prompt: str) -> str:
         if prompt in self.cache:
             return self.cache[prompt]
-        data = ask_with_memory(
+        text = ask_with_memory(
             self.client,
             "conversation_manager_bot._chatgpt",
             prompt,
             memory=self.gpt_memory,
             context_builder=self.client.context_builder,
             tags=[FEEDBACK, IMPROVEMENT_PATH, ERROR_FIX, INSIGHT],
-        )
-        text = (
-            data.get("choices", [{}])[0]
-            .get("message", {})
-            .get("content", "")
         )
         self.cache[prompt] = text
         return text

--- a/newsreader_bot.py
+++ b/newsreader_bot.py
@@ -275,7 +275,7 @@ def monetise_event(client: "ChatGPTClient", event: Event) -> str:
     prompt = (
         f"Suggest monetisation strategies for this event: {event.title} - {event.summary}"
     )
-    data = ask_with_memory(
+    return ask_with_memory(
         client,
         "newsreader_bot.monetise_event",
         prompt,
@@ -283,7 +283,6 @@ def monetise_event(client: "ChatGPTClient", event: Event) -> str:
         context_builder=client.context_builder,
         tags=[FEEDBACK, IMPROVEMENT_PATH, ERROR_FIX, INSIGHT],
     )
-    return data.get("choices", [{}])[0].get("message", {}).get("content", "")
 
 
 def send_to_evaluation_bot(event: Event, strategy: str) -> None:

--- a/query_bot.py
+++ b/query_bot.py
@@ -215,16 +215,13 @@ class QueryBot:
         except Exception:
             vec_prompt = "{}"
         prompt = f"Summarize the following data: {json.dumps(data)}\nContext: {vec_prompt}"
-        answer = ask_with_memory(
+        text = ask_with_memory(
             self.client,
             "query_bot.process",
             prompt,
             memory=self.local_knowledge,
             context_builder=self.context_builder,
             tags=[FEEDBACK, IMPROVEMENT_PATH, ERROR_FIX, INSIGHT],
-        )
-        text = (
-            answer.get("choices", [{}])[0].get("message", {}).get("content", "")
         )
         return QueryResult(text=text, data=data)
 

--- a/tests/test_chatgpt_idea_bot.py
+++ b/tests/test_chatgpt_idea_bot.py
@@ -2,6 +2,7 @@ import pytest
 pytest.skip("optional dependencies not installed", allow_module_level=True)
 import json  # noqa: E402
 import types
+from prompt_types import Prompt  # noqa: E402
 import menace_sandbox.chatgpt_idea_bot as cib  # noqa: E402
 
 
@@ -63,8 +64,8 @@ def test_generate_and_filter(monkeypatch):
         def refresh_db_weights(self):
             pass
 
-        def build(self, query, **_):
-            return ""
+        def build_prompt(self, query, **_):
+            return Prompt(user=query)
     builder = DummyBuilder()
     client = cib.ChatGPTClient("key", context_builder=builder)
     monkeypatch.setattr(client, "ask", lambda msgs, **kw: fake_resp)

--- a/tests/test_conversation_manager_bot.py
+++ b/tests/test_conversation_manager_bot.py
@@ -9,12 +9,15 @@ import menace.conversation_manager_bot as cmb  # noqa: E402
 import menace.chatgpt_idea_bot as cib  # noqa: E402
 
 
+from prompt_types import Prompt
+
+
 class DummyBuilder:
     def refresh_db_weights(self):
         pass
 
-    def build(self, query, **_):
-        return ""
+    def build_prompt(self, query, **_):
+        return Prompt(user=query)
 
 
 def test_cache(monkeypatch):

--- a/tests/test_memory_aware_gpt_client.py
+++ b/tests/test_memory_aware_gpt_client.py
@@ -25,7 +25,11 @@ def test_context_injection_and_logging():
 
     client.ask = fake_ask
     knowledge = DummyKnowledge()
-    builder = SimpleNamespace(build=lambda *a, **k: "")
+    from prompt_types import Prompt
+
+    builder = SimpleNamespace(
+        build_prompt=lambda q, **k: Prompt(user=q)
+    )
 
     magc.ask_with_memory(
         client,

--- a/tests/test_newsreader_bot_monetise.py
+++ b/tests/test_newsreader_bot_monetise.py
@@ -3,14 +3,15 @@ import types
 
 # Ensure lightweight stubs for modules expected by chatgpt_idea_bot
 sys.modules.setdefault(
-    "menace.database_manager", types.SimpleNamespace(DB_PATH="db", search_models=lambda *a, **k: [])
+    "menace_sandbox.database_manager",
+    types.SimpleNamespace(DB_PATH="db", search_models=lambda *a, **k: []),
 )
 sys.modules.setdefault(
-    "menace.database_management_bot", types.SimpleNamespace(DatabaseManagementBot=object)
+    "menace_sandbox.database_management_bot", types.SimpleNamespace(DatabaseManagementBot=object)
 )
 
-import menace.chatgpt_idea_bot as cib  # noqa: E402
-import menace.newsreader_bot as nrb  # noqa: E402
+import menace_sandbox.chatgpt_idea_bot as cib  # noqa: E402
+import menace_sandbox.newsreader_bot as nrb  # noqa: E402
 
 
 class FakeMemory:
@@ -24,12 +25,14 @@ class FakeMemory:
 def test_monetise_event_records_interaction(monkeypatch):
     mem = FakeMemory()
 
+    from prompt_types import Prompt
+
     class DummyBuilder:
         def refresh_db_weights(self):
             pass
 
-        def build(self, query, **_):
-            return ""
+        def build_prompt(self, query, **_):
+            return Prompt(user=query)
 
     client = cib.ChatGPTClient(gpt_memory=mem, context_builder=DummyBuilder())
     client.session = None  # force offline mode


### PR DESCRIPTION
## Summary
- replace manual context concatenation in `ask_with_memory` with `ContextBuilder.build_prompt`
- allow optional intent/metadata and convert prompts to ChatGPT messages, returning the model text
- update dependent bots and tests to use new API

## Testing
- `pytest tests/test_memory_aware_gpt_client.py tests/test_memory_continuity.py tests/test_memory_aware_gpt_client_persistence.py tests/test_newsreader_bot_monetise.py tests/test_conversation_manager_bot.py tests/test_chatgpt_idea_bot.py tests/test_query_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68c78cbc615c832e91737c24d447115e