### PR TITLE
Enforce explicit context builder in build_prompt

### DIFF
--- a/docs/context_builder.md
+++ b/docs/context_builder.md
@@ -106,7 +106,7 @@ print(prompt.metadata["intent"])
 print(prompt.metadata["vectors"][:1])
 
 # or use the module level helper
-prompt2 = build_prompt("optimise database")
+prompt2 = build_prompt("optimise database", context_builder=builder)
 ```
 
 Example output::

--- a/docs/vectorized_cognition.md
+++ b/docs/vectorized_cognition.md
@@ -44,10 +44,12 @@ prioritises the most relevant examples before packing them into a
 token-limited :class:`Prompt`:
 
 ```python
-from vector_service.context_builder import build_prompt
+from vector_service.context_builder import ContextBuilder, build_prompt
 
+builder = ContextBuilder()
 prompt = build_prompt(
     "optimise cache eviction",
+    context_builder=builder,
     intent={"tags": ["performance", "cache"]},
 )
 

--- a/vector_service/context_builder.py
+++ b/vector_service/context_builder.py
@@ -1632,7 +1632,10 @@ def build_prompt(
     if intent is None and intent_metadata is not None:
         intent = intent_metadata
 
-    builder = context_builder or ContextBuilder()
+    if context_builder is None:
+        raise ValueError("context_builder is required")
+
+    builder = context_builder
 
     queries: List[str] = [goal]
     if latent_queries:


### PR DESCRIPTION
## Summary
- require callers to provide a `ContextBuilder` to `build_prompt`
- document new usage in context builder guides

## Testing
- `pytest tests/test_context_builder_build_prompt.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7d5ddeb28832ea9956389f4a4d793