### PR TITLE
Implement Stack dataset streaming ingestor

### DIFF
--- a/tests/test_stack_ingestor.py
+++ b/tests/test_stack_ingestor.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Iterator, List, Mapping
+
+import pytest
+
+from vector_service.stack_ingestor import StackIngestor, StackMetadataStore
+
+
+class DummyDataset:
+    def __init__(self, samples: Iterable[Mapping[str, object]]) -> None:
+        self._samples = [dict(sample) for sample in samples]
+
+    def __iter__(self) -> Iterator[Mapping[str, object]]:
+        for sample in self._samples:
+            yield dict(sample)
+
+
+class DummyVectorStore:
+    def __init__(self) -> None:
+        self.records: List[dict] = []
+
+    def add(
+        self,
+        kind: str,
+        record_id: str,
+        vector: Iterable[float],
+        *,
+        origin_db: str | None = None,
+        metadata: Mapping[str, object] | None = None,
+    ) -> None:
+        self.records.append(
+            {
+                "kind": kind,
+                "record_id": record_id,
+                "vector": list(vector),
+                "origin_db": origin_db,
+                "metadata": dict(metadata or {}),
+            }
+        )
+
+    def query(self, vector: Iterable[float], top_k: int = 5) -> List[tuple[str, float]]:
+        return []
+
+    def load(self) -> None:
+        return None
+
+
+@pytest.fixture
+def sample_records() -> List[Mapping[str, object]]:
+    return [
+        {
+            "language": "Python",
+            "repo_name": "repo/example",
+            "path": "a.py",
+            "content": "print('hi')\nprint('bye')",
+        },
+        {
+            "language": "python",
+            "repo_name": "repo/example",
+            "path": "b.py",
+            "content": "def foo():\n    return 1",
+        },
+    ]
+
+
+def _patch_load_dataset(monkeypatch: pytest.MonkeyPatch, samples: Iterable[Mapping[str, object]]) -> None:
+    def fake_load_dataset(name: str, **kwargs):  # type: ignore[override]
+        assert kwargs.get("streaming") is True
+        return DummyDataset(samples)
+
+    monkeypatch.setattr("vector_service.stack_ingestor.load_dataset", fake_load_dataset)
+
+
+def test_stack_ingestor_batches_and_persists_metadata(tmp_path: Path, sample_records, monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_load_dataset(monkeypatch, sample_records)
+
+    calls: List[List[str]] = []
+
+    def fake_embeddings(texts: List[str], **_: object) -> List[List[float]]:
+        calls.append(list(texts))
+        return [[float(len(text)), float(text.count("\n") + 1)] for text in texts]
+
+    metadata_path = tmp_path / "meta.db"
+    metadata_store = StackMetadataStore(metadata_path, namespace="test")
+    vector_store = DummyVectorStore()
+    ingestor = StackIngestor(
+        languages=("python",),
+        chunk_lines=1,
+        batch_size=2,
+        metadata_path=metadata_path,
+        index_path=tmp_path / "stack.index",
+        vector_backend="annoy",
+        embedding_fn=fake_embeddings,
+        vector_store=vector_store,
+        metadata_store=metadata_store,
+    )
+
+    processed = ingestor.ingest(resume=False)
+
+    assert processed == 2
+    assert len(vector_store.records) == 4
+    assert all(set(entry["metadata"].keys()) == {"repo", "path", "language", "hash"} for entry in vector_store.records)
+    assert all(len(batch) <= 2 for batch in calls)
+
+    cur = metadata_store.conn.cursor()
+    cur.execute(f"PRAGMA table_info({metadata_store.metadata_table})")
+    columns = {row[1] for row in cur.fetchall()}
+    assert "chunk_hash" in columns
+    assert "content" not in columns
+
+    cur.execute(f"SELECT chunk_hash FROM {metadata_store.metadata_table}")
+    hashes = {row[0] for row in cur.fetchall()}
+    assert all("print" not in chunk_hash for chunk_hash in hashes)
+
+
+def test_stack_ingestor_resume_skips_existing(tmp_path: Path, sample_records, monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_load_dataset(monkeypatch, sample_records)
+
+    metadata_path = tmp_path / "meta.db"
+    metadata_store = StackMetadataStore(metadata_path, namespace="resume")
+    vector_store = DummyVectorStore()
+    ingestor = StackIngestor(
+        languages=("python",),
+        chunk_lines=1,
+        batch_size=2,
+        metadata_path=metadata_path,
+        index_path=tmp_path / "stack.index",
+        vector_backend="annoy",
+        embedding_fn=lambda texts, **_: [[float(len(t))] for t in texts],
+        vector_store=vector_store,
+        metadata_store=metadata_store,
+    )
+
+    first_processed = ingestor.ingest(resume=False)
+    initial_records = len(vector_store.records)
+
+    second_processed = ingestor.ingest(resume=True)
+
+    assert first_processed == 2
+    assert second_processed == 0
+    assert len(vector_store.records) == initial_records
+

--- a/vector_service/stack_ingestion.py
+++ b/vector_service/stack_ingestion.py
@@ -1,31 +1,15 @@
+"""CLI for streaming embeddings from The Stack dataset."""
+
 from __future__ import annotations
-
-"""Streaming ingestion pipeline for The Stack dataset."""
-
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Dict, Iterable, Iterator, Mapping, MutableMapping, Sequence
 
 import argparse
 import logging
 import os
-import sqlite3
 import sys
-import time
-import uuid
+from typing import Sequence
 
-try:  # pragma: no cover - optional dependency
-    from datasets import load_dataset  # type: ignore
-except Exception:  # pragma: no cover - dataset ingestion optional in tests
-    load_dataset = None  # type: ignore
-
-from chunking import CodeChunk, split_into_chunks
-from code_vectorizer import CodeVectorizer
 from config import StackDatasetConfig, get_config
-from vector_service.embed_utils import EMBED_DIM
-from vector_service.vector_store import VectorStore, create_vector_store
-
-from .vectorizer import SharedVectorService
+from vector_service.stack_ingestor import StackIngestor
 
 LOGGER = logging.getLogger(__name__)
 
@@ -54,343 +38,17 @@ def _resolve_hf_token() -> str | None:
     return None
 
 
-class SQLiteMetadataStore:
-    """Track Stack ingestion metadata and progress in SQLite."""
-
-    def __init__(self, path: str | Path, namespace: str = "stack") -> None:
-        self.path = Path(path)
-        self.namespace = namespace
-        self.metadata_table = f"{namespace}_metadata"
-        self.progress_table = f"{namespace}_progress"
-        self.conn = sqlite3.connect(self.path)
-        self._init_schema()
-
-    def _init_schema(self) -> None:
-        cur = self.conn.cursor()
-        cur.execute(
-            f"""
-            CREATE TABLE IF NOT EXISTS {self.metadata_table} (
-                embedding_id TEXT PRIMARY KEY,
-                file_id TEXT NOT NULL,
-                repo TEXT,
-                path TEXT,
-                language TEXT,
-                license TEXT,
-                chunk_index INTEGER NOT NULL,
-                start_line INTEGER,
-                end_line INTEGER,
-                token_count INTEGER,
-                updated_at REAL NOT NULL
-            )
-            """
-        )
-        cur.execute(
-            f"""
-            CREATE TABLE IF NOT EXISTS {self.progress_table} (
-                file_id TEXT PRIMARY KEY,
-                processed_at REAL NOT NULL
-            )
-            """
-        )
-        self.conn.commit()
-
-    def upsert_chunk_metadata(
-        self,
-        *,
-        embedding_id: str,
-        file_id: str,
-        repo: str,
-        path: str,
-        language: str,
-        license: str,
-        chunk_index: int,
-        start_line: int | None,
-        end_line: int | None,
-        token_count: int | None,
-    ) -> None:
-        cur = self.conn.cursor()
-        cur.execute(
-            f"""
-            INSERT OR REPLACE INTO {self.metadata_table} (
-                embedding_id,
-                file_id,
-                repo,
-                path,
-                language,
-                license,
-                chunk_index,
-                start_line,
-                end_line,
-                token_count,
-                updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                embedding_id,
-                file_id,
-                repo or None,
-                path or None,
-                language or None,
-                license or None,
-                chunk_index,
-                start_line,
-                end_line,
-                token_count,
-                time.time(),
-            ),
-        )
-        self.conn.commit()
-
-    def has_processed(self, file_id: str) -> bool:
-        cur = self.conn.cursor()
-        cur.execute(f"SELECT 1 FROM {self.progress_table} WHERE file_id = ?", (file_id,))
-        return cur.fetchone() is not None
-
-    def mark_processed(self, file_id: str) -> None:
-        cur = self.conn.cursor()
-        cur.execute(
-            f"INSERT OR REPLACE INTO {self.progress_table} (file_id, processed_at) VALUES (?, ?)",
-            (file_id, time.time()),
-        )
-        self.conn.commit()
-
-    def reset(self) -> None:
-        cur = self.conn.cursor()
-        cur.execute(f"DELETE FROM {self.metadata_table}")
-        cur.execute(f"DELETE FROM {self.progress_table}")
-        self.conn.commit()
-
-
-@dataclass
-class StackIngestionService:
-    """Stream and embed documents from The Stack dataset."""
-
-    languages: Sequence[str] | None = None
-    chunk_size: int = 2048
-    dataset_name: str = "bigcode/the-stack-dedup"
-    split: str = "train"
-    namespace: str = "stack"
-    db_path: str | Path = "stack_embeddings.db"
-    index_path: str | Path | None = None
-    vector_backend: str | None = None
-    use_auth_token: str | None = None
-    max_lines_per_document: int = 0
-    max_chunk_lines: int | None = None
-
-    def __post_init__(self) -> None:
-        self.languages = tuple(lang.lower() for lang in (self.languages or ()))
-        if self.max_lines_per_document < 0:
-            raise ValueError("max_lines_per_document must be non-negative")
-        if self.max_chunk_lines is None and self.max_lines_per_document:
-            self.max_chunk_lines = self.max_lines_per_document
-        self.metadata_store = SQLiteMetadataStore(self.db_path, namespace=self.namespace)
-        self.index_path = Path(self.index_path or Path(self.db_path).with_suffix(".index"))
-        self._vector_store: VectorStore | None = None
-        self.vector_service: SharedVectorService | None = None
-        self.code_vectorizer = CodeVectorizer()
-        LOGGER.debug(
-            "StackIngestionService initialised",
-            extra={
-                "languages": self.languages,
-                "index_path": str(self.index_path),
-                "backend": self.vector_backend or "annoy",
-            },
-        )
-
-    # Public API -----------------------------------------------------------
-    def run(self, *, resume: bool = False, limit: int | None = None) -> None:
-        self._initialise_vector_pipeline(reset=not resume)
-        dataset_iter = self._stream_dataset()
-        processed = 0
-        for sample in dataset_iter:
-            if limit is not None and processed >= limit:
-                break
-            try:
-                if self._handle_sample(sample):
-                    processed += 1
-            except KeyboardInterrupt:  # pragma: no cover - manual interruption
-                raise
-            except Exception as exc:
-                LOGGER.exception("Failed to process sample: %s", exc)
-        LOGGER.info("Stack ingestion completed: processed %d files", processed)
-
-    # Internal helpers -----------------------------------------------------
-    def _stream_dataset(self) -> Iterator[MutableMapping[str, object]]:
-        if load_dataset is None:  # pragma: no cover - optional dependency
-            raise RuntimeError(
-                "datasets package not available - install `datasets` to stream The Stack"
-            )
-        LOGGER.info(
-            "Loading dataset %s split %s (streaming)",
-            self.dataset_name,
-            self.split,
-        )
-        kwargs: Dict[str, object] = {"streaming": True, "split": self.split}
-        if self.use_auth_token:
-            kwargs["use_auth_token"] = self.use_auth_token
-        return iter(load_dataset(self.dataset_name, **kwargs))
-
-    def _handle_sample(self, sample: Mapping[str, object]) -> bool:
-        language = str(sample.get("language") or "").lower()
-        if self.languages and language not in self.languages:
-            return False
-        repo = str(sample.get("repo_name") or "")
-        path = str(sample.get("path") or "")
-        file_id = self._file_identifier(repo, path, sample)
-        if self.metadata_store.has_processed(file_id):
-            LOGGER.debug("Skipping previously processed file: %s", file_id)
-            return False
-        content = sample.get("content")
-        if not isinstance(content, str) or not content.strip():
-            LOGGER.debug("Skipping empty content for file: %s", file_id)
-            self.metadata_store.mark_processed(file_id)
-            return True
-        if self.max_lines_per_document:
-            lines = content.splitlines()
-            if len(lines) > self.max_lines_per_document:
-                LOGGER.debug(
-                    "Truncating %s to %d lines before embedding",
-                    file_id,
-                    self.max_lines_per_document,
-                )
-                content = "\n".join(lines[: self.max_lines_per_document])
-
-        chunk_count = 0
-        license_info = str(sample.get("license") or "")
-        for chunk_index, chunk in self._chunk_content(content):
-            record_id = self._chunk_identifier(file_id, chunk_index)
-            vector = self._embed_chunk(chunk)
-            metadata = {
-                "repo": repo,
-                "path": path,
-                "language": language,
-                "license": license_info,
-                "chunk_index": chunk_index,
-                "start_line": chunk.start_line,
-                "end_line": chunk.end_line,
-                "token_count": chunk.token_count,
-            }
-            if self._vector_store is None:
-                raise RuntimeError("Vector store not initialised")
-            self._vector_store.add(
-                self.namespace,
-                record_id,
-                vector,
-                origin_db=self.namespace,
-                metadata=metadata,
-            )
-            self.metadata_store.upsert_chunk_metadata(
-                embedding_id=record_id,
-                file_id=file_id,
-                repo=repo,
-                path=path,
-                language=language,
-                license=license_info,
-                chunk_index=chunk_index,
-                start_line=chunk.start_line,
-                end_line=chunk.end_line,
-                token_count=chunk.token_count,
-            )
-            chunk_count += 1
-
-        self.metadata_store.mark_processed(file_id)
-        LOGGER.info(
-            "Embedded %d chunks for %s (%s)",
-            chunk_count,
-            path or file_id,
-            language,
-        )
-        return True
-
-    def _chunk_content(self, content: str) -> Iterable[tuple[int, CodeChunk]]:
-        token_limit = max(1, int(self.chunk_size))
-        chunks = split_into_chunks(content, token_limit)
-        for idx, chunk in enumerate(chunks):
-            text = chunk.text
-            if self.max_chunk_lines:
-                lines = text.splitlines()
-                if len(lines) > self.max_chunk_lines:
-                    text = "\n".join(lines[: self.max_chunk_lines])
-                    approx_tokens = len(text.split())
-                    chunk = CodeChunk(
-                        start_line=chunk.start_line,
-                        end_line=min(chunk.end_line, chunk.start_line + self.max_chunk_lines - 1),
-                        text=text,
-                        hash=chunk.hash,
-                        token_count=approx_tokens,
-                    )
-            yield idx, chunk
-
-    def _embed_chunk(self, chunk: CodeChunk) -> Sequence[float]:
-        record = {"content": chunk.text}
-        if self.vector_service is not None:
-            try:
-                return self.vector_service.vectorise("code", record)
-            except Exception as exc:
-                LOGGER.debug("SharedVectorService fallback for chunk failed: %s", exc)
-        return self.code_vectorizer.transform(record)
-
-    @staticmethod
-    def _file_identifier(repo: str, path: str, sample: Mapping[str, object]) -> str:
-        base = f"{repo}:{path}" if repo or path else str(sample.get("id", ""))
-        if not base:
-            base = str(uuid.uuid4())
-        return base
-
-    @staticmethod
-    def _chunk_identifier(file_id: str, chunk_index: int) -> str:
-        return f"{file_id}::chunk-{chunk_index}"
-
-    def _initialise_vector_pipeline(self, *, reset: bool) -> None:
-        if reset:
-            LOGGER.info("Resetting existing Stack embeddings at %s", self.db_path)
-            self.metadata_store.reset()
-            self._reset_vector_index()
-        backend = (self.vector_backend or "annoy").lower()
-        self.index_path.parent.mkdir(parents=True, exist_ok=True)
-        self._vector_store = create_vector_store(
-            EMBED_DIM,
-            self.index_path,
-            backend=backend,
-            metric="angular",
-        )
-        self.vector_service = SharedVectorService(vector_store=self._vector_store)
-
-    def _reset_vector_index(self) -> None:
-        path = Path(self.index_path)
-        candidates = {
-            path,
-            path.with_suffix(path.suffix + ".meta"),
-            path.with_suffix(path.suffix + ".meta.json"),
-            path.with_suffix(".meta"),
-            path.with_suffix(".meta.json"),
-        }
-        for candidate in candidates:
-            try:
-                if candidate.exists():
-                    candidate.unlink()
-            except Exception:
-                LOGGER.debug("Failed to remove vector index file: %s", candidate)
-
-
 def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Stream embeddings from The Stack dataset")
-    parser.add_argument(
-        "--languages",
-        nargs="*",
-        default=None,
-        help="Languages to include (defaults to stack_dataset.allowed_languages)",
-    )
-    parser.add_argument(
-        "--chunk-size",
-        type=int,
-        default=None,
-        help="Maximum tokens per chunk (defaults to stack_dataset.chunk_size)",
-    )
-    parser.add_argument("--split", default="train", help="Dataset split to stream")
     parser.add_argument("--dataset", default="bigcode/the-stack-dedup", help="Dataset identifier")
-    parser.add_argument("--db", default="stack_embeddings.db", help="SQLite database path")
-    parser.add_argument("--namespace", default="stack", help="Vector store namespace")
+    parser.add_argument("--split", default="train", help="Dataset split to stream")
+    parser.add_argument("--languages", nargs="*", default=None, help="Languages to include")
+    parser.add_argument("--chunk-lines", type=int, default=None, help="Maximum lines per embedded chunk")
+    parser.add_argument("--max-lines", type=int, default=None, help="Maximum lines retained per file")
+    parser.add_argument("--max-bytes", type=int, default=None, help="Maximum bytes retained per file")
+    parser.add_argument("--batch-size", type=int, default=16, help="Embedding batch size")
+    parser.add_argument("--db", default="stack_embeddings.db", help="SQLite database path for metadata")
+    parser.add_argument("--namespace", default="stack", help="Namespace for vector entries")
     parser.add_argument(
         "--index-path",
         default=None,
@@ -422,34 +80,37 @@ def main(argv: Sequence[str] | None = None) -> int:
         LOGGER.info("Stack dataset ingestion disabled via configuration")
         return 0
 
+    languages = args.languages
+    if languages is None:
+        languages = sorted(stack_cfg.allowed_languages)
+
+    chunk_lines = args.chunk_lines if args.chunk_lines is not None else stack_cfg.chunk_size
+    max_lines = args.max_lines if args.max_lines is not None else stack_cfg.max_lines_per_document
+
     auth_token = _resolve_hf_token()
     if not auth_token:
         LOGGER.info(
             "No Hugging Face credentials found (set STACK_HF_TOKEN if required); proceeding unauthenticated"
         )
 
-    languages = args.languages
-    if languages is None:
-        languages = sorted(stack_cfg.allowed_languages)
-
-    chunk_size = args.chunk_size if args.chunk_size is not None else stack_cfg.chunk_size
-
-    service = StackIngestionService(
-        languages=languages,
-        chunk_size=chunk_size,
+    ingestor = StackIngestor(
         dataset_name=args.dataset,
         split=args.split,
+        languages=languages,
+        max_lines=max_lines,
+        max_bytes=args.max_bytes,
+        chunk_lines=chunk_lines,
+        batch_size=args.batch_size,
         namespace=args.namespace,
-        db_path=args.db,
+        metadata_path=args.db,
         index_path=args.index_path,
         vector_backend=args.backend,
         use_auth_token=auth_token,
-        max_lines_per_document=stack_cfg.max_lines_per_document,
-        max_chunk_lines=stack_cfg.max_lines_per_document,
     )
-    service.run(resume=args.resume, limit=args.limit)
+    ingestor.ingest(resume=args.resume, limit=args.limit)
     return 0
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point
     sys.exit(main())
+

--- a/vector_service/stack_ingestor.py
+++ b/vector_service/stack_ingestor.py
@@ -1,0 +1,449 @@
+"""Streaming ingestion helpers for The Stack dataset.
+
+This module provides a light-weight pipeline that streams code files from the
+`bigcode/the-stack-dedup` dataset, embeds the resulting snippets and persists
+only anonymised metadata alongside the vectors.  The focus is on keeping memory
+usage predictable (by batching embeddings) and avoiding the storage of raw
+source code which is immediately discarded after the embeddings are computed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable, Iterator, List, Mapping, MutableMapping, Sequence
+
+import hashlib
+import logging
+import sqlite3
+import time
+
+try:  # pragma: no cover - optional dependency for runtime environments
+    from datasets import load_dataset  # type: ignore
+except Exception:  # pragma: no cover - tests provide a stub
+    load_dataset = None  # type: ignore
+
+from vector_service.embed_utils import EMBED_DIM, get_text_embeddings
+from vector_service.vector_store import VectorStore, create_vector_store
+
+LOGGER = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data containers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StackFile:
+    """Simple container representing a single file from The Stack."""
+
+    file_id: str
+    repo: str
+    path: str
+    language: str
+    license: str | None
+    content: str
+
+    @property
+    def byte_size(self) -> int:
+        return len(self.content.encode("utf-8"))
+
+    @property
+    def line_count(self) -> int:
+        if not self.content:
+            return 0
+        return self.content.count("\n") + 1
+
+
+@dataclass(frozen=True)
+class StackChunk:
+    """Represents a chunked snippet derived from a :class:`StackFile`."""
+
+    file_id: str
+    index: int
+    text: str
+
+    @property
+    def sha256(self) -> str:
+        return hashlib.sha256(self.text.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Metadata persistence
+# ---------------------------------------------------------------------------
+
+
+class StackMetadataStore:
+    """Persist embedding metadata and ingestion progress in SQLite."""
+
+    def __init__(self, path: str | Path, *, namespace: str = "stack") -> None:
+        self.path = Path(path)
+        self.namespace = namespace
+        self.conn = sqlite3.connect(self.path)
+        self._init_schema()
+
+    @property
+    def metadata_table(self) -> str:
+        return f"{self.namespace}_embeddings"
+
+    @property
+    def progress_table(self) -> str:
+        return f"{self.namespace}_progress"
+
+    def _init_schema(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {self.metadata_table} (
+                embedding_id TEXT PRIMARY KEY,
+                file_id TEXT NOT NULL,
+                repo TEXT,
+                path TEXT,
+                language TEXT,
+                chunk_hash TEXT NOT NULL,
+                chunk_index INTEGER NOT NULL,
+                created_at REAL NOT NULL
+            )
+            """
+        )
+        cur.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {self.progress_table} (
+                file_id TEXT PRIMARY KEY,
+                processed_at REAL NOT NULL
+            )
+            """
+        )
+        self.conn.commit()
+
+    # Progress ---------------------------------------------------------
+    def has_processed(self, file_id: str) -> bool:
+        cur = self.conn.cursor()
+        cur.execute(f"SELECT 1 FROM {self.progress_table} WHERE file_id = ?", (file_id,))
+        return cur.fetchone() is not None
+
+    def mark_processed(self, file_id: str) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            f"INSERT OR REPLACE INTO {self.progress_table} (file_id, processed_at) VALUES (?, ?)",
+            (file_id, time.time()),
+        )
+        self.conn.commit()
+
+    def reset(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(f"DELETE FROM {self.metadata_table}")
+        cur.execute(f"DELETE FROM {self.progress_table}")
+        self.conn.commit()
+
+    # Metadata ---------------------------------------------------------
+    def upsert_embedding(
+        self,
+        *,
+        embedding_id: str,
+        file_id: str,
+        repo: str,
+        path: str,
+        language: str,
+        chunk_hash: str,
+        chunk_index: int,
+    ) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            f"""
+            INSERT OR REPLACE INTO {self.metadata_table} (
+                embedding_id,
+                file_id,
+                repo,
+                path,
+                language,
+                chunk_hash,
+                chunk_index,
+                created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                embedding_id,
+                file_id,
+                repo or None,
+                path or None,
+                language or None,
+                chunk_hash,
+                chunk_index,
+                time.time(),
+            ),
+        )
+        self.conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Dataset streaming
+# ---------------------------------------------------------------------------
+
+
+class StackDatasetStream:
+    """Wrapper around :func:`datasets.load_dataset` yielding :class:`StackFile`."""
+
+    def __init__(
+        self,
+        dataset_name: str = "bigcode/the-stack-dedup",
+        *,
+        split: str = "train",
+        languages: Sequence[str] | None = None,
+        max_lines: int | None = None,
+        max_bytes: int | None = None,
+        use_auth_token: str | None = None,
+    ) -> None:
+        self.dataset_name = dataset_name
+        self.split = split
+        self.languages = tuple(lang.lower() for lang in (languages or ())) or None
+        self.max_lines = max_lines if (max_lines or 0) > 0 else None
+        self.max_bytes = max_bytes if (max_bytes or 0) > 0 else None
+        self.use_auth_token = use_auth_token
+
+    # Public API -------------------------------------------------------
+    def __iter__(self) -> Iterator[StackFile]:
+        return self.iter_files()
+
+    def iter_files(self) -> Iterator[StackFile]:
+        if load_dataset is None:  # pragma: no cover - runtime dependency missing
+            raise RuntimeError("datasets package not available; install `datasets` to stream The Stack")
+
+        kwargs: MutableMapping[str, object] = {"streaming": True, "split": self.split}
+        if self.use_auth_token:
+            kwargs["use_auth_token"] = self.use_auth_token
+
+        LOGGER.info("Loading dataset %s (split=%s)", self.dataset_name, self.split)
+        dataset = load_dataset(self.dataset_name, **kwargs)
+        iterator: Iterable[Mapping[str, object]]
+        if isinstance(dataset, Mapping):
+            # Some dataset versions return a mapping of splits; pick the requested one.
+            iterator = dataset[self.split]  # type: ignore[index]
+        else:
+            iterator = dataset
+
+        for sample in iterator:
+            file = self._coerce_sample(sample)
+            if file is None:
+                continue
+            yield file
+
+    # Internal helpers -------------------------------------------------
+    def _coerce_sample(self, sample: Mapping[str, object]) -> StackFile | None:
+        language = str(sample.get("language") or "").strip().lower()
+        if self.languages and language not in self.languages:
+            return None
+        content = sample.get("content")
+        if not isinstance(content, str) or not content.strip():
+            return None
+
+        truncated = self._truncate_content(content)
+        repo = str(sample.get("repo_name") or "")
+        path = str(sample.get("path") or "")
+        license_info = sample.get("license")
+        license_str = str(license_info) if license_info is not None else None
+        file_id = self._file_identifier(repo, path, sample)
+
+        return StackFile(
+            file_id=file_id,
+            repo=repo,
+            path=path,
+            language=language,
+            license=license_str,
+            content=truncated,
+        )
+
+    def _truncate_content(self, content: str) -> str:
+        text = content
+        if self.max_lines is not None:
+            lines = text.splitlines()
+            text = "\n".join(lines[: self.max_lines])
+        if self.max_bytes is not None:
+            encoded = text.encode("utf-8")
+            if len(encoded) > self.max_bytes:
+                text = encoded[: self.max_bytes].decode("utf-8", errors="ignore")
+        return text
+
+    @staticmethod
+    def _file_identifier(repo: str, path: str, sample: Mapping[str, object]) -> str:
+        base = f"{repo}:{path}".strip(":")
+        if not base:
+            base = str(sample.get("id") or "")
+        if not base:
+            base = hashlib.sha1(repr(sorted(sample.items())).encode("utf-8")).hexdigest()
+        return base
+
+
+# ---------------------------------------------------------------------------
+# Ingestion pipeline
+# ---------------------------------------------------------------------------
+
+
+EmbeddingFn = Callable[[List[str]], List[List[float]]]
+
+
+@dataclass
+class StackIngestor:
+    """Stream files from The Stack and persist embeddings and metadata."""
+
+    dataset_name: str = "bigcode/the-stack-dedup"
+    split: str = "train"
+    languages: Sequence[str] | None = None
+    max_lines: int | None = None
+    max_bytes: int | None = None
+    chunk_lines: int = 200
+    batch_size: int = 16
+    namespace: str = "stack"
+    metadata_path: str | Path = "stack_embeddings.db"
+    index_path: str | Path | None = None
+    vector_backend: str | None = None
+    use_auth_token: str | None = None
+    embedding_fn: Callable[..., List[List[float]]] = get_text_embeddings
+    vector_store: VectorStore | None = None
+    metadata_store: StackMetadataStore | None = None
+
+    def __post_init__(self) -> None:
+        self.languages = tuple(lang.lower() for lang in (self.languages or ())) or None
+        if self.batch_size < 1:
+            raise ValueError("batch_size must be positive")
+        if self.chunk_lines < 1:
+            raise ValueError("chunk_lines must be positive")
+        meta_path = Path(self.metadata_path)
+        self.metadata_store = self.metadata_store or StackMetadataStore(meta_path, namespace=self.namespace)
+        if self.index_path is None:
+            self.index_path = Path(meta_path).with_suffix(".index")
+        else:
+            self.index_path = Path(self.index_path)
+        self.vector_store = self.vector_store or create_vector_store(
+            EMBED_DIM,
+            self.index_path,
+            backend=self.vector_backend,
+            metric="angular",
+        )
+        self.stream = StackDatasetStream(
+            self.dataset_name,
+            split=self.split,
+            languages=self.languages,
+            max_lines=self.max_lines,
+            max_bytes=self.max_bytes,
+            use_auth_token=self.use_auth_token,
+        )
+
+    # Public API -------------------------------------------------------
+    def ingest(self, *, resume: bool = False, limit: int | None = None) -> int:
+        """Stream the dataset and persist embeddings.
+
+        Parameters
+        ----------
+        resume:
+            When ``True`` previously processed files are preserved and ingestion
+            resumes from the recorded checkpoint.  Otherwise the metadata and
+            vector index are reset before processing starts.
+        limit:
+            Optional maximum number of files to process.  Useful for smoke tests
+            or to bound runtime during development.
+        Returns
+        -------
+        int
+            The number of files processed during this run.
+        """
+
+        if not resume:
+            LOGGER.info("Resetting Stack ingestion state")
+            self.metadata_store.reset()  # type: ignore[union-attr]
+            self._reset_vector_index()
+
+        processed = 0
+        for file in self.stream:
+            if limit is not None and processed >= limit:
+                break
+            if self.metadata_store.has_processed(file.file_id):  # type: ignore[union-attr]
+                LOGGER.debug("Skipping already processed file: %s", file.file_id)
+                continue
+            chunk_count = self._process_file(file)
+            if chunk_count:
+                processed += 1
+            self.metadata_store.mark_processed(file.file_id)  # type: ignore[union-attr]
+
+        LOGGER.info("Completed Stack ingestion for %d files", processed)
+        return processed
+
+    # Internal helpers -------------------------------------------------
+    def _process_file(self, file: StackFile) -> int:
+        chunks = list(self._chunk_file(file))
+        if not chunks:
+            return 0
+
+        for start in range(0, len(chunks), self.batch_size):
+            batch = chunks[start : start + self.batch_size]
+            texts = [chunk.text for chunk in batch]
+            embeddings = self._embed_batch(texts)
+            for chunk, vector in zip(batch, embeddings):
+                embedding_id = f"{file.file_id}::chunk-{chunk.index}"
+                metadata = {
+                    "repo": file.repo,
+                    "path": file.path,
+                    "language": file.language,
+                    "hash": chunk.sha256,
+                }
+                self.vector_store.add(  # type: ignore[union-attr]
+                    self.namespace,
+                    embedding_id,
+                    vector,
+                    origin_db=self.namespace,
+                    metadata=metadata,
+                )
+                self.metadata_store.upsert_embedding(  # type: ignore[union-attr]
+                    embedding_id=embedding_id,
+                    file_id=file.file_id,
+                    repo=file.repo,
+                    path=file.path,
+                    language=file.language,
+                    chunk_hash=chunk.sha256,
+                    chunk_index=chunk.index,
+                )
+        # Wipe chunk texts eagerly to help the GC drop references quickly.
+        chunks.clear()
+        return 1
+
+    def _chunk_file(self, file: StackFile) -> Iterator[StackChunk]:
+        lines = file.content.splitlines()
+        chunk_size = max(1, int(self.chunk_lines))
+        for idx in range(0, len(lines), chunk_size):
+            segment = "\n".join(lines[idx : idx + chunk_size])
+            if not segment.strip():
+                continue
+            yield StackChunk(file.file_id, idx // chunk_size, segment)
+
+    def _embed_batch(self, texts: List[str]) -> List[List[float]]:
+        kwargs = {}
+        return self.embedding_fn(texts, **kwargs)
+
+    def _reset_vector_index(self) -> None:
+        if self.index_path is None:
+            return
+        self.index_path.parent.mkdir(parents=True, exist_ok=True)
+        candidates = {
+            self.index_path,
+            self.index_path.with_suffix(self.index_path.suffix + ".meta"),
+            self.index_path.with_suffix(self.index_path.suffix + ".meta.json"),
+            self.index_path.with_suffix(".meta"),
+            self.index_path.with_suffix(".meta.json"),
+        }
+        for candidate in candidates:
+            try:
+                if candidate.exists():
+                    candidate.unlink()
+            except Exception:
+                LOGGER.debug("Failed to remove vector index candidate %s", candidate)
+
+
+__all__ = [
+    "StackChunk",
+    "StackDatasetStream",
+    "StackFile",
+    "StackIngestor",
+    "StackMetadataStore",
+]
+


### PR DESCRIPTION
## Summary
- add a dedicated `StackIngestor` module that streams The Stack dataset, batches embeddings, and stores only hashed metadata
- refresh the Stack ingestion CLI to rely on the new ingestor, honouring language and throttling options
- cover the ingestion flow with pytest fixtures that mock the Hugging Face stream and verify resume behaviour

## Testing
- pytest tests/test_stack_ingestor.py

------
https://chatgpt.com/codex/tasks/task_e_68d614aa4fa8832ebb73d47afb55dfbd