### PR TITLE
Add Stack environment discovery and credential warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2395,7 +2395,11 @@ provision infrastructure automatically.
 `DefaultConfigManager` now auto-generates missing configuration values and
 persists them to `.env` so the system can start unattended. `ConfigDiscovery`
 additionally inspects Terraform directories and host lists to set
-`TERRAFORM_DIR`, `CLUSTER_HOSTS` and `REMOTE_HOSTS` automatically.
+`TERRAFORM_DIR`, `CLUSTER_HOSTS` and `REMOTE_HOSTS` automatically. When Stack
+retrieval or ingestion is enabled it also ensures `.env.auto` contains
+`STACK_STREAMING` (defaulting to `1`) and a placeholder `HUGGINGFACE_TOKEN` so
+Hugging Face credentials can be shared with downstream services. Populate
+`HUGGINGFACE_TOKEN` with a valid API token to unlock Stack ingestion.
 
 ### Autoscaling and self-healing
 `Autoscaler` integrates with `PredictiveResourceAllocator` for dynamic scaling, while `SelfHealingOrchestrator` redeploys crashed bots and triggers automatic rollbacks when failures persist.

--- a/vector_service/README.md
+++ b/vector_service/README.md
@@ -185,6 +185,22 @@ python -m vector_service.download_model
 The command fetches the model from Hugging Face and writes the compressed
 archive to the expected location.
 
+### Stack dataset ingestion
+
+`vector_service.stack_ingestion` streams repositories from The Stack dataset.
+Set `STACK_STREAMING=1` (the default) to enable the pipeline and provide a
+valid Hugging Face access token via `HUGGINGFACE_TOKEN`.  The bootstrap process
+adds both variables to `.env.auto`; update the placeholder token before running
+the ingestion CLI:
+
+```bash
+STACK_STREAMING=1 HUGGINGFACE_TOKEN=hf_your_token \
+python -m vector_service.stack_ingestion --languages python javascript
+```
+
+When `STACK_STREAMING` is disabled or the token is missing, the ingestion script
+logs a warning and exits without processing.
+
 ## Safety filtering
 
 `ContextBuilder` and `Retriever` apply configurable safety thresholds:


### PR DESCRIPTION
## Summary
- ensure `ConfigDiscovery` persists `STACK_STREAMING` and `HUGGINGFACE_TOKEN` defaults into `.env.auto`
- gate Stack ingestion/retrieval on the new environment variables and warn when the Hugging Face token is missing
- extend the documentation and tests to cover the new configuration flow

## Testing
- `pytest tests/test_config_discovery.py -q` *(fails: ImportError: cannot import name 'RAISE_ERRORS' from 'menace')*

------
https://chatgpt.com/codex/tasks/task_e_68d6005ebfa4832eac02e77916f84991