### PR TITLE
Require explicit ContextBuilder

### DIFF
--- a/bot_registry.py
+++ b/bot_registry.py
@@ -270,6 +270,7 @@ class BotRegistry:
                                         Path(module),
                                         desc,
                                         context_meta=event,
+                                        context_builder=_mgr.refresh_quick_fix_context(),
                                         provenance_token=token,
                                     )
                                     commit = commit or new_commit

--- a/tests/integration/test_custom_commands.py
+++ b/tests/integration/test_custom_commands.py
@@ -441,7 +441,7 @@ def test_run_patch_custom_clone_command(monkeypatch, tmp_path):
 
     monkeypatch.setattr(scm, "ensure_fresh_weights", lambda builder: None)
 
-    def _fake_qf():
+    def _fake_qf(_builder=None):
         mgr.quick_fix = types.SimpleNamespace()
         return mgr.quick_fix
 

--- a/tests/integration/test_internalize_metrics_breach_patch_cycle.py
+++ b/tests/integration/test_internalize_metrics_breach_patch_cycle.py
@@ -110,6 +110,7 @@ class SelfCodingManager:
         description: str,
         *,
         context_meta: dict | None = None,
+        context_builder=None,
         provenance_token: str | None = None,
         **kwargs,
     ) -> tuple[None, str]:
@@ -169,7 +170,11 @@ class EvolutionOrchestrator:
         if self.selfcoding_manager:
             self.selfcoding_manager.register_patch_cycle(desc, context_meta=event)
             self.selfcoding_manager.generate_and_patch(
-                self.module_path, desc, context_meta=event, provenance_token="prov"
+                self.module_path,
+                desc,
+                context_meta=event,
+                context_builder=object(),
+                provenance_token="prov",
             )
 
 

--- a/tests/integration/test_internalized_degradation_patch_flow.py
+++ b/tests/integration/test_internalized_degradation_patch_flow.py
@@ -210,7 +210,11 @@ class EvolutionOrchestrator:
         desc = f"auto_patch_due_to_degradation:{event.get('bot', '')}"
         if self.selfcoding_manager:
             self.selfcoding_manager.generate_and_patch(
-                self.module_path, desc, context_meta=event, provenance_token="prov"
+                self.module_path,
+                desc,
+                context_meta=event,
+                context_builder=object(),
+                provenance_token="prov",
             )
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_quick_fix_engine_chunked_patch.py
+++ b/tests/integration/test_quick_fix_engine_chunked_patch.py
@@ -135,11 +135,11 @@ def test_patch_fails_without_validation(monkeypatch):
         def __init__(self):
             self.quick_fix = None
 
-        def _ensure_quick_fix_engine(self):
+        def _ensure_quick_fix_engine(self, _builder=None):
             return None
 
         def run_patch(self, path, desc, **kw):
-            self._ensure_quick_fix_engine()
+            self._ensure_quick_fix_engine(object())
             if self.quick_fix is None:
                 raise RuntimeError("QuickFixEngine validation unavailable")
 


### PR DESCRIPTION
## Summary
- require callers to supply a ContextBuilder when generating or applying patches
- update bot registry and tests for explicit builder usage
- add regression tests for missing ContextBuilder

## Testing
- `pytest tests/test_self_coding_manager.py::test_generate_patch_requires_builder tests/test_self_coding_manager.py::test_generate_and_patch_requires_builder -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7ec1145ac832ea4eafa29ca3f9421