### PR TITLE
Add stack dataset configuration defaults and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,31 +115,34 @@ Avoid inline ``Prompt(...)`` strings; run
 
 `ContextBuilderConfig` now exposes an optional `stack_dataset` section for
 configuring retrieval from embeddings produced by
-`vector_service.stack_ingestion`. Defaults live alongside the self-coding
-thresholds in `config/self_coding_thresholds.yaml` under the `stack` key and can
-be overridden per profile via `config/<mode>.yaml` or environment variables such
-as `STACK_DATA_ENABLED`, `STACK_LANGUAGES`, `STACK_TOP_K`, `STACK_DATA_INDEX`
-and `STACK_METADATA_DB`.  Sandbox profiles can further refine allow-lists or
-weights with the corresponding fields in `SandboxSettings`, ensuring ingestion
-and retrieval share the same language filters, chunk sizing and index
+`vector_service.stack_ingestion`. Baseline defaults ship in
+`config/stack_retrieval.yaml` and cover ingestion filters, retrieval weights and
+context budgets. These values are merged after `config/settings.yaml`, so
+profile-specific overrides in `config/<mode>.yaml` or environment variables such
+as `STACK_DATA_ENABLED`, `STACK_LANGUAGES`, `STACK_TOP_K`, `STACK_CONTEXT_LINES`,
+`STACK_DATA_INDEX` and `STACK_METADATA_DB` win automatically. Sandbox profiles
+can further refine allow-lists or weights via `SandboxSettings`, keeping
+ingestion and retrieval aligned across language filters, chunk sizing and cache
 locations.
 
 Environment overrides are merged before Pydantic validation, so invalid values
 (for example an unknown language or negative chunk size) fail fast at startup.
 When adding new embeddings, keep ingestion (`StackDatasetStreamer`) and
 retrieval (`ContextBuilder`) aligned by updating both the YAML defaults and the
-sandbox settings to reference the same vector and metadata paths.
+sandbox settings to reference the same vector, metadata and document-cache
+paths.
 
 `ConfigDiscovery` now looks for a `.stack_env` file in the project directory or
 home folder and exports any `STACK_*` variables it contains.  When the file is
 absent, sensible defaults are derived automatically: `STACK_DATA_DIR` defaults
 to `~/.cache/menace/stack`, `STACK_METADATA_DB`/`STACK_METADATA_PATH` point to a
 `stack_metadata.db` file under that directory, `STACK_CACHE_DIR` is set to a
-`cache` subfolder and `STACK_VECTOR_PATH` points at `stack_vectors`.  The
-discovery step also disables streaming by default (`STACK_STREAMING=0`) so
-ingestion only runs when explicitly enabled.  These values are persisted to
-`.env.auto` via `ensure_config`, keeping local development environments in sync
-with the detected defaults.
+`cache` subfolder, `STACK_DOCUMENT_CACHE` targets a `documents` folder for
+snippet caching and `STACK_VECTOR_PATH` points at `stack_vectors`.  The discovery
+step also disables streaming by default (`STACK_STREAMING=0`) so ingestion only
+runs when explicitly enabled.  These values are persisted to `.env.auto` via
+`ensure_config`, keeping local development environments in sync with the detected
+defaults.
 
 Hugging Face credentials are surfaced in the same pass: if
 `HUGGINGFACE_TOKEN`/`HUGGINGFACE_API_TOKEN`/`HF_TOKEN` are not set, the

--- a/config/stack_retrieval.yaml
+++ b/config/stack_retrieval.yaml
@@ -1,0 +1,26 @@
+context_builder:
+  stack_dataset:
+    enabled: false
+    dataset_name: bigcode/the-stack-v2-dedup
+    split: train
+    ingestion:
+      streaming: false
+      languages: []
+      max_document_lines: 200
+      chunk_overlap: 20
+    retrieval:
+      top_k: 50
+      weight: 1.0
+      max_context_documents: 8
+      max_context_lines: 400
+    cache:
+      data_dir: ~/.cache/menace/stack
+      index_path: vector_service/stack_vectors
+      metadata_path: vector_service/stack_metadata.db
+      document_cache: chunk_summary_cache/stack_documents
+    tokens:
+      env_vars:
+        - HUGGINGFACE_TOKEN
+        - HF_TOKEN
+        - HUGGINGFACEHUB_API_TOKEN
+      required: false

--- a/config_discovery.py
+++ b/config_discovery.py
@@ -98,6 +98,8 @@ class ConfigDiscovery:
         token = self._discover_huggingface_token()
         if token:
             os.environ["HUGGINGFACE_TOKEN"] = token
+            os.environ.setdefault("HF_TOKEN", token)
+            os.environ.setdefault("HUGGINGFACEHUB_API_TOKEN", token)
             self._token_missing_logged = False
             return
 
@@ -216,6 +218,7 @@ class ConfigDiscovery:
             "STACK_METADATA_PATH": str(base_path / "stack_metadata.db"),
             "STACK_CACHE_DIR": str(base_path / "cache"),
             "STACK_VECTOR_PATH": str(base_path / "stack_vectors"),
+            "STACK_DOCUMENT_CACHE": str(base_path / "documents"),
         }
         for key, value in defaults.items():
             if not os.environ.get(key):
@@ -336,6 +339,7 @@ def _stack_auto_defaults() -> dict[str, str]:
         "STACK_METADATA_PATH": str(base_path / "stack_metadata.db"),
         "STACK_CACHE_DIR": str(base_path / "cache"),
         "STACK_VECTOR_PATH": str(base_path / "stack_vectors"),
+        "STACK_DOCUMENT_CACHE": str(base_path / "documents"),
     }
     return defaults
 

--- a/tests/test_stack_context_config.py
+++ b/tests/test_stack_context_config.py
@@ -1,0 +1,108 @@
+import importlib
+
+import pytest
+
+import config as config_module
+
+
+@pytest.fixture(autouse=True)
+def _reload_config_module():
+    # Ensure each test gets a fresh view of environment driven settings.
+    importlib.reload(config_module)
+    yield
+    importlib.reload(config_module)
+
+
+def test_stack_dataset_overrides(monkeypatch):
+    overrides = {
+        "context_builder": {
+            "stack_dataset": {
+                "enabled": True,
+                "dataset_name": "bigcode/test",
+                "split": "eval",
+                "ingestion": {
+                    "languages": ["python", "rust"],
+                    "max_document_lines": 512,
+                    "chunk_overlap": 32,
+                    "streaming": True,
+                },
+                "retrieval": {
+                    "top_k": 12,
+                    "weight": 2.5,
+                    "max_context_documents": 6,
+                    "max_context_lines": 900,
+                },
+                "cache": {
+                    "data_dir": "/tmp/stack",
+                    "index_path": "/tmp/stack/index.faiss",
+                    "metadata_path": "/tmp/stack/meta.db",
+                    "document_cache": "/tmp/stack/docs.cache",
+                },
+                "tokens": {
+                    "env_vars": ["HF_TOKEN", "STACK_HF_TOKEN"],
+                    "required": True,
+                },
+            }
+        }
+    }
+
+    cfg = config_module.load_config(mode="dev", overrides=overrides)
+    stack = cfg.context_builder.stack_dataset
+    assert stack is not None
+    assert stack.enabled is True
+    assert stack.dataset_name == "bigcode/test"
+    assert stack.split == "eval"
+    assert stack.ingestion.languages == ["python", "rust"]
+    assert stack.ingestion.max_document_lines == 512
+    assert stack.ingestion.chunk_overlap == 32
+    assert stack.ingestion.streaming is True
+    assert stack.retrieval.top_k == 12
+    assert pytest.approx(stack.retrieval.weight, rel=1e-9) == 2.5
+    assert stack.retrieval.max_context_documents == 6
+    assert stack.retrieval.max_context_lines == 900
+    assert stack.cache.data_dir == "/tmp/stack"
+    assert stack.cache.index_path == "/tmp/stack/index.faiss"
+    assert stack.cache.metadata_path == "/tmp/stack/meta.db"
+    assert stack.cache.document_cache == "/tmp/stack/docs.cache"
+    assert stack.tokens.env_vars == ["HF_TOKEN", "STACK_HF_TOKEN"]
+    assert stack.tokens.required is True
+
+
+def test_stack_dataset_environment(monkeypatch):
+    monkeypatch.setenv("STACK_DATA_ENABLED", "1")
+    monkeypatch.setenv("STACK_DATASET", "bigcode/the-stack-test")
+    monkeypatch.setenv("STACK_SPLIT", "validation")
+    monkeypatch.setenv("STACK_LANGUAGES", "Python,Go")
+    monkeypatch.setenv("STACK_STREAMING", "true")
+    monkeypatch.setenv("STACK_MAX_LINES", "256")
+    monkeypatch.setenv("STACK_CHUNK_OVERLAP", "64")
+    monkeypatch.setenv("STACK_TOP_K", "33")
+    monkeypatch.setenv("STACK_WEIGHT", "0.75")
+    monkeypatch.setenv("STACK_CONTEXT_DOCS", "5")
+    monkeypatch.setenv("STACK_CONTEXT_LINES", "640")
+    monkeypatch.setenv("STACK_DATA_DIR", "/var/cache/stack")
+    monkeypatch.setenv("STACK_CACHE_DIR", "/var/cache/stack")
+    monkeypatch.setenv("STACK_VECTOR_PATH", "/var/cache/stack/index")
+    monkeypatch.setenv("STACK_METADATA_PATH", "/var/cache/stack/meta.sqlite")
+    monkeypatch.setenv("STACK_DOCUMENT_CACHE", "/var/cache/stack/docs")
+
+    cfg = config_module.load_config(mode="dev")
+    stack = cfg.context_builder.stack_dataset
+    assert stack is not None
+    assert stack.enabled is True
+    assert stack.dataset_name == "bigcode/the-stack-test"
+    assert stack.split == "validation"
+    assert stack.ingestion.languages == ["python", "go"]
+    assert stack.ingestion.streaming is True
+    assert stack.ingestion.max_document_lines == 256
+    assert stack.ingestion.chunk_overlap == 64
+    assert stack.retrieval.top_k == 33
+    assert pytest.approx(stack.retrieval.weight, rel=1e-9) == 0.75
+    assert stack.retrieval.max_context_documents == 5
+    assert stack.retrieval.max_context_lines == 640
+    assert stack.cache.data_dir == "/var/cache/stack"
+    assert stack.cache.index_path == "/var/cache/stack/index"
+    assert stack.cache.metadata_path == "/var/cache/stack/meta.sqlite"
+    assert stack.cache.document_cache == "/var/cache/stack/docs"
+    # Tokens fall back to defaults when not provided via environment overrides.
+    assert "HF_TOKEN" in stack.tokens.env_vars


### PR DESCRIPTION
## Summary
- extend ContextBuilderConfig with structured Stack ingestion, retrieval, cache, and token settings
- merge stack defaults from a dedicated YAML file and surface additional environment overrides
- expose HF_TOKEN during config discovery and document new options with regression tests

## Testing
- pytest tests/test_stack_context_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d73eae2518832eaf369b0ee83fbd9a