### PR TITLE
Use explicit context builder in research bot ask

### DIFF
--- a/chatgpt_research_bot.py
+++ b/chatgpt_research_bot.py
@@ -691,13 +691,9 @@ class ChatGPTResearchBot:
                 "chatgpt_research_bot._ask",
                 [FEEDBACK, IMPROVEMENT_PATH, ERROR_FIX, INSIGHT],
             )
-            builder = getattr(self.client, "context_builder", None)
-            if builder is None:
-                raise ValueError("client is missing required context_builder")
-
             result = self.client.generate(
                 prompt_obj,
-                context_builder=builder,
+                context_builder=context_builder,
                 tags=full_tags,
             )
 


### PR DESCRIPTION
## Summary
- use the `context_builder` argument passed to `_ask` when generating responses
- remove reliance on the client's `context_builder` attribute so the dependency stays explicit

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c951024478832e9db8cf44248560ae