### PR TITLE
Track getattr-based generate wrappers in context builder check

### DIFF
--- a/tests/test_context_builder_static.py
+++ b/tests/test_context_builder_static.py
@@ -186,7 +186,8 @@ def test_flags_build_with_optional_builder(tmp_path):
     path = tmp_path / "snippet.py"
     path.write_text(code)
     assert check_file(path) == [
-        (3, "builder.build disallowed or missing context_builder")
+        (2, "context_builder default disallowed or missing context_builder"),
+        (3, "builder.build disallowed or missing context_builder"),
     ]
 
 
@@ -453,3 +454,31 @@ def test_flags_builder_default_none(tmp_path):
     assert check_file(path) == [
         (1, "context_builder default disallowed or missing context_builder")
     ]
+
+
+def test_flags_getattr_generate_wrapper(tmp_path):
+    from scripts.check_context_builder_usage import check_file
+
+    code = (
+        "def demo(client, prompt):\n"
+        "    handler = getattr(client, 'generate', client)\n"
+        "    handler(prompt)\n"
+    )
+    path = tmp_path / "snippet.py"
+    path.write_text(code)
+    assert check_file(path) == [
+        (3, "handler disallowed or missing context_builder")
+    ]
+
+
+def test_allows_getattr_generate_wrapper_with_context_builder(tmp_path):
+    from scripts.check_context_builder_usage import check_file
+
+    code = (
+        "def demo(client, prompt, builder):\n"
+        "    handler = getattr(client, 'generate', client)\n"
+        "    handler(prompt, context_builder=builder)\n"
+    )
+    path = tmp_path / "snippet.py"
+    path.write_text(code)
+    assert check_file(path) == []


### PR DESCRIPTION
## Summary
- extend the static checker to treat getattr-based `generate` fallbacks as tracked aliases that must pass a `context_builder`
- avoid flagging tracked aliases when the required keyword is provided
- expand context builder static tests to cover updated optional-builder messaging and new getattr alias scenarios

## Testing
- pytest tests/test_context_builder_static.py

------
https://chatgpt.com/codex/tasks/task_e_68c9208ca4e0832ea4f1e04336ae49e3