### PR TITLE
Fix pydantic validator shim for mode parameter

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -37,6 +37,15 @@ except Exception:  # pragma: no cover
     def field_validator(*fields, **kwargs):  # type: ignore[misc]
         """Shim for ``pydantic.validator`` with ``allow_reuse`` defaulting to ``True``."""
 
+        mode = kwargs.pop("mode", None)
+        if mode is not None:
+            translated: dict[str, bool] = {"before": True, "after": False, "plain": False}
+            if mode not in translated:
+                raise ValueError(
+                    f"Unsupported validation mode for pydantic<2: {mode!r}"
+                )
+            kwargs["pre"] = translated[mode]
+
         kwargs.setdefault("allow_reuse", True)
         base_validator = _pydantic_validator(*fields, **kwargs)
 


### PR DESCRIPTION
## Summary
- translate pydantic v2 `mode` arguments into v1-compatible `pre` flags in the validator shim
- raise a clear error if an unsupported validation mode is requested while using the shim

## Testing
- python -m compileall sandbox_settings.py

------
https://chatgpt.com/codex/tasks/task_e_68ce463935e0832e842b8fbe0580f4c3