### PR TITLE
Improve Prompt alias detection in context builder linter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,8 @@ also fails fast when it encounters any of the following patterns:
 * imports of `get_default_context_builder` outside of test directories;
 * literal prompt strings or message lists passed directly to LLM clients instead of
   the output of `ContextBuilder.build_prompt` or `SelfCodingEngine.build_enriched_prompt`;
-* direct `Prompt(...)` instantiation outside `vector_service/context_builder.py`;
+* direct `Prompt(...)` instantiation outside `vector_service/context_builder.py`
+  (renaming or aliasing the import does not bypass the check);
 * direct `PromptEngine.build_prompt` calls that bypass the builder interface.
 
 Results of `ContextBuilder.build(...)` must be sent straight to the LLM client.

--- a/tests/test_check_context_builder_usage.py
+++ b/tests/test_check_context_builder_usage.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from pathlib import Path
 import textwrap
 
 from scripts import check_context_builder_usage as ccb
@@ -33,6 +36,39 @@ def test_prompt_engine_build_prompt_flagged(tmp_path):
     assert any("PromptEngine.build_prompt disallowed" in message for message in messages)
 
 
+def test_prompt_alias_instantiation_flagged(tmp_path):
+    bad_file = _write_source(
+        tmp_path,
+        "chatgpt_idea_bot.py",
+        """
+        from prompt_types import Prompt as IdeaPrompt
+
+        IdeaPrompt('raw prompt text')
+        """,
+    )
+
+    messages = _extract_messages(ccb.check_file(bad_file))
+
+    assert any("Prompt instantiation disallowed" in message for message in messages)
+
+
+def test_prompt_assignment_alias_flagged(tmp_path):
+    bad_file = _write_source(
+        tmp_path,
+        "alias_assignment.py",
+        """
+        from prompt_types import Prompt
+
+        IdeaPrompt = Prompt
+        IdeaPrompt('raw prompt text')
+        """,
+    )
+
+    messages = _extract_messages(ccb.check_file(bad_file))
+
+    assert any("Prompt instantiation disallowed" in message for message in messages)
+
+
 def test_main_returns_failure_on_banned_usage(tmp_path, monkeypatch):
     bad_file = _write_source(tmp_path, "banned_usage.py", """
     Prompt('raw prompt text')
@@ -41,3 +77,9 @@ def test_main_returns_failure_on_banned_usage(tmp_path, monkeypatch):
     monkeypatch.setattr(ccb, "iter_python_files", lambda _root: [bad_file])
 
     assert ccb.main() == 1
+
+
+def test_chatgpt_idea_bot_is_clean():
+    messages = _extract_messages(ccb.check_file(Path("chatgpt_idea_bot.py")))
+
+    assert not any("Prompt instantiation disallowed" in message for message in messages)


### PR DESCRIPTION
## Summary
- track Prompt aliases and reassignments in `scripts/check_context_builder_usage.py` so renamed constructors are still reported
- expand `tests/test_check_context_builder_usage.py` to cover alias usage and validate the real chatgpt_idea_bot module stays clean
- document in CONTRIBUTING.md that renaming Prompt does not avoid the linter

## Testing
- pytest tests/test_check_context_builder_usage.py

------
https://chatgpt.com/codex/tasks/task_e_68ca1c2fa6fc832eae5dfddfe3057638