### PR TITLE
Require context builder when evaluating enhancements

### DIFF
--- a/research_aggregator_bot.py
+++ b/research_aggregator_bot.py
@@ -994,16 +994,11 @@ class ResearchAggregatorBot:
                         evaluation = None
                         if self.prediction_bot:
                             try:
-                                try:
-                                    evaluation = self.prediction_bot.evaluate_enhancement(
-                                        enh.idea,
-                                        enh.rationale,
-                                        context_builder=self.context_builder,
-                                    )
-                                except TypeError:
-                                    evaluation = self.prediction_bot.evaluate_enhancement(
-                                        enh.idea, enh.rationale
-                                    )
+                                evaluation = self.prediction_bot.evaluate_enhancement(
+                                    enh.idea,
+                                    enh.rationale,
+                                    context_builder=self.context_builder,
+                                )
                                 enh.score = evaluation.value
                             except Exception:
                                 evaluation = None
@@ -1122,16 +1117,11 @@ class ResearchAggregatorBot:
             enh_id = 0
             try:
                 if self.prediction_bot:
-                    try:
-                        evaluation = self.prediction_bot.evaluate_enhancement(
-                            enh.idea,
-                            enh.rationale,
-                            context_builder=self.context_builder,
-                        )
-                    except TypeError:
-                        evaluation = self.prediction_bot.evaluate_enhancement(
-                            enh.idea, enh.rationale
-                        )
+                    evaluation = self.prediction_bot.evaluate_enhancement(
+                        enh.idea,
+                        enh.rationale,
+                        context_builder=self.context_builder,
+                    )
                     enh.score = evaluation.value
                 if getattr(self.info_db, "current_model_id", 0):
                     enh.model_ids = [self.info_db.current_model_id]

--- a/tests/test_chatgpt_prediction_bot.py
+++ b/tests/test_chatgpt_prediction_bot.py
@@ -110,7 +110,12 @@ def test_batch_prediction(tmp_path):
 def test_evaluate_enhancement():
     bot = cpb.ChatGPTPredictionBot.__new__(cpb.ChatGPTPredictionBot)
     bot.pipeline = None  # bypass loading
-    ev = bot.evaluate_enhancement("Improve", "Adds more features and efficiency")
+    builder = _StubContextBuilder()
+    ev = bot.evaluate_enhancement(
+        "Improve",
+        "Adds more features and efficiency",
+        context_builder=builder,
+    )
     assert -1.0 <= ev.value <= 1.0
     assert ev.description and ev.reason
 

--- a/tests/test_chatgpt_prediction_bot_memory.py
+++ b/tests/test_chatgpt_prediction_bot_memory.py
@@ -75,7 +75,11 @@ def test_enhancement_uses_memory(monkeypatch):
         lambda msgs: {"choices": [{"message": {"content": "resp"}}]},
     )
 
-    bot.evaluate_enhancement("idea", "rationale")
+    bot.evaluate_enhancement(
+        "idea",
+        "rationale",
+        context_builder=bot.context_builder,
+    )
 
     assert mem.context_calls[0] == "chatgpt_prediction_bot.evaluate_enhancement"
     assert mem.logged[0][0].startswith("dbctx")

--- a/tests/test_research_aggregator_bot.py
+++ b/tests/test_research_aggregator_bot.py
@@ -121,7 +121,7 @@ def test_enhancement_prediction(monkeypatch, tmp_path):
         ],
     )
     pred_bot = cpb.ChatGPTPredictionBot.__new__(cpb.ChatGPTPredictionBot)
-    pred_bot.evaluate_enhancement = lambda i, r: cpb.EnhancementEvaluation(
+    pred_bot.evaluate_enhancement = lambda i, r, *, context_builder: cpb.EnhancementEvaluation(
         description="d", reason="r", value=0.5
     )
     bot = rab.ResearchAggregatorBot(


### PR DESCRIPTION
## Summary
- require `ChatGPTPredictionBot.evaluate_enhancement` to accept a `context_builder` argument and propagate prompt build failures via `PromptBuildError`
- update research aggregator call sites and supporting tests to pass the builder explicitly

## Testing
- pytest tests/test_chatgpt_prediction_bot.py tests/test_chatgpt_prediction_bot_memory.py tests/test_research_aggregator_bot.py tests/integration/test_research_aggregator_context.py *(fails: optional dependencies missing in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e8e0a184832e929c79514a103a34