### PR TITLE
Refactor ChatGPT bots to use standardized LLMClient interface

### DIFF
--- a/chatgpt_enhancement_bot.py
+++ b/chatgpt_enhancement_bot.py
@@ -1105,29 +1105,20 @@ class ChatGPTEnhancementBot:
         ideas: List[Enhancement]
         try:
             generate = getattr(client, "generate", None)
-            if callable(generate):
-                result = generate(
-                    prompt_obj,
-                    parse_fn=parse_enhancements,
-                    context_builder=context_builder,
-                )
-                parsed = getattr(result, "parsed", None)
-                if parsed is None:
-                    payload: Any = getattr(result, "raw", None)
-                    if not payload:
-                        payload = getattr(result, "text", "")
-                    parsed = parse_enhancements(payload)
-                ideas = list(parsed or [])
-            else:
-                base_tags = [IMPROVEMENT_PATH, INSIGHT]
-                if tags:
-                    base_tags.extend(tags)
-                data = client.ask(  # type: ignore[call-arg]
-                    prompt_obj,
-                    tags=base_tags,
-                    memory_manager=self.gpt_memory,
-                )
-                ideas = parse_enhancements(data)
+            if not callable(generate):
+                raise TypeError("client must implement generate()")
+            result = generate(
+                prompt_obj,
+                parse_fn=parse_enhancements,
+                context_builder=context_builder,
+            )
+            parsed = getattr(result, "parsed", None)
+            if parsed is None:
+                payload: Any = getattr(result, "raw", None)
+                if not payload:
+                    payload = getattr(result, "text", "")
+                parsed = parse_enhancements(payload)
+            ideas = list(parsed or [])
         except Exception as exc:
             logger.exception("chatgpt request failed: %s", exc)
             if RAISE_ERRORS:

--- a/tests/test_chatgpt_client_knowledge.py
+++ b/tests/test_chatgpt_client_knowledge.py
@@ -33,10 +33,6 @@ sys.modules.setdefault(
         get_error_fixes=lambda *a, **k: [],
     ),
 )
-sys.modules.setdefault(
-    "governed_retrieval",
-    types.SimpleNamespace(govern_retrieval=lambda *a, **k: None, redact=lambda x: x),
-)
 
 import menace_sandbox.chatgpt_idea_bot as cib
 cib.log_with_tags = _log_with_tags
@@ -93,6 +89,8 @@ def test_ask_injects_context_and_logs(monkeypatch):
             return ""
 
     client = cib.ChatGPTClient(api_key="key", session=session, context_builder=DummyBuilder())
+    monkeypatch.setattr(cib, "govern_retrieval", lambda *a, **k: ({}, None))
+    monkeypatch.setattr(cib, "redact", lambda x: x)
     knowledge = DummyKnowledge(record)
 
     resp = client.ask(

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -13,7 +13,7 @@ class StubClient(LLMClient):
         self.fail = fail
         self.calls = 0
 
-    def _generate(self, prompt: Prompt) -> LLMResult:
+    def _generate(self, prompt: Prompt, *, context_builder) -> LLMResult:
         self.calls += 1
         if self.fail:
             raise RuntimeError("boom")
@@ -24,7 +24,9 @@ def test_router_uses_local_for_small_prompts():
     local = StubClient("local")
     remote = StubClient("remote")
     router = LLMRouter(remote=remote, local=local, size_threshold=5)
-    res = router.generate(Prompt(text="hi", origin="context_builder"))
+    res = router.generate(
+        Prompt(text="hi", vector_confidence=0.5, origin="context_builder")
+    )
     assert res.text == "local"
     assert local.calls == 1
     assert remote.calls == 0
@@ -34,7 +36,13 @@ def test_router_uses_remote_for_large_prompts():
     local = StubClient("local")
     remote = StubClient("remote")
     router = LLMRouter(remote=remote, local=local, size_threshold=5)
-    res = router.generate(Prompt(text="this is a long prompt for testing", origin="context_builder"))
+    res = router.generate(
+        Prompt(
+            text="this is a long prompt for testing",
+            vector_confidence=0.5,
+            origin="context_builder",
+        )
+    )
     assert res.text == "remote"
     assert remote.calls == 1
 
@@ -43,7 +51,9 @@ def test_router_fallback_on_failure():
     local = StubClient("local", fail=True)
     remote = StubClient("remote")
     router = LLMRouter(remote=remote, local=local, size_threshold=5)
-    res = router.generate(Prompt(text="hi", origin="context_builder"))
+    res = router.generate(
+        Prompt(text="hi", vector_confidence=0.5, origin="context_builder")
+    )
 
     assert res.text == "remote"
     assert remote.calls == 1
@@ -53,9 +63,23 @@ def test_router_respects_roi_tags():
     local = StubClient("local")
     remote = StubClient("remote")
     router = LLMRouter(remote=remote, local=local, size_threshold=5)
-    res = router.generate(Prompt(text="hi", tags=["high_roi"], origin="context_builder"))
+    res = router.generate(
+        Prompt(
+            text="hi",
+            tags=["high_roi"],
+            vector_confidence=0.5,
+            origin="context_builder",
+        )
+    )
     assert res.text == "remote"
-    res = router.generate(Prompt(text="this is a long prompt for testing", tags=["low_roi"], origin="context_builder"))
+    res = router.generate(
+        Prompt(
+            text="this is a long prompt for testing",
+            tags=["low_roi"],
+            vector_confidence=0.5,
+            origin="context_builder",
+        )
+    )
     assert res.text == "local"
 
 
@@ -67,12 +91,24 @@ def test_router_avoids_recent_failures(monkeypatch):
     now = [0.0]
     monkeypatch.setattr(llm_router.time, "time", lambda: now[0])
 
-    router.generate(Prompt(text="this is a long prompt for testing", origin="context_builder"))
+    router.generate(
+        Prompt(
+            text="this is a long prompt for testing",
+            vector_confidence=0.5,
+            origin="context_builder",
+        )
+    )
     assert remote.calls == 1
 
     remote.fail = False
     now[0] = 1.0
-    router.generate(Prompt(text="this is a long prompt for testing", origin="context_builder"))
+    router.generate(
+        Prompt(
+            text="this is a long prompt for testing",
+            vector_confidence=0.5,
+            origin="context_builder",
+        )
+    )
     assert remote.calls == 1
     assert local.calls == 2
 
@@ -91,7 +127,9 @@ def test_router_logs_backend_choice(monkeypatch):
 
     monkeypatch.setattr(lr, "PromptDB", DummyDB)
     router = LLMRouter(remote=StubClient("remote"), local=StubClient("local"), size_threshold=5)
-    res = router.generate(Prompt(text="hi", origin="context_builder"))
+    res = router.generate(
+        Prompt(text="hi", vector_confidence=0.5, origin="context_builder")
+    )
     assert logged == ["local"]
     assert res.raw["backend"] == "local"
 
@@ -112,15 +150,21 @@ def test_router_logs_prompt_metadata(monkeypatch):
 
     monkeypatch.setattr(lr, "PromptDB", DummyDB)
     router = LLMRouter(remote=StubClient("remote"), local=StubClient("local"), size_threshold=5)
-    prompt = Prompt(text="hi", examples=["ex"], outcome_tags=["tag"], vector_confidence=0.8, origin="context_builder")
+    prompt = Prompt(
+        text="hi",
+        examples=["ex"],
+        outcome_tags=["tag"],
+        vector_confidence=0.1,
+        origin="context_builder",
+    )
     router.generate(prompt)
 
     assert logged["backend"] == "local"
     assert logged["prompt"].examples == ["ex"]
-    assert logged["prompt"].vector_confidence == 0.8
+    assert logged["prompt"].vector_confidence == 0.1
     assert logged["prompt"].outcome_tags == ["tag"]
     assert logged["raw"]["tags"] == ["tag"]
-    assert logged["raw"]["vector_confidence"] == 0.8
+    assert logged["raw"]["vector_confidence"] == 0.1
 
 
 def custom_factory() -> StubClient:
@@ -138,11 +182,15 @@ def test_client_from_settings_dynamic_backend(monkeypatch):
         available_backends={"custom": "tests.test_llm_router.custom_factory"},
     )
     client = client_from_settings(settings)
-    res = client.generate(Prompt(text="hi", origin="context_builder"))
+    res = client.generate(
+        Prompt(text="hi", vector_confidence=0.5, origin="context_builder")
+    )
     assert res.text == "custom"
 
 
 def test_registry_decorator_helper():
     client = create_backend("decorator")
-    res = client.generate(Prompt(text="hi", origin="context_builder"))
+    res = client.generate(
+        Prompt(text="hi", vector_confidence=0.5, origin="context_builder")
+    )
     assert res.text == "decorator"

--- a/tests/test_prompt_engine_llm_client_integration.py
+++ b/tests/test_prompt_engine_llm_client_integration.py
@@ -21,7 +21,7 @@ class CapturingClient(LLMClient):
         super().__init__("capture", log_prompts=False)
         self.seen: list[Prompt] = []
 
-    def _generate(self, prompt: Prompt) -> LLMResult:
+    def _generate(self, prompt: Prompt, *, context_builder) -> LLMResult:
         self.seen.append(prompt)
         # Return JSON to exercise parsed handling
         return LLMResult(text='{"result": "ok"}', parsed={"result": "ok"})


### PR DESCRIPTION
## Summary
- extend `ChatGPTClient` to implement the `LLMClient` protocol and centralize `_generate` handling while keeping prompt origin validation
- update conversation manager and enhancement bots to invoke the standardized generate API and add regression coverage for missing prompt origins
- allow optional context builder fallbacks in `LLMClient`, propagate vector confidence metadata, and align tests with the stricter interface expectations

## Testing
- pytest tests/test_chatgpt_client_context_builder.py tests/test_chatgpt_client_local_context.py tests/test_chatgpt_client_memory.py tests/test_chatgpt_client_gpt_memory.py tests/test_chatgpt_client_knowledge.py tests/test_chatgpt_idea_bot.py tests/test_chatgpt_enhancement_bot.py tests/test_conversation_manager_bot.py tests/test_llm_interface.py tests/test_llm_router.py tests/test_new_backends.py tests/test_openai_client_http.py

------
https://chatgpt.com/codex/tasks/task_e_68c89fc32330832ebf3287687264db31