### PR TITLE
Expand Stack context configuration options

### DIFF
--- a/config/self_coding_thresholds.yaml
+++ b/config/self_coding_thresholds.yaml
@@ -1,3 +1,32 @@
+stack:
+  context_builder:
+    enabled: false
+    languages:
+      - python
+      - javascript
+    max_lines: 200
+    max_bytes: 65536
+    top_k: 3
+    index_path: stack/index.faiss
+    metadata_path: stack/metadata.db
+    cache_dir: stack/cache
+    progress_path: stack/cache/progress.sqlite
+    requests_per_minute: 60
+    tokens_per_minute: 60000
+  dataset:
+    enabled: false
+    languages:
+      - python
+      - javascript
+    max_lines: 200
+    max_bytes: 65536
+    top_k: 3
+    index_path: stack/index.faiss
+    metadata_path: stack/metadata.db
+    cache_dir: stack/cache
+    progress_path: stack/cache/progress.sqlite
+    chunk_lines: 256
+
 default:
   roi_drop: -0.1
   error_increase: 1.0

--- a/tests/test_config_discovery.py
+++ b/tests/test_config_discovery.py
@@ -24,6 +24,8 @@ def test_discover_populates_stack_env(tmp_path, monkeypatch, caplog):
         "STACK_HF_TOKEN",
         "STACK_INDEX_PATH",
         "STACK_METADATA_PATH",
+        "STACK_CACHE_DIR",
+        "STACK_PROGRESS_PATH",
         "HUGGINGFACE_TOKEN",
         "HF_TOKEN",
         "HUGGINGFACEHUB_API_TOKEN",
@@ -39,12 +41,16 @@ def test_discover_populates_stack_env(tmp_path, monkeypatch, caplog):
     assert f"STACK_HF_TOKEN={cd._HF_PLACEHOLDER}" in text
     assert "STACK_INDEX_PATH=" in text
     assert "STACK_METADATA_PATH=" in text
+    assert "STACK_CACHE_DIR=" in text
+    assert "STACK_PROGRESS_PATH=" in text
     assert f"HUGGINGFACE_TOKEN={cd._HF_PLACEHOLDER}" in text
     assert f"HF_TOKEN={cd._HF_PLACEHOLDER}" in text
     assert os.environ.get("STACK_STREAMING") == "0"
     assert os.environ.get("STACK_HF_TOKEN") == cd._HF_PLACEHOLDER
     assert os.environ.get("HUGGINGFACE_TOKEN") == cd._HF_PLACEHOLDER
     assert os.environ.get("HF_TOKEN") == cd._HF_PLACEHOLDER
+    assert os.environ.get("STACK_CACHE_DIR") == ""
+    assert os.environ.get("STACK_PROGRESS_PATH") == ""
     assert any("missing Hugging Face credentials" in rec.message for rec in caplog.records)
     assert any("Stack processing disabled" in rec.message for rec in caplog.records)
 
@@ -56,6 +62,8 @@ def test_discover_persists_existing_token(tmp_path, monkeypatch):
         "STACK_HF_TOKEN",
         "STACK_INDEX_PATH",
         "STACK_METADATA_PATH",
+        "STACK_CACHE_DIR",
+        "STACK_PROGRESS_PATH",
         "HUGGINGFACE_TOKEN",
         "HF_TOKEN",
     ]:
@@ -98,11 +106,21 @@ context_builder:
     metadata_path: /opt/meta-cb.db
 """
     )
+    (tmp_path / "config" / "self_coding_thresholds.yaml").write_text(
+        """
+stack:
+  context_builder:
+    cache_dir: /var/lib/stack/cache
+    progress_path: /var/lib/stack/progress.sqlite
+"""
+    )
     for var in [
         "STACK_STREAMING",
         "STACK_HF_TOKEN",
         "STACK_INDEX_PATH",
         "STACK_METADATA_PATH",
+        "STACK_CACHE_DIR",
+        "STACK_PROGRESS_PATH",
         "HUGGINGFACE_TOKEN",
         "HF_TOKEN",
     ]:
@@ -117,6 +135,8 @@ context_builder:
     # values from the environment file take precedence over config hints
     assert os.environ.get("STACK_INDEX_PATH") == "/var/lib/stack/index"
     assert os.environ.get("STACK_METADATA_PATH") == "/var/lib/stack/meta.sqlite"
+    assert os.environ.get("STACK_CACHE_DIR") == "/var/lib/stack/cache"
+    assert os.environ.get("STACK_PROGRESS_PATH") == "/var/lib/stack/progress.sqlite"
 
 
 def test_discover_streaming_hint_from_config(tmp_path, monkeypatch, caplog):
@@ -128,6 +148,8 @@ def test_discover_streaming_hint_from_config(tmp_path, monkeypatch, caplog):
         "STACK_HF_TOKEN",
         "STACK_INDEX_PATH",
         "STACK_METADATA_PATH",
+        "STACK_CACHE_DIR",
+        "STACK_PROGRESS_PATH",
         "HUGGINGFACE_TOKEN",
         "HF_TOKEN",
     ]:

--- a/tests/test_config_stack_env.py
+++ b/tests/test_config_stack_env.py
@@ -12,6 +12,8 @@ def test_stack_env_overrides_enable_streaming(monkeypatch):
     monkeypatch.setenv("STACK_STREAMING", "1")
     monkeypatch.setenv("STACK_INDEX_PATH", "/tmp/stack.index")
     monkeypatch.setenv("STACK_METADATA_PATH", "/tmp/stack.db")
+    monkeypatch.setenv("STACK_CACHE_DIR", "/tmp/stack-cache")
+    monkeypatch.setenv("STACK_PROGRESS_PATH", "/tmp/stack-progress.sqlite")
     _reset_config(monkeypatch)
 
     cfg = config.load_config()
@@ -22,6 +24,13 @@ def test_stack_env_overrides_enable_streaming(monkeypatch):
     assert cfg.stack_dataset.metadata_path == "/tmp/stack.db"
     assert cfg.context_builder.stack.index_path == "/tmp/stack.index"
     assert cfg.context_builder.stack.metadata_path == "/tmp/stack.db"
+    assert cfg.context_builder.stack.cache_dir == "/tmp/stack-cache"
+    assert cfg.context_builder.stack.progress_path == "/tmp/stack-progress.sqlite"
+    assert cfg.context_builder.stack_enabled is True
+    assert cfg.context_builder.stack_index_path == "/tmp/stack.index"
+    assert cfg.context_builder.stack_metadata_path == "/tmp/stack.db"
+    assert cfg.context_builder.stack_cache_dir == "/tmp/stack-cache"
+    assert cfg.context_builder.stack_progress_path == "/tmp/stack-progress.sqlite"
 
 
 def test_stack_env_defaults_when_unset(monkeypatch):
@@ -42,3 +51,8 @@ def test_stack_env_defaults_when_unset(monkeypatch):
     assert cfg.context_builder.stack.enabled is False
     assert cfg.stack_dataset.index_path
     assert cfg.stack_dataset.metadata_path
+    assert cfg.context_builder.stack_enabled is False
+    assert cfg.context_builder.stack_index_path == cfg.stack_dataset.index_path
+    assert cfg.context_builder.stack_metadata_path == cfg.stack_dataset.metadata_path
+    assert cfg.context_builder.stack_cache_dir == cfg.stack_dataset.cache_dir
+    assert cfg.context_builder.stack_progress_path == cfg.stack_dataset.progress_path

--- a/tests/test_stack_configuration.py
+++ b/tests/test_stack_configuration.py
@@ -25,6 +25,17 @@ def test_context_builder_stack_defaults(monkeypatch):
         assert stack.chunk_lines == 256
         assert cfg.context_builder.stack_prompt_enabled is False
         assert cfg.context_builder.stack_prompt_limit == 2
+        assert cfg.context_builder.stack_enabled is False
+        assert cfg.context_builder.stack_languages == {"python", "javascript"}
+        assert cfg.context_builder.stack_top_k == 3
+        assert cfg.context_builder.stack_max_lines == 200
+        assert cfg.context_builder.stack_max_bytes == 65536
+        assert cfg.context_builder.stack_index_path == "stack/index.faiss"
+        assert cfg.context_builder.stack_metadata_path == "stack/metadata.db"
+        assert cfg.context_builder.stack_cache_dir == "stack/cache"
+        assert cfg.context_builder.stack_progress_path == "stack/cache/progress.sqlite"
+        assert cfg.context_builder.stack_requests_per_minute == 60
+        assert cfg.context_builder.stack_tokens_per_minute == 60000
     finally:
         _reset_config()
 
@@ -48,6 +59,17 @@ def test_context_builder_stack_roundtrip(monkeypatch):
             },
             "stack_prompt_enabled": True,
             "stack_prompt_limit": 5,
+            "stack_enabled": True,
+            "stack_languages": ["python", "rust"],
+            "stack_max_lines": 64,
+            "stack_max_bytes": 4096,
+            "stack_top_k": 7,
+            "stack_index_path": "custom/index.faiss",
+            "stack_metadata_path": "custom/meta.db",
+            "stack_cache_dir": "custom/cache",
+            "stack_progress_path": "custom/cache/progress.sqlite",
+            "stack_requests_per_minute": 120,
+            "stack_tokens_per_minute": 90000,
         }
     }
     updated = cfg.apply_overrides(overrides)
@@ -65,5 +87,16 @@ def test_context_builder_stack_roundtrip(monkeypatch):
         assert stack.chunk_lines == 128
         assert updated.context_builder.stack_prompt_enabled is True
         assert updated.context_builder.stack_prompt_limit == 5
+        assert updated.context_builder.stack_enabled is True
+        assert updated.context_builder.stack_languages == {"python", "rust"}
+        assert updated.context_builder.stack_top_k == 7
+        assert updated.context_builder.stack_max_lines == 64
+        assert updated.context_builder.stack_max_bytes == 4096
+        assert updated.context_builder.stack_index_path == "custom/index.faiss"
+        assert updated.context_builder.stack_metadata_path == "custom/meta.db"
+        assert updated.context_builder.stack_cache_dir == "custom/cache"
+        assert updated.context_builder.stack_progress_path == "custom/cache/progress.sqlite"
+        assert updated.context_builder.stack_requests_per_minute == 120
+        assert updated.context_builder.stack_tokens_per_minute == 90000
     finally:
         _reset_config()


### PR DESCRIPTION
## Summary
- extend ContextBuilderConfig with stack-specific toggles, language filters, cache paths, and rate limits
- pull Stack defaults from self_coding_thresholds.yaml, filtering out generated secret tokens when reading env overrides
- update config discovery to surface new Stack hints and adjust tests to cover the new fields

## Testing
- pytest tests/test_stack_configuration.py tests/test_config_stack_env.py tests/test_config_discovery.py

------
https://chatgpt.com/codex/tasks/task_e_68d6262d31f8832ea6fae5921fbcfac2