### PR TITLE
Require explicit context builders for LLM client usage

### DIFF
--- a/tests/test_codex_fallback.py
+++ b/tests/test_codex_fallback.py
@@ -116,7 +116,7 @@ def test_codex_fallback_retries_and_simplified_prompt(monkeypatch):
 
     call_delays = []
 
-    def fake_call(client, prompt, *, logger=None, timeout=30.0):
+    def fake_call(client, prompt, *, context_builder=None, logger=None, timeout=30.0):
         delays = list(self_coding_engine._settings.codex_retry_delays)
         call_delays.append(delays)
         for _ in delays:

--- a/tests/test_codex_fallback_behavior.py
+++ b/tests/test_codex_fallback_behavior.py
@@ -118,7 +118,7 @@ def test_timeout_error_prompts_simplified_and_builtin_fallback(monkeypatch):
 
     calls = []
 
-    def fake_call(client, prompt, *, logger=None, timeout=30.0):
+    def fake_call(client, prompt, *, context_builder=None, logger=None, timeout=30.0):
         calls.append(prompt)
         delays = list(self_coding_engine._settings.codex_retry_delays)
         for _ in delays:
@@ -163,7 +163,9 @@ def test_empty_completion_reroutes_and_queues(monkeypatch):
         codex_fallback_strategy="reroute"
     )
 
-    def simple_call(client, prompt, *, logger=None, timeout=30.0):
+    def simple_call(
+        client, prompt, *, context_builder=None, logger=None, timeout=30.0
+    ):
         return client.generate(prompt)
 
     monkeypatch.setattr(self_coding_engine, 'call_codex_with_backoff', simple_call)
@@ -197,7 +199,9 @@ def test_handle_returns_llmresult_used_by_engine(monkeypatch):
     mock_llm = MagicMock(return_value=LLMResult(text=''))
     engine = make_engine(mock_llm, monkeypatch)
 
-    def simple_call(client, prompt, *, logger=None, timeout=30.0):
+    def simple_call(
+        client, prompt, *, context_builder=None, logger=None, timeout=30.0
+    ):
         return client.generate(prompt)
 
     monkeypatch.setattr(self_coding_engine, 'call_codex_with_backoff', simple_call)

--- a/tests/test_self_coding_engine.py
+++ b/tests/test_self_coding_engine.py
@@ -617,8 +617,11 @@ def test_call_codex_with_backoff_retries(monkeypatch):
             raise Exception("boom")
 
     client = FailClient()
+    builder = object()
     with pytest.raises(sce.RetryError):
-        sce.call_codex_with_backoff(client, sce.Prompt("x"))
+        sce.call_codex_with_backoff(
+            client, sce.Prompt("x"), context_builder=builder
+        )
 
     assert sleeps == delays
     assert client.calls == len(delays) + 1

--- a/unit_tests/test_self_coding_engine.py
+++ b/unit_tests/test_self_coding_engine.py
@@ -269,8 +269,9 @@ def test_call_codex_with_backoff_retries(monkeypatch):
             raise Exception("boom")
 
     client = FailClient()
+    builder = object()
     with pytest.raises(sce.RetryError):
-        sce.call_codex_with_backoff(client, sce.Prompt("x"))
+        sce.call_codex_with_backoff(client, sce.Prompt("x"), context_builder=builder)
 
     assert sleeps == delays
     assert client.calls == len(delays) + 1


### PR DESCRIPTION
## Summary
- add a helper in `LLMClient` to resolve context builders and remove the fallback stub usage
- require an explicit builder for `call_codex_with_backoff` and forward it through `_invoke_llm`
- update self-coding related tests to supply a context builder and adapt patched helpers

## Testing
- pytest unit_tests/test_self_coding_engine.py -q *(fails: ImportError loading self_coding_engine dependencies in test environment)*
- pytest tests/test_codex_fallback_behavior.py -q *(fails: ImportError loading self_coding_engine dependencies in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c982231bb8832e87d90b33d75cdcb9