### PR TITLE
Add context builder pre-commit guard and regression tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,7 @@ repos:
         entry: python scripts/check_context_builder_usage.py
         language: system
         pass_filenames: false
+        always_run: true
         files: '\.py$'
       - id: check-self-coding-integrity
         name: Prevent direct SelfCodingEngine patch usage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,15 +133,15 @@ python scripts/check_context_builder_usage.py
 The script prints every violation and exits with a non-zero status when issues
 are found. Continuous integration runs both the pre-commit hook and the
 standalone script, and any emitted output causes the build to fail. The script
-also flags disallowed
-defaults for `context_builder` parameters (including sentinel objects), calls to
-helpers like `generate_candidates` that omit a `context_builder` keyword, or
-imports of `get_default_context_builder`, and CI fails when these patterns
-appear.  Literal prompt strings passed directly to LLM clients are likewise
-rejected unless produced by `ContextBuilder.build_prompt` or
-`SelfCodingEngine.build_enriched_prompt`.  Direct `Prompt(...)` calls are banned
-outside `vector_service/context_builder.py`, and direct calls to
-`PromptEngine.build_prompt` are disallowed.
+also fails fast when it encounters any of the following patterns:
+
+* defaults for `context_builder` parameters (including sentinel objects);
+* helper calls such as `generate_candidates` that omit a `context_builder` keyword;
+* imports of `get_default_context_builder` outside of test directories;
+* literal prompt strings or message lists passed directly to LLM clients instead of
+  the output of `ContextBuilder.build_prompt` or `SelfCodingEngine.build_enriched_prompt`;
+* direct `Prompt(...)` instantiation outside `vector_service/context_builder.py`;
+* direct `PromptEngine.build_prompt` calls that bypass the builder interface.
 
 Results of `ContextBuilder.build(...)` must be sent straight to the LLM client.
 Combining them with additional strings, f-strings or lists before invoking the

--- a/tests/test_check_context_builder_usage.py
+++ b/tests/test_check_context_builder_usage.py
@@ -1,0 +1,43 @@
+import textwrap
+
+from scripts import check_context_builder_usage as ccb
+
+
+def _write_source(tmp_path, name, source):
+    path = tmp_path / name
+    path.write_text(textwrap.dedent(source))
+    return path
+
+
+def _extract_messages(errors):
+    return [message for _, message in errors]
+
+
+def test_prompt_instantiation_flagged(tmp_path):
+    bad_file = _write_source(tmp_path, "direct_prompt.py", """
+    Prompt('raw prompt text')
+    """)
+
+    messages = _extract_messages(ccb.check_file(bad_file))
+
+    assert any("Prompt instantiation disallowed" in message for message in messages)
+
+
+def test_prompt_engine_build_prompt_flagged(tmp_path):
+    bad_file = _write_source(tmp_path, "prompt_engine.py", """
+    PromptEngine.build_prompt('raw text')
+    """)
+
+    messages = _extract_messages(ccb.check_file(bad_file))
+
+    assert any("PromptEngine.build_prompt disallowed" in message for message in messages)
+
+
+def test_main_returns_failure_on_banned_usage(tmp_path, monkeypatch):
+    bad_file = _write_source(tmp_path, "banned_usage.py", """
+    Prompt('raw prompt text')
+    """)
+
+    monkeypatch.setattr(ccb, "iter_python_files", lambda _root: [bad_file])
+
+    assert ccb.main() == 1


### PR DESCRIPTION
## Summary
- force the context builder usage hook to run on every commit so the repository always executes `scripts/check_context_builder_usage.py`
- document the banned prompt patterns and how to run the check locally in CONTRIBUTING.md
- add regression tests covering direct `Prompt()` and `PromptEngine.build_prompt` usage plus the hook's failure path

## Testing
- python - <<'PY'
import tempfile
from pathlib import Path

import tests.test_check_context_builder_usage as t


class DummyMonkeyPatch:
    def __init__(self) -> None:
        self._stack = []

    def setattr(self, obj, name, value):
        original = getattr(obj, name)
        setattr(obj, name, value)
        self._stack.append((obj, name, original))

    def undo(self):
        while self._stack:
            obj, name, original = self._stack.pop()
            setattr(obj, name, original)


with tempfile.TemporaryDirectory() as tmpdir:
    tmp_path = Path(tmpdir)
    t.test_prompt_instantiation_flagged(tmp_path)
    t.test_prompt_engine_build_prompt_flagged(tmp_path)

    monkeypatch = DummyMonkeyPatch()
    try:
        t.test_main_returns_failure_on_banned_usage(tmp_path, monkeypatch)
    finally:
        monkeypatch.undo()
PY
- pytest tests/test_check_context_builder_usage.py -q *(fails: missing numpy dependency in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c89a7053ec832ea3ff756ba5300320