### PR TITLE
Handle context builder errors before local generation

### DIFF
--- a/neurosales/neurosales/response_generation.py
+++ b/neurosales/neurosales/response_generation.py
@@ -5,6 +5,7 @@ import random
 from typing import Dict, List
 
 from context_builder import handle_failure
+from prompt_types import Prompt
 
 try:
     from sklearn.feature_extraction.text import TfidfVectorizer
@@ -176,9 +177,15 @@ class ResponseCandidateGenerator:
             except Exception as exc:
                 handle_failure("failed to build response generation prompt", exc)
             else:
+                enriched_prompt = prompt_obj
+                if not isinstance(enriched_prompt, Prompt):
+                    handle_failure(
+                        "SelfCodingEngine.build_enriched_prompt must return a Prompt instance",
+                        TypeError(f"unexpected prompt type: {type(enriched_prompt)!r}"),
+                    )
                 try:
                     outputs = self.wrapper.generate(
-                        prompt_obj,
+                        enriched_prompt,
                         context_builder=context_builder,
                         max_length=max_len,
                         num_return_sequences=n,


### PR DESCRIPTION
## Summary
- wrap sandbox section prompt creation with handle_failure so ContextBuilder errors are surfaced consistently
- guard QueryBot prompt creation with the same error handling helper
- ensure neurosales response generation forwards the Prompt returned by build_enriched_prompt directly to LocalModelWrapper after validating its type

## Testing
- pytest tests/test_query_bot.py
- pytest neurosales/tests/test_response_generation.py
- pytest tests/test_sandbox_runner_metrics.py::test_build_section_prompt_vector_context

------
https://chatgpt.com/codex/tasks/task_e_68c95ce4aecc832ebeb6c6c1cf3caca4