### PR TITLE
Handle missing vector metrics database

### DIFF
--- a/vector_metrics_analytics.py
+++ b/vector_metrics_analytics.py
@@ -17,9 +17,9 @@ from typing import Any
 from dynamic_path_router import resolve_path
 
 try:  # pragma: no cover - allow running as a script
-    from .vector_metrics_db import VectorMetricsDB
+    from .vector_metrics_db import VectorMetricsDB, default_vector_metrics_path
 except Exception:  # pragma: no cover - fallback when executed directly
-    from vector_metrics_db import VectorMetricsDB  # type: ignore
+    from vector_metrics_db import VectorMetricsDB, default_vector_metrics_path  # type: ignore
 
 
 # ---------------------------------------------------------------------------
@@ -178,7 +178,7 @@ def cli(argv: list[str] | None = None) -> None:
     )
     parser.add_argument(
         "--db",
-        default=resolve_path("vector_metrics.db"),
+        default=str(default_vector_metrics_path()),
         help="Path to VectorMetricsDB",
     )
     parser.add_argument(

--- a/vector_service_api.py
+++ b/vector_service_api.py
@@ -20,6 +20,11 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from dynamic_path_router import resolve_path
 
+try:  # pragma: no cover - compatibility when packaged
+    from .vector_metrics_db import default_vector_metrics_path
+except Exception:  # pragma: no cover - direct execution fallback
+    from vector_metrics_db import default_vector_metrics_path  # type: ignore
+
 from vector_service import (
     CognitionLayer,
     EmbeddingBackfill,
@@ -312,7 +317,7 @@ __all__ = ["app", "create_app"]
 
 # ---------------------------------------------------------------------------
 def evaluate_ranker(
-    vector_db: str | os.PathLike[str] = resolve_path("vector_metrics.db"),
+    vector_db: str | os.PathLike[str] = default_vector_metrics_path(),
     patch_db: str | os.PathLike[str] = resolve_path("metrics.db"),
     strategy: str = "roi_weighted_cosine",
 ) -> dict[str, float]:
@@ -353,7 +358,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Vector service utilities")
     sub = parser.add_subparsers(dest="cmd", required=True)
     ev = sub.add_parser("evaluate", help="Evaluate ranking effectiveness")
-    ev.add_argument("--vector-db", default=resolve_path("vector_metrics.db"))
+    ev.add_argument("--vector-db", default=str(default_vector_metrics_path()))
     ev.add_argument("--patch-db", default=resolve_path("metrics.db"))
     ev.add_argument(
         "--strategy",


### PR DESCRIPTION
## Summary
- add a helper that resolves the default vector metrics database path and creates it on demand
- update analytics and API utilities to rely on the new helper so imports work before the database exists

## Testing
- python - <<'PY'
from pathlib import Path
from vector_metrics_db import VectorMetricsDB, default_vector_metrics_path
path = default_vector_metrics_path()
print('exists after helper:', path.exists())
db = VectorMetricsDB()
print('exists after init:', path.exists())
print('table count:', db.conn.execute('SELECT COUNT(*) FROM vector_metrics').fetchone()[0])
PY


------
https://chatgpt.com/codex/tasks/task_e_68ce8efb5940832e8c3b2f787a9fa1e4