### PR TITLE
Use ContextBuilder for ping in external service check

### DIFF
--- a/neurosales/tests/test_external_integrations.py
+++ b/neurosales/tests/test_external_integrations.py
@@ -220,7 +220,11 @@ def test_check_external_services_injects_notice(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "context_builder_util",
-        SimpleNamespace(create_context_builder=lambda: SimpleNamespace(build=lambda _: "CTX")),
+        SimpleNamespace(
+            create_context_builder=lambda: SimpleNamespace(
+                build_prompt=lambda *_args, **_kwargs: Prompt(user="CTX")
+            )
+        ),
     )
     from neurosales.scripts import check_external_services as ces
     monkeypatch.setattr(ces.config, "is_openai_enabled", lambda cfg: True)


### PR DESCRIPTION
## Summary
- Build OpenAI connectivity ping via ContextBuilder.build_prompt and use its messages for chat_completion_create
- Log and fail when ContextBuilder cannot initialize or build prompt

## Testing
- `pytest 'neurosales/tests/test_external_integrations.py::test_check_external_services_injects_notice' -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7acae72fc832eb97793d79c9f110a