### PR TITLE
Fix ContextBuilder instantiation keywords

### DIFF
--- a/config/create_context_builder.py
+++ b/config/create_context_builder.py
@@ -7,7 +7,12 @@ from vector_service.context_builder import ContextBuilder
 
 
 def create_context_builder() -> ContextBuilder:
-    """Return a :class:`ContextBuilder` wired to the standard local databases."""
+    """Return a :class:`ContextBuilder` wired to the standard local databases.
+
+    All four database paths (``bots.db``, ``code.db``, ``errors.db`` and
+    ``workflows.db``) are mandatory and must be provided to the
+    :class:`ContextBuilder` constructor.
+    """
     data_dir = Path(os.getenv("SANDBOX_DATA_DIR", "."))
     bot_db = Path(os.getenv("BOT_DB_PATH", data_dir / "bots.db"))
     code_db = Path(os.getenv("CODE_DB_PATH", data_dir / "code.db"))
@@ -15,7 +20,10 @@ def create_context_builder() -> ContextBuilder:
     workflow_db = Path(os.getenv("WORKFLOW_DB_PATH", data_dir / "workflows.db"))
     try:
         return ContextBuilder(
-            str(bot_db), str(code_db), str(error_db), str(workflow_db)
+            bots_db=str(bot_db),
+            code_db=str(code_db),
+            errors_db=str(error_db),
+            workflows_db=str(workflow_db),
         )
     except TypeError as exc:  # pragma: no cover - for simple stubs in tests
         raise ValueError(


### PR DESCRIPTION
## Summary
- instantiate ContextBuilder with explicit keyword arguments for the four database paths
- document that ContextBuilder requires all four database paths when constructing the default builder

## Testing
- python -m compileall config/create_context_builder.py

------
https://chatgpt.com/codex/tasks/task_e_68c8e75da0c4832e8e09bc22b5e88150