### PR TITLE
Handle missing database files and improve telemetry routing

### DIFF
--- a/evaluation_dashboard.py
+++ b/evaluation_dashboard.py
@@ -347,9 +347,14 @@ class EvaluationDashboard:
     def relevancy_radar_panel(self, threshold: int = 5) -> List[Dict[str, Any]]:
         """Return modules with low relevancy scores and annotations."""
 
-        metrics_path = Path(resolve_path("sandbox_data/relevancy_metrics.json"))
-        if not metrics_path.exists():
-            return []
+        module_dir = Path(__file__).resolve().parent
+        local_metrics = module_dir / "sandbox_data" / "relevancy_metrics.json"
+        if local_metrics.exists():
+            metrics_path = local_metrics
+        else:
+            metrics_path = Path(resolve_path("sandbox_data/relevancy_metrics.json"))
+            if not metrics_path.exists():
+                return []
         try:
             with metrics_path.open("r", encoding="utf-8") as fh:
                 data = json.load(fh)


### PR DESCRIPTION
## Summary
- allow `init_db_router` to fall back to project-root database locations when default files are missing
- ensure `TelemetryBackend` reinitialises the router when the global instance targets a different menace or database file
- prefer metrics data colocated with the dashboard module before falling back to repository-level paths

## Testing
- `pytest tests/test_evaluation_dashboard.py`
- `pytest tests/test_telemetry_backend.py tests/test_telemetry_backend_scope.py`


------
https://chatgpt.com/codex/tasks/task_e_68ce4a667214832e99240e1cae33749a