### PR TITLE
Require explicit context builder for code summarizer

### DIFF
--- a/code_summarizer.py
+++ b/code_summarizer.py
@@ -65,16 +65,16 @@ def _heuristic_summary(code: str, limit: int) -> str:
 def summarize_code(
     code: str,
     *,
-    context_builder: "ContextBuilder" | None,
+    context_builder: "ContextBuilder",
     max_summary_tokens: int = 128,
 ) -> str:
     """Return a short description of ``code``.
 
     The function attempts several local summarisation strategies before falling
     back to a simple heuristic based on the first line of the snippet.  When the
-    micro-model path is unavailable a provided :class:`ContextBuilder` is used to
-    build an enriched prompt with vector context and metadata.  If the builder is
-    missing or fails, a simple heuristic is used as a last resort.
+    micro-model path is unavailable the provided :class:`ContextBuilder` is used
+    to build an enriched prompt with vector context and metadata.  If prompt
+    generation fails, a simple heuristic is used as a last resort.
     """
 
     code = code.strip()
@@ -102,15 +102,7 @@ def summarize_code(
     except Exception:  # pragma: no cover - client may be missing
         OllamaClient = None  # type: ignore[assignment]
 
-    if context_builder is None:
-        try:  # pragma: no cover - builder creation best effort
-            from context_builder_util import create_context_builder
-
-            context_builder = create_context_builder()
-        except Exception:  # pragma: no cover - builder may be unavailable
-            context_builder = None
-
-    if OllamaClient is not None and context_builder is not None:
+    if OllamaClient is not None:
         try:  # pragma: no cover - defensive against runtime failures
             client = OllamaClient()  # type: ignore[call-arg]
             prompt = context_builder.build_prompt(

--- a/tests/test_code_summarizer.py
+++ b/tests/test_code_summarizer.py
@@ -105,17 +105,3 @@ def test_summarize_code_enriched_context(monkeypatch):
     assert prompt.metadata["vectors"] == [("s", "id", 0.7)]
     assert prompt.metadata["vector_confidences"] == [0.7]
     assert prompt.vector_confidence == 0.7
-
-
-def test_summarize_code_no_builder_falls_back(monkeypatch):
-    monkeypatch.setattr("micro_models.diff_summarizer.summarize_diff", lambda *a, **k: "")
-
-    class DummyClient:
-        def __init__(self, *a, **k):  # pragma: no cover - should not run
-            raise AssertionError("LLM client should not be used")
-
-    monkeypatch.setattr("local_client.OllamaClient", DummyClient)
-
-    code = "# header\n\nclass Foo:\n    pass\n"
-    summary = summarize_code(code, context_builder=None, max_summary_tokens=10)
-    assert summary.startswith("class Foo")


### PR DESCRIPTION
## Summary
- require callers to explicitly pass a context builder to `code_summarizer.summarize_code`
- drop the internal builder creation path and clean up the accompanying unit test

## Testing
- pytest tests/test_code_summarizer.py unit_tests/test_chunking.py

------
https://chatgpt.com/codex/tasks/task_e_68c8cddf0850832eaa04dafcc5e72c38