### PR TITLE
Add Stack dataset configuration to ingestion and retrieval

### DIFF
--- a/config/stack_context.yaml
+++ b/config/stack_context.yaml
@@ -1,0 +1,14 @@
+# Configuration defaults for Stack dataset ingestion and retrieval.
+#
+# These values are merged into the main configuration by ``config.load_config``
+# and can be overridden per-environment by editing this file. ``enabled`` acts
+# as a global kill-switch so deployments without Stack embeddings can skip
+# ingestion and retrieval logic entirely.
+stack_dataset:
+  enabled: false
+  allowed_languages:
+    - python
+    - javascript
+  max_lines_per_document: 800
+  chunk_size: 2048
+  retrieval_top_k: 5


### PR DESCRIPTION
## Summary
- add a StackDatasetConfig model and merge the new config/stack_context.yaml defaults into the global configuration
- wire Stack ingestion to honour configuration toggles, language allow-list, chunk sizing, and document line caps
- limit Stack retrievals in the context builder while filtering by configured languages and truncating oversized snippets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5faed6f00832e97050f6b86521d79