### PR TITLE
Use client.generate in newsreader_bot

### DIFF
--- a/newsreader_bot.py
+++ b/newsreader_bot.py
@@ -287,12 +287,8 @@ def monetise_event(client: "ChatGPTClient", event: Event) -> str:
             exc,
             logger=logger,
         )
-    data = client.ask(prompt_obj, use_memory=False, memory_manager=None, tags=full_tags)
-    return (
-        data.get("choices", [{}])[0]
-        .get("message", {})
-        .get("content", "")
-    )
+    result = client.generate(prompt_obj, context_builder=client.context_builder)
+    return result.text
 
 
 def send_to_evaluation_bot(event: Event, strategy: str) -> None:


### PR DESCRIPTION
## Summary
- use the ChatGPT client `generate` helper in `newsreader_bot.monetise_event` instead of the manual ask handling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c8ae6ca704832ea3248f97f70d2b5d