### PR TITLE
Fix self_improvement imports in flat layout

### DIFF
--- a/self_improvement/__init__.py
+++ b/self_improvement/__init__.py
@@ -2,10 +2,30 @@ from __future__ import annotations
 
 """Self-improvement engine public API."""
 
+import sys as _sys
+from types import ModuleType as _ModuleType
+from pathlib import Path as _Path
+
+
+if __name__ == "self_improvement":  # pragma: no cover - runtime import aliasing
+    # Allow the package to operate both as ``menace_sandbox.self_improvement`` and
+    # as the legacy top-level ``self_improvement`` module.  Older entrypoints
+    # import the package directly, which breaks the ``from ..`` relative imports
+    # defined throughout the module tree.  Registering this alias ensures Python
+    # recognises ``menace_sandbox`` as the parent package so those imports
+    # resolve correctly when running in a flat layout.
+    __package__ = "menace_sandbox.self_improvement"
+    parent = _sys.modules.get("menace_sandbox")
+    if parent is None:
+        parent = _ModuleType("menace_sandbox")
+        parent.__path__ = [str(_Path(__file__).resolve().parent.parent)]
+        _sys.modules["menace_sandbox"] = parent
+    _sys.modules["menace_sandbox.self_improvement"] = _sys.modules[__name__]
+
+
 from .api import *  # noqa: F401,F403
 from .api import __all__  # noqa: F401
 
 # Backwards compatibility for the deprecated `state_snapshot` module
 from . import snapshot_tracker as state_snapshot  # noqa: F401
-import sys as _sys
 _sys.modules[__name__ + ".state_snapshot"] = state_snapshot

--- a/self_improvement/utils.py
+++ b/self_improvement/utils.py
@@ -29,9 +29,20 @@ from pathlib import Path
 from functools import lru_cache
 from typing import Any, Callable
 
-from ..dynamic_path_router import resolve_dir, get_project_root
-from ..metrics_exporter import self_improvement_failure_total
-from ..sandbox_settings import SandboxSettings
+try:  # pragma: no cover - prefer package-relative import when available
+    from ..dynamic_path_router import resolve_dir, get_project_root
+except ImportError:  # pragma: no cover - support flat execution layout
+    from dynamic_path_router import resolve_dir, get_project_root  # type: ignore
+
+try:  # pragma: no cover - prefer package-relative import when available
+    from ..metrics_exporter import self_improvement_failure_total
+except ImportError:  # pragma: no cover - support flat execution layout
+    from metrics_exporter import self_improvement_failure_total  # type: ignore
+
+try:  # pragma: no cover - prefer package-relative import when available
+    from ..sandbox_settings import SandboxSettings
+except ImportError:  # pragma: no cover - support flat execution layout
+    from sandbox_settings import SandboxSettings  # type: ignore
 
 
 _diagnostics_lock = threading.Lock()


### PR DESCRIPTION
## Summary
- ensure the self_improvement package registers an alias under menace_sandbox when imported directly so relative imports continue to function
- add fallbacks to self_improvement.utils for flat-layout imports of shared modules

## Testing
- python -m compileall self_improvement

------
https://chatgpt.com/codex/tasks/task_e_68d46692e0f0832eb271e583fbd81c94