### PR TITLE
Tweak bootstrap logging for optional dependencies

### DIFF
--- a/environment_bootstrap.py
+++ b/environment_bootstrap.py
@@ -305,16 +305,21 @@ class EnvironmentBootstrapper:
             self.install_dependencies(missing)
         if importlib.util.find_spec("apscheduler") is None:
             self.install_dependencies(["apscheduler"])
-        try:
-            subprocess.run(
-                ["systemctl", "enable", "--now", "sandbox_autopurge.timer"],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                check=True,
-            )
-        except Exception as exc:  # pragma: no cover - log only
-            self.logger.warning(
-                "failed enabling sandbox_autopurge.timer: %s", exc
+        if shutil.which("systemctl"):
+            try:
+                subprocess.run(
+                    ["systemctl", "enable", "--now", "sandbox_autopurge.timer"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=True,
+                )
+            except Exception as exc:  # pragma: no cover - log only
+                self.logger.warning(
+                    "failed enabling sandbox_autopurge.timer: %s", exc
+                )
+        else:
+            self.logger.info(
+                "systemctl not available; skipping sandbox_autopurge timer activation"
             )
         deps = os.getenv("MENACE_BOOTSTRAP_DEPS", "").split(",")
         deps = [d.strip() for d in deps if d.strip()]

--- a/meta_workflow_planner.py
+++ b/meta_workflow_planner.py
@@ -50,8 +50,10 @@ from context_builder_util import ensure_fresh_weights
 
 try:  # pragma: no cover - optional heavy dependency
     from roi_tracker import ROITracker  # type: ignore
-except Exception:  # pragma: no cover - allow running without ROI tracker
-    logger.warning("roi_tracker import failed; using no-op ROITracker fallback")
+except Exception as exc:  # pragma: no cover - allow running without ROI tracker
+    logger.info(
+        "ROI tracker unavailable (%s); using deterministic no-op fallback", exc
+    )
 
     class ROITracker:  # type: ignore[no-redef]
         """Deterministic no-op fallback used when ``roi_tracker`` is unavailable."""
@@ -82,9 +84,10 @@ except Exception:  # pragma: no cover - executed when networkx missing
 
 try:  # pragma: no cover - optional heavy dependency
     from workflow_synergy_comparator import WorkflowSynergyComparator  # type: ignore
-except Exception:  # pragma: no cover - allow running without comparator
-    logger.warning(
-        "workflow_synergy_comparator import failed; synergy metrics disabled"
+except Exception as exc:  # pragma: no cover - allow running without comparator
+    logger.info(
+        "Workflow synergy comparator unavailable (%s); synergy metrics disabled",
+        exc,
     )
 
     class WorkflowSynergyComparator:  # type: ignore[no-redef]

--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -1343,7 +1343,10 @@ try:  # pragma: no cover - optional dependency
     import docker  # type: ignore
     from docker.errors import DockerException, APIError
 except Exception as exc:  # pragma: no cover - docker may be unavailable
-    logger.warning("docker import failed: %s", exc)
+    logger.info(
+        "Docker SDK unavailable (%s); container pooling features will be skipped",
+        exc,
+    )
     docker = None  # type: ignore
     DockerException = Exception  # type: ignore
     APIError = Exception  # type: ignore
@@ -1352,7 +1355,10 @@ else:
     try:
         _DOCKER_CLIENT = docker.from_env()
     except DockerException as exc:  # pragma: no cover - docker may be unavailable
-        logger.warning("docker client init failed: %s", exc)
+        logger.info(
+            "Docker client unavailable (%s); container pooling features disabled",
+            exc,
+        )
         _DOCKER_CLIENT = None
 
 _CONTAINER_POOL_SIZE = int(os.getenv("SANDBOX_CONTAINER_POOL_SIZE", "2"))


### PR DESCRIPTION
## Summary
- lower the severity of ROI tracker and workflow synergy comparator import failures to avoid noisy warnings when optional packages are missing
- treat missing Docker SDK/client as informational and skip enabling the sandbox_autopurge timer when `systemctl` is unavailable to better support non-Linux platforms

## Testing
- `python -m compileall meta_workflow_planner.py environment_bootstrap.py sandbox_runner/environment.py`


------
https://chatgpt.com/codex/tasks/task_e_68cea8c2d83c832eabebb42bf6819aa1