### PR TITLE
Improve config discovery for Stack ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,24 @@ When adding new embeddings, keep ingestion (`StackDatasetStreamer`) and
 retrieval (`ContextBuilder`) aligned by updating both the YAML defaults and the
 sandbox settings to reference the same vector and metadata paths.
 
+`ConfigDiscovery` now looks for a `.stack_env` file in the project directory or
+home folder and exports any `STACK_*` variables it contains.  When the file is
+absent, sensible defaults are derived automatically: `STACK_DATA_DIR` defaults
+to `~/.cache/menace/stack`, `STACK_METADATA_DB`/`STACK_METADATA_PATH` point to a
+`stack_metadata.db` file under that directory, `STACK_CACHE_DIR` is set to a
+`cache` subfolder and `STACK_VECTOR_PATH` points at `stack_vectors`.  The
+discovery step also disables streaming by default (`STACK_STREAMING=0`) so
+ingestion only runs when explicitly enabled.  These values are persisted to
+`.env.auto` via `ensure_config`, keeping local development environments in sync
+with the detected defaults.
+
+Hugging Face credentials are surfaced in the same pass: if
+`HUGGINGFACE_TOKEN`/`HUGGINGFACE_API_TOKEN`/`HF_TOKEN` are not set, the
+discovery helper probes the standard cache paths such as
+`~/.huggingface/token`.  When the token cannot be located, the helper logs a
+warning and increments its failure counter so long-running services can detect
+credential drift.
+
 ### BotDevelopmentBot
 
 ```python

--- a/docs/vector_service.md
+++ b/docs/vector_service.md
@@ -184,6 +184,7 @@ The streamer consumes the following environment variables:
 | Variable | Description |
 | --- | --- |
 | `STACK_STREAMING` | Set to `1`/`true` to enable continuous background ingestion.  Any other value pauses the loop. |
+| `STACK_DATA_DIR` | Base directory used for metadata, cache and vector store defaults (`~/.cache/menace/stack` when unspecified). |
 | `STACK_LANGUAGES` | Comma-separated allow-list of languages to embed (empty = all). |
 | `STACK_MAX_LINES` | Maximum number of lines per chunk (default `200`). |
 | `STACK_VECTOR_DIM` | Expected embedding dimensionality when creating the vector store. |
@@ -214,6 +215,15 @@ simply by editing the file—no code changes are required.  The JSON object uses
 the following format where each key is the canonical name for a database
 category and the value specifies the import path and class name of the
 `EmbeddableDBMixin` implementation:
+
+`ConfigDiscovery` will automatically load `.stack_env` (if present) and export
+any `STACK_*` variables defined within.  When the file is absent, it derives
+defaults based on `STACK_DATA_DIR`, falling back to `~/.cache/menace/stack` for
+local development.  The helper also scans the standard Hugging Face cache
+locations (`~/.huggingface/token`, `~/.cache/huggingface/token`, honouring
+`HF_HOME`) and exports the token as `HUGGINGFACE_TOKEN`.  Continuous reloads are
+supported so long-running ingestion services can pick up credential updates
+without restarting.
 
 ```json
 {


### PR DESCRIPTION
## Summary
- extend ConfigDiscovery to read `.stack_env`, derive stack defaults, and auto-discover Hugging Face tokens with reload helpers
- surface stack defaults in `.env.auto` generation and document the new environment variables and token behaviour
- add regression tests covering stack env overrides and Hugging Face token detection

## Testing
- `pytest tests/test_config_discovery.py`


------
https://chatgpt.com/codex/tasks/task_e_68d7357d8688832eb7ff1f6fb7a46fe3