### PR TITLE
Handle missing ROI sentiment config gracefully

### DIFF
--- a/vector_service/weight_adjuster.py
+++ b/vector_service/weight_adjuster.py
@@ -29,8 +29,12 @@ def _load_tag_sentiment() -> Dict[RoiTag, float]:
         RoiTag.BLOCKED: -1.0,
     }
 
-    cfg_path = resolve_path("config/roi_tag_sentiment.yaml")
-    if cfg_path.exists():
+    try:
+        cfg_path = resolve_path("config/roi_tag_sentiment.yaml")
+    except FileNotFoundError:
+        cfg_path = None
+
+    if cfg_path and cfg_path.exists():
         try:  # pragma: no cover - configuration loading is best effort
             data = yaml.safe_load(cfg_path.read_text()) or {}
             if isinstance(data, dict):


### PR DESCRIPTION
## Summary
- guard the ROI tag sentiment loader against missing configuration files so weight adjustments fall back to defaults

## Testing
- python manual_bootstrap.py *(fails: script not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4de84ca0832e93b366c4ac43de1f