### PR TITLE
Fix flat-layout import fallback in error_logger

### DIFF
--- a/error_logger.py
+++ b/error_logger.py
@@ -18,8 +18,12 @@ from datetime import datetime
 from functools import wraps
 from typing import Any, Callable, Optional
 
-from .db_router import GLOBAL_ROUTER, init_db_router
-from .scope_utils import Scope, build_scope_clause, apply_scope
+try:
+    from .db_router import GLOBAL_ROUTER, init_db_router
+    from .scope_utils import Scope, build_scope_clause, apply_scope
+except ImportError:  # pragma: no cover - fallback for flat layout
+    from db_router import GLOBAL_ROUTER, init_db_router  # type: ignore
+    from scope_utils import Scope, build_scope_clause, apply_scope  # type: ignore
 
 try:
     from .sentry_client import SentryClient


### PR DESCRIPTION
## Summary
- add a flat-layout import fallback for `db_router` and `scope_utils` in `error_logger`
- avoid ImportError when modules are imported without the menace_sandbox package context

## Testing
- python -m compileall menace_sandbox/error_logger.py

------
https://chatgpt.com/codex/tasks/task_e_68ce9c788648832eb5fc0178ffe0fdfb