### PR TITLE
Improve data_bot flat import support

### DIFF
--- a/tests/test_data_bot_import_guard.py
+++ b/tests/test_data_bot_import_guard.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def test_flat_import_exposes_scope(monkeypatch) -> None:
+    module_names = ["data_bot", "menace_sandbox.data_bot"]
+    saved_modules = {name: sys.modules[name] for name in module_names if name in sys.modules}
+    saved_package = sys.modules.get("menace_sandbox")
+
+    try:
+        for name in module_names:
+            sys.modules.pop(name, None)
+
+        module = importlib.import_module("data_bot")
+        from menace_sandbox.scope_utils import Scope as PackageScope
+
+        assert module.__package__ == "menace_sandbox"
+        assert module.Scope is PackageScope
+        assert callable(module.build_scope_clause)
+        assert callable(module.apply_scope)
+        assert sys.modules["data_bot"] is module
+        assert sys.modules["menace_sandbox.data_bot"] is module
+
+        pkg_module = sys.modules.get("menace_sandbox")
+        assert pkg_module is not None
+        pkg_paths = [Path(p).resolve() for p in getattr(pkg_module, "__path__", [])]
+        package_root = Path(module.__file__).resolve().parent
+        assert package_root in pkg_paths
+    finally:
+        for name in module_names:
+            sys.modules.pop(name, None)
+        if saved_package is not None:
+            sys.modules["menace_sandbox"] = saved_package
+        else:
+            sys.modules.pop("menace_sandbox", None)
+        sys.modules.update(saved_modules)


### PR DESCRIPTION
## Summary
- ensure `data_bot` configures `menace_sandbox` on flat imports by amending `sys.path`, package metadata, and module registrations
- register the module under both package-qualified and flat names so legacy entry points continue to work
- add a regression test that imports `data_bot` from a flat context and validates the scope helpers are available

## Testing
- python manual_bootstrap.py --skip-environment *(fails: missing system packages ffmpeg, tesseract, qemu-system-x86_64 but quick_fix_engine import no longer raises)*
- pytest tests/test_data_bot_import_guard.py


------
https://chatgpt.com/codex/tasks/task_e_68d3715c61d4832eb3bc82c8b9405a5b