### PR TITLE
Fix PolicySettings validator signature

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -736,11 +736,33 @@ class PolicySettings(BaseModel):
     temperature: float = 1.0
     exploration: str = "epsilon_greedy"
 
-    @field_validator("alpha", "gamma", "epsilon")
-    def _policy_unit_range(cls, v: float, info: Any) -> float:
-        if not 0 <= v <= 1:
-            raise ValueError(f"{info.field_name} must be between 0 and 1")
-        return v
+    if PYDANTIC_V2:
+
+        @field_validator("alpha", "gamma", "epsilon")
+        def _policy_unit_range(
+            cls,
+            v: float,
+            info: FieldValidationInfo,
+        ) -> float:
+            if not 0 <= v <= 1:
+                raise ValueError(f"{info.field_name} must be between 0 and 1")
+            return v
+
+    else:  # pragma: no cover - compatibility for pydantic<2
+
+        @field_validator("alpha", "gamma", "epsilon")
+        def _policy_unit_range(
+            cls,
+            v: float,
+            values: dict[str, Any],
+            config: Any,
+            field: ModelField,
+        ) -> float:
+            if not 0 <= v <= 1:
+                raise ValueError(
+                    f"{_field_name(field=field)} must be between 0 and 1"
+                )
+            return v
 
     @field_validator("temperature")
     def _policy_temperature(cls, v: float) -> float:


### PR DESCRIPTION
## Summary
- update PolicySettings validators to support both Pydantic v2 and legacy v1 signatures
- keep legacy behaviour using ModelField when running with older Pydantic releases

## Testing
- python - <<'PY'
from sandbox_settings import PolicySettings
print(PolicySettings())
PY

------
https://chatgpt.com/codex/tasks/task_e_68ce4421a414832e9b58f6170897a80d