### PR TITLE
Handle manual bootstrap import fallbacks

### DIFF
--- a/quick_fix_engine.py
+++ b/quick_fix_engine.py
@@ -617,7 +617,23 @@ def _requires_helper(hints: list[Dict[str, Any]]) -> bool:
     return False
 
 
-ErrorDB = load_internal("error_bot").ErrorDB  # noqa: E402
+_error_bot_module = load_internal("error_bot")
+try:
+    ErrorDB = _error_bot_module.ErrorDB  # type: ignore[attr-defined]
+except AttributeError as exc:  # pragma: no cover - compatibility shim
+    logging.getLogger(__name__).warning(
+        "error_bot.ErrorDB unavailable; falling back to disabled implementation",
+        exc_info=exc,
+    )
+
+    class _UnavailableErrorDB:  # pragma: no cover - simple guard
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            raise RuntimeError(
+                "error_bot.ErrorDB is unavailable; reinstall menace_sandbox or "
+                "enable optional dependencies"
+            )
+
+    ErrorDB = _UnavailableErrorDB  # type: ignore[assignment]
 
 SelfCodingManager = load_internal("self_coding_manager").SelfCodingManager  # noqa: E402
 

--- a/self_improvement/meta_planning.py
+++ b/self_improvement/meta_planning.py
@@ -32,12 +32,12 @@ if "menace.logging_utils" in sys.modules and not hasattr(
 
 try:  # pragma: no cover - allow flat package layout
     from ..logging_utils import get_logger, log_record
-except ImportError:  # pragma: no cover - fallback for manual_bootstrap environments
+except (ImportError, ValueError):  # pragma: no cover - fallback for manual_bootstrap environments
     from logging_utils import get_logger, log_record  # type: ignore
 
 try:  # pragma: no cover - allow flat package layout
     from ..sandbox_settings import SandboxSettings, DEFAULT_SEVERITY_SCORE_MAP
-except ImportError:  # pragma: no cover - fallback for manual_bootstrap environments
+except (ImportError, ValueError):  # pragma: no cover - fallback for manual_bootstrap environments
     from sandbox_settings import (  # type: ignore
         SandboxSettings,
         DEFAULT_SEVERITY_SCORE_MAP,
@@ -47,24 +47,24 @@ from . import init as _init
 
 try:  # pragma: no cover - allow flat package layout
     from ..workflow_stability_db import WorkflowStabilityDB
-except ImportError:  # pragma: no cover - fallback for manual_bootstrap environments
+except (ImportError, ValueError):  # pragma: no cover - fallback for manual_bootstrap environments
     from workflow_stability_db import WorkflowStabilityDB  # type: ignore
 
 try:  # pragma: no cover - allow flat package layout
     from ..roi_results_db import ROIResultsDB
-except ImportError:  # pragma: no cover - fallback for manual_bootstrap environments
+except (ImportError, ValueError):  # pragma: no cover - fallback for manual_bootstrap environments
     from roi_results_db import ROIResultsDB  # type: ignore
 
 try:  # pragma: no cover - allow flat package layout
     from ..lock_utils import SandboxLock, Timeout, LOCK_TIMEOUT
-except ImportError:  # pragma: no cover - fallback for manual_bootstrap environments
+except (ImportError, ValueError):  # pragma: no cover - fallback for manual_bootstrap environments
     from lock_utils import SandboxLock, Timeout, LOCK_TIMEOUT  # type: ignore
 
 from .baseline_tracker import BaselineTracker, TRACKER as BASELINE_TRACKER
 
 try:  # pragma: no cover - allow flat package layout
     from ..error_logger import TelemetryEvent
-except ImportError:  # pragma: no cover - fallback for manual_bootstrap environments
+except (ImportError, ValueError):  # pragma: no cover - fallback for manual_bootstrap environments
     from error_logger import TelemetryEvent  # type: ignore
 
 from .sandbox_score import get_latest_sandbox_score
@@ -77,7 +77,7 @@ _stop_event: threading.Event | None = None
 
 try:  # pragma: no cover - optional dependency
     from ..unified_event_bus import UnifiedEventBus
-except ImportError as exc:  # pragma: no cover - fallback when event bus missing
+except (ImportError, ValueError) as exc:  # pragma: no cover - fallback when event bus missing
     get_logger(__name__).warning(
         "unified event bus unavailable",  # noqa: TRY300
         extra=log_record(component=__name__, dependency="unified_event_bus"),


### PR DESCRIPTION
## Summary
- allow self_improvement.meta_planning to fall back to flat imports even when Python raises ValueError for relative imports run from scripts
- add a compatibility shim in quick_fix_engine so the module loads when error_bot.ErrorDB is missing, logging a warning and exposing a disabled placeholder implementation

## Testing
- python -m compileall self_improvement/meta_planning.py quick_fix_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68d46d88af0c832e842892d316016692