### PR TITLE
Add workflow test configuration and helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,10 @@ from the active ``threshold_service`` or per-bot configuration.  The default
 environment variable or `SandboxSettings.self_coding_test_command`.  Per-bot
 commands are specified with a `test_command` entry in
 `config/self_coding_thresholds.yaml` or within `SandboxSettings.bot_thresholds`.
-The active command may be refreshed at runtime using
-``policy.update_test_command([...])``.
+Workflow suites executed during post-patch validation can be declared with the
+matching `workflow_tests` field and resolved at runtime through
+``menace_sandbox.bot_registry.get_bot_workflow_tests``. The active command may
+be refreshed at runtime using ``policy.update_test_command([...])``.
 
 ### SelfCodingEngine
 

--- a/config/self_coding_thresholds.yaml
+++ b/config/self_coding_thresholds.yaml
@@ -5,11 +5,15 @@ default:
   patch_success_drop: -0.2
   model: exponential
   confidence: 0.95
+  workflow_tests:
+  - tests/workflows/test_smoke.py::test_default_workflow
 bots:
   AICounterBot:
     roi_drop: -0.1
     error_increase: 1.0
     test_failure_increase: 0.0
+    workflow_tests:
+    - tests/workflows/test_ai_counter.py::test_metrics_cycle
   AntifragilityPredictionBot:
     roi_drop: -0.1
     error_increase: 1.0

--- a/conftest.py
+++ b/conftest.py
@@ -30,7 +30,10 @@ sys.modules.setdefault("metrics_exporter", metrics_stub)
 sys.modules.setdefault("menace.metrics_exporter", metrics_stub)
 sys.modules.setdefault(
     "menace.sandbox_settings",
-    types.SimpleNamespace(SandboxSettings=lambda: types.SimpleNamespace()),
+    types.SimpleNamespace(
+        SandboxSettings=lambda: types.SimpleNamespace(),
+        normalize_workflow_tests=lambda value=None: [],
+    ),
 )
 
 # Stub neurosales package and optional billing dependencies

--- a/docs/sandbox_self_improvement_configuration.md
+++ b/docs/sandbox_self_improvement_configuration.md
@@ -30,8 +30,8 @@ advice for common setup problems.
 ## Self-coding thresholds
 Per-bot regression limits are stored in `config/self_coding_thresholds.yaml`.
 Each entry defines the maximum allowed ROI drop, error increase and test
-failure increase before a bot is considered degraded. A custom test command can
-also be provided. Example:
+failure increase before a bot is considered degraded. Custom test commands and
+workflow suites can also be provided. Example:
 
 ```yaml
 default:
@@ -39,16 +39,22 @@ default:
   error_increase: 1.0
   test_failure_increase: 0.0
   test_command: ["pytest", "-q"]
+  workflow_tests:
+    - tests/workflows/test_default.py::test_smoke
 bots:
   QuickFixEngine:
     roi_drop: -0.1
     error_increase: 1.0
     test_failure_increase: 0.0
     test_command: ["pytest", "tests/quickfix", "-q"]
+    workflow_tests:
+      - tests/workflows/test_quickfix.py::test_happy_path
   BotDevelopmentBot:
     roi_drop: -0.1
     error_increase: 1.0
     test_failure_increase: 0.0
+    workflow_tests:
+      - scripts/run_botdev_workflow.py
   ImplementationOptimiserBot:
     roi_drop: -0.1
     error_increase: 1.0
@@ -63,6 +69,10 @@ it queries the active ``threshold_service`` and falls back to
 ``SandboxSettings.bot_thresholds`` for per-bot overrides.  The selected
 command can be changed on a running policy via
 ``PatchApprovalPolicy.update_test_command``.
+
+Workflow suites declared via the ``workflow_tests`` field are discovered using
+``menace_sandbox.bot_registry.get_bot_workflow_tests`` and automatically passed
+to post-patch validation in :class:`SelfCodingManager`.
 
 ## Security considerations
 - Resource and network limits are controlled through environment variables.

--- a/self_coding_thresholds.py
+++ b/self_coding_thresholds.py
@@ -4,10 +4,11 @@ The configuration file ``config/self_coding_thresholds.yaml`` stores
 thresholds keyed by bot name.  Each entry may define ``roi_drop``
 (allowable decrease in ROI), ``error_increase`` (maximum allowed
 increase in errors), ``test_failure_increase`` (allowed growth in
-failing tests) and ``test_command`` (custom test runner).  Forecast
-configuration is also stored allowing each bot to select a forecasting
-model, confidence interval and optional parameters via ``model``,
-``confidence`` and ``model_params`` fields.
+failing tests), ``test_command`` (custom test runner) and
+``workflow_tests`` (pytest selectors or scripts covering key flows).
+Forecast configuration is also stored allowing each bot to select a
+forecasting model, confidence interval and optional parameters via
+``model``, ``confidence`` and ``model_params`` fields.
 
 Long running services cache threshold values after the first lookup.
 When the YAML file is edited at runtime these values can be refreshed by
@@ -26,6 +27,7 @@ Example configuration snippet::
       confidence: 0.95
       model_params: {alpha: 0.3}
       test_command: ["pytest", "-q"]
+      workflow_tests: ["tests/workflows/test_default.py::test_smoke"]
     bots:
       example-bot:
         roi_drop: -0.2
@@ -35,6 +37,7 @@ Example configuration snippet::
         confidence: 0.9
         model_params: {order: [1, 1, 1]}
         test_command: ["pytest", "tests/example", "-q"]
+        workflow_tests: ["python", "scripts/run_example_workflow.py"]
 
 You can modify the file directly or use :func:`update_thresholds`::
 
@@ -51,13 +54,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Any
 
 import os
 import shlex
 import yaml
 
-from .sandbox_settings import SandboxSettings
+from .sandbox_settings import SandboxSettings, normalize_workflow_tests
 from .dynamic_path_router import resolve_path
 from .roi_thresholds import ROIThresholds
 
@@ -81,6 +84,7 @@ class SelfCodingThresholds:
     patch_success_weight: float = 0.1
     auto_recalibrate: bool = True
     test_command: list[str] | None = None
+    workflow_tests: list[str] | None = None
     model: str = "exponential"
     confidence: float = 0.95
     model_params: dict | None = None
@@ -136,6 +140,32 @@ def get_thresholds(
             cmd = shlex.split(cmd_val)
         else:
             cmd = cmd_val
+    workflow_tests: list[str] = []
+    workflow_cfg_set = False
+
+    def _override_from_value(value: Any, *, explicit: bool) -> None:
+        nonlocal workflow_tests, workflow_cfg_set
+        normalized = normalize_workflow_tests(value)
+        if normalized or explicit:
+            workflow_tests = list(normalized)
+            if explicit:
+                workflow_cfg_set = True
+            else:
+                workflow_cfg_set = workflow_cfg_set or bool(normalized)
+
+    def _override_from_bt(bt: Any) -> None:
+        if bt is None:
+            return
+        fields_set = getattr(bt, "__fields_set__", set())
+        explicit = "workflow_tests" in fields_set
+        _override_from_value(getattr(bt, "workflow_tests", None), explicit=explicit)
+
+    thresholds_cfg = getattr(s, "bot_thresholds", {})
+    if isinstance(thresholds_cfg, dict):
+        _override_from_bt(thresholds_cfg.get("default"))
+        if bot:
+            _override_from_bt(thresholds_cfg.get(bot))
+
     data = _load_config(path)
     default = data.get("default", {})
     bots = data.get("bots", {})
@@ -152,6 +182,8 @@ def get_thresholds(
     conf = float(default.get("confidence", 0.95))
     params = default.get("model_params", {})
     cmd_cfg = default.get("test_command", cmd)
+    if "workflow_tests" in default:
+        _override_from_value(default.get("workflow_tests"), explicit=True)
     if bot and bot in bots:
         cfg = bots[bot] or {}
         roi_drop = float(cfg.get("roi_drop", roi_drop))
@@ -167,12 +199,15 @@ def get_thresholds(
         conf = float(cfg.get("confidence", conf))
         params = cfg.get("model_params", params)
         cmd_cfg = cfg.get("test_command", cmd_cfg)
+        if "workflow_tests" in cfg:
+            _override_from_value(cfg.get("workflow_tests"), explicit=True)
     if isinstance(cmd_cfg, str):
         cmd_cfg = shlex.split(cmd_cfg)
     elif cmd_cfg is not None:
         cmd_cfg = list(cmd_cfg)
     if not isinstance(params, dict):
         params = {}
+    final_workflow_tests = workflow_tests if (workflow_cfg_set or workflow_tests) else None
     return SelfCodingThresholds(
         roi_drop=roi_drop,
         error_increase=err_inc,
@@ -184,6 +219,7 @@ def get_thresholds(
         patch_success_weight=patch_weight,
         auto_recalibrate=auto_recal,
         test_command=cmd_cfg,
+        workflow_tests=final_workflow_tests,
         model=model,
         confidence=conf,
         model_params=params,
@@ -203,6 +239,7 @@ def update_thresholds(
     patch_success_weight: float | None = None,
     auto_recalibrate: bool | None = None,
     test_command: list[str] | None = None,
+    workflow_tests: list[str] | None = None,
     forecast_model: str | None = None,
     confidence: float | None = None,
     forecast_params: dict | None = None,
@@ -234,6 +271,8 @@ def update_thresholds(
         cfg["auto_recalibrate"] = bool(auto_recalibrate)
     if test_command is not None:
         cfg["test_command"] = list(test_command)
+    if workflow_tests is not None:
+        cfg["workflow_tests"] = list(workflow_tests)
     if forecast_model is not None:
         cfg["model"] = forecast_model
     if confidence is not None:


### PR DESCRIPTION
## Summary
- extend bot threshold configuration with a workflow_tests field and normalization helper
- expose get_bot_workflow_tests via the bot registry, integrate it into SelfCodingManager and update stubs/tests
- document workflow suite configuration and refresh the self-coding config template

## Testing
- pytest tests/test_bot_registry.py
- pytest tests/test_data_bot_thresholds.py *(fails: QuickFixEngine is required but could not be imported)*

------
https://chatgpt.com/codex/tasks/task_e_68ca39ff9b14832ebb3c74a36da96c83