### PR TITLE
Refactor idea bot prompts to use LLMClient generate

### DIFF
--- a/tests/test_chatgpt_client_context_builder.py
+++ b/tests/test_chatgpt_client_context_builder.py
@@ -84,18 +84,17 @@ class DummyBuilder:
 def test_builder_context_included():
     builder = DummyBuilder()
     client = cib.ChatGPTClient(context_builder=builder)
-    msgs = client.build_prompt_with_memory(
+    prompt = client.build_prompt_with_memory(
         ["alpha", "beta"], prior="hi", context_builder=builder
     )
     assert builder.calls == ["alpha beta"]
     assert "session_id" in builder.kwargs[0]
     assert (
         builder.kwargs[0]["session_id"]
-        == msgs[0]["metadata"]["retrieval_session_id"]
+        == prompt.metadata["retrieval_session_id"]
     )
-    assert msgs[0]["role"] == "user"
-    assert msgs[0]["content"].startswith("hi")
-    assert "vector:alpha beta" in msgs[0]["content"]
+    assert prompt.user.startswith("hi")
+    assert "vector:alpha beta" in prompt.user
 
 
 def test_fallback_result_empty_context():
@@ -106,14 +105,13 @@ def test_fallback_result_empty_context():
 
     builder = FB()
     client = cib.ChatGPTClient(context_builder=builder)
-    msgs = client.build_prompt_with_memory(
+    prompt = client.build_prompt_with_memory(
         ["alpha"], prior="hi", context_builder=builder
     )
     assert builder.calls == ["alpha"]
     assert "session_id" in builder.kwargs[0]
-    assert msgs[0]["role"] == "user"
-    assert msgs[0]["content"] == "hi"
-    assert msgs[0]["metadata"]["retrieval_session_id"]
+    assert prompt.user == "hi"
+    assert prompt.metadata["retrieval_session_id"]
 
 
 def test_requires_context_builder():
@@ -133,9 +131,9 @@ def test_builder_context_compressed():
 
     builder = LongBuilder()
     client = cib.ChatGPTClient(context_builder=builder)
-    msgs = client.build_prompt_with_memory(
+    prompt = client.build_prompt_with_memory(
         ["alpha"], prior="hi", context_builder=builder
     )
-    content = msgs[0]["content"].split("\n", 1)[1]
+    content = prompt.user.split("\n", 1)[1]
     assert len(content) <= 200
     assert content.endswith("...")

--- a/tests/test_chatgpt_client_gpt_memory.py
+++ b/tests/test_chatgpt_client_gpt_memory.py
@@ -139,13 +139,16 @@ def test_build_prompt_injects_summary_and_logs(monkeypatch):
         ),
     )
 
-    msgs = client.build_prompt_with_memory(
+    prompt = client.build_prompt_with_memory(
         ["topic"], prior="new question", context_builder=client.context_builder
     )
-    assert msgs[0]["role"] == "user"
-    assert "early prompt" in msgs[0]["content"]
+    assert "early prompt" in prompt.user
 
-    client.ask(msgs)
+    client.generate(
+        prompt,
+        context_builder=client.context_builder,
+        tags=["topic"],
+    )
     entries = mem.search_context("new question")
     assert any(e.response == "later resp" for e in entries)
 

--- a/tests/test_chatgpt_client_local_context.py
+++ b/tests/test_chatgpt_client_local_context.py
@@ -97,9 +97,9 @@ def test_prompts_embed_local_db_data(tmp_path):
 
     builder = DBContextBuilder(paths)
     client = cib.ChatGPTClient(context_builder=builder)
-    msgs = client.build_prompt_with_memory(["x"], prior="y", context_builder=builder)
+    prompt = client.build_prompt_with_memory(["x"], prior="y", context_builder=builder)
 
-    content = msgs[0]["content"]
+    content = prompt.user
     for text in db_contents.values():
         assert text in content
 

--- a/tests/test_chatgpt_client_memory.py
+++ b/tests/test_chatgpt_client_memory.py
@@ -92,12 +92,11 @@ def test_build_prompt_with_memory():
     builder = DummyBuilder()
     builder.memory = mem
     client = cib.ChatGPTClient(gpt_memory=mem, context_builder=builder)
-    msgs = client.build_prompt_with_memory(
+    prompt = client.build_prompt_with_memory(
         ["ai"], prior="hello", context_builder=builder
     )
-    assert msgs[0]["role"] == "user"
-    assert "hello" in msgs[0]["content"]
-    assert "ctx:ai" in msgs[0]["content"]
+    assert "hello" in prompt.user
+    assert "ctx:ai" in prompt.user
 
 
 def test_ask_logs_interaction(monkeypatch):

--- a/tests/test_memory_based_context.py
+++ b/tests/test_memory_based_context.py
@@ -111,11 +111,15 @@ def test_memory_based_context(monkeypatch):
 
     monkeypatch.setattr(client, "_offline_response", offline_response)
 
-    messages = client.build_prompt_with_memory(
+    prompt = client.build_prompt_with_memory(
         [IMPROVEMENT_PATH], prior="What's next?", context_builder=builder
     )
-    result = client.ask(messages, use_memory=False)
-    text = result["choices"][0]["message"]["content"]
+    result = client.generate(
+        prompt,
+        context_builder=builder,
+        tags=[IMPROVEMENT_PATH],
+    )
+    text = result.text or result.raw["choices"][0]["message"]["content"]
 
     assert mem.fetch_calls, "memory context was not retrieved"
     assert "Improve caching strategy" in text


### PR DESCRIPTION
## Summary
- return Prompt objects from ChatGPTClient.build_prompt_with_memory and annotate metadata for context-builder usage
- call client.generate for follow_up and generate_and_filter and allow parse_ideas to accept LLMResult outputs
- relax ChatGPTClient.ask to normalise prompt-like objects and update tests to assert against Prompt structures

## Testing
- pytest tests/test_chatgpt_idea_bot.py tests/test_chatgpt_client_context_builder.py tests/test_chatgpt_client_memory.py tests/test_chatgpt_client_local_context.py tests/test_chatgpt_client_gpt_memory.py tests/test_memory_based_context.py tests/test_prompt_failure_policy.py


------
https://chatgpt.com/codex/tasks/task_e_68c8bf182420832e8c7cb4e852322af3