### PR TITLE
Warn on concatenated builder output and literal messages in LLM calls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,15 @@ rejected unless produced by `ContextBuilder.build_prompt` or
 outside `vector_service/context_builder.py`, and direct calls to
 `PromptEngine.build_prompt` are disallowed.
 
+Results of `ContextBuilder.build(...)` must be sent straight to the LLM client.
+Combining them with additional strings, f-strings or lists before invoking the
+client is flagged; pass the raw builder output to
+`build_prompt`/`build_enriched_prompt` instead.  Calls to
+`chat_completion_create` or `client.ask` that assemble `messages` from literal
+lists or dictionaries are also rejected – construct a `Prompt` object with the
+builder and supply it directly.  Tests that intentionally exercise these
+behaviours may silence the check with a trailing `# nocb` comment.
+
 When `pre-commit run check-context-builder-usage --all-files` reports
 "Prompt instantiation disallowed", replace the `Prompt(...)` constructor with
 `context_builder.build_prompt(...)` or

--- a/tests/test_context_builder_static.py
+++ b/tests/test_context_builder_static.py
@@ -65,7 +65,9 @@ def test_flags_chat_completion_wrapper(tmp_path):
     assert check_file(path) == [
         (
             3,
-            "direct message list/dict disallowed; use ContextBuilder.build_prompt or SelfCodingEngine.build_enriched_prompt",
+            "direct message list/dict disallowed; use "
+            "ContextBuilder.build_prompt or "
+            "SelfCodingEngine.build_enriched_prompt",
         )
     ]
 
@@ -98,7 +100,9 @@ def test_allows_context_builder_call(tmp_path):
     code = (
         "from vector_service.context_builder import ContextBuilder\n"
         "def demo():\n"
-        "    ContextBuilder(bots_db='bots.db', code_db='code.db', errors_db='errors.db', workflows_db='workflows.db')\n"
+        "    ContextBuilder("
+        "bots_db='bots.db', code_db='code.db', "
+        "errors_db='errors.db', workflows_db='workflows.db')\n"
     )
     path = tmp_path / "snippet.py"
     path.write_text(code)
@@ -182,7 +186,8 @@ def test_flags_build_with_fallback_builder(tmp_path):
     code = (
         "from vector_service.context_builder import ContextBuilder\n"
         "def demo(builder):\n"
-        "    builder = builder or ContextBuilder('bots.db', 'code.db', 'errors.db', 'workflows.db')\n"
+        "    builder = builder or ContextBuilder("
+        "'bots.db', 'code.db', 'errors.db', 'workflows.db')\n"
         "    builder.build()\n"
     )
     path = tmp_path / "snippet.py"
@@ -219,7 +224,9 @@ def test_flags_manual_string_prompt(tmp_path):
     assert check_file(path) == [
         (
             4,
-            "manual string prompt disallowed; use context_builder.build_prompt or SelfCodingEngine.build_enriched_prompt",
+            "manual string prompt disallowed; use "
+            "context_builder.build_prompt or "
+            "SelfCodingEngine.build_enriched_prompt",
         )
     ]
 
@@ -238,7 +245,9 @@ def test_flags_string_concatenation_prompt(tmp_path):
     assert check_file(path) == [
         (
             4,
-            "manual string prompt disallowed; use context_builder.build_prompt or SelfCodingEngine.build_enriched_prompt",
+            "manual string prompt disallowed; use "
+            "context_builder.build_prompt or "
+            "SelfCodingEngine.build_enriched_prompt",
         )
     ]
 
@@ -298,3 +307,49 @@ def test_flags_ask_with_memory(tmp_path):
     assert check_file(path) == [
         (2, "ask_with_memory disallowed; use ContextBuilder.build_prompt")
     ]
+
+
+def test_flags_builder_build_concat_via_var(tmp_path):
+    from scripts.check_context_builder_usage import check_file
+
+    code = (
+        "def demo(llm, context_builder):\n"
+        "    prompt = context_builder.build('x') + 'y'\n"
+        "    llm.generate(prompt, context_builder=context_builder)\n"
+    )
+    path = tmp_path / "snippet.py"
+    path.write_text(code)
+    assert check_file(path) == [
+        (3, "context_builder.build result concatenation disallowed; pass directly")
+    ]
+
+
+def test_flags_client_ask_literal_messages(tmp_path):
+    from scripts.check_context_builder_usage import check_file
+
+    code = (
+        "def demo(client):\n"
+        "    client.ask([{'role': 'user', 'content': 'hi'}])\n"
+    )
+    path = tmp_path / "snippet.py"
+    path.write_text(code)
+    assert check_file(path) == [
+        (
+            2,
+            "direct message list/dict disallowed; use "
+            "ContextBuilder.build_prompt or "
+            "SelfCodingEngine.build_enriched_prompt",
+        )
+    ]
+
+
+def test_client_ask_literal_messages_nocb(tmp_path):
+    from scripts.check_context_builder_usage import check_file
+
+    code = (
+        "def demo(client):\n"
+        "    client.ask([{'role': 'user', 'content': 'hi'}])  # nocb\n"
+    )
+    path = tmp_path / "snippet.py"
+    path.write_text(code)
+    assert check_file(path) == []


### PR DESCRIPTION
## Summary
- extend context builder linter to track `ContextBuilder.build(...)` results stored in variables and flag their concatenation before LLM calls
- detect literal message lists passed to `chat_completion_create` or `client.ask`
- document how to handle the new checks and silence them in tests

## Testing
- `pytest tests/test_context_builder_static.py`
- `pre-commit run --files scripts/check_context_builder_usage.py tests/test_context_builder_static.py CONTRIBUTING.md` *(fails: self-coding-audit missing watch_events)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c80eda54832e8c4a3f699a383b72