### PR TITLE
Require Prompt inputs for ChatGPTClient.ask

### DIFF
--- a/tests/test_chatgpt_client_gpt_memory.py
+++ b/tests/test_chatgpt_client_gpt_memory.py
@@ -195,7 +195,10 @@ def test_summarize_and_prune_via_client(monkeypatch):
     )
 
     for i in range(3):
-        client.ask([{"role": "user", "content": f"ask{i}"}], tags=["insight"])
+        prompt_obj = builder.build_prompt(
+            f"ask{i}", intent_metadata={"tags": ["insight"]}
+        )
+        client.ask(prompt_obj, tags=["insight"])
 
     assert len(mem.search_context("", tags=["insight"])) == 3
     mem.compact({"insight": 1})

--- a/tests/test_chatgpt_client_knowledge.py
+++ b/tests/test_chatgpt_client_knowledge.py
@@ -113,8 +113,12 @@ def test_ask_injects_context_and_logs(monkeypatch):
     monkeypatch.setattr(cib, "redact", lambda x: x)
     knowledge = DummyKnowledge(record)
 
+    prompt_obj = client.context_builder.build_prompt(
+        "hello", intent_metadata={"tags": ["t"]}
+    )
+
     resp = client.ask(
-        [{"role": "user", "content": "hello"}],
+        prompt_obj,
         knowledge=knowledge,
         use_memory=True,
         relevance_threshold=0.5,

--- a/tests/test_chatgpt_client_memory.py
+++ b/tests/test_chatgpt_client_memory.py
@@ -191,7 +191,8 @@ def test_ask_logs_interaction(monkeypatch):
         "log_with_tags",
         lambda mem, prompt, response, tags: logged.append((prompt, response, tags)),
     )
-    client.ask([{"role": "user", "content": "hi"}], use_memory=False)
+    prompt_obj = builder.build_prompt("hi")
+    client.ask(prompt_obj, use_memory=False)
     assert "hi" in logged[0][0]
     assert logged[0][1] == "resp"
     assert cib.INSIGHT in logged[0][2]

--- a/tests/test_chatgpt_client_prompt_validation.py
+++ b/tests/test_chatgpt_client_prompt_validation.py
@@ -1,0 +1,117 @@
+import sys
+import types
+
+import pytest
+
+sys.modules.setdefault(
+    "menace_sandbox.database_manager",
+    types.SimpleNamespace(DB_PATH="db", search_models=lambda *a, **k: []),
+)
+sys.modules.setdefault(
+    "menace_sandbox.database_management_bot",
+    types.SimpleNamespace(DatabaseManagementBot=object),
+)
+sys.modules.setdefault(
+    "menace_sandbox.shared_gpt_memory", types.SimpleNamespace(GPT_MEMORY_MANAGER=None)
+)
+sys.modules.setdefault(
+    "menace_sandbox.memory_logging", types.SimpleNamespace(log_with_tags=lambda *a, **k: None)
+)
+sys.modules.setdefault(
+    "menace_sandbox.memory_aware_gpt_client",
+    types.SimpleNamespace(ask_with_memory=lambda *a, **k: {}),
+)
+sys.modules.setdefault(
+    "menace_sandbox.local_knowledge_module",
+    types.SimpleNamespace(LocalKnowledgeModule=lambda *a, **k: types.SimpleNamespace(memory=None)),
+)
+sys.modules.setdefault(
+    "menace_sandbox.knowledge_retriever",
+    types.SimpleNamespace(
+        get_feedback=lambda *a, **k: [],
+        get_improvement_paths=lambda *a, **k: [],
+        get_error_fixes=lambda *a, **k: [],
+    ),
+)
+sys.modules.setdefault(
+    "governed_retrieval",
+    types.SimpleNamespace(govern_retrieval=lambda *a, **k: None, redact=lambda x: x),
+)
+sys.modules.setdefault(
+    "vector_service",
+    types.SimpleNamespace(SharedVectorService=object),
+)
+
+import menace_sandbox.chatgpt_idea_bot as cib  # noqa: E402
+from prompt_types import Prompt  # noqa: E402
+
+
+class TrackingBuilder:
+    def __init__(self):
+        self.enrich_calls: list = []
+
+    def refresh_db_weights(self) -> None:
+        pass
+
+    def build_prompt(self, goal, *, intent_metadata=None, **_):
+        meta = dict(intent_metadata or {})
+        tags = list(meta.get("tags", []) or [])
+        if tags and not meta.get("intent_tags"):
+            meta["intent_tags"] = list(tags)
+        meta.setdefault("origin", "context_builder")
+        return Prompt(
+            goal,
+            tags=tags,
+            metadata=meta,
+            origin=meta.get("origin"),
+        )
+
+    def enrich_prompt(self, prompt, *, tags=None, metadata=None, origin=None):
+        self.enrich_calls.append((prompt, tuple(tags) if tags is not None else None, metadata, origin))
+        meta = dict(getattr(prompt, "metadata", {}) or {})
+        if metadata:
+            meta.update(metadata)
+        prompt.metadata = meta
+        if origin:
+            prompt.origin = origin
+        return prompt
+
+
+@pytest.fixture
+def offline_response(monkeypatch):
+    def _factory(client):
+        client.session = None
+        monkeypatch.setattr(
+            client,
+            "_offline_response",
+            lambda _msgs: {"choices": [{"message": {"content": "ok"}}]},
+        )
+        monkeypatch.setattr(cib, "log_with_tags", lambda *a, **k: None)
+        return client
+
+    return _factory
+
+
+def test_ask_rejects_message_list(offline_response):
+    builder = TrackingBuilder()
+    client = cib.ChatGPTClient(context_builder=builder, gpt_memory=None)
+    offline_response(client)
+
+    with pytest.raises(ValueError):
+        client.ask([{"role": "user", "content": "hi"}])
+
+
+def test_prompt_input_invokes_enrichment(offline_response):
+    builder = TrackingBuilder()
+    client = cib.ChatGPTClient(context_builder=builder, gpt_memory=None)
+    offline_response(client)
+
+    prompt_obj = builder.build_prompt("hello", intent_metadata={"tags": ["alpha"]})
+    client.ask(prompt_obj, tags=["alpha"], use_memory=False)
+
+    assert builder.enrich_calls, "context builder enrichment should be invoked"
+    prompt_used, tags_used, metadata_used, origin_used = builder.enrich_calls[0]
+    assert prompt_used is prompt_obj
+    assert tags_used is None or list(tags_used)  # ensure tags were provided or normalized
+    assert metadata_used is None or metadata_used.get("origin") == "context_builder"
+    assert origin_used == "context_builder"


### PR DESCRIPTION
## Summary
- require ChatGPTClient.ask to receive a Prompt instance and reject list based inputs
- drive logging and memory integration from the Prompt data when submitting to the API
- update and extend tests to cover Prompt-only inputs and validation errors

## Testing
- `pytest tests/test_chatgpt_client_memory.py tests/test_chatgpt_client_knowledge.py tests/test_chatgpt_client_gpt_memory.py tests/test_chatgpt_client_context_builder.py tests/test_chatgpt_client_local_context.py tests/test_chatgpt_client_prompt_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68ca2cc1bc1c832ebf6c7f5d85d86dd2