### PR TITLE
Add configurable Stack dataset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,25 @@ Avoid inline ``Prompt(...)`` strings; run
 ``python scripts/check_context_builder_usage.py`` to statically flag missing
 ``context_builder`` wiring.
 
+### Stack dataset retrieval
+
+`ContextBuilderConfig` now exposes an optional `stack_dataset` section for
+configuring retrieval from embeddings produced by
+`vector_service.stack_ingestion`. Defaults live alongside the self-coding
+thresholds in `config/self_coding_thresholds.yaml` under the `stack` key and can
+be overridden per profile via `config/<mode>.yaml` or environment variables such
+as `STACK_DATA_ENABLED`, `STACK_LANGUAGES`, `STACK_TOP_K`, `STACK_DATA_INDEX`
+and `STACK_METADATA_DB`.  Sandbox profiles can further refine allow-lists or
+weights with the corresponding fields in `SandboxSettings`, ensuring ingestion
+and retrieval share the same language filters, chunk sizing and index
+locations.
+
+Environment overrides are merged before Pydantic validation, so invalid values
+(for example an unknown language or negative chunk size) fail fast at startup.
+When adding new embeddings, keep ingestion (`StackDatasetStreamer`) and
+retrieval (`ContextBuilder`) aligned by updating both the YAML defaults and the
+sandbox settings to reference the same vector and metadata paths.
+
 ### BotDevelopmentBot
 
 ```python

--- a/config/self_coding_thresholds.yaml
+++ b/config/self_coding_thresholds.yaml
@@ -1,3 +1,14 @@
+stack:
+  enabled: false
+  dataset_name: bigcode/the-stack-v2-dedup
+  split: train
+  languages: []
+  max_lines: 200
+  chunk_overlap: 20
+  top_k: 50
+  index_path: vector_service/stack_vectors
+  metadata_path: vector_service/stack_metadata.db
+  weight: 1.0
 default:
   roi_drop: -0.1
   error_increase: 1.0

--- a/docs/vector_service.md
+++ b/docs/vector_service.md
@@ -193,6 +193,14 @@ The streamer consumes the following environment variables:
 | `STACK_CACHE_DIR` | Directory used for the datasets disk cache. |
 | `STACK_BATCH_SIZE` | When set, limits each background pass to at most this many chunks before sleeping. |
 
+Longer-lived defaults live in `config/self_coding_thresholds.yaml` under the
+`stack` section, which mirrors the fields in `ContextBuilderConfig.stack_dataset`.
+Environment overrides are merged ahead of validation, ensuring invalid values
+such as unsupported languages or negative chunk limits are rejected early.
+Sandbox profiles can refine allow-lists, retrieval weights and storage paths via
+the new `stack_*` settings on `SandboxSettings`, keeping ingestion and
+retrieval aligned without editing production YAML.
+
 Any Hugging Face token defined in `CONFIG.huggingface_token` (or exposed via
 `HUGGINGFACE_API_TOKEN`/`HF_TOKEN`) is forwarded to `datasets.load_dataset`.  The
 module keeps memory usage bounded by chunking files eagerly, avoiding in-memory

--- a/stack_dataset_defaults.py
+++ b/stack_dataset_defaults.py
@@ -1,0 +1,71 @@
+"""Shared constants and helpers for Stack dataset configuration."""
+from __future__ import annotations
+
+from typing import Iterable, List
+
+STACK_LANGUAGE_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "assembly",
+        "bash",
+        "c",
+        "c#",
+        "c++",
+        "clojure",
+        "cmake",
+        "cobol",
+        "coffeescript",
+        "cuda",
+        "dart",
+        "elixir",
+        "elm",
+        "erlang",
+        "fortran",
+        "fsharp",
+        "go",
+        "groovy",
+        "haskell",
+        "java",
+        "javascript",
+        "julia",
+        "kotlin",
+        "lua",
+        "matlab",
+        "nim",
+        "objective-c",
+        "ocaml",
+        "perl",
+        "php",
+        "powershell",
+        "python",
+        "r",
+        "ruby",
+        "rust",
+        "scala",
+        "shell",
+        "solidity",
+        "sql",
+        "swift",
+        "typescript",
+        "vb",
+        "zig",
+    }
+)
+
+
+def normalise_stack_languages(value: Iterable[str] | str | None) -> List[str]:
+    """Return a normalised list of Stack dataset language identifiers."""
+
+    if value is None:
+        return []
+    if isinstance(value, str):
+        candidates = [part.strip() for part in value.split(",")]
+    else:
+        candidates = [str(part).strip() for part in value]
+    seen: list[str] = []
+    for candidate in candidates:
+        if not candidate:
+            continue
+        lowered = candidate.lower()
+        if lowered not in seen:
+            seen.append(lowered)
+    return seen

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,132 @@
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import config as config_module
+from config import Config
+from pydantic import ValidationError
+
+
+BASE_CONFIG = {
+    "paths": {"data_dir": "/data", "log_dir": "/logs"},
+    "thresholds": {"error": 0.1, "alert": 0.9},
+    "api_keys": {"openai": "test-openai", "serp": "test-serp"},
+    "logging": {"verbosity": "INFO"},
+    "vector": {"dimensions": 256, "distance_metric": "cosine"},
+    "vector_store": {"backend": "faiss", "path": "vectors.index"},
+    "bot": {"learning_rate": 0.01, "epsilon": 0.1},
+}
+
+
+def test_context_builder_without_stack_section():
+    config = Config.model_validate(BASE_CONFIG)
+    assert config.context_builder.stack_dataset is None
+
+
+def test_context_builder_with_stack_section():
+    data = {
+        **BASE_CONFIG,
+        "context_builder": {
+            "stack_dataset": {
+                "enabled": True,
+                "dataset_name": "bigcode/the-stack-v2-dedup",
+                "languages": ["python", "rust"],
+                "max_lines": 400,
+                "chunk_overlap": 20,
+                "top_k": 25,
+                "weight": 1.5,
+            }
+        },
+    }
+    config = Config.model_validate(data)
+    stack = config.context_builder.stack_dataset
+    assert stack is not None
+    assert stack.enabled is True
+    assert stack.languages == ["python", "rust"]
+    assert stack.top_k == 25
+    assert stack.weight == pytest.approx(1.5)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "context_builder": {
+                "stack_dataset": {
+                    "languages": ["klingon"],
+                }
+            }
+        },
+        {
+            "context_builder": {
+                "stack_dataset": {
+                    "max_lines": -5,
+                }
+            }
+        },
+    ],
+)
+def test_invalid_stack_dataset_values_raise(payload):
+    data = {**BASE_CONFIG, **payload}
+    with pytest.raises(ValidationError):
+        Config.model_validate(data)
+
+
+def test_environment_overrides_merge_stack(tmp_path, monkeypatch):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    settings_path = config_dir / "settings.yaml"
+    settings_path.write_text(
+        textwrap.dedent(
+            """
+            paths:
+              data_dir: /tmp/data
+              log_dir: /tmp/logs
+            thresholds:
+              error: 0.2
+              alert: 0.8
+            api_keys:
+              openai: test-openai
+              serp: test-serp
+            logging:
+              verbosity: INFO
+            vector:
+              dimensions: 128
+              distance_metric: cosine
+            vector_store:
+              backend: faiss
+              path: vectors.index
+            bot:
+              learning_rate: 0.05
+              epsilon: 0.2
+            """
+        )
+    )
+    (config_dir / "dev.yaml").write_text("{}")
+
+    monkeypatch.setenv("MENACE_MODE", "dev")
+    monkeypatch.setenv("STACK_LANGUAGES", "python, rust")
+    monkeypatch.setenv("STACK_TOP_K", "7")
+    monkeypatch.setenv("STACK_DATA_ENABLED", "1")
+    monkeypatch.setenv("STACK_DATA_INDEX", "/var/stack/index")
+    monkeypatch.setenv("STACK_METADATA_DB", "/var/stack/meta.db")
+
+    monkeypatch.setattr(config_module, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(config_module, "DEFAULT_SETTINGS_FILE", settings_path)
+    monkeypatch.setattr(config_module, "CONFIG", None)
+    monkeypatch.setattr(config_module, "_WATCHER", None)
+    monkeypatch.setattr(config_module, "_CONFIG_PATH", None)
+    monkeypatch.setattr(config_module, "_OVERRIDES", {})
+
+    cfg = config_module.load_config()
+    stack = cfg.context_builder.stack_dataset
+    assert stack is not None
+    assert stack.enabled is True
+    assert stack.languages == ["python", "rust"]
+    assert stack.top_k == 7
+    assert stack.index_path == "/var/stack/index"
+    assert stack.metadata_path == "/var/stack/meta.db"
+
+    # Reset module state so subsequent tests are unaffected
+    config_module.CONFIG = None


### PR DESCRIPTION
## Summary
- introduce a StackDatasetConfig on ContextBuilderConfig with environment overrides driven by stack-specific env vars
- expose stack ingestion overrides through SandboxSettings and merge defaults from self_coding_thresholds.yaml via a helper
- document the new configuration knobs and add tests covering config loading, validation, and env overrides

## Testing
- pytest tests/test_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d72c35c918832eaab4dbc0cd5a5a64