### PR TITLE
Add Stack retriever integration

### DIFF
--- a/vector_service/__init__.py
+++ b/vector_service/__init__.py
@@ -86,7 +86,7 @@ class VectorServiceError(Exception):  # pragma: no cover - default error type
 
 RateLimitError = MalformedPromptError = VectorServiceError
 
-Retriever = PatchLogger = CognitionLayer = EmbeddingBackfill = ContextBuilder = _Stub  # type: ignore
+Retriever = PatchLogger = CognitionLayer = EmbeddingBackfill = ContextBuilder = StackRetriever = _Stub  # type: ignore
 SharedVectorService: type[_SimpleSharedVectorService] | type[_Stub] = _SimpleSharedVectorService
 
 try:  # pragma: no cover - upgrade default errors when available
@@ -103,12 +103,17 @@ else:
     MalformedPromptError = _MalformedPromptError
 
 try:  # pragma: no cover - optional heavy dependency
-    from .retriever import Retriever as _Retriever, FallbackResult as _FallbackResult
+    from .retriever import (
+        Retriever as _Retriever,
+        FallbackResult as _FallbackResult,
+        StackRetriever as _StackRetriever,
+    )
 except Exception:
     pass
 else:
     Retriever = _Retriever
     FallbackResult = _FallbackResult
+    StackRetriever = _StackRetriever
 
 try:  # pragma: no cover - optional heavy dependency
     from .patch_logger import PatchLogger as _PatchLogger
@@ -178,6 +183,7 @@ __all__ = [
     "PatchLogger",
     "CognitionLayer",
     "EmbeddingBackfill",
+    "StackRetriever",
     "SharedVectorService",
     "ContextBuilder",
     "EmbeddableDBMixin",


### PR DESCRIPTION
## Summary
- implement a StackRetriever that queries Stack embeddings through the shared vector service with existing safety and ROI adjustments
- update ContextBuilder and the self-coding workflow to instantiate and reuse the stack retriever when Stack ingestion is enabled
- expose the new retriever via the vector_service package for downstream consumers

## Testing
- python -m compileall vector_service/retriever.py vector_service/context_builder.py vector_service/__init__.py self_coding_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68d5fca33624832ebde281be98c71d97