### PR TITLE
Fix pydantic v1 validator compatibility

### DIFF
--- a/config.py
+++ b/config.py
@@ -88,10 +88,12 @@ else:  # pragma: no cover - executed when running under pydantic v1
         def wrapper(func):
             method = func.__func__ if isinstance(func, classmethod) else func
 
-            @wraps(method)
             def _validator(cls, value, values, config, field):  # type: ignore[override]
                 info = SimpleNamespace(field_name=getattr(field, "name", None))
                 return method(cls, value, info)
+
+            _validator.__name__ = getattr(method, "__name__", "validator")
+            _validator.__qualname__ = getattr(method, "__qualname__", _validator.__qualname__)
 
             return decorator(_validator)
 


### PR DESCRIPTION
## Summary
- ensure the pydantic v1 `field_validator` shim returns a callable with the signature expected by v1
- preserve the original method's name/qualname without copying its incompatible signature

## Testing
- python manual_bootstrap.py *(fails: script not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8a8e725c832e93bfa5d1be6973c2