### PR TITLE
Fix pydantic v1 validator reuse error

### DIFF
--- a/config.py
+++ b/config.py
@@ -116,7 +116,7 @@ else:  # pragma: no cover - executed when running under pydantic v1
                     return result.dict()
                 return values if result is None else result
 
-            return root_validator(skip_on_failure=True)(_validator)
+            return root_validator(skip_on_failure=True, allow_reuse=True)(_validator)
 
         return decorator
 


### PR DESCRIPTION
## Summary
- allow the pydantic v1 compatibility root_validator shim to reuse validator functions without raising duplicate errors

## Testing
- python -m compileall config.py

------
https://chatgpt.com/codex/tasks/task_e_68ce8b6fb1bc832e8c48930165c4107f