### PR TITLE
Fix self-improvement bootstrap imports

### DIFF
--- a/self_improvement/engine.py
+++ b/self_improvement/engine.py
@@ -23,6 +23,7 @@ that transient failures are retried while permanent issues propagate errors.
 # flake8: noqa
 
 import logging
+from pathlib import Path
 
 try:
     from logging_utils import log_record, get_logger, setup_logging, set_correlation_id
@@ -66,16 +67,33 @@ from .init import (
     _atomic_write,
     get_default_synergy_weights,
 )
-try:  # pragma: no cover - allow flat imports
+try:  # pragma: no cover - prefer absolute imports when running from repo root
+    from dynamic_path_router import resolve_path, resolve_module_path
+except Exception:  # pragma: no cover - fallback for package-relative layout
     from ..dynamic_path_router import resolve_path, resolve_module_path
-except Exception:  # pragma: no cover - fallback for flat layout
-    from dynamic_path_router import resolve_path, resolve_module_path  # type: ignore
-from ..metrics_exporter import (
-    synergy_weight_updates_total,
-    synergy_weight_update_failures_total,
-    synergy_weight_update_alerts_total,
-    orphan_modules_reintroduced_total,
-    orphan_modules_passed_total,
+try:  # pragma: no cover - prefer absolute imports when running from repo root
+    from metrics_exporter import (
+        synergy_weight_updates_total,
+        synergy_weight_update_failures_total,
+        synergy_weight_update_alerts_total,
+        orphan_modules_reintroduced_total,
+        orphan_modules_passed_total,
+        orphan_modules_tested_total,
+        orphan_modules_failed_total,
+        orphan_modules_reclassified_total,
+        orphan_modules_redundant_total,
+        orphan_modules_legacy_total,
+        prediction_mae,
+        prediction_reliability,
+        self_improvement_failure_total,
+    )
+except ImportError:  # pragma: no cover - fallback for package-relative layout
+    from ..metrics_exporter import (
+        synergy_weight_updates_total,
+        synergy_weight_update_failures_total,
+        synergy_weight_update_alerts_total,
+        orphan_modules_reintroduced_total,
+        orphan_modules_passed_total,
     orphan_modules_tested_total,
     orphan_modules_failed_total,
     orphan_modules_reclassified_total,
@@ -84,14 +102,32 @@ from ..metrics_exporter import (
     prediction_mae,
     prediction_reliability,
     self_improvement_failure_total,
-)
+    )
 
-from ..composite_workflow_scorer import CompositeWorkflowScorer
-from ..neuroplasticity import PathwayDB
-from ..data_bot import MetricsDB
-from ..roi_results_db import ROIResultsDB
-from ..workflow_scorer_core import EvaluationResult
-from ..workflow_stability_db import WorkflowStabilityDB
+try:  # pragma: no cover - prefer absolute imports when running from repo root
+    from composite_workflow_scorer import CompositeWorkflowScorer
+except ImportError:  # pragma: no cover - fallback for package-relative layout
+    from ..composite_workflow_scorer import CompositeWorkflowScorer
+try:  # pragma: no cover - prefer absolute imports when running from repo root
+    from neuroplasticity import PathwayDB
+except ImportError:  # pragma: no cover - fallback for package-relative layout
+    from ..neuroplasticity import PathwayDB
+try:  # pragma: no cover - prefer absolute imports when running from repo root
+    from data_bot import MetricsDB
+except ImportError:  # pragma: no cover - fallback for package-relative layout
+    from ..data_bot import MetricsDB
+try:  # pragma: no cover - prefer absolute imports when running from repo root
+    from roi_results_db import ROIResultsDB
+except ImportError:  # pragma: no cover - fallback for package-relative layout
+    from ..roi_results_db import ROIResultsDB
+try:  # pragma: no cover - prefer absolute imports when running from repo root
+    from workflow_scorer_core import EvaluationResult
+except ImportError:  # pragma: no cover - fallback for package-relative layout
+    from ..workflow_scorer_core import EvaluationResult
+try:  # pragma: no cover - prefer absolute imports when running from repo root
+    from workflow_stability_db import WorkflowStabilityDB
+except ImportError:  # pragma: no cover - fallback for package-relative layout
+    from ..workflow_stability_db import WorkflowStabilityDB
 try:  # pragma: no cover - optional dependency
     from task_handoff_bot import WorkflowDB, WorkflowRecord
 except ImportError:  # pragma: no cover - best effort fallback
@@ -151,7 +187,6 @@ import shutil
 import ast
 import yaml
 import traceback
-from pathlib import Path
 from typing import Mapping, Callable, Iterable, Dict, Any, Sequence, List, TYPE_CHECKING
 from datetime import datetime
 from dynamic_module_mapper import build_module_map, discover_module_groups

--- a/self_improvement/init.py
+++ b/self_improvement/init.py
@@ -36,32 +36,37 @@ from filelock import FileLock
 
 from sandbox_settings import SandboxSettings, load_sandbox_settings
 from sandbox_runner.bootstrap import initialize_autonomous_sandbox
-try:  # pragma: no cover - prefer package-relative import when available
-    from ..metrics_exporter import self_improvement_failure_total
-except ImportError:  # pragma: no cover - support flat execution layout
-    from metrics_exporter import self_improvement_failure_total  # type: ignore
+try:  # pragma: no cover - prefer absolute imports when running from repo root
+    from metrics_exporter import self_improvement_failure_total
+except ImportError:  # pragma: no cover - fallback to package-relative import
+    from ..metrics_exporter import self_improvement_failure_total  # type: ignore
 
-try:  # pragma: no cover - fallback for flat layout
+try:  # pragma: no cover - prefer absolute imports when running from repo root
+    from dynamic_path_router import resolve_path
+except Exception:  # pragma: no cover - fallback to package-relative import
     from ..dynamic_path_router import resolve_path
-except Exception:  # pragma: no cover - fallback
-    from dynamic_path_router import resolve_path  # type: ignore
 
 try:
-    from ..logging_utils import get_logger, setup_logging, log_record
-except (ImportError, AttributeError) as exc:  # pragma: no cover - simplified environments
-    logging.getLogger(__name__).warning(
-        "logging utils unavailable", exc_info=exc, extra={"component": __name__}
-    )
-    self_improvement_failure_total.labels(reason="logging_utils_import").inc()
+    from logging_utils import get_logger, setup_logging, log_record  # type: ignore
+except (ImportError, AttributeError):  # pragma: no cover - fallback to package layout
+    try:
+        from ..logging_utils import get_logger, setup_logging, log_record
+    except (ImportError, AttributeError) as exc:  # pragma: no cover - simplified environments
+        logging.getLogger(__name__).warning(
+            "logging utils unavailable",
+            exc_info=exc,
+            extra={"component": __name__},
+        )
+        self_improvement_failure_total.labels(reason="logging_utils_import").inc()
 
-    def get_logger(name: str) -> logging.Logger:  # type: ignore
-        return logging.getLogger(name)
+        def get_logger(name: str) -> logging.Logger:  # type: ignore
+            return logging.getLogger(name)
 
-    def setup_logging() -> None:  # type: ignore
-        return None
+        def setup_logging() -> None:  # type: ignore
+            return None
 
-    def log_record(**fields: Any) -> dict[str, Any]:  # type: ignore
-        return fields
+        def log_record(**fields: Any) -> dict[str, Any]:  # type: ignore
+            return fields
 
 
 logger = get_logger(__name__)


### PR DESCRIPTION
## Summary
- Prefer absolute imports for self-improvement bootstrap helpers so scripts run from the repository root without relative import failures.
- Load pathlib.Path before use and auto-create the relevancy metrics database when missing during bootstrap.
- Add absolute-import fallbacks for self-improvement engine dependencies to support both package and flat layouts.

## Testing
- python manual_bootstrap.py

------
https://chatgpt.com/codex/tasks/task_e_68d46beb8f88832eba617c746562d100