### PR TITLE
Ensure embeddable db mixin bootstraps package aliases

### DIFF
--- a/embeddable_db_mixin.py
+++ b/embeddable_db_mixin.py
@@ -14,10 +14,70 @@ Subclasses must provide a ``self.conn`` database connection and override
 
 from __future__ import annotations
 
-from datetime import datetime
+import importlib
+import importlib.util
+import sys
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Sequence, Tuple
+from types import ModuleType
+
+if __package__ in {None, ""}:  # pragma: no cover - support execution as script
+    _THIS_FILE = Path(__file__).resolve()
+    _REPO_ROOT = _THIS_FILE.parent
+    if str(_REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT))
+
+    _PKG_NAME = "menace_sandbox"
+    globals()["__package__"] = _PKG_NAME
+
+    _pkg_module = sys.modules.get(_PKG_NAME)
+    if _pkg_module is None:
+        _spec = importlib.util.spec_from_file_location(
+            _PKG_NAME,
+            _REPO_ROOT / "__init__.py",
+            submodule_search_locations=[str(_REPO_ROOT)],
+        )
+        if _spec and _spec.loader:
+            _pkg_module = importlib.util.module_from_spec(_spec)
+            sys.modules[_PKG_NAME] = _pkg_module
+            _spec.loader.exec_module(_pkg_module)
+        else:  # pragma: no cover - fallback when spec cannot be created
+            _pkg_module = ModuleType(_PKG_NAME)
+            _pkg_module.__file__ = str(_REPO_ROOT / "__init__.py")
+            _pkg_module.__path__ = [str(_REPO_ROOT)]
+            sys.modules[_PKG_NAME] = _pkg_module
+
+    _pkg_path = getattr(_pkg_module, "__path__", None)
+    _pkg_root_str = str(_REPO_ROOT)
+    if _pkg_path is None:
+        _pkg_module.__path__ = [_pkg_root_str]
+    else:
+        try:
+            _existing_paths = list(_pkg_path)
+        except TypeError:  # pragma: no cover - exotic path container
+            _pkg_module.__path__ = [_pkg_root_str]
+        else:
+            if _pkg_root_str not in _existing_paths:
+                try:
+                    _pkg_path.insert(0, _pkg_root_str)
+                except Exception:  # pragma: no cover - immutable path
+                    _pkg_module.__path__ = [_pkg_root_str, *_existing_paths]
+
+    _module = sys.modules.get(__name__)
+    if _module is None:  # pragma: no cover - defensive fallback
+        _module = ModuleType(__name__)
+        _module.__file__ = str(_THIS_FILE)
+        sys.modules[__name__] = _module
+    sys.modules.setdefault(f"{_PKG_NAME}.embeddable_db_mixin", _module)
+    sys.modules.setdefault("embeddable_db_mixin", _module)
+
+_CURRENT_MODULE = sys.modules.get(__name__)
+if _CURRENT_MODULE is not None:
+    sys.modules.setdefault("menace_sandbox.embeddable_db_mixin", _CURRENT_MODULE)
+    sys.modules.setdefault("embeddable_db_mixin", _CURRENT_MODULE)
+
+from datetime import datetime
 from time import perf_counter
+from typing import Any, Dict, Iterator, List, Sequence, Tuple
 import hashlib
 import json
 import logging
@@ -50,30 +110,17 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - NumPy not installed
     np = None  # type: ignore
 
-try:
-    from .vector_metrics_db import VectorMetricsDB
-    from .embedding_stats_db import EmbeddingStatsDB
-    from .metrics_exporter import (
-        embedding_tokens_total as _EMBED_TOKENS,
-        embedding_wall_seconds_total as _EMBED_WALL_TOTAL,
-        embedding_store_seconds_total as _EMBED_STORE_TOTAL,
-        embedding_stale_cost_seconds as _EMBED_STALE,
-        embedding_wall_time_seconds as _EMBED_WALL_LAST,
-        embedding_store_latency_seconds as _EMBED_STORE_LAST,
-    )
-    from .data_bot import MetricsDB
-except Exception:  # pragma: no cover - fallback to absolute imports
-    from vector_metrics_db import VectorMetricsDB  # type: ignore
-    from embedding_stats_db import EmbeddingStatsDB  # type: ignore
-    from metrics_exporter import (
-        embedding_tokens_total as _EMBED_TOKENS,
-        embedding_wall_seconds_total as _EMBED_WALL_TOTAL,
-        embedding_store_seconds_total as _EMBED_STORE_TOTAL,
-        embedding_stale_cost_seconds as _EMBED_STALE,
-        embedding_wall_time_seconds as _EMBED_WALL_LAST,
-        embedding_store_latency_seconds as _EMBED_STORE_LAST,
-    )
-    from data_bot import MetricsDB  # type: ignore
+from menace_sandbox.data_bot import MetricsDB
+from menace_sandbox.embedding_stats_db import EmbeddingStatsDB
+from menace_sandbox.metrics_exporter import (
+    embedding_store_latency_seconds as _EMBED_STORE_LAST,
+    embedding_store_seconds_total as _EMBED_STORE_TOTAL,
+    embedding_stale_cost_seconds as _EMBED_STALE,
+    embedding_tokens_total as _EMBED_TOKENS,
+    embedding_wall_seconds_total as _EMBED_WALL_TOTAL,
+    embedding_wall_time_seconds as _EMBED_WALL_LAST,
+)
+from menace_sandbox.vector_metrics_db import VectorMetricsDB
 
 logger = logging.getLogger(__name__)
 

--- a/unit_tests/test_embeddable_db_mixin_bootstrap.py
+++ b/unit_tests/test_embeddable_db_mixin_bootstrap.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Dict
+from unittest import mock
+
+
+_MODULE_ALIASES = (
+    "embeddable_db_mixin",
+    "menace_sandbox.embeddable_db_mixin",
+)
+
+
+def _snapshot_and_clear() -> Dict[str, object]:
+    """Remove mixin aliases while returning any prior modules."""
+
+    existing: Dict[str, object] = {}
+    for name in _MODULE_ALIASES:
+        module = sys.modules.get(name)
+        if module is not None:
+            existing[name] = module
+        sys.modules.pop(name, None)
+    return existing
+
+
+def _restore_modules(existing: Dict[str, object]) -> None:
+    """Restore module aliases after a test run."""
+
+    for name in _MODULE_ALIASES:
+        sys.modules.pop(name, None)
+    for name, module in existing.items():
+        sys.modules[name] = module
+
+
+def _exercise_import_sequence(first: str, second: str) -> None:
+    """Import the mixin using *first* and *second* module paths."""
+
+    previous = _snapshot_and_clear()
+    try:
+        with (
+            mock.patch("menace_sandbox.vector_metrics_db.VectorMetricsDB") as mock_vec_db,
+            mock.patch("menace_sandbox.embedding_stats_db.EmbeddingStatsDB") as mock_stats_db,
+        ):
+            module_first = importlib.import_module(first)
+            module_second = importlib.import_module(second)
+
+            assert module_first is module_second
+            assert module_first._VEC_METRICS is mock_vec_db.return_value
+            assert module_first._EMBED_STATS_DB is mock_stats_db.return_value
+            assert mock_vec_db.call_count == 1
+            assert mock_stats_db.call_count == 1
+    finally:
+        _restore_modules(previous)
+
+
+def test_embeddable_db_mixin_bootstrap_aliases_and_singletons() -> None:
+    """The mixin must load identically via package and flat import paths."""
+
+    _exercise_import_sequence("embeddable_db_mixin", "menace_sandbox.embeddable_db_mixin")
+    _exercise_import_sequence("menace_sandbox.embeddable_db_mixin", "embeddable_db_mixin")


### PR DESCRIPTION
## Summary
- add a bootstrap routine to embeddable_db_mixin so it loads via flat or package imports and always resolves package dependencies through menace_sandbox
- update the mixin to import vector metrics dependencies via package-qualified modules
- add a regression test that verifies both import paths share the same module instance and initialises singletons once

## Testing
- pytest unit_tests/test_embeddable_db_mixin_bootstrap.py


------
https://chatgpt.com/codex/tasks/task_e_68d3965450e0832e9cb90a1da25d877b