### PR TITLE
Improve Stack environment discovery and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2395,11 +2395,13 @@ provision infrastructure automatically.
 `DefaultConfigManager` now auto-generates missing configuration values and
 persists them to `.env` so the system can start unattended. `ConfigDiscovery`
 additionally inspects Terraform directories and host lists to set
-`TERRAFORM_DIR`, `CLUSTER_HOSTS` and `REMOTE_HOSTS` automatically. When Stack
-retrieval or ingestion is enabled it also ensures `.env.auto` contains
-`STACK_STREAMING` (defaulting to `1`) and a placeholder `HUGGINGFACE_TOKEN` so
-Hugging Face credentials can be shared with downstream services. Populate
-`HUGGINGFACE_TOKEN` with a valid API token to unlock Stack ingestion.
+`TERRAFORM_DIR`, `CLUSTER_HOSTS` and `REMOTE_HOSTS` automatically. It also
+exports Stack-related hints discovered in `.env` or `config/stack_context.yaml`
+so services share a consistent setup. The bootstrap step now writes
+placeholders for `STACK_STREAMING=0`, `STACK_HF_TOKEN=`,
+`STACK_INDEX_PATH=` and `STACK_METADATA_PATH=` to `.env.auto`, alongside
+`HUGGINGFACE_TOKEN=`. Overwrite the defaults with real values to enable Stack
+streaming and point the retrievers at pre-built Stack indices.
 
 ### Autoscaling and self-healing
 `Autoscaler` integrates with `PredictiveResourceAllocator` for dynamic scaling, while `SelfHealingOrchestrator` redeploys crashed bots and triggers automatic rollbacks when failures persist.

--- a/config/stack_context.yaml
+++ b/config/stack_context.yaml
@@ -21,6 +21,10 @@ context_builder:
   # embeddings are unavailable in the current deployment.
   stack_enabled: false
 
+  # The environment variable STACK_STREAMING should remain 0 until Stack
+  # ingestion is explicitly enabled with valid STACK_HF_TOKEN/HUGGINGFACE_TOKEN
+  # credentials. Updating this file alone does not trigger ingestion.
+
   # Restrict Stack snippets to these languages. Leave empty to accept every
   # language present in the embeddings.
   stack_languages:
@@ -36,6 +40,7 @@ context_builder:
   stack_max_lines: 200
 
   # Optional overrides for deployments storing Stack embeddings outside the
-  # default locations. Leave unset to rely on automatic discovery.
+  # default locations. Leave unset to rely on automatic discovery. You can also
+  # export STACK_INDEX_PATH / STACK_METADATA_PATH to set these at runtime.
   stack_index_path: null
   stack_metadata_path: null

--- a/vector_service/README.md
+++ b/vector_service/README.md
@@ -188,18 +188,22 @@ archive to the expected location.
 ### Stack dataset ingestion
 
 `vector_service.stack_ingestion` streams repositories from The Stack dataset.
-Set `STACK_STREAMING=1` (the default) to enable the pipeline and provide a
-valid Hugging Face access token via `HUGGINGFACE_TOKEN`.  The bootstrap process
-adds both variables to `.env.auto`; update the placeholder token before running
-the ingestion CLI:
+Set `STACK_STREAMING=1` to enable the pipeline and provide a valid Hugging Face
+access token via either `STACK_HF_TOKEN` or `HUGGINGFACE_TOKEN`.  The bootstrap
+process seeds `.env.auto` with safe defaults
+(`STACK_STREAMING=0`, `STACK_HF_TOKEN=`, `STACK_INDEX_PATH=`,
+`STACK_METADATA_PATH=` and `HUGGINGFACE_TOKEN=`); update the placeholders before
+running the ingestion CLI:
 
 ```bash
 STACK_STREAMING=1 HUGGINGFACE_TOKEN=hf_your_token \
 python -m vector_service.stack_ingestion --languages python javascript
 ```
 
-When `STACK_STREAMING` is disabled or the token is missing, the ingestion script
-logs a warning and exits without processing.
+Use `STACK_INDEX_PATH` and `STACK_METADATA_PATH` to point ingestion at existing
+Stack indices if they are stored outside the default locations. When
+`STACK_STREAMING` is disabled or the token is missing, the ingestion script logs
+a warning and exits without processing.
 
 ## Safety filtering
 


### PR DESCRIPTION
## Summary
- extend configuration discovery to read Stack streaming hints from environment files and config, synchronising safe defaults into `.env.auto`
- add Stack placeholders to the generated default environment variables so ensure_config avoids accidental ingestion by default
- document the Stack-related environment variables and add regression tests covering the new discovery logic

## Testing
- pytest tests/test_config_discovery.py

------
https://chatgpt.com/codex/tasks/task_e_68d6110e5f64832eb77dfe130a9876ff