### PR TITLE
feat: build prompts for local generation

### DIFF
--- a/tests/test_action_justifier_llm.py
+++ b/tests/test_action_justifier_llm.py
@@ -2,6 +2,7 @@ import json
 
 import action_justifier as aj
 import local_model_wrapper as lmw
+from prompt_types import Prompt
 
 
 class DummyTokenizer:
@@ -44,9 +45,9 @@ class Builder:
     def __init__(self):
         self.queries = []
 
-    def build(self, query, **_):
+    def build_prompt(self, query, **_):
         self.queries.append(query)
-        return "builder-context"
+        return Prompt(user=query, examples=["builder-context"])
 
 
 def test_llm_justification_includes_vector_context(monkeypatch, tmp_path):

--- a/tests/test_local_model_wrapper.py
+++ b/tests/test_local_model_wrapper.py
@@ -1,22 +1,40 @@
 import pytest
 
 from local_model_wrapper import LocalModelWrapper
+from prompt_types import Prompt
 
 
 class DummyModel:
     def generate(self, input_ids, **_):  # pragma: no cover - simple stub
-        return [input_ids]
+        return [input_ids[0] + [" out"]]
 
 
 class DummyTokenizer:
     def encode(self, text, return_tensors=None):  # pragma: no cover - simple stub
-        return text
+        return [[text]]
 
     def decode(self, tokens, skip_special_tokens=True):  # pragma: no cover - simple stub
-        return tokens
+        return "".join(tokens)
 
 
 def test_wrapper_requires_context_builder():
     wrapper = LocalModelWrapper(DummyModel(), DummyTokenizer())
     with pytest.raises(TypeError):
         wrapper.generate("hi")  # type: ignore[misc]
+
+
+def test_string_prompt_uses_builder():
+    wrapper = LocalModelWrapper(DummyModel(), DummyTokenizer())
+
+    class Builder:
+        def __init__(self) -> None:
+            self.queries: list[str] = []
+
+        def build_prompt(self, query: str, **_):
+            self.queries.append(query)
+            return Prompt(user=query, examples=["ctx"])
+
+    builder = Builder()
+    out = wrapper.generate("hi", context_builder=builder)
+    assert builder.queries == ["hi"]
+    assert out.strip() == "out"


### PR DESCRIPTION
## Summary
- require callers to pass a Prompt to LocalModelWrapper
- build Prompt from strings via ContextBuilder.build_prompt
- tokenize concatenated system/examples/user text instead of manual concatenation

## Testing
- `pytest tests/test_local_model_wrapper.py tests/test_user_style_model.py tests/test_action_justifier_llm.py`


------
https://chatgpt.com/codex/tasks/task_e_68c79bc54144832e95bd3f705bbc887b