### PR TITLE
Improve Stack streaming environment handling

### DIFF
--- a/tests/test_config_stack_env.py
+++ b/tests/test_config_stack_env.py
@@ -1,0 +1,44 @@
+import menace.config as config
+
+
+def _reset_config(monkeypatch):
+    monkeypatch.setattr(config, "CONFIG", None)
+    monkeypatch.setattr(config, "_CONFIG_STORE", None)
+    monkeypatch.setattr(config, "UnifiedConfigStore", None, raising=False)
+
+
+def test_stack_env_overrides_enable_streaming(monkeypatch):
+    monkeypatch.setenv("MENACE_MODE", "dev")
+    monkeypatch.setenv("STACK_STREAMING", "1")
+    monkeypatch.setenv("STACK_INDEX_PATH", "/tmp/stack.index")
+    monkeypatch.setenv("STACK_METADATA_PATH", "/tmp/stack.db")
+    _reset_config(monkeypatch)
+
+    cfg = config.load_config()
+
+    assert cfg.stack_dataset.enabled is True
+    assert cfg.context_builder.stack.enabled is True
+    assert cfg.stack_dataset.index_path == "/tmp/stack.index"
+    assert cfg.stack_dataset.metadata_path == "/tmp/stack.db"
+    assert cfg.context_builder.stack.index_path == "/tmp/stack.index"
+    assert cfg.context_builder.stack.metadata_path == "/tmp/stack.db"
+
+
+def test_stack_env_defaults_when_unset(monkeypatch):
+    monkeypatch.setenv("MENACE_MODE", "dev")
+    for name in [
+        "STACK_STREAMING",
+        "STACK_INDEX_PATH",
+        "STACK_METADATA_PATH",
+        "STACK_CACHE_DIR",
+        "STACK_PROGRESS_PATH",
+    ]:
+        monkeypatch.delenv(name, raising=False)
+    _reset_config(monkeypatch)
+
+    cfg = config.load_config()
+
+    assert cfg.stack_dataset.enabled is False
+    assert cfg.context_builder.stack.enabled is False
+    assert cfg.stack_dataset.index_path
+    assert cfg.stack_dataset.metadata_path

--- a/vector_service/vector_store.py
+++ b/vector_service/vector_store.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Sequence, Tuple, Protocol
+import os
 
 import json
 import math
@@ -409,6 +410,17 @@ def _stack_vector_store_config() -> Tuple[int, Path, str, str, Path | None]:
     metric = "angular"
     index_path: Path | None = None
     metadata_path: Path | None = None
+
+    env_index_override = os.getenv("STACK_INDEX_PATH")
+    env_metadata_override = os.getenv("STACK_METADATA_PATH")
+    if env_index_override:
+        coerced = _coerce_path(env_index_override)
+        if coerced is not None:
+            index_path = coerced
+    if env_metadata_override:
+        coerced = _coerce_path(env_metadata_override)
+        if coerced is not None:
+            metadata_path = coerced
 
     try:  # pragma: no cover - configuration may be missing in tests
         from config import CONFIG


### PR DESCRIPTION
## Summary
- ensure ConfigDiscovery surfaces Stack streaming defaults, Hugging Face token placeholders, and logs credential issues
- allow stack-related environment variables to override config and vector store settings
- add targeted tests covering Stack env discovery and configuration overrides

## Testing
- pytest tests/test_config_discovery.py tests/test_config_stack_env.py

------
https://chatgpt.com/codex/tasks/task_e_68d61f736b48832eaf5398bfb483c13a