### PR TITLE
Use client's context builder for self-improvement suggestions

### DIFF
--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -1486,14 +1486,10 @@ class SelfImprovementEngine:
                 )
                 result = client.generate(
                     prompt_obj,
-                    context_builder=self.context_builder,
+                    context_builder=client.context_builder,
                     tags=full_tags,
                 )
-                raw_text = getattr(result, "text", result)
-                if isinstance(raw_text, str):
-                    text = raw_text.strip()
-                else:
-                    text = str(raw_text or "").strip()
+                text = (result.text or "").strip()
                 try:
                     log_prompt = "\n\n".join(
                         getattr(prompt_obj, "examples", []) + [prompt_obj.user]


### PR DESCRIPTION
## Summary
- use the LLM client's context builder when generating memory prompts
- rely on the LLMResult text field instead of custom parsing for suggestion logging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8ef84b620832e8e4eca252388a7a1