### PR TITLE
Integrate Stack retriever into context builder

### DIFF
--- a/tests/vector_service/test_stack_wrapper.py
+++ b/tests/vector_service/test_stack_wrapper.py
@@ -1,0 +1,57 @@
+from vector_service.retriever import StackRetriever
+
+
+class DummyBackend:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def retrieve(self, embedding, k=0, similarity_threshold=0.0):  # pragma: no cover - simple stub
+        self.calls.append(
+            {
+                "embedding": list(embedding),
+                "k": k,
+                "threshold": similarity_threshold,
+            }
+        )
+        return [
+            {
+                "score": 0.8,
+                "metadata": {
+                    "language": "Python",
+                    "summary": "py snippet",
+                    "size": 80,
+                    "redacted": True,
+                },
+            },
+            {
+                "score": 0.6,
+                "metadata": {
+                    "language": "JavaScript",
+                    "summary": "js snippet",
+                    "size": 40,
+                    "redacted": True,
+                },
+            },
+        ]
+
+
+def test_stack_retriever_filters_languages():
+    backend = DummyBackend()
+    retriever = StackRetriever(backend=backend, top_k=5)
+
+    hits = retriever.retrieve([0.1, 0.2], k=3, languages=["python"])
+
+    assert len(hits) == 1
+    assert hits[0]["metadata"]["language"] == "Python"
+    assert backend.calls[0]["k"] == 3
+
+
+def test_stack_retriever_limits_by_size():
+    backend = DummyBackend()
+    retriever = StackRetriever(backend=backend, top_k=5)
+
+    hits = retriever.retrieve([0.1], max_lines=50)
+
+    assert len(hits) == 1
+    assert hits[0]["metadata"]["language"] == "JavaScript"
+    assert hits[0]["metadata"]["size"] == 40

--- a/vector_service/__init__.py
+++ b/vector_service/__init__.py
@@ -170,6 +170,13 @@ except Exception:
 else:
     StackRetriever = _StackRetriever
 
+try:  # pragma: no cover - prefer lightweight stack retriever facade when available
+    from .retriever import StackRetriever as _StackContextRetriever
+except Exception:
+    pass
+else:
+    StackRetriever = _StackContextRetriever
+
 try:  # pragma: no cover - optional heavy dependency
     from .context_builder import ContextBuilder as _ContextBuilder
 except Exception:


### PR DESCRIPTION
## Summary
- add a lightweight `StackRetriever` facade to `vector_service.retriever` that filters by language and size before returning stack snippets
- wire the new retriever into `ContextBuilder`, expose language/max-line configuration, and update stack weighting
- propagate stack language/line preferences through `SelfCodingEngine` and add unit tests covering the new stack behaviour

## Testing
- pytest tests/vector_service/test_stack_wrapper.py tests/test_context_builder.py::test_stack_context_respects_language_filter unit_tests/test_self_coding_engine.py::test_stack_snippets_appended

------
https://chatgpt.com/codex/tasks/task_e_68d73aa16394832e855eaac69ed06642