### PR TITLE
Validate context markers in LLM prompts

### DIFF
--- a/llm_interface.py
+++ b/llm_interface.py
@@ -221,6 +221,12 @@ class LLMClient:
         called directly.
         """
 
+        meta = getattr(prompt, "metadata", {})
+        if not any(k in meta for k in ("vector_confidences", "intent_tags")):
+            raise ValueError(
+                "prompt.metadata missing context-builder markers"
+            )
+
         # If explicit backends are configured act as a router
         if self.backends:
             order = list(self.backends)
@@ -268,6 +274,11 @@ class LLMClient:
         self, prompt: Prompt, *, context_builder: ContextBuilder
     ) -> AsyncGenerator[str, None]:
         """Asynchronously yield completion chunks for *prompt* and log the result."""
+        meta = getattr(prompt, "metadata", {})
+        if not any(k in meta for k in ("vector_confidences", "intent_tags")):
+            raise ValueError(
+                "prompt.metadata missing context-builder markers"
+            )
 
         cfg = llm_config.get_config()
 

--- a/tests/test_context_markers.py
+++ b/tests/test_context_markers.py
@@ -1,0 +1,21 @@
+import pytest
+
+from llm_interface import LLMClient, LLMResult, Prompt
+
+
+class DummyClient(LLMClient):
+    def __init__(self):
+        super().__init__("dummy", log_prompts=False)
+
+    def _generate(self, prompt, *, context_builder):  # type: ignore[override]
+        return LLMResult(text="ok")
+
+
+def test_generate_requires_context_builder_markers():
+    client = DummyClient()
+    with pytest.raises(ValueError):
+        client.generate(Prompt(text="hi"), context_builder=object())
+
+    prompt = Prompt(text="hi", metadata={"vector_confidences": [1.0]})
+    res = client.generate(prompt, context_builder=object())
+    assert res.text == "ok"


### PR DESCRIPTION
## Summary
- ensure `LLMClient.generate` and `async_generate` reject prompts lacking context-builder metadata
- add regression test for required metadata markers

## Testing
- `pytest -q tests/test_context_markers.py -q`
- ⚠️ `pre-commit run --files llm_interface.py tests/test_context_markers.py` *(missing dynamic_path_router and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c7da62dc14832eafd52721424698f9