### PR TITLE
Add structured stack dataset configuration to context builder

### DIFF
--- a/config/create_context_builder.py
+++ b/config/create_context_builder.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import os
 import logging
 from pathlib import Path
-from typing import Dict, Iterable, Tuple
+from typing import Any, Dict, Iterable, Tuple
 
+from config import ContextBuilderConfig, StackDatasetConfig, get_config
 from vector_service.context_builder import ContextBuilder
 
 DB_SPEC: Tuple[Tuple[str, str, str], ...] = (
@@ -35,6 +36,18 @@ def _ensure_readable(path: Path, filename: str) -> str:
     return str(path)
 
 
+def _resolve_stack_path(value: Any, base_dir: Path) -> Path | None:
+    if value in {None, "", b""}:
+        return None
+    try:
+        candidate = Path(str(value))
+    except Exception:
+        return None
+    if not candidate.is_absolute():
+        candidate = (base_dir / candidate).resolve()
+    return candidate
+
+
 def create_context_builder() -> ContextBuilder:
     """Return a :class:`ContextBuilder` wired to the standard local databases.
 
@@ -49,7 +62,71 @@ def create_context_builder() -> ContextBuilder:
         builder_kwargs[attr] = _ensure_readable(path, filename)
 
     try:
-        builder = ContextBuilder(**builder_kwargs)
+        cfg = get_config()
+        context_cfg = getattr(cfg, "context_builder", ContextBuilderConfig())
+    except Exception:
+        context_cfg = ContextBuilderConfig()
+
+    stack_cfg: StackDatasetConfig = getattr(context_cfg, "stack", StackDatasetConfig())
+    stack_enabled = bool(getattr(stack_cfg, "enabled", False))
+
+    env_index = os.getenv("STACK_INDEX_PATH")
+    env_metadata = os.getenv("STACK_METADATA_PATH")
+    env_cache = os.getenv("STACK_CACHE_DIR")
+    env_progress = os.getenv("STACK_PROGRESS_PATH")
+
+    index_path = _resolve_stack_path(env_index, data_dir) or _resolve_stack_path(
+        getattr(stack_cfg, "index_path", None), data_dir
+    )
+    metadata_path = _resolve_stack_path(env_metadata, data_dir) or _resolve_stack_path(
+        getattr(stack_cfg, "metadata_path", None), data_dir
+    )
+    cache_dir = _resolve_stack_path(env_cache, data_dir) or _resolve_stack_path(
+        getattr(stack_cfg, "cache_dir", None), data_dir
+    )
+    progress_path = _resolve_stack_path(env_progress, data_dir) or _resolve_stack_path(
+        getattr(stack_cfg, "progress_path", None), data_dir
+    )
+
+    stack_kwargs: Dict[str, Any] = {
+        "config": context_cfg,
+        "stack_config": stack_cfg,
+    }
+
+    if stack_enabled:
+        if index_path is None:
+            raise FileNotFoundError(
+                "Stack retrieval enabled but no index_path configured. "
+                "Set context_builder.stack.index_path or STACK_INDEX_PATH."
+            )
+        if not index_path.exists():
+            raise FileNotFoundError(
+                f"Stack index expected at {index_path} but was not found"
+            )
+        stack_kwargs["stack_index_path"] = str(index_path)
+
+        if metadata_path is None:
+            raise FileNotFoundError(
+                "Stack retrieval enabled but no metadata_path configured. "
+                "Set context_builder.stack.metadata_path or STACK_METADATA_PATH."
+            )
+        metadata_str = _ensure_readable(metadata_path, "stack metadata store")
+        stack_kwargs["stack_metadata_path"] = metadata_str
+    else:
+        if index_path is not None:
+            stack_kwargs["stack_index_path"] = str(index_path)
+        if metadata_path is not None:
+            stack_kwargs["stack_metadata_path"] = str(metadata_path)
+
+    if cache_dir is not None:
+        stack_kwargs["stack_cache_dir"] = str(cache_dir)
+    if progress_path is not None:
+        stack_kwargs["stack_progress_path"] = str(progress_path)
+
+    try:
+        init_kwargs: Dict[str, Any] = dict(builder_kwargs)
+        init_kwargs.update(stack_kwargs)
+        builder = ContextBuilder(**init_kwargs)
     except TypeError as exc:  # pragma: no cover - for simple stubs in tests
         raise ValueError(
             "ContextBuilder requires paths to 'bots.db', 'code.db', 'errors.db', "

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -8,6 +8,13 @@ bot:
 api_keys:
   openai: dev-openai-key
   serp: dev-serp-key
+# Stack retrieval paths for local development
+context_builder:
+  stack:
+    index_path: ./data/stack/index.faiss
+    metadata_path: ./data/stack/metadata.db
+    cache_dir: ./data/stack/cache
+    progress_path: ./data/stack/cache/progress.sqlite
 # Ranker scheduler environment variables:
 # - RANKER_SCHEDULER_INTERVAL: seconds between retrains (0 disables)
 # - RANKER_SCHEDULER_ROI_THRESHOLD: ROI delta triggering immediate retrain

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -10,6 +10,13 @@ bot:
 api_keys:
   openai: prod-openai-key
   serp: prod-serp-key
+# Dedicated Stack retrieval paths for production deployments
+context_builder:
+  stack:
+    index_path: /srv/igi/data/stack/index.faiss
+    metadata_path: /srv/igi/data/stack/metadata.db
+    cache_dir: /srv/igi/data/stack/cache
+    progress_path: /srv/igi/data/stack/cache/progress.sqlite
 # Ranker scheduler environment variables:
 # - RANKER_SCHEDULER_INTERVAL: seconds between retrains (0 disables)
 # - RANKER_SCHEDULER_ROI_THRESHOLD: ROI delta triggering immediate retrain

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -29,3 +29,17 @@ context_builder:
     bug-introduced: 0.5
     needs-review: 0.3
     blocked: 1.0
+  stack:
+    enabled: false
+    languages:
+      - python
+    max_lines: 200
+    max_bytes: 65536
+    retrieval_top_k: 3
+    index_path: stack/index.faiss
+    metadata_path: stack/metadata.db
+    cache_dir: stack/cache
+    progress_path: stack/cache/progress.sqlite
+    chunk_lines: 256
+  stack_prompt_enabled: false
+  stack_prompt_limit: 2

--- a/config/stack_context.yaml
+++ b/config/stack_context.yaml
@@ -6,12 +6,17 @@
 # ingestion and retrieval logic entirely.
 stack_dataset:
   enabled: false
-  allowed_languages:
+  languages:
     - python
     - javascript
-  max_lines_per_document: 800
-  chunk_size: 2048
+  max_lines: 800
+  max_bytes: 262144
   retrieval_top_k: 5
+  index_path: stack/index.faiss
+  metadata_path: stack/metadata.db
+  cache_dir: stack/cache
+  progress_path: stack/cache/progress.sqlite
+  chunk_lines: 512
 
 # Context builder specific tuning for Stack retrieval. These settings control
 # whether Stack snippets are considered alongside the primary databases and how
@@ -19,28 +24,19 @@ stack_dataset:
 context_builder:
   # Toggle Stack retrieval without touching ingestion. Disable when the Stack
   # embeddings are unavailable in the current deployment.
-  stack_enabled: false
+  stack:
+    enabled: false
+    languages:
+      - python
+      - javascript
+    max_lines: 200
+    max_bytes: 65536
+    retrieval_top_k: 3
+    index_path: stack/index.faiss
+    metadata_path: stack/metadata.db
+    cache_dir: stack/cache
+    progress_path: stack/cache/progress.sqlite
+    chunk_lines: 256
 
-  # The environment variable STACK_STREAMING should remain 0 until Stack
-  # ingestion is explicitly enabled with valid STACK_HF_TOKEN/HUGGINGFACE_TOKEN
-  # credentials. Updating this file alone does not trigger ingestion.
-
-  # Restrict Stack snippets to these languages. Leave empty to accept every
-  # language present in the embeddings.
-  stack_languages:
-    - python
-    - javascript
-
-  # Number of Stack candidates fetched for each query. Lower values reduce the
-  # amount of metadata merged into prompts.
-  stack_top_k: 3
-
-  # Maximum number of lines preserved per Stack snippet before summarisation.
-  # Set to 0 to keep the full snippet.
-  stack_max_lines: 200
-
-  # Optional overrides for deployments storing Stack embeddings outside the
-  # default locations. Leave unset to rely on automatic discovery. You can also
-  # export STACK_INDEX_PATH / STACK_METADATA_PATH to set these at runtime.
-  stack_index_path: null
-  stack_metadata_path: null
+  stack_prompt_enabled: false
+  stack_prompt_limit: 2

--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -696,7 +696,7 @@ class SelfCodingEngine:
                     stack_index=stack_store,
                     metadata_db_path=metadata_path,
                     top_k=max(1, int(getattr(stack_cfg, "retrieval_top_k", 5) or 5)),
-                    max_lines=max(0, int(getattr(stack_cfg, "max_lines_per_document", 0) or 0)),
+                    max_lines=max(0, int(getattr(stack_cfg, "max_lines", 0) or 0)),
                     patch_safety=getattr(builder, "patch_safety", None),
                     license_denylist=set(getattr(builder, "license_denylist", set())),
                     risk_penalty=getattr(builder, "risk_penalty", 1.0),

--- a/tests/test_config_discovery.py
+++ b/tests/test_config_discovery.py
@@ -84,9 +84,12 @@ def test_discover_reads_stack_hints(tmp_path, monkeypatch):
         """
 stack_dataset:
   enabled: true
+  index_path: /opt/index-dataset
+  metadata_path: /opt/meta-dataset.db
 context_builder:
-  stack_index_path: /opt/index
-  stack_metadata_path: /opt/meta.db
+  stack:
+    index_path: /opt/index-cb
+    metadata_path: /opt/meta-cb.db
 """
     )
     for var in [

--- a/tests/test_stack_configuration.py
+++ b/tests/test_stack_configuration.py
@@ -1,0 +1,69 @@
+from menace import config
+
+
+def _reset_config():
+    config.CONFIG = None
+    config._OVERRIDES = {}
+    config._MODE = None
+    config._CONFIG_PATH = None
+
+
+def test_context_builder_stack_defaults(monkeypatch):
+    _reset_config()
+    cfg = config.load_config(mode="dev")
+    try:
+        stack = cfg.context_builder.stack
+        assert stack.enabled is False
+        assert stack.languages == {"python", "javascript"}
+        assert stack.max_lines == 200
+        assert stack.max_bytes == 65536
+        assert stack.retrieval_top_k == 3
+        assert stack.index_path == "stack/index.faiss"
+        assert stack.metadata_path == "stack/metadata.db"
+        assert stack.cache_dir == "stack/cache"
+        assert stack.progress_path == "stack/cache/progress.sqlite"
+        assert stack.chunk_lines == 256
+        assert cfg.context_builder.stack_prompt_enabled is False
+        assert cfg.context_builder.stack_prompt_limit == 2
+    finally:
+        _reset_config()
+
+
+def test_context_builder_stack_roundtrip(monkeypatch):
+    _reset_config()
+    cfg = config.load_config(mode="dev")
+    overrides = {
+        "context_builder": {
+            "stack": {
+                "enabled": True,
+                "languages": ["python", "rust"],
+                "max_lines": 64,
+                "max_bytes": 4096,
+                "retrieval_top_k": 7,
+                "index_path": "custom/index.faiss",
+                "metadata_path": "custom/meta.db",
+                "cache_dir": "custom/cache",
+                "progress_path": "custom/cache/progress.sqlite",
+                "chunk_lines": 128,
+            },
+            "stack_prompt_enabled": True,
+            "stack_prompt_limit": 5,
+        }
+    }
+    updated = cfg.apply_overrides(overrides)
+    try:
+        stack = updated.context_builder.stack
+        assert stack.enabled is True
+        assert stack.languages == {"python", "rust"}
+        assert stack.max_lines == 64
+        assert stack.max_bytes == 4096
+        assert stack.retrieval_top_k == 7
+        assert stack.index_path == "custom/index.faiss"
+        assert stack.metadata_path == "custom/meta.db"
+        assert stack.cache_dir == "custom/cache"
+        assert stack.progress_path == "custom/cache/progress.sqlite"
+        assert stack.chunk_lines == 128
+        assert updated.context_builder.stack_prompt_enabled is True
+        assert updated.context_builder.stack_prompt_limit == 5
+    finally:
+        _reset_config()

--- a/vector_service/README.md
+++ b/vector_service/README.md
@@ -205,6 +205,21 @@ Stack indices if they are stored outside the default locations. When
 `STACK_STREAMING` is disabled or the token is missing, the ingestion script logs
 a warning and exits without processing.
 
+#### Configuration
+
+`ContextBuilder` reads Stack retrieval settings from the nested
+`context_builder.stack` section in `config/settings.yaml`. The defaults keep the
+integration disabled and favour conservative limits (`max_lines`, `max_bytes`
+and `retrieval_top_k`) so deployments can opt-in gradually. Paths for the Stack
+index, metadata store and caches can be customised per environment; relative
+paths are resolved against `SANDBOX_DATA_DIR` by `config.create_context_builder`.
+
+Environment variables `STACK_INDEX_PATH`, `STACK_METADATA_PATH`,
+`STACK_CACHE_DIR` and `STACK_PROGRESS_PATH` override the YAML values. When the
+Stack integration is enabled but either the index or metadata store is missing,
+`create_context_builder` raises a clear error instead of silently disabling the
+feature.
+
 ## Safety filtering
 
 `ContextBuilder` and `Retriever` apply configurable safety thresholds:

--- a/vector_service/stack_ingestion.py
+++ b/vector_service/stack_ingestion.py
@@ -82,10 +82,11 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     languages = args.languages
     if languages is None:
-        languages = sorted(stack_cfg.allowed_languages)
+        languages = sorted(stack_cfg.languages)
 
-    chunk_lines = args.chunk_lines if args.chunk_lines is not None else stack_cfg.chunk_size
-    max_lines = args.max_lines if args.max_lines is not None else stack_cfg.max_lines_per_document
+    chunk_lines = args.chunk_lines if args.chunk_lines is not None else stack_cfg.chunk_lines
+    max_lines = args.max_lines if args.max_lines is not None else stack_cfg.max_lines
+    max_bytes = args.max_bytes if args.max_bytes is not None else stack_cfg.max_bytes
 
     auth_token = _resolve_hf_token()
     if not auth_token:
@@ -98,7 +99,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         split=args.split,
         languages=languages,
         max_lines=max_lines,
-        max_bytes=args.max_bytes,
+        max_bytes=max_bytes,
         chunk_lines=chunk_lines,
         batch_size=args.batch_size,
         namespace=args.namespace,


### PR DESCRIPTION
## Summary
- define a richer StackDatasetConfig and embed it in ContextBuilderConfig with new stack defaults
- update settings and discovery helpers to surface context_builder.stack options and refresh stack ingestion utilities
- pass stack settings through create_context_builder, refresh docs, and add configuration round-trip tests

## Testing
- pytest tests/test_stack_configuration.py tests/test_config_discovery.py

------
https://chatgpt.com/codex/tasks/task_e_68d61b1081e0832eb8e566fbb103aed4