### PR TITLE
Add fallbacks for self-test service imports

### DIFF
--- a/self_test_service.py
+++ b/self_test_service.py
@@ -145,8 +145,15 @@ from orphan_analyzer import classify_module
 from logging_utils import log_record, get_logger
 from pydantic import ValidationError
 
-from .self_services_config import SelfTestConfig
-from .sandbox_runner.scoring import record_run
+try:  # pragma: no cover - allow execution without package context
+    from .self_services_config import SelfTestConfig
+except (ImportError, ValueError):  # pragma: no cover - fallback for manual bootstrap
+    from self_services_config import SelfTestConfig  # type: ignore
+
+try:  # pragma: no cover - allow execution without package context
+    from .sandbox_runner.scoring import record_run
+except (ImportError, ValueError):  # pragma: no cover - fallback for manual bootstrap
+    from sandbox_runner.scoring import record_run  # type: ignore
 
 try:
     from self_improvement.metrics import (


### PR DESCRIPTION
## Summary
- add non-package import fallbacks for `SelfTestConfig` and the sandbox scoring helper in `self_test_service`
- allow `manual_bootstrap.py` to proceed past self-test imports when the package is executed flatly

## Testing
- python manual_bootstrap.py *(fails: Missing system packages: ffmpeg, tesseract, qemu-system-x86_64)*

------
https://chatgpt.com/codex/tasks/task_e_68d472269f14832e9d3d88958d86cc05