### PR TITLE
Ensure coding_bot_interface supports flat imports

### DIFF
--- a/coding_bot_interface.py
+++ b/coding_bot_interface.py
@@ -18,22 +18,63 @@ Example:
     ...     ...
 """
 
+from pathlib import Path
+import importlib
+import sys
 from functools import wraps
 import inspect
 import logging
 from typing import Any, Callable, TypeVar, TYPE_CHECKING
 import time
 
+if __package__ in {None, ""}:  # pragma: no cover - allow flat execution
+    package_root = Path(__file__).resolve().parent
+    repo_root = package_root.parent
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    package = importlib.import_module(package_root.name)
+    sys.modules.setdefault(package_root.name, package)
+    globals()["__package__"] = package_root.name
+
 from context_builder_util import create_context_builder
 
-from .self_coding_thresholds import update_thresholds, _load_config
+
+def _should_use_flat_import(exc: ImportError, module: str) -> bool:
+    """Return ``True`` when *exc* indicates a missing package context."""
+
+    name = getattr(exc, "name", None)
+    if name in {module, f"menace_sandbox.{module}"}:
+        return True
+    msg = str(exc)
+    return "attempted relative import" in msg or "relative import with no known parent" in msg
+
+
+try:  # pragma: no cover - prefer package-relative import when available
+    from .self_coding_thresholds import update_thresholds, _load_config
+except ImportError as exc:  # pragma: no cover - support execution without package context
+    if not _should_use_flat_import(exc, "self_coding_thresholds"):
+        raise
+    from self_coding_thresholds import update_thresholds, _load_config  # type: ignore
 
 try:  # pragma: no cover - optional self-coding dependency
     from .self_coding_manager import SelfCodingManager
-except ImportError:  # pragma: no cover - self-coding unavailable
-    SelfCodingManager = Any  # type: ignore
+except ImportError as exc:  # pragma: no cover - self-coding unavailable
+    if _should_use_flat_import(exc, "self_coding_manager"):
+        try:
+            from self_coding_manager import SelfCodingManager  # type: ignore
+        except ImportError:  # pragma: no cover - degrade gracefully when absent
+            SelfCodingManager = Any  # type: ignore
+    else:
+        SelfCodingManager = Any  # type: ignore
 try:  # pragma: no cover - allow tests to stub engine
     from .self_coding_engine import MANAGER_CONTEXT
+except ImportError as exc:  # pragma: no cover - support execution without package context
+    if not _should_use_flat_import(exc, "self_coding_engine"):
+        raise ImportError("Self-coding engine is required for operation") from exc
+    try:
+        from self_coding_engine import MANAGER_CONTEXT  # type: ignore
+    except ImportError as flat_exc:  # pragma: no cover - propagate requirement
+        raise ImportError("Self-coding engine is required for operation") from flat_exc
 except Exception as exc:  # pragma: no cover - fail fast when engine unavailable
     raise ImportError("Self-coding engine is required for operation") from exc
 

--- a/tests/test_coding_bot_interface_imports.py
+++ b/tests/test_coding_bot_interface_imports.py
@@ -1,0 +1,106 @@
+"""Ensure ``coding_bot_interface`` imports work in both flat and packaged modes."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+_DEF_MODULES = (
+    "coding_bot_interface",
+    "menace_sandbox.coding_bot_interface",
+)
+
+
+@pytest.fixture(autouse=True)
+def _stub_self_coding_modules() -> None:
+    """Provide lightweight stand-ins for self-coding dependencies."""
+
+    installed: dict[str, ModuleType | None] = {}
+
+    def install(name: str, module: ModuleType) -> None:
+        installed[name] = sys.modules.get(name)
+        sys.modules[name] = module
+
+    thresholds = ModuleType("self_coding_thresholds")
+    thresholds.update_thresholds = lambda *args, **kwargs: None  # type: ignore[attr-defined]
+    thresholds._load_config = lambda *args, **kwargs: {}  # type: ignore[attr-defined]
+    for key in ("self_coding_thresholds", "menace_sandbox.self_coding_thresholds"):
+        install(key, thresholds)
+
+    manager = ModuleType("self_coding_manager")
+
+    class _StubManager:
+        def __init__(self) -> None:
+            self.engine = SimpleNamespace(
+                generate_helper=lambda *args, **kwargs: "",
+                context_builder=None,
+            )
+            self.bot_registry = SimpleNamespace(register_bot=lambda *args, **kwargs: None)
+            self.data_bot = SimpleNamespace(reload_thresholds=lambda name: None)
+            self.evolution_orchestrator = None
+
+    manager.SelfCodingManager = _StubManager  # type: ignore[attr-defined]
+    for key in ("self_coding_manager", "menace_sandbox.self_coding_manager"):
+        install(key, manager)
+
+    engine = ModuleType("self_coding_engine")
+
+    class _ManagerContext:
+        def set(self, value: object) -> object:
+            return object()
+
+        def reset(self, token: object) -> None:  # pragma: no cover - simple stub
+            return None
+
+    engine.MANAGER_CONTEXT = _ManagerContext()  # type: ignore[attr-defined]
+    for key in ("self_coding_engine", "menace_sandbox.self_coding_engine"):
+        install(key, engine)
+
+    try:
+        yield
+    finally:
+        for name, original in installed.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+def _clear_module_state() -> None:
+    """Remove cached modules and package attributes for repeatable imports."""
+
+    for name in _DEF_MODULES:
+        sys.modules.pop(name, None)
+    package = sys.modules.get("menace_sandbox")
+    if isinstance(package, ModuleType):
+        package_dict = getattr(package, "__dict__", {})
+        if "coding_bot_interface" in package_dict:
+            del package_dict["coding_bot_interface"]
+
+
+def _assert_helpers_available(module: ModuleType) -> None:
+    """Validate that the helper API is available without bootstrap errors."""
+
+    assert module.__package__ == "menace_sandbox"
+    assert hasattr(module, "self_coding_managed")
+    assert hasattr(module, "manager_generate_helper")
+
+
+def test_flat_import_bootstraps_relative_imports() -> None:
+    """Importing the module flat should engage the bootstrap shims."""
+
+    _clear_module_state()
+    module = importlib.import_module("coding_bot_interface")
+    _assert_helpers_available(module)
+
+
+def test_package_import_remains_supported() -> None:
+    """Package-style imports should continue to work for compatibility."""
+
+    _clear_module_state()
+    module = __import__("menace_sandbox", fromlist=["coding_bot_interface"]).coding_bot_interface
+    _assert_helpers_available(module)


### PR DESCRIPTION
## Summary
- add a bootstrap shim to `coding_bot_interface` so flat imports set up the package context
- handle self-coding dependencies with package-relative imports that fall back only when needed
- add regression tests covering both flat and package-style imports for `coding_bot_interface`

## Testing
- pytest tests/test_coding_bot_interface_imports.py

------
https://chatgpt.com/codex/tasks/task_e_68d38312bc24832e805c70ed04dcd066