### PR TITLE
Support flat shared GPT memory imports

### DIFF
--- a/local_knowledge_module.py
+++ b/local_knowledge_module.py
@@ -18,7 +18,13 @@ except Exception:  # pragma: no cover - keep import lightweight
 
 from governed_embeddings import get_embedder
 
-from menace_sandbox.gpt_memory import GPTMemoryManager
+try:
+    from .gpt_memory import GPTMemoryManager
+except ImportError:  # pragma: no cover - allow flat imports
+    try:
+        from menace_sandbox.gpt_memory import GPTMemoryManager  # type: ignore
+    except ImportError:  # pragma: no cover - flat layout fallback
+        from gpt_memory import GPTMemoryManager  # type: ignore
 from gpt_knowledge_service import GPTKnowledgeService
 from vector_service import CognitionLayer
 try:  # pragma: no cover - allow flat imports

--- a/shared_gpt_memory.py
+++ b/shared_gpt_memory.py
@@ -1,11 +1,83 @@
 from __future__ import annotations
 
-"""Shared GPT memory manager instance for all ChatGPT clients."""
+"""Shared GPT memory manager instance for all ChatGPT clients.
 
-from .gpt_memory import GPTMemoryManager
-from .shared_knowledge_module import LOCAL_KNOWLEDGE_MODULE
+This module prefers package-relative imports (``menace_sandbox.*``) so it can
+be used as part of the installed package, but it transparently falls back to
+flat imports when executed as a standalone script (``python shared_gpt_memory.py``).
+In that situation :mod:`importlib` is used to resolve dependencies and the
+loaded module is registered under both the package and flat names so every
+import path shares the same singleton state.
+"""
+
+from importlib import import_module
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+from types import ModuleType
+
+
+def _ensure_package_alias() -> None:
+    """Ensure ``menace_sandbox`` is registered in :mod:`sys.modules`."""
+
+    if "menace_sandbox" in sys.modules:
+        return
+
+    package_root = Path(__file__).resolve().parent
+    init_path = package_root / "__init__.py"
+    spec = spec_from_file_location("menace_sandbox", init_path)
+    if spec and spec.loader:
+        module = module_from_spec(spec)
+        module.__path__ = [str(package_root)]
+        sys.modules["menace_sandbox"] = module
+        spec.loader.exec_module(module)
+    else:  # pragma: no cover - fallback when loader unavailable
+        module = ModuleType("menace_sandbox")
+        module.__path__ = [str(package_root)]
+        module.__file__ = str(init_path)
+        sys.modules["menace_sandbox"] = module
+
+
+def _import_with_optional_package(module: str) -> ModuleType:
+    """Import *module* preferring the ``menace_sandbox`` package."""
+
+    qualified = f"menace_sandbox.{module}"
+    try:
+        return import_module(qualified)
+    except ModuleNotFoundError as exc:
+        if exc.name not in {"menace_sandbox", qualified}:
+            raise
+
+    _ensure_package_alias()
+
+    try:
+        return import_module(qualified)
+    except ModuleNotFoundError as exc:
+        if exc.name != qualified:
+            raise
+
+    module_obj = import_module(module)
+    sys.modules.setdefault(qualified, module_obj)
+    return module_obj
+
+
+try:  # pragma: no cover - exercised via dedicated import test
+    from .gpt_memory import GPTMemoryManager
+except ImportError:  # pragma: no cover - fallback for flat layout
+    GPTMemoryManager = _import_with_optional_package("gpt_memory").GPTMemoryManager
+
+try:  # pragma: no cover - exercised via dedicated import test
+    from .shared_knowledge_module import LOCAL_KNOWLEDGE_MODULE
+except ImportError:  # pragma: no cover - fallback for flat layout
+    LOCAL_KNOWLEDGE_MODULE = _import_with_optional_package(
+        "shared_knowledge_module"
+    ).LOCAL_KNOWLEDGE_MODULE
 
 # Single global GPT memory instance reused across bots
 GPT_MEMORY_MANAGER: GPTMemoryManager = LOCAL_KNOWLEDGE_MODULE.memory
+
+_MODULE = sys.modules[__name__]
+sys.modules["menace_sandbox.shared_gpt_memory"] = _MODULE
+sys.modules["shared_gpt_memory"] = _MODULE
 
 __all__ = ["GPT_MEMORY_MANAGER"]

--- a/shared_knowledge_module.py
+++ b/shared_knowledge_module.py
@@ -1,22 +1,85 @@
 from __future__ import annotations
 
-"""Process-wide LocalKnowledgeModule shared across components.
+"""Process-wide :class:`LocalKnowledgeModule` shared across components.
 
-This module exposes a single :data:`LOCAL_KNOWLEDGE_MODULE` instance which
-combines :class:`gpt_memory.GPTMemoryManager` with
+The module favours package-relative imports (``menace_sandbox.*``) but gracefully
+falls back to flat imports when run directly.  Both entry points register the
+resulting module object in :data:`sys.modules` so that the singleton
+``LOCAL_KNOWLEDGE_MODULE`` remains shared regardless of the import style.
+
+It exposes a single :data:`LOCAL_KNOWLEDGE_MODULE` instance which combines
+:class:`gpt_memory.GPTMemoryManager` with
 :class:`gpt_knowledge_service.GPTKnowledgeService`.  The underlying database
 location can be customised through the ``GPT_MEMORY_DB`` environment variable.
 """
 
 import os
+from importlib import import_module
+from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
+import sys
+from types import ModuleType
 
-from local_knowledge_module import init_local_knowledge, LocalKnowledgeModule
+
+def _ensure_package_alias() -> None:
+    """Ensure ``menace_sandbox`` is registered in :mod:`sys.modules`."""
+
+    if "menace_sandbox" in sys.modules:
+        return
+
+    package_root = Path(__file__).resolve().parent
+    init_path = package_root / "__init__.py"
+    spec = spec_from_file_location("menace_sandbox", init_path)
+    if spec and spec.loader:
+        module = module_from_spec(spec)
+        module.__path__ = [str(package_root)]
+        sys.modules["menace_sandbox"] = module
+        spec.loader.exec_module(module)
+    else:  # pragma: no cover - fallback when loader unavailable
+        module = ModuleType("menace_sandbox")
+        module.__path__ = [str(package_root)]
+        module.__file__ = str(init_path)
+        sys.modules["menace_sandbox"] = module
+
+
+def _import_with_optional_package(module: str) -> ModuleType:
+    """Import *module* preferring the ``menace_sandbox`` package."""
+
+    qualified = f"menace_sandbox.{module}"
+    try:
+        return import_module(qualified)
+    except ModuleNotFoundError as exc:
+        if exc.name not in {"menace_sandbox", qualified}:
+            raise
+
+    _ensure_package_alias()
+
+    try:
+        return import_module(qualified)
+    except ModuleNotFoundError as exc:
+        if exc.name != qualified:
+            raise
+
+    module_obj = import_module(module)
+    sys.modules.setdefault(qualified, module_obj)
+    return module_obj
+
+
+try:  # pragma: no cover - exercised via dedicated import test
+    from .local_knowledge_module import init_local_knowledge, LocalKnowledgeModule
+except ImportError:  # pragma: no cover - fallback for flat layout
+    _local_module = _import_with_optional_package("local_knowledge_module")
+    init_local_knowledge = _local_module.init_local_knowledge
+    LocalKnowledgeModule = _local_module.LocalKnowledgeModule
 
 # Resolve database path from environment or fall back to default location.
 _MEM_DB = Path(os.getenv("GPT_MEMORY_DB", "gpt_memory.db"))
 
 # Public singleton instance reused by all modules.
 LOCAL_KNOWLEDGE_MODULE: LocalKnowledgeModule = init_local_knowledge(_MEM_DB)
+
+_MODULE = sys.modules[__name__]
+sys.modules["menace_sandbox.shared_knowledge_module"] = _MODULE
+sys.modules["shared_knowledge_module"] = _MODULE
 
 __all__ = ["LOCAL_KNOWLEDGE_MODULE", "LocalKnowledgeModule"]

--- a/tests/test_shared_gpt_memory_import.py
+++ b/tests/test_shared_gpt_memory_import.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def _resolve(path: str) -> Path | None:
+    try:
+        return Path(path).resolve()
+    except (OSError, RuntimeError):
+        return None
+
+
+def test_flat_import_constructs_manager(monkeypatch):
+    """``import shared_gpt_memory`` should succeed when run as a script."""
+
+    for name in (
+        "menace_sandbox.shared_gpt_memory",
+        "shared_gpt_memory",
+        "menace_sandbox.shared_knowledge_module",
+        "shared_knowledge_module",
+        "menace_sandbox.gpt_memory",
+        "gpt_memory",
+        "menace_sandbox",
+    ):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    package_root = Path(__file__).resolve().parents[1]
+    parent_dir = package_root.parent.resolve()
+
+    new_sys_path = [str(package_root)]
+    for entry in sys.path:
+        resolved = _resolve(entry)
+        if resolved is None or resolved != parent_dir:
+            new_sys_path.append(entry)
+
+    monkeypatch.setattr(sys, "path", new_sys_path)
+
+    module = importlib.import_module("shared_gpt_memory")
+
+    assert module.GPT_MEMORY_MANAGER is not None
+    assert module.GPT_MEMORY_MANAGER.__class__.__name__ == "GPTMemoryManager"
+    assert sys.modules["shared_gpt_memory"] is module
+    assert sys.modules["menace_sandbox.shared_gpt_memory"] is module


### PR DESCRIPTION
## Summary
- document and harden `shared_gpt_memory`/`shared_knowledge_module` so both package and flat imports share the same singleton state
- allow `local_knowledge_module` to fall back to flat `gpt_memory` imports when the package wrapper is unavailable
- add a regression test that simulates running `python shared_gpt_memory.py` and asserts the manager singleton still materialises

## Testing
- `pytest tests/test_shared_gpt_memory_import.py`
- `make self-coding-check` *(fails: chatgpt_research_bot.py and chatgpt_prediction_bot.py missing internalize_coding_bot)*

------
https://chatgpt.com/codex/tasks/task_e_68d37aabe24c832e8417a0ef335419cd