### PR TITLE
Use context builder prompts in prediction evaluation

### DIFF
--- a/tests/test_chatgpt_prediction_bot_memory.py
+++ b/tests/test_chatgpt_prediction_bot_memory.py
@@ -16,12 +16,15 @@ vector_service_pkg.SharedVectorService = object
 vector_service_pkg.CognitionLayer = object
 
 
+from prompt_types import Prompt
+
+
 class _StubContextBuilder:
     def refresh_db_weights(self):
         pass
 
-    def build(self, *args, **kwargs):
-        return "dbctx"
+    def build_prompt(self, prompt: str, **_: object) -> Prompt:
+        return Prompt(user=prompt, examples=["dbctx"])
 
 
 ctx_mod = types.ModuleType("vector_service.context_builder")


### PR DESCRIPTION
## Summary
- replace `ask_with_memory` in `ChatGPTPredictionBot.evaluate_enhancement` with direct `context_builder.build_prompt` call
- send the built prompt to `client.ask` and log responses to memory
- adjust prediction bot memory test to stub `build_prompt`

## Testing
- `pytest tests/test_chatgpt_prediction_bot_memory.py::test_enhancement_uses_memory -q` *(fails: missing dependencies / heavy imports)*

------
https://chatgpt.com/codex/tasks/task_e_68c8131ea5d4832e8fabe78461564b53