### PR TITLE
refactor: expose context builder arg

### DIFF
--- a/neurosales/neurosales/cortex_responder.py
+++ b/neurosales/neurosales/cortex_responder.py
@@ -83,7 +83,13 @@ class CortexAwareResponder:
     ) -> str:
         # GPT-4 first pass
         first_pass = "".join(
-            self.client.stream_chat(user_id, [], profile.archetype, text)
+            self.client.stream_chat(
+                user_id,
+                [],
+                profile.archetype,
+                text,
+                context_builder=self.client.context_builder,
+            )
         )
 
         history_texts = [m.content for m in memory.get_recent_messages()]

--- a/neurosales/neurosales/external_integrations.py
+++ b/neurosales/neurosales/external_integrations.py
@@ -120,12 +120,15 @@ class GPT4Client:
         emotion_tensor: List[float],
         objective: str,
         text: str,
+        *,
+        context_builder: "ContextBuilder" | None = None,
     ) -> Iterator[str]:
         if not self.enabled:
             logger.warning("GPT4Client disabled: backend unavailable")
             yield ""
             return
-        prompt = self.context_builder.build_prompt(
+        context_builder = context_builder or self.context_builder
+        prompt = context_builder.build_prompt(
             text,
             intent={
                 "archetype": archetype,

--- a/neurosales/neurosales/trend_monitor.py
+++ b/neurosales/neurosales/trend_monitor.py
@@ -23,7 +23,12 @@ class MediumFetcher:
     def __init__(self, session: requests.Session | None = None) -> None:
         self.session = session or requests.Session()
 
-    def fetch_posts(self, user: str, keywords: Iterable[str], limit: int = 5) -> List[Dict[str, str]]:
+    def fetch_posts(
+        self,
+        user: str,
+        keywords: Iterable[str],
+        limit: int = 5,
+    ) -> List[Dict[str, str]]:
         url = f"https://medium.com/feed/@{user}"
         resp = self.session.get(url, timeout=10)
         posts: List[Dict[str, str]] = []
@@ -121,7 +126,15 @@ class TrendMonitor:
     # ------------------------------------------------------------------
     def generate_content(self, trend: Dict[str, Any]) -> Dict[str, Any]:
         text = trend["text"]
-        summary = "".join(self.gpt4.stream_chat("monitor", [0.0], "summary", text))
+        summary = "".join(
+            self.gpt4.stream_chat(
+                "monitor",
+                [0.0],
+                "summary",
+                text,
+                context_builder=self.gpt4.context_builder,
+            )
+        )
         trend["summary"] = summary
         self.vector.log("trend", [0.0] * 1536, summary)
         return trend


### PR DESCRIPTION
## Summary
- allow enhancement summarizer to receive explicit context builder
- add optional context builder parameter for GPT4Client.stream_chat and pass through callers

## Testing
- `pre-commit run flake8 --files enhancement_bot.py neurosales/neurosales/external_integrations.py neurosales/neurosales/trend_monitor.py neurosales/neurosales/cortex_responder.py`
- `python scripts/check_context_builder_usage.py` *(fails: build_prompt disallowed or missing context_builder)*

------
https://chatgpt.com/codex/tasks/task_e_68c80836b8b0832e95f62de88b1364a1