### PR TITLE
Use generate API in query bot

### DIFF
--- a/query_bot.py
+++ b/query_bot.py
@@ -200,16 +200,12 @@ class QueryBot:
             "Summarize the following data",
             intent={"data": data},
         )
-        data_resp = self.client.ask(
+        result = self.client.generate(
             prompt_obj,
+            context_builder=self.context_builder,
             tags=[FEEDBACK, IMPROVEMENT_PATH, ERROR_FIX, INSIGHT],
-            memory_manager=self.gpt_memory,
         )
-        text = (
-            data_resp.get("choices", [{}])[0]
-            .get("message", {})
-            .get("content", "")
-        )
+        text = result.text
         return QueryResult(text=text, data=data)
 
     def history(self, context_id: str) -> List[str]:


### PR DESCRIPTION
## Summary
- extend `ChatGPTClient.generate` so callers can pass optional tags into prompts
- update `QueryBot.process` to call `client.generate` with standard feedback tags and use the returned text directly

## Testing
- pytest tests/test_query_bot.py

------
https://chatgpt.com/codex/tasks/task_e_68c8b4834308832ea1f5db4ba4b12227