### PR TITLE
Use create_context_builder in bot registry

### DIFF
--- a/bot_registry.py
+++ b/bot_registry.py
@@ -135,10 +135,10 @@ class BotRegistry:
                         from .data_bot import DataBot
                         from .code_database import CodeDB
                         from .gpt_memory import GPTMemoryManager
-                        from vector_service.context_builder import ContextBuilder
+                        from context_builder_util import create_context_builder
                         from .self_coding_thresholds import get_thresholds
 
-                        ctx = ContextBuilder()
+                        ctx = create_context_builder()
                         engine = SelfCodingEngine(
                             CodeDB(), GPTMemoryManager(), context_builder=ctx
                         )


### PR DESCRIPTION
## Summary
- replace the direct ContextBuilder instantiation in `BotRegistry.register_bot`
- construct the builder through `create_context_builder()` before wiring it into the self-coding components

## Testing
- python -m compileall bot_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68c8bd2b8594832eb6d1f5fa170ab542