### PR TITLE
Run context builder usage script in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,8 @@ jobs:
         run: "python tools/check_dynamic_paths.py $(git ls-files '*.py')"
       - name: Enforce ContextBuilder usage
         run: pre-commit run check-context-builder-usage --all-files
+      - name: Run context builder usage script
+        run: python scripts/check_context_builder_usage.py
       - name: Ensure SelfCodingEngine bots are decorated and registered
         run: python tools/check_coding_bot_decorators.py
       - name: Check for direct SelfCodingEngine patch usage
@@ -93,6 +95,8 @@ jobs:
         run: pip install pre-commit
       - name: Enforce ContextBuilder usage
         run: pre-commit run check-context-builder-usage --all-files
+      - name: Run context builder usage script
+        run: python scripts/check_context_builder_usage.py
       - name: Check for ungoverned embedding calls
         run: pre-commit run check-governed-embeddings --all-files
       - name: Check for direct sqlite3 connections

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,8 +124,16 @@ The pre-commit hook `check-context-builder-usage` wraps
 pre-commit run check-context-builder-usage --all-files
 ```
 
-Continuous integration runs this hook and fails the build when missing or
-implicit `ContextBuilder` usage is detected. The script also flags disallowed
+For the most thorough signal, run the standalone script as well:
+
+```bash
+python scripts/check_context_builder_usage.py
+```
+
+The script prints every violation and exits with a non-zero status when issues
+are found. Continuous integration runs both the pre-commit hook and the
+standalone script, and any emitted output causes the build to fail. The script
+also flags disallowed
 defaults for `context_builder` parameters (including sentinel objects), calls to
 helpers like `generate_candidates` that omit a `context_builder` keyword, or
 imports of `get_default_context_builder`, and CI fails when these patterns


### PR DESCRIPTION
## Summary
- ensure the tests workflow explicitly runs `python scripts/check_context_builder_usage.py` in both the path-checks and test jobs
- document that CI runs the standalone context builder usage script so contributors run it locally as part of the workflow

## Testing
- python scripts/check_context_builder_usage.py *(fails on current main due to existing context builder violations, matching the new CI behavior)*

------
https://chatgpt.com/codex/tasks/task_e_68c83c6011c8832e86149014720d98fa