### PR TITLE
Fix adaptive ROI imports for flat execution

### DIFF
--- a/adaptive_roi_dataset.py
+++ b/adaptive_roi_dataset.py
@@ -33,9 +33,14 @@ import numpy as np
 from db_router import DBRouter, GLOBAL_ROUTER, init_db_router
 from scope_utils import Scope, build_scope_clause, apply_scope
 
-from .evolution_history_db import EvolutionHistoryDB
-from .evaluation_history_db import EvaluationHistoryDB
-from .roi_tracker import ROITracker
+if __package__:
+    from .evolution_history_db import EvolutionHistoryDB
+    from .evaluation_history_db import EvaluationHistoryDB
+    from .roi_tracker import ROITracker
+else:  # pragma: no cover - fallback for flat module layout
+    from evolution_history_db import EvolutionHistoryDB  # type: ignore
+    from evaluation_history_db import EvaluationHistoryDB  # type: ignore
+    from roi_tracker import ROITracker  # type: ignore
 
 try:  # pragma: no cover - allow running as script
     from .dynamic_path_router import resolve_path  # type: ignore

--- a/adaptive_roi_predictor.py
+++ b/adaptive_roi_predictor.py
@@ -73,12 +73,32 @@ except Exception:  # pragma: no cover - statsmodels missing
 
 import pickle
 
-from .logging_utils import get_logger
-from .adaptive_roi_dataset import build_dataset, _label_growth
-from .roi_tracker import ROITracker
-from .evaluation_history_db import EvaluationHistoryDB
-from .evolution_history_db import EvolutionHistoryDB
-from .truth_adapter import TruthAdapter
+if __package__:
+    from .logging_utils import get_logger
+    from .adaptive_roi_dataset import build_dataset, _label_growth
+    from .roi_tracker import ROITracker
+    from .evaluation_history_db import EvaluationHistoryDB
+    from .evolution_history_db import EvolutionHistoryDB
+    from .truth_adapter import TruthAdapter
+else:  # pragma: no cover - fallback when executed outside package
+    import sys
+    from importlib import import_module
+    from pathlib import Path
+
+    _pkg_root = Path(__file__).resolve().parent
+    _pkg_name = _pkg_root.name
+    _parent = _pkg_root.parent
+    if str(_parent) not in sys.path:
+        sys.path.append(str(_parent))
+
+    get_logger = import_module(f"{_pkg_name}.logging_utils").get_logger  # type: ignore[attr-defined]
+    dataset_mod = import_module(f"{_pkg_name}.adaptive_roi_dataset")
+    build_dataset = dataset_mod.build_dataset  # type: ignore[attr-defined]
+    _label_growth = dataset_mod._label_growth  # type: ignore[attr-defined]
+    ROITracker = import_module(f"{_pkg_name}.roi_tracker").ROITracker  # type: ignore[attr-defined]
+    EvaluationHistoryDB = import_module(f"{_pkg_name}.evaluation_history_db").EvaluationHistoryDB  # type: ignore[attr-defined]
+    EvolutionHistoryDB = import_module(f"{_pkg_name}.evolution_history_db").EvolutionHistoryDB  # type: ignore[attr-defined]
+    TruthAdapter = import_module(f"{_pkg_name}.truth_adapter").TruthAdapter  # type: ignore[attr-defined]
 from db_router import DBRouter, GLOBAL_ROUTER, init_db_router
 
 MENACE_ID = "adaptive_roi_predictor"


### PR DESCRIPTION
## Summary
- add package-aware fallbacks in `adaptive_roi_predictor` so it can run when executed from the repository root
- mirror the fallback logic in `adaptive_roi_dataset` to avoid relative-import failures in manual bootstrap flows

## Testing
- python -c "import adaptive_roi_predictor"
- python -m compileall adaptive_roi_predictor.py adaptive_roi_dataset.py

------
https://chatgpt.com/codex/tasks/task_e_68ce93ac4bd8832e96876b8239b8ee80