### PR TITLE
Require context builder for manager helper and enrich prompts

### DIFF
--- a/automated_reviewer.py
+++ b/automated_reviewer.py
@@ -180,7 +180,11 @@ class AutomatedReviewer:
                 ctx = ""
                 vectors = []
             try:
-                manager_generate_helper(self.manager, f"review for bot {bot_id}")
+                manager_generate_helper(
+                    self.manager,
+                    f"review for bot {bot_id}",
+                    context_builder=self.context_builder,
+                )
             except Exception:
                 self.logger.exception("helper generation failed")
             try:

--- a/bot_development_bot.py
+++ b/bot_development_bot.py
@@ -785,7 +785,11 @@ class BotDevelopmentBot:
                 code = path.read_text()
             else:
                 code = self.engine_retry.run(
-                    lambda: manager_generate_helper(manager, prompt),
+                    lambda: manager_generate_helper(
+                        manager,
+                        prompt,
+                        context_builder=self.context_builder,
+                    ),
                     logger=self.logger,
                 )
             return EngineResult(True, code, None)

--- a/enhancement_bot.py
+++ b/enhancement_bot.py
@@ -224,17 +224,19 @@ class EnhancementBot:
             intent_meta["refactor_summary"] = hint
         if context:
             intent_meta["retrieved_context"] = context
+        intent_payload = dict(intent_meta)
+        intent_payload.setdefault("top_k", 0)
         try:
-            prompt = context_builder.build_prompt(
+            prompt = engine.build_enriched_prompt(
                 "Summarize the code change.",
-                intent=intent_meta,
-                top_k=0,
+                intent=intent_payload,
+                context_builder=context_builder,
             )
         except Exception as exc:
             if isinstance(exc, PromptBuildError):
                 raise
             handle_failure(
-                "ContextBuilder.build_prompt failed for codex summary prompt",
+                "build_enriched_prompt failed for codex summary prompt",
                 exc,
                 logger=logger,
             )

--- a/quick_fix_engine.py
+++ b/quick_fix_engine.py
@@ -464,13 +464,18 @@ def generate_patch(
                         return helper(
                             manager,
                             desc,
+                            context_builder=builder,
                             path=path,
                             metadata=context_meta,
                             target_region=target_region,
                         )
                     except TypeError:
                         try:
-                            return helper(manager, desc)
+                            return helper(
+                                manager,
+                                desc,
+                                context_builder=builder,
+                            )
                         except Exception as exc2:  # fall through to logging
                             err: Exception = exc2
                     except Exception as exc:

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -1631,6 +1631,7 @@ class SelfCodingEngine:
             code = manager_generate_helper(
                 manager,
                 description,
+                context_builder=self.context_builder,
                 path=path,
                 metadata=context_meta,
                 chunk_index=chunk_index,
@@ -1638,7 +1639,12 @@ class SelfCodingEngine:
                 strategy=strategy,
             )
         except TypeError:
-            code = manager_generate_helper(manager, description, strategy=strategy)
+            code = manager_generate_helper(
+                manager,
+                description,
+                context_builder=self.context_builder,
+                strategy=strategy,
+            )
         self.logger.info(
             "patch file",
             extra={
@@ -1898,6 +1904,7 @@ class SelfCodingEngine:
             generated = manager_generate_helper(
                 manager,
                 description,
+                context_builder=self.context_builder,
                 path=path,
                 metadata=context_meta,
                 target_region=target_region,
@@ -1919,6 +1926,7 @@ class SelfCodingEngine:
                     generated = manager_generate_helper(
                         manager,
                         description,
+                        context_builder=self.context_builder,
                         path=path,
                         metadata=context_meta,
                         target_region=func_region,
@@ -1939,6 +1947,7 @@ class SelfCodingEngine:
                 generated = manager_generate_helper(
                     manager,
                     description,
+                    context_builder=self.context_builder,
                     path=path,
                     metadata=context_meta,
                     target_region=func_region,
@@ -2016,6 +2025,7 @@ class SelfCodingEngine:
                 return manager_generate_helper(
                     manager,
                     description,
+                    context_builder=self.context_builder,
                     path=path,
                     metadata=context_meta,
                     chunk_index=idx,

--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -1481,8 +1481,11 @@ class SelfImprovementEngine:
                 intent_meta: dict[str, object] = {"module": module, "user_query": action}
                 if mem_ctx:
                     intent_meta["memory_context"] = mem_ctx
-                prompt_obj = client.context_builder.build_prompt(
-                    action, intent_metadata=intent_meta, tags=full_tags
+                intent_meta.setdefault("intent_tags", list(full_tags))
+                prompt_obj = self.self_coding_engine.build_enriched_prompt(
+                    action,
+                    intent=intent_meta,
+                    context_builder=client.context_builder,
                 )
                 result = client.generate(
                     prompt_obj,

--- a/tests/integration/test_baseline_shift_patch.py
+++ b/tests/integration/test_baseline_shift_patch.py
@@ -121,7 +121,7 @@ sys.modules["menace_sandbox.patch_provenance"] = pp_mod
 
 # Stub coding bot interface and thresholds
 cbi_mod = types.ModuleType("menace_sandbox.coding_bot_interface")
-def manager_generate_helper(manager, description, **kwargs):
+def manager_generate_helper(manager, description, *, context_builder, **kwargs):
     return ""
 cbi_mod.manager_generate_helper = manager_generate_helper
 sys.modules["menace_sandbox.coding_bot_interface"] = cbi_mod

--- a/tests/integration/test_evolution_patch_cycle.py
+++ b/tests/integration/test_evolution_patch_cycle.py
@@ -76,7 +76,7 @@ def test_evolution_orchestrator_patch_cycle(tmp_path, monkeypatch):
 
     cbi.self_coding_managed = self_coding_managed
 
-    def _manager_generate_helper(self, description, path=None):
+    def _manager_generate_helper(self, description, *, context_builder, path=None):
         return self.engine.generate_helper(description)
 
     cbi.manager_generate_helper = _manager_generate_helper
@@ -252,7 +252,12 @@ def test_evolution_orchestrator_patch_cycle(tmp_path, monkeypatch):
         def generate_and_patch(self, path, description, *, context_meta=None, context_builder=None):
             context_builder.build(description)
             self.engine.cognition_layer.context_builder = context_builder
-            code = manager_generate_helper(self, description, path=str(path))
+            code = manager_generate_helper(
+                self,
+                description,
+                context_builder=context_builder,
+                path=str(path),
+            )
             self.quick_fix.validate_patch(str(path), code)
             patch_id = self.quick_fix.apply_patch(str(path), code)
             self._last_patch_id = patch_id

--- a/tests/integration/test_full_self_coding_flow.py
+++ b/tests/integration/test_full_self_coding_flow.py
@@ -121,7 +121,12 @@ class SelfCodingManager:
         return 123, "deadbeef"
 
     def run_patch(self, path: Path, description: str, *, context_meta=None, context_builder=None):
-        manager_generate_helper(self, description, path=str(path))
+        manager_generate_helper(
+            self,
+            description,
+            context_builder=context_builder,
+            path=str(path),
+        )
         self.quick_fix.apply_validated_patch(str(path), description, context_meta or {})
         self._last_patch_id = 123
         self._last_commit_hash = "deadbeef"

--- a/tests/integration/test_internalized_degradation_patch_flow.py
+++ b/tests/integration/test_internalized_degradation_patch_flow.py
@@ -30,7 +30,7 @@ sys.modules.setdefault("menace.sandbox_runner.test_harness", th)
 
 # Stub coding bot interface before importing helper
 cbi_stub = types.ModuleType("menace.coding_bot_interface")
-def manager_generate_helper(manager, description, path=None):
+def manager_generate_helper(manager, description, *, context_builder, path=None):
     return manager.engine.generate_helper(description)
 cbi_stub.manager_generate_helper = manager_generate_helper
 cbi_stub.self_coding_managed = lambda cls: cls
@@ -137,7 +137,12 @@ class SelfCodingManager:
         **kwargs,
     ):
         self.gen_calls.append((path, description))
-        manager_generate_helper(self, description, path=str(path))
+        manager_generate_helper(
+            self,
+            description,
+            context_builder=context_builder,
+            path=str(path),
+        )
         if self.quick_fix:
             self.quick_fix.apply_validated_patch(str(path), description, context_meta or {})
         self._last_patch_id = 123

--- a/tests/test_billing_prompt_injection.py
+++ b/tests/test_billing_prompt_injection.py
@@ -69,5 +69,9 @@ def test_billing_instructions_in_prompt(monkeypatch):
         sce, "fetch_recent_billing_issues", lambda limit=5: ["invoice overdue"]
     )
 
-    manager_generate_helper(types.SimpleNamespace(engine=engine), "demo task")
+    manager_generate_helper(
+        types.SimpleNamespace(engine=engine),
+        "demo task",
+        context_builder=engine.context_builder,
+    )
     assert "invoice overdue" in engine._last_prompt.text

--- a/tests/test_codex_fallback.py
+++ b/tests/test_codex_fallback.py
@@ -130,7 +130,11 @@ def test_codex_fallback_retries_and_simplified_prompt(monkeypatch):
     patch_history(monkeypatch)
 
     manager = types.SimpleNamespace(engine=engine)
-    result = manager_generate_helper(manager, "do something")
+    result = manager_generate_helper(
+        manager,
+        "do something",
+        context_builder=engine.context_builder,
+    )
 
     assert call_delays == [[2, 5, 10], [2, 5, 10]]
     assert mock_llm.generate.call_count == 6
@@ -163,5 +167,9 @@ def test_codex_fallback_queue_on_malformed(monkeypatch):
     )
     patch_history(monkeypatch)
 
-    manager_generate_helper(types.SimpleNamespace(engine=engine), "do something")
+    manager_generate_helper(
+        types.SimpleNamespace(engine=engine),
+        "do something",
+        context_builder=engine.context_builder,
+    )
     queue_mock.assert_called_once()

--- a/tests/test_codex_fallback_behavior.py
+++ b/tests/test_codex_fallback_behavior.py
@@ -135,7 +135,11 @@ def test_timeout_error_prompts_simplified_and_builtin_fallback(monkeypatch):
     patch_history(monkeypatch)
 
     manager = types.SimpleNamespace(engine=engine)
-    result = manager_generate_helper(manager, 'do something')
+    result = manager_generate_helper(
+        manager,
+        'do something',
+        context_builder=engine.context_builder,
+    )
 
     assert len(calls) == 2
     assert calls[1].system == ''
@@ -179,7 +183,11 @@ def test_empty_completion_reroutes_and_queues(monkeypatch):
     patch_history(monkeypatch)
 
     manager = types.SimpleNamespace(engine=engine)
-    result = manager_generate_helper(manager, 'do something')
+    result = manager_generate_helper(
+        manager,
+        'do something',
+        context_builder=engine.context_builder,
+    )
 
     q_mock.assert_called_once()
     assert result == _expected_fallback('do something')
@@ -201,7 +209,11 @@ def test_handle_returns_llmresult_used_by_engine(monkeypatch):
     patch_history(monkeypatch)
 
     manager = types.SimpleNamespace(engine=engine)
-    result = manager_generate_helper(manager, 'do something')
+    result = manager_generate_helper(
+        manager,
+        'do something',
+        context_builder=engine.context_builder,
+    )
 
     handle_mock.assert_called_once()
     assert isinstance(handle_mock.return_value, LLMResult)

--- a/tests/test_context_builder.py
+++ b/tests/test_context_builder.py
@@ -279,7 +279,7 @@ def test_self_coding_engine_includes_context(monkeypatch):
         gpt_memory=gpt_mem,
     )
     manager = types.SimpleNamespace(engine=engine)
-    manager_generate_helper(manager, "alpha issue")
+    manager_generate_helper(manager, "alpha issue", context_builder=builder)
     assert "### Retrieval context" in client.last_prompt
     assert pretty in client.last_prompt
 

--- a/tests/test_fallback_ast.py
+++ b/tests/test_fallback_ast.py
@@ -47,7 +47,11 @@ def test_fallback_compiles_and_uses_snippet_context():
     snippet = """total = 0\nfor item in items:\n    total += item\nif total > 0:\n    return total"""
     engine.suggest_snippets = lambda *a, **k: [SimpleNamespace(code=snippet)]
     manager = SimpleNamespace(engine=engine)
-    result = manager_generate_helper(manager, "summation helper")
+    result = manager_generate_helper(
+        manager,
+        "summation helper",
+        context_builder=engine.context_builder,
+    )
     compile(result, "<generated>", "exec")
     assert "for item in items" in result
     assert "total" in result

--- a/tests/test_quick_fix_engine.py
+++ b/tests/test_quick_fix_engine.py
@@ -272,9 +272,17 @@ def test_patch_uses_refreshed_weights(monkeypatch: pytest.MonkeyPatch) -> None:
     import menace.quick_fix_engine as qfe
 
     weights["value"] = 1
-    qfe.manager_generate_helper(mgr, "first")
+    qfe.manager_generate_helper(
+        mgr,
+        "first",
+        context_builder=mgr.engine.cognition_layer.context_builder,
+    )
     weights["value"] = 2
-    qfe.manager_generate_helper(mgr, "second")
+    qfe.manager_generate_helper(
+        mgr,
+        "second",
+        context_builder=mgr.engine.cognition_layer.context_builder,
+    )
 
     assert seen == [1, 2]
 
@@ -313,8 +321,16 @@ def test_manager_helper_gets_new_builder_each_call(
     sys.modules.pop("quick_fix_engine", None)
     import menace.quick_fix_engine as qfe
 
-    qfe.manager_generate_helper(object(), "first")
-    qfe.manager_generate_helper(object(), "second")
+    qfe.manager_generate_helper(
+        object(),
+        "first",
+        context_builder=scm.ContextBuilder(),
+    )
+    qfe.manager_generate_helper(
+        object(),
+        "second",
+        context_builder=scm.ContextBuilder(),
+    )
 
     assert seen == [0, 1]
     sys.modules["quick_fix_engine"] = qfe_stub

--- a/tests/test_self_coding_codex_fallback.py
+++ b/tests/test_self_coding_codex_fallback.py
@@ -149,7 +149,11 @@ def test_empty_output_triggers_fallback(monkeypatch):
     patch_history(monkeypatch)
 
     manager = types.SimpleNamespace(engine=engine)
-    result = manager_generate_helper(manager, "do something")
+    result = manager_generate_helper(
+        manager,
+        "do something",
+        context_builder=engine.context_builder,
+    )
 
     assert model_used["model"] == fallback_model
     assert result == "print('hi')\n"
@@ -186,7 +190,11 @@ def test_malformed_output_triggers_fallback(monkeypatch):
     patch_history(monkeypatch)
 
     manager = types.SimpleNamespace(engine=engine)
-    result = manager_generate_helper(manager, "do something")
+    result = manager_generate_helper(
+        manager,
+        "do something",
+        context_builder=engine.context_builder,
+    )
 
     assert model_used["model"] == fallback_model
     assert result == "print('fixed')\n"
@@ -206,5 +214,9 @@ def test_fallback_uses_existing_context_builder(monkeypatch):
         self_coding_engine.codex_fallback_handler, "handle", handle
     )
     patch_history(monkeypatch)
-    manager_generate_helper(types.SimpleNamespace(engine=engine), "do something")
+    manager_generate_helper(
+        types.SimpleNamespace(engine=engine),
+        "do something",
+        context_builder=engine.context_builder,
+    )
 

--- a/tests/test_self_coding_engine_chunking.py
+++ b/tests/test_self_coding_engine_chunking.py
@@ -272,7 +272,12 @@ def test_generate_helper_injects_chunk_summaries(monkeypatch, tmp_path):
     target = tmp_path / "big.py"  # path-ignore
     target.write_text("print('hi')\n")
 
-    manager_generate_helper(types.SimpleNamespace(engine=engine), "do something", path=target)
+    manager_generate_helper(
+        types.SimpleNamespace(engine=engine),
+        "do something",
+        context_builder=engine.context_builder,
+        path=target,
+    )
 
     assert called["limit"] == engine.chunk_token_threshold
     assert "Chunk 0: sum1" in captured["context"]
@@ -334,8 +339,18 @@ def test_generate_helper_uses_cached_chunk_summaries(monkeypatch, tmp_path):
     target.write_text("print('hi')\n")
 
     mgr = types.SimpleNamespace(engine=engine)
-    manager_generate_helper(mgr, "do something", path=target)
-    manager_generate_helper(mgr, "do something", path=target)
+    manager_generate_helper(
+        mgr,
+        "do something",
+        context_builder=engine.context_builder,
+        path=target,
+    )
+    manager_generate_helper(
+        mgr,
+        "do something",
+        context_builder=engine.context_builder,
+        path=target,
+    )
 
     assert calls["n"] == 2  # summaries computed once and then served from cache
 
@@ -394,6 +409,7 @@ def test_generate_helper_builds_line_range_prompt(monkeypatch, tmp_path):
     manager_generate_helper(
         types.SimpleNamespace(engine=engine),
         "do something",
+        context_builder=engine.context_builder,
         path=target,
         target_region=region,
     )

--- a/tests/test_self_coding_engine_logging.py
+++ b/tests/test_self_coding_engine_logging.py
@@ -187,7 +187,12 @@ def test_knowledge_service_logging(monkeypatch, caplog):
     caplog.set_level(logging.WARNING)
     caplog.clear()
     target = dynamic_path_router.resolve_path("tests/fixtures/semantic/a.py")  # path-ignore
-    manager_generate_helper(types.SimpleNamespace(engine=engine), "desc", path=target)
+    manager_generate_helper(
+        types.SimpleNamespace(engine=engine),
+        "desc",
+        context_builder=engine.context_builder,
+        path=target,
+    )
     messages = [record.message for record in caplog.records]
     assert any("recent_feedback" in m for m in messages)
     assert any("recent_improvement_path" in m for m in messages)

--- a/unit_tests/test_self_coding_engine.py
+++ b/unit_tests/test_self_coding_engine.py
@@ -318,7 +318,7 @@ def test_context_builder_shared(monkeypatch):
     assert builder is engine.cognition_layer.context_builder
 
     manager = types.SimpleNamespace(engine=engine)
-    manager_generate_helper(manager, "alpha issue")
+    manager_generate_helper(manager, "alpha issue", context_builder=builder)
     assert "### Retrieval context" in client.last_prompt
     assert "ctx:alpha issue" in client.last_prompt
 


### PR DESCRIPTION
## Summary
- require a ContextBuilder argument when invoking manager_generate_helper and update the builder-backed helper to reuse the provided instance
- switch metadata-heavy prompt construction to SelfCodingEngine.build_enriched_prompt in the prediction bot, research bot, enhancement bot and self-improvement workflow
- propagate the new helper contract through engine flows, quick fix helper usage, and supporting tests

## Testing
- pytest tests/test_codex_fallback_behavior.py tests/test_self_coding_codex_fallback.py tests/test_quick_fix_engine.py tests/test_self_coding_engine.py tests/test_self_coding_engine_chunking.py tests/test_context_builder.py tests/test_billing_prompt_injection.py tests/test_fallback_ast.py unit_tests/test_self_coding_engine.py unit_tests/test_quick_fix_engine.py tests/integration/test_evolution_patch_cycle.py tests/integration/test_full_self_coding_flow.py tests/integration/test_internalized_degradation_patch_flow.py *(fails: missing optional menace dependencies during import)*

------
https://chatgpt.com/codex/tasks/task_e_68c9522b3368832eaf161a567c7842a7