### PR TITLE
Fix quick_fix_engine circular import with ErrorDB

### DIFF
--- a/quick_fix_engine.py
+++ b/quick_fix_engine.py
@@ -28,6 +28,9 @@ import symtable
 from dataclasses import dataclass, field
 from typing import Tuple, Iterable, Dict, Any, List, TYPE_CHECKING, Callable
 
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .error_bot import ErrorDB
+
 _HELPER_NAME = "import_compat"
 _PACKAGE_NAME = "menace_sandbox"
 
@@ -616,24 +619,6 @@ def _requires_helper(hints: list[Dict[str, Any]]) -> bool:
             return True
     return False
 
-
-_error_bot_module = load_internal("error_bot")
-try:
-    ErrorDB = _error_bot_module.ErrorDB  # type: ignore[attr-defined]
-except AttributeError as exc:  # pragma: no cover - compatibility shim
-    logging.getLogger(__name__).warning(
-        "error_bot.ErrorDB unavailable; falling back to disabled implementation",
-        exc_info=exc,
-    )
-
-    class _UnavailableErrorDB:  # pragma: no cover - simple guard
-        def __init__(self, *args: object, **kwargs: object) -> None:
-            raise RuntimeError(
-                "error_bot.ErrorDB is unavailable; reinstall menace_sandbox or "
-                "enable optional dependencies"
-            )
-
-    ErrorDB = _UnavailableErrorDB  # type: ignore[assignment]
 
 SelfCodingManager = load_internal("self_coding_manager").SelfCodingManager  # noqa: E402
 
@@ -1411,7 +1396,7 @@ class QuickFixEngine:
 
     def __init__(
         self,
-        error_db: ErrorDB,
+        error_db: "ErrorDB",
         manager: SelfCodingManager,
         *,
         threshold: int = 3,


### PR DESCRIPTION
## Summary
- avoid importing `error_bot.ErrorDB` at runtime to prevent circular imports when bootstrapping
- rely on typing-only import and forward reference for `ErrorDB` annotations

## Testing
- python manual_bootstrap.py

------
https://chatgpt.com/codex/tasks/task_e_68d47ff69434832eb2e928b8841dad49