### PR TITLE
Handle optional import cleanup for repo modules

### DIFF
--- a/unit_tests/test_bootstrap_optional_imports.py
+++ b/unit_tests/test_bootstrap_optional_imports.py
@@ -170,3 +170,147 @@ def test_optional_import_cleans_partial_modules(tmp_path: Path) -> None:
         )
         bootstrap._OPTIONAL_MODULE_CACHE.clear()
         bootstrap._OPTIONAL_MODULE_CACHE.update(cache_snapshot)
+
+
+def test_optional_import_dependency_failure_resets_repo_modules(tmp_path: Path) -> None:
+    """Dependency failures should not poison future package-qualified imports."""
+
+    module_name = "embeddable_db_mixin"
+    repo_package = bootstrap._REPO_PACKAGE
+
+    bad_root = tmp_path / "bad"
+    good_root = tmp_path / "good"
+    bad_pkg = bad_root / repo_package
+    good_pkg = good_root / repo_package
+
+    bad_pkg.mkdir(parents=True)
+    good_pkg.mkdir(parents=True)
+
+    (bad_pkg / "__init__.py").write_text("", encoding="utf-8")
+    (good_pkg / "__init__.py").write_text("", encoding="utf-8")
+
+    import_compat_stub = textwrap.dedent(
+        """
+        import sys
+
+        def bootstrap(name: str, filename: str) -> None:
+            return None
+
+        sys.modules.setdefault("import_compat", sys.modules[__name__])
+        """
+    )
+
+    (bad_pkg / "import_compat.py").write_text(import_compat_stub, encoding="utf-8")
+    (good_pkg / "import_compat.py").write_text(import_compat_stub, encoding="utf-8")
+
+    (bad_pkg / f"{module_name}.py").write_text(
+        textwrap.dedent(
+            """
+            from . import import_compat  # ensure alias entries are created
+            raise ImportError("simulated dependency failure")
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    (bad_root / f"{module_name}.py").write_text(
+        "raise ImportError('attempted relative import with no known parent package')\n",
+        encoding="utf-8",
+    )
+
+    (good_pkg / "helper_module.py").write_text("VALUE = 'ok'\n", encoding="utf-8")
+    (good_pkg / f"{module_name}.py").write_text(
+        textwrap.dedent(
+            """
+            from . import import_compat
+            from . import helper_module as helper
+
+            VALUE = helper.VALUE
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    (good_root / f"{module_name}.py").write_text(
+        "from . import missing_helper  # pragma: no cover - fallback guard\n",
+        encoding="utf-8",
+    )
+
+    tracked_modules = [
+        module_name,
+        f"{repo_package}.{module_name}",
+        f"sandbox_runner.{module_name}",
+        f"{repo_package}.import_compat",
+        f"{repo_package}.helper_module",
+        "import_compat",
+        repo_package,
+    ]
+
+    original_sys_path = list(sys.path)
+    original_modules = {name: sys.modules.get(name) for name in tracked_modules}
+    cache_snapshot = dict(bootstrap._OPTIONAL_MODULE_CACHE)
+    missing_snapshot = set(bootstrap._MISSING_OPTIONAL)
+    warned_snapshot = set(bootstrap._OPTIONAL_DEPENDENCY_WARNED)
+
+    cache_keys = (
+        module_name,
+        f"{repo_package}.{module_name}",
+        f"sandbox_runner.{module_name}",
+    )
+
+    try:
+        for name in tracked_modules:
+            sys.modules.pop(name, None)
+        for key in cache_keys:
+            bootstrap._OPTIONAL_MODULE_CACHE.pop(key, None)
+        bootstrap._MISSING_OPTIONAL.discard(module_name)
+        bootstrap._OPTIONAL_DEPENDENCY_WARNED.discard(module_name)
+
+        sys.path.insert(0, str(bad_root))
+        importlib.invalidate_caches()
+
+        with pytest.raises(ModuleNotFoundError):
+            bootstrap._import_optional_module(module_name)
+
+        assert repo_package not in sys.modules
+        assert f"{repo_package}.import_compat" not in sys.modules
+        assert "import_compat" not in sys.modules
+
+        sys.path.pop(0)
+        (bad_pkg / f"{module_name}.py").unlink()
+        sys.path.insert(0, str(good_root))
+        importlib.invalidate_caches()
+
+        for name in tracked_modules:
+            sys.modules.pop(name, None)
+        for key in cache_keys:
+            bootstrap._OPTIONAL_MODULE_CACHE.pop(key, None)
+        bootstrap._MISSING_OPTIONAL.discard(module_name)
+        bootstrap._OPTIONAL_DEPENDENCY_WARNED.discard(module_name)
+
+        try:
+            module = bootstrap._import_optional_module(module_name)
+        except ImportError as exc:  # pragma: no cover - regression guard
+            pytest.fail(f"optional import should have recovered: {exc}")
+
+        assert module.VALUE == "ok"
+        assert module.__name__ == f"{repo_package}.{module_name}"
+        assert str(good_pkg) in (module.__file__ or "")
+        assert sys.modules[module_name] is module
+    finally:
+        sys.path[:] = original_sys_path
+        importlib.invalidate_caches()
+
+        for name in tracked_modules:
+            sys.modules.pop(name, None)
+
+        for name, module in original_modules.items():
+            if module is not None:
+                sys.modules[name] = module
+
+        bootstrap._OPTIONAL_MODULE_CACHE.clear()
+        bootstrap._OPTIONAL_MODULE_CACHE.update(cache_snapshot)
+        bootstrap._MISSING_OPTIONAL.clear()
+        bootstrap._MISSING_OPTIONAL.update(missing_snapshot)
+        bootstrap._OPTIONAL_DEPENDENCY_WARNED.clear()
+        bootstrap._OPTIONAL_DEPENDENCY_WARNED.update(warned_snapshot)


### PR DESCRIPTION
## Summary
- snapshot sys.modules during optional imports and prune newly-added repo modules on failure
- clear alias entries when rolling back partial optional imports
- add regression coverage ensuring dependency failures don't leave stale modules behind

## Testing
- `pytest unit_tests/test_bootstrap_optional_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_68d3c122a19c832ea4135e2f3462d748