### PR TITLE
Ensure OpenAI check passes context builder

### DIFF
--- a/neurosales/scripts/check_external_services.py
+++ b/neurosales/scripts/check_external_services.py
@@ -17,10 +17,15 @@ def check_openai(cfg: config.ServiceConfig) -> bool:
     except Exception as e:
         print(f"ContextBuilder error: {e}")
         return False
+    if context_builder is None:
+        print("ContextBuilder error: create_context_builder returned None")
+        return False
     try:
         os.environ.setdefault("OPENAI_API_KEY", cfg.openai_key)
         chat_completion_create(
-            context_builder.build_prompt("ping"), model="gpt-3.5-turbo"
+            context_builder.build_prompt("ping"),
+            model="gpt-3.5-turbo",
+            context_builder=context_builder,
         )
         print("OpenAI reachable")
         return True


### PR DESCRIPTION
## Summary
- guard against create_context_builder returning None in the OpenAI service check
- pass the context_builder instance to chat_completion_create when validating OpenAI reachability

## Testing
- flake8 neurosales/scripts/check_external_services.py
- pytest tests/test_context_builder_static.py::test_check_external_services_passes_linter

------
https://chatgpt.com/codex/tasks/task_e_68c8ebba60a0832ea79e5ac7c611014b