### PR TITLE
refactor: use context builder factory

### DIFF
--- a/automated_reviewer.py
+++ b/automated_reviewer.py
@@ -22,6 +22,7 @@ from .self_coding_manager import (
 )
 from .self_coding_thresholds import get_thresholds
 from .shared_evolution_orchestrator import get_orchestrator
+from context_builder_util import create_context_builder, ensure_fresh_weights
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
     from .auto_escalation_manager import AutoEscalationManager
@@ -50,13 +51,12 @@ except Exception:  # pragma: no cover - module missing the attribute
         pass
 
 from snippet_compressor import compress_snippets
-from context_builder_util import ensure_fresh_weights
 
 
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-_context_builder = ContextBuilder()
+_context_builder = create_context_builder()
 engine = SelfCodingEngine(CodeDB(), MenaceMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 evolution_orchestrator = get_orchestrator("AutomatedReviewer", data_bot, engine)

--- a/bot_creation_bot.py
+++ b/bot_creation_bot.py
@@ -40,6 +40,7 @@ from .admin_bot_base import AdminBotBase
 from .self_coding_manager import SelfCodingManager, internalize_coding_bot
 from .self_coding_thresholds import get_thresholds
 from .shared_evolution_orchestrator import get_orchestrator
+from context_builder_util import create_context_builder
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .evolution_orchestrator import EvolutionOrchestrator
@@ -67,7 +68,7 @@ from .coding_bot_interface import self_coding_managed
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-_context_builder = ContextBuilder()
+_context_builder = create_context_builder()
 engine = SelfCodingEngine(CodeDB(), MenaceMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 evolution_orchestrator = get_orchestrator("BotCreationBot", data_bot, engine)

--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -18,7 +18,7 @@ import shutil
 import sys
 import uuid
 from dynamic_path_router import resolve_path
-from context_builder_util import ensure_fresh_weights
+from context_builder_util import ensure_fresh_weights, create_context_builder
 from secret_redactor import redact_secrets
 
 try:
@@ -62,7 +62,7 @@ from .shared_evolution_orchestrator import get_orchestrator
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-_context_builder = ContextBuilder()
+_context_builder = create_context_builder()
 engine = SelfCodingEngine(CodeDB(), MenaceMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 evolution_orchestrator = get_orchestrator("BotDevelopmentBot", data_bot, engine)

--- a/bot_planning_bot.py
+++ b/bot_planning_bot.py
@@ -25,6 +25,7 @@ from vector_service.context_builder import ContextBuilder
 from dataclasses import dataclass, field
 from typing import Iterable, List, Dict, Optional
 from .shared_evolution_orchestrator import get_orchestrator
+from context_builder_util import create_context_builder
 
 import networkx as nx
 try:
@@ -41,7 +42,7 @@ import pulp
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-_context_builder = ContextBuilder()
+_context_builder = create_context_builder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 evolution_orchestrator = get_orchestrator("BotPlanningBot", data_bot, engine)

--- a/bot_testing_bot.py
+++ b/bot_testing_bot.py
@@ -34,6 +34,7 @@ from .self_coding_thresholds import get_thresholds
 from vector_service.context_builder import ContextBuilder
 from typing import TYPE_CHECKING
 from .shared_evolution_orchestrator import get_orchestrator
+from context_builder_util import create_context_builder
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .evolution_orchestrator import EvolutionOrchestrator
@@ -43,7 +44,7 @@ logger = logging.getLogger("BotTester")
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-_context_builder = ContextBuilder()
+_context_builder = create_context_builder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 evolution_orchestrator = get_orchestrator("BotTestingBot", data_bot, engine)

--- a/enhancement_bot.py
+++ b/enhancement_bot.py
@@ -14,6 +14,7 @@ from vector_service.context_builder import ContextBuilder
 from .coding_bot_interface import self_coding_managed
 from typing import TYPE_CHECKING, Dict, Any
 from .shared_evolution_orchestrator import get_orchestrator
+from context_builder_util import create_context_builder
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .evolution_orchestrator import EvolutionOrchestrator
@@ -21,7 +22,7 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-_context_builder = ContextBuilder()
+_context_builder = create_context_builder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 evolution_orchestrator = get_orchestrator("EnhancementBot", data_bot, engine)

--- a/error_bot.py
+++ b/error_bot.py
@@ -101,11 +101,12 @@ from .self_coding_thresholds import get_thresholds
 from vector_service.context_builder import ContextBuilder
 from .shared_evolution_orchestrator import get_orchestrator
 from db_dedup import insert_if_unique, ensure_content_hash_column
+from context_builder_util import create_context_builder
 
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-_context_builder = ContextBuilder()
+_context_builder = create_context_builder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 

--- a/implementation_optimiser_bot.py
+++ b/implementation_optimiser_bot.py
@@ -22,13 +22,14 @@ from .data_bot import DataBot, persist_sc_thresholds
 from .coding_bot_interface import self_coding_managed
 from .task_handoff_bot import TaskPackage, TaskInfo
 from .shared_evolution_orchestrator import get_orchestrator
+from context_builder_util import create_context_builder
 
 logger = logging.getLogger(__name__)
 
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-_context_builder = ContextBuilder()
+_context_builder = create_context_builder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 evolution_orchestrator = get_orchestrator(

--- a/research_aggregator_bot.py
+++ b/research_aggregator_bot.py
@@ -16,6 +16,7 @@ from .self_coding_thresholds import get_thresholds
 from vector_service.context_builder import ContextBuilder
 from typing import TYPE_CHECKING
 from .shared_evolution_orchestrator import get_orchestrator
+from context_builder_util import create_context_builder
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .evolution_orchestrator import EvolutionOrchestrator
@@ -63,7 +64,7 @@ logger = logging.getLogger(__name__)
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-_context_builder = ContextBuilder()
+_context_builder = create_context_builder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 evolution_orchestrator = get_orchestrator("ResearchAggregatorBot", data_bot, engine)

--- a/structural_evolution_bot.py
+++ b/structural_evolution_bot.py
@@ -34,6 +34,7 @@ from .self_coding_thresholds import get_thresholds
 from vector_service.context_builder import ContextBuilder
 from typing import TYPE_CHECKING
 from .shared_evolution_orchestrator import get_orchestrator
+from context_builder_util import create_context_builder
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .evolution_orchestrator import EvolutionOrchestrator
@@ -43,7 +44,7 @@ logger = logging.getLogger(__name__)
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-_context_builder = ContextBuilder()
+_context_builder = create_context_builder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 evolution_orchestrator = get_orchestrator("StructuralEvolutionBot", data_bot, engine)

--- a/workflow_evolution_bot.py
+++ b/workflow_evolution_bot.py
@@ -21,6 +21,7 @@ from .self_coding_thresholds import get_thresholds
 from vector_service.context_builder import ContextBuilder
 from typing import TYPE_CHECKING
 from .shared_evolution_orchestrator import get_orchestrator
+from context_builder_util import create_context_builder
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .evolution_orchestrator import EvolutionOrchestrator
@@ -68,7 +69,7 @@ logger = logging.getLogger(__name__)
 registry = BotRegistry()
 data_bot = DataBot(start_server=False)
 
-_context_builder = ContextBuilder()
+_context_builder = create_context_builder()
 engine = SelfCodingEngine(CodeDB(), GPTMemoryManager(), context_builder=_context_builder)
 pipeline = ModelAutomationPipeline(context_builder=_context_builder)
 evolution_orchestrator = get_orchestrator("WorkflowEvolutionBot", data_bot, engine)


### PR DESCRIPTION
## Summary
- use `create_context_builder()` instead of direct `ContextBuilder()` in major bots
- allow dependency injection for context builders

## Testing
- `pre-commit run --files automated_reviewer.py research_aggregator_bot.py structural_evolution_bot.py workflow_evolution_bot.py bot_planning_bot.py bot_creation_bot.py enhancement_bot.py error_bot.py implementation_optimiser_bot.py bot_development_bot.py bot_testing_bot.py` (failed: ModuleNotFoundError: No module named 'dynamic_path_router')
- `pytest tests/test_context_builder_static.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7f03c8e5c832e9b72684942505d25