### PR TITLE
refactor memory aware prompt builder usage

### DIFF
--- a/chatgpt_enhancement_bot.py
+++ b/chatgpt_enhancement_bot.py
@@ -31,10 +31,7 @@ try:  # pragma: no cover - allow flat imports
 except Exception:  # pragma: no cover - fallback for flat layout
     from memory_aware_gpt_client import ask_with_memory  # type: ignore
 from . import RAISE_ERRORS
-from vector_service.context_builder import (
-    ContextBuilder,
-    build_prompt as cb_build_prompt,
-)
+from vector_service.context_builder import ContextBuilder
 try:  # canonical tag constants
     from .log_tags import IMPROVEMENT_PATH, INSIGHT
 except Exception:  # pragma: no cover - fallback for flat layout
@@ -1084,22 +1081,8 @@ class ChatGPTEnhancementBot:
             "instruction": instruction,
             "num_ideas": num_ideas,
         }
-        latent: List[str] | None = None
         if context:
             intent_meta["context"] = context
-            latent = [context]
-        try:
-            prompt_obj = self.context_builder.build_prompt(
-                instruction,
-                intent=intent_meta,
-                latent_queries=latent,
-            )
-        except Exception:
-            logger.exception("failed to build prompt from context builder")
-            prompt_obj = cb_build_prompt(
-                instruction, intent_metadata=intent_meta, latent_queries=latent
-            )
-        logger.debug("sending prompt to ChatGPT: %s", prompt_obj.user)
         try:
             base_tags = [IMPROVEMENT_PATH, INSIGHT]
             if tags:
@@ -1107,7 +1090,7 @@ class ChatGPTEnhancementBot:
             data = ask_with_memory(
                 self.client,
                 "chatgpt_enhancement_bot.propose",
-                prompt_obj,
+                instruction,
                 memory=self.gpt_memory,
                 context_builder=self.context_builder,
                 tags=base_tags,

--- a/query_bot.py
+++ b/query_bot.py
@@ -200,17 +200,14 @@ class QueryBot:
         ents = [t[1] for t in parsed.get("entities", [])]
         data = self.fetcher.fetch(ents)
         self.store.add(context_id, query)
-        prompt = self.context_builder.build_prompt(
-            "Summarize the following data", intent={"data": data}
-        )
         text = ask_with_memory(
             self.client,
             "query_bot.process",
-            prompt.user,
+            "Summarize the following data",
             memory=self.local_knowledge,
             context_builder=self.context_builder,
             tags=[FEEDBACK, IMPROVEMENT_PATH, ERROR_FIX, INSIGHT],
-            intent=prompt.metadata,
+            intent={"data": data},
         )
         return QueryResult(text=text, data=data)
 


### PR DESCRIPTION
## Summary
- use ContextBuilder.build_prompt in ask_with_memory and record session, tags, and context in metadata
- simplify query_bot and chatgpt_enhancement_bot to pass raw queries and let ask_with_memory enrich them

## Testing
- `pytest tests/test_memory_aware_gpt_client.py tests/test_memory_aware_gpt_client_persistence.py tests/test_memory_continuity.py`
- `pytest tests/test_memory_aware_gpt_client.py tests/test_memory_aware_gpt_client_persistence.py tests/test_chatgpt_enhancement_bot.py tests/test_enhancement_bot.py tests/test_memory_continuity.py` *(fails: ImportError: cannot import name 'self_coding_managed')*
- `flake8 memory_aware_gpt_client.py query_bot.py chatgpt_enhancement_bot.py` *(fails: E402 module level import not at top of file)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c29864ec832e9dc03694742d8464