### PR TITLE
Expose Stack snippet controls in prompts

### DIFF
--- a/config.py
+++ b/config.py
@@ -363,6 +363,15 @@ class ContextBuilderConfig(_StrictBaseModel):
         None,
         description="Optional override for the Stack metadata SQLite database",
     )
+    stack_prompt_enabled: bool = Field(
+        True,
+        description="Include Stack snippets when assembling prompts by default",
+    )
+    stack_prompt_limit: int = Field(
+        2,
+        ge=0,
+        description="Maximum number of Stack snippets surfaced in prompts (0 disables)",
+    )
 
     @field_validator("stack_languages")
     @classmethod

--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -1411,6 +1411,22 @@ class SandboxSettings(BaseSettings):
             "is unavailable."
         ),
     )
+    stack_prompt_enabled: bool = Field(
+        True,
+        env="STACK_PROMPT_ENABLED",
+        description="Enable inclusion of Stack dataset context when building prompts.",
+    )
+    stack_prompt_snippets: int | None = Field(
+        2,
+        env="STACK_PROMPT_SNIPPETS",
+        description="Maximum Stack snippets appended to prompts (0 disables).",
+    )
+    
+    @field_validator("stack_prompt_snippets")
+    def _validate_stack_prompt_snippets(cls, value: int | None) -> int | None:
+        if value is not None and value < 0:
+            raise ValueError("stack_prompt_snippets must be non-negative")
+        return value
     chunk_token_threshold: int = Field(
         3500,
         env="CHUNK_TOKEN_THRESHOLD",

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -1259,6 +1259,19 @@ class SelfCodingEngine:
             "intent": intent,
             "error_log": error_log,
         }
+        stack_enabled = getattr(_settings, "stack_prompt_enabled", True)
+        prompt_kwargs.setdefault("include_stack_snippets", bool(stack_enabled))
+        stack_limit_setting = getattr(_settings, "stack_prompt_snippets", None)
+        try:
+            stack_limit_int = (
+                int(stack_limit_setting)
+                if stack_limit_setting is not None
+                else None
+            )
+        except (TypeError, ValueError):
+            stack_limit_int = None
+        if stack_limit_int is not None:
+            prompt_kwargs.setdefault("stack_snippet_limit", stack_limit_int)
         if isinstance(intent, Mapping):
             if "top_k" in intent:
                 try:


### PR DESCRIPTION
## Summary
- add configuration knobs for enabling Stack context and limiting surfaced snippets
- extend ContextBuilder to capture Stack metadata, enforce snippet limits, and emit retrieval details
- wire stack snippet options through self-coding and sandbox prompts and cover with focused tests

## Testing
- pytest tests/test_context_builder_build_prompt.py

------
https://chatgpt.com/codex/tasks/task_e_68d60d217014832e818f84f20e779243