### PR TITLE
Improve shared_gpt_memory bootstrap and add import test

### DIFF
--- a/tests/test_shared_gpt_memory_import.py
+++ b/tests/test_shared_gpt_memory_import.py
@@ -1,45 +1,77 @@
 from __future__ import annotations
 
 import importlib
-import sys
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
 from pathlib import Path
+import sys
+from types import ModuleType
+from typing import Dict, Iterable
 
 
-def _resolve(path: str) -> Path | None:
-    try:
-        return Path(path).resolve()
-    except (OSError, RuntimeError):
-        return None
+def _load_flat_shared_gpt_memory(module_path: Path) -> ModuleType:
+    loader = SourceFileLoader("shared_gpt_memory", str(module_path))
+    spec = spec_from_loader("shared_gpt_memory", loader)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive guard
+        raise ImportError("Unable to create module specification for shared_gpt_memory")
+
+    module = module_from_spec(spec)
+    assert module is not None  # for type checkers
+    sys.modules[spec.name] = module
+    loader.exec_module(module)
+    return module
 
 
-def test_flat_import_constructs_manager(monkeypatch):
-    """``import shared_gpt_memory`` should succeed when run as a script."""
+def _clear_modules(names: Iterable[str]) -> None:
+    for name in names:
+        sys.modules.pop(name, None)
 
-    for name in (
-        "menace_sandbox.shared_gpt_memory",
+
+def test_shared_gpt_memory_import_paths() -> None:
+    module_path = Path(__file__).resolve().parents[1] / "shared_gpt_memory.py"
+    tracked_modules = [
         "shared_gpt_memory",
-        "menace_sandbox.shared_knowledge_module",
-        "shared_knowledge_module",
-        "menace_sandbox.gpt_memory",
-        "gpt_memory",
+        "menace_sandbox.shared_gpt_memory",
         "menace_sandbox",
-    ):
-        monkeypatch.delitem(sys.modules, name, raising=False)
+        "gpt_memory",
+        "menace_sandbox.gpt_memory",
+        "shared_knowledge_module",
+        "menace_sandbox.shared_knowledge_module",
+    ]
 
-    package_root = Path(__file__).resolve().parents[1]
-    parent_dir = package_root.parent.resolve()
+    saved_modules: Dict[str, ModuleType | None] = {
+        name: sys.modules.get(name) for name in tracked_modules
+    }
 
-    new_sys_path = [str(package_root)]
-    for entry in sys.path:
-        resolved = _resolve(entry)
-        if resolved is None or resolved != parent_dir:
-            new_sys_path.append(entry)
+    try:
+        _clear_modules(tracked_modules)
 
-    monkeypatch.setattr(sys, "path", new_sys_path)
+        flat_module = _load_flat_shared_gpt_memory(module_path)
+        manager_from_flat = flat_module.GPT_MEMORY_MANAGER
+        assert flat_module.__package__ == "menace_sandbox"
+        assert manager_from_flat is flat_module.GPT_MEMORY_MANAGER
+        assert (
+            sys.modules["shared_gpt_memory"].GPT_MEMORY_MANAGER is manager_from_flat
+        )
+        assert (
+            sys.modules["menace_sandbox.shared_gpt_memory"].GPT_MEMORY_MANAGER
+            is manager_from_flat
+        )
 
-    module = importlib.import_module("shared_gpt_memory")
+        package_alias = importlib.import_module("menace_sandbox.shared_gpt_memory")
+        assert package_alias.GPT_MEMORY_MANAGER is manager_from_flat
 
-    assert module.GPT_MEMORY_MANAGER is not None
-    assert module.GPT_MEMORY_MANAGER.__class__.__name__ == "GPTMemoryManager"
-    assert sys.modules["shared_gpt_memory"] is module
-    assert sys.modules["menace_sandbox.shared_gpt_memory"] is module
+        _clear_modules(["shared_gpt_memory", "menace_sandbox.shared_gpt_memory"])
+
+        package_module = importlib.import_module("menace_sandbox.shared_gpt_memory")
+        manager_from_package = package_module.GPT_MEMORY_MANAGER
+        flat_alias = importlib.import_module("shared_gpt_memory")
+        assert flat_alias is package_module
+        assert flat_alias.GPT_MEMORY_MANAGER is manager_from_package
+    finally:
+        _clear_modules(["shared_gpt_memory", "menace_sandbox.shared_gpt_memory"])
+        for name, module in saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module


### PR DESCRIPTION
## Summary
- ensure `shared_gpt_memory` bootstraps the `menace_sandbox` package context when executed flat, including sys.path updates and module aliasing
- fall back to flat imports for `gpt_memory` and `shared_knowledge_module` once bootstrap is in place
- expand the shared GPT memory import test to cover both package and flat import paths

## Testing
- pytest tests/test_shared_gpt_memory_import.py

------
https://chatgpt.com/codex/tasks/task_e_68d3804835f0832e979278b0cddcf894