### PR TITLE
Integrate self-test summaries into auto patch flows

### DIFF
--- a/menace_master.py
+++ b/menace_master.py
@@ -571,7 +571,12 @@ def deploy_patch(
     )
     manager.context_builder = builder
     try:
-        manager.auto_run_patch(path, description)
+        summary = manager.auto_run_patch(path, description)
+        failed_tests = int(summary.get("self_tests", {}).get("failed", 0)) if summary else 0
+        if summary is None or failed_tests:
+            if summary is None:
+                raise RuntimeError("post validation summary unavailable")
+            raise RuntimeError(f"self tests failed ({failed_tests})")
     except Exception:
         rb.auto_rollback("latest", [])
 

--- a/service_supervisor.py
+++ b/service_supervisor.py
@@ -482,7 +482,12 @@ class ServiceSupervisor:
                 evolution_orchestrator=evolution_orchestrator,
             )
             manager.context_builder = self.context_builder
-            manager.auto_run_patch(path, description)
+            summary = manager.auto_run_patch(path, description)
+            failed_tests = int(summary.get("self_tests", {}).get("failed", 0)) if summary else 0
+            if summary is None or failed_tests:
+                if summary is None:
+                    raise RuntimeError("post validation summary unavailable")
+                raise RuntimeError(f"self tests failed ({failed_tests})")
             added_modules = getattr(engine, "last_added_modules", None)
             if not added_modules:
                 added_modules = getattr(engine, "added_modules", None)


### PR DESCRIPTION
## Summary
- have SelfCodingManager.auto_run_patch trigger post-validation by default and publish the returned summary for downstream consumers
- update orchestrators and automation callers to consume the validation results, rolling back when self-tests fail or are missing
- refactor QuickFixEngine and helper bots to rely on SelfTestService summaries instead of ad-hoc pytest execution

## Testing
- pytest tests/test_self_coding_scheduler.py tests/test_self_debugger_patch_flow.py -q *(fails: ImportError: cannot import name 'ROITracker')*


------
https://chatgpt.com/codex/tasks/task_e_68ca491d86a8832eb444d1d2e0935095