### PR TITLE
Require explicit context builder for enhancement proposals

### DIFF
--- a/chatgpt_enhancement_bot.py
+++ b/chatgpt_enhancement_bot.py
@@ -1073,7 +1073,7 @@ class ChatGPTEnhancementBot:
         ratio: float = DEFAULT_PROPOSE_RATIO,
         *,
         tags: Sequence[str] | None = None,
-        context_builder: ContextBuilder | None = None,
+        context_builder: ContextBuilder,
     ) -> List[Enhancement]:
         intent_meta: Dict[str, Any] = {
             "instruction": instruction,
@@ -1087,14 +1087,14 @@ class ChatGPTEnhancementBot:
             logger.error("ChatGPT client unavailable")
             return []
 
-        builder = context_builder or self.context_builder
-        if builder is None:
+        if context_builder is None:
             logger.error("ContextBuilder unavailable for enhancement prompt")
             if RAISE_ERRORS:
                 raise ValueError("context_builder is required")
             return []
+
         try:
-            prompt_obj = builder.build_prompt(
+            prompt_obj = context_builder.build_prompt(
                 instruction, intent=intent_meta
             )
         except Exception as exc:
@@ -1120,7 +1120,7 @@ class ChatGPTEnhancementBot:
             result = generate(
                 prompt_obj,
                 parse_fn=parse_enhancements,
-                context_builder=builder,
+                context_builder=context_builder,
             )
             parsed = getattr(result, "parsed", None)
             if parsed is None:

--- a/research_aggregator_bot.py
+++ b/research_aggregator_bot.py
@@ -979,17 +979,12 @@ class ResearchAggregatorBot:
                     logger.exception("Video bot failed for %s: %s", topic, exc)
             if self.enhancement_bot and (not missing or "enhancement" in targets):
                 try:
-                    try:
-                        enhs = self.enhancement_bot.propose(
-                            topic,
-                            num_ideas=1,
-                            context=ctx,
-                            context_builder=self.context_builder,
-                        )
-                    except TypeError:
-                        enhs = self.enhancement_bot.propose(
-                            topic, num_ideas=1, context=ctx
-                        )
+                    enhs = self.enhancement_bot.propose(
+                        topic,
+                        num_ideas=1,
+                        context=ctx,
+                        context_builder=self.context_builder,
+                    )
                     for enh in enhs:
                         evaluation = None
                         if self.prediction_bot:
@@ -1099,17 +1094,12 @@ class ResearchAggregatorBot:
         if ctx:
             instruction = f"{ctx}\n\n{instruction}"
         try:
-            try:
-                enhancements = self.enhancement_bot.propose(
-                    instruction,
-                    num_ideas=1,
-                    context=ctx or topic,
-                    context_builder=self.context_builder,
-                )
-            except TypeError:
-                enhancements = self.enhancement_bot.propose(
-                    instruction, num_ideas=1, context=ctx or topic
-                )
+            enhancements = self.enhancement_bot.propose(
+                instruction,
+                num_ideas=1,
+                context=ctx or topic,
+                context_builder=self.context_builder,
+            )
         except Exception:
             return
         for enh in enhancements:

--- a/tests/test_chatgpt_enhancement_bot.py
+++ b/tests/test_chatgpt_enhancement_bot.py
@@ -104,7 +104,9 @@ def test_propose(monkeypatch, tmp_path):
     db.add_embedding = lambda *a, **k: None
     bot = ceb.ChatGPTEnhancementBot(client, db=db, context_builder=builder)
     monkeypatch.setattr(bot, "_feasible", lambda e: True)
-    results = bot.propose("Improve", num_ideas=1, context="ctx")
+    results = bot.propose(
+        "Improve", num_ideas=1, context="ctx", context_builder=builder
+    )
     assert results and results[0].context == "ctx"
     assert client.calls == 1
     assert client.last_prompt is builder.last_prompt
@@ -131,7 +133,7 @@ def test_propose_requires_context_builder_origin(monkeypatch, tmp_path):
     db = ceb.EnhancementDB(tmp_path / "enh_bad.db", router=router)
     db.add_embedding = lambda *a, **k: None
     bot = ceb.ChatGPTEnhancementBot(client, db=db, context_builder=builder)
-    results = bot.propose("Improve", num_ideas=1)
+    results = bot.propose("Improve", num_ideas=1, context_builder=builder)
     assert results == []
     assert builder.last_prompt is not None
     assert builder.last_prompt.origin == ""


### PR DESCRIPTION
## Summary
- require callers to supply a ContextBuilder to `ChatGPTEnhancementBot.propose`
- update research aggregator flow and tests to pass the explicit builder

## Testing
- pytest tests/test_chatgpt_enhancement_bot.py

------
https://chatgpt.com/codex/tasks/task_e_68c935526db0832ebd561049a9b12142