### PR TITLE
Require explicit context builder when streaming GPT-4 chat

### DIFF
--- a/neurosales/neurosales/external_integrations.py
+++ b/neurosales/neurosales/external_integrations.py
@@ -121,13 +121,12 @@ class GPT4Client:
         objective: str,
         text: str,
         *,
-        context_builder: "ContextBuilder" | None = None,
+        context_builder: "ContextBuilder",
     ) -> Iterator[str]:
         if not self.enabled:
             logger.warning("GPT4Client disabled: backend unavailable")
             yield ""
             return
-        context_builder = context_builder or self.context_builder
         prompt = context_builder.build_prompt(
             text,
             intent={
@@ -137,7 +136,9 @@ class GPT4Client:
             },
         )
         try:
-            resp = chat_completion_create(prompt, model="gpt-4")
+            resp = chat_completion_create(
+                prompt, model="gpt-4", context_builder=context_builder
+            )
             content = ""
             try:
                 content = resp["choices"][0]["message"]["content"]


### PR DESCRIPTION
## Summary
- require callers of `GPT4Client.stream_chat` to supply a context builder and forward it to `chat_completion_create`
- update neurosales unit tests to pass the explicit builder and clean up OPENAI_API_KEY between runs

## Testing
- pytest neurosales/tests/test_external_integrations.py

------
https://chatgpt.com/codex/tasks/task_e_68c8ed575260832ea0f1cefb0528f1e8