### PR TITLE
Use client.generate in ask_with_memory

### DIFF
--- a/tests/test_memory_continuity.py
+++ b/tests/test_memory_continuity.py
@@ -11,6 +11,7 @@ from gpt_memory import (
     INSIGHT,
     _summarise_text,
 )
+from llm_interface import LLMResult
 
 
 class DummyClient:
@@ -18,10 +19,10 @@ class DummyClient:
         self.responses = list(responses)
         self.calls = 0
 
-    def ask(self, messages, **kwargs):
+    def generate(self, prompt, **kwargs):
         resp = self.responses[self.calls]
         self.calls += 1
-        return {"choices": [{"message": {"content": resp}}]}
+        return LLMResult(text=resp)
 
 
 def test_memory_continuity_across_sessions(tmp_path):


### PR DESCRIPTION
## Summary
- switch ask_with_memory to call client.generate and rely on returned text
- update the memory-aware client tests to stub generate, verify tags, and expect PromptBuildError when no builder is provided
- adjust the continuity test helper client to implement generate instead of ask

## Testing
- pytest tests/test_memory_aware_gpt_client.py tests/test_memory_continuity.py

------
https://chatgpt.com/codex/tasks/task_e_68c8d704d7a4832eb0d56037d138f9d3