### PR TITLE
Require explicit context builder for snippet summarization

### DIFF
--- a/tests/test_chunking_prompt_builder.py
+++ b/tests/test_chunking_prompt_builder.py
@@ -1,5 +1,8 @@
 import types
 import sys
+
+import pytest
+
 import chunking as pc
 
 
@@ -38,3 +41,8 @@ def test_summarize_snippet_invokes_build_prompt(monkeypatch):
     assert result == "summary"
     assert "built" in prompts, "context_builder.build_prompt was not invoked"
     assert called["prompt"] is prompts["built"], "llm.generate did not receive built prompt"
+
+
+def test_summarize_snippet_requires_context_builder():
+    with pytest.raises(ValueError, match="context_builder is required"):
+        pc.summarize_snippet("example", context_builder=None)

--- a/tests/test_chunking_summarize_cache.py
+++ b/tests/test_chunking_summarize_cache.py
@@ -1,6 +1,7 @@
 import hashlib
 
 from llm_interface import LLMClient, LLMResult
+from prompt_types import Prompt
 
 import chunking as pc
 
@@ -17,9 +18,11 @@ class DummyLLM(LLMClient):
 
 class DummyBuilder:
     def build_prompt(self, text: str, *, intent=None, top_k=5, **kwargs):  # pragma: no cover - simple stub
-        from prompt_types import Prompt
-
-        return Prompt(user=text, metadata={})
+        metadata = {
+            "vector_confidences": [0.5],
+            "retrieval_metadata": {"code": [{"desc": "ctx", "score": 0.5}]},
+        }
+        return Prompt(user=text, metadata=metadata, origin="context_builder")
 
 
 def test_summarize_code_uses_cache(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- raise a clear error when `chunking.summarize_snippet` is called without a context builder instead of silently creating one
- simplify the LLM path by assuming callers supply the builder and update tests to cover the new contract and provide valid prompt metadata

## Testing
- pytest tests/test_chunking_prompt_builder.py tests/test_chunking_enriched_prompt.py tests/test_prompt_failure_policy.py tests/test_chunking_cache.py tests/test_chunking_summarize_cache.py tests/test_chunk_summary_cache.py tests/test_chunking_split.py
- pytest tests/test_chunking_summarize_cache.py


------
https://chatgpt.com/codex/tasks/task_e_68c8db2038cc832e8c39d472c6236a1b