### PR TITLE
feat: add stack context configuration

### DIFF
--- a/config/stack_retrieval.yaml
+++ b/config/stack_retrieval.yaml
@@ -1,5 +1,5 @@
 context_builder:
-  stack_dataset:
+  stack_dataset: &stack_dataset_defaults
     enabled: false
     dataset_name: bigcode/the-stack-v2-dedup
     split: train
@@ -24,3 +24,12 @@ context_builder:
         - HF_TOKEN
         - HUGGINGFACEHUB_API_TOKEN
       required: false
+  stack:
+    <<: *stack_dataset_defaults
+    summary_tokens: 160
+    text_max_tokens: 320
+    penalty: 0.0
+    ingestion_enabled: true
+    ingestion_throttle_seconds: 600
+    ingestion_batch_limit: null
+    ensure_before_search: true

--- a/tests/test_stack_context_config.py
+++ b/tests/test_stack_context_config.py
@@ -1,5 +1,7 @@
 import importlib
 
+import importlib
+
 import pytest
 
 import config as config_module
@@ -67,6 +69,21 @@ def test_stack_dataset_overrides(monkeypatch):
     assert stack.tokens.env_vars == ["HF_TOKEN", "STACK_HF_TOKEN"]
     assert stack.tokens.required is True
 
+    stack_cfg = cfg.context_builder.stack
+    assert stack_cfg is not None
+    assert stack_cfg.enabled is True
+    assert stack_cfg.dataset_name == "bigcode/test"
+    assert stack_cfg.split == "eval"
+    assert stack_cfg.languages == ["python", "rust"]
+    assert stack_cfg.max_lines == 512
+    assert stack_cfg.chunk_overlap == 32
+    assert stack_cfg.streaming is True
+    assert stack_cfg.top_k == 12
+    assert pytest.approx(stack_cfg.weight, rel=1e-9) == 2.5
+    assert stack_cfg.cache_dir == "/tmp/stack"
+    assert stack_cfg.index_path == "/tmp/stack/index.faiss"
+    assert stack_cfg.metadata_path == "/tmp/stack/meta.db"
+
 
 def test_stack_dataset_environment(monkeypatch):
     monkeypatch.setenv("STACK_DATA_ENABLED", "1")
@@ -83,6 +100,7 @@ def test_stack_dataset_environment(monkeypatch):
     monkeypatch.setenv("STACK_DATA_DIR", "/var/cache/stack")
     monkeypatch.setenv("STACK_CACHE_DIR", "/var/cache/stack")
     monkeypatch.setenv("STACK_VECTOR_PATH", "/var/cache/stack/index")
+    monkeypatch.setenv("STACK_METADATA_DB", "/var/cache/stack/meta.sqlite")
     monkeypatch.setenv("STACK_METADATA_PATH", "/var/cache/stack/meta.sqlite")
     monkeypatch.setenv("STACK_DOCUMENT_CACHE", "/var/cache/stack/docs")
 
@@ -106,3 +124,18 @@ def test_stack_dataset_environment(monkeypatch):
     assert stack.cache.document_cache == "/var/cache/stack/docs"
     # Tokens fall back to defaults when not provided via environment overrides.
     assert "HF_TOKEN" in stack.tokens.env_vars
+
+    stack_cfg = cfg.context_builder.stack
+    assert stack_cfg is not None
+    assert stack_cfg.enabled is True
+    assert stack_cfg.dataset_name == "bigcode/the-stack-test"
+    assert stack_cfg.split == "validation"
+    assert stack_cfg.languages == ["python", "go"]
+    assert stack_cfg.streaming is True
+    assert stack_cfg.max_lines == 256
+    assert stack_cfg.chunk_overlap == 64
+    assert stack_cfg.top_k == 33
+    assert pytest.approx(stack_cfg.weight, rel=1e-9) == 0.75
+    assert stack_cfg.cache_dir == "/var/cache/stack"
+    assert stack_cfg.index_path == "/var/cache/stack/index"
+    assert stack_cfg.metadata_path == "/var/cache/stack/meta.sqlite"


### PR DESCRIPTION
## Summary
- extend `ContextBuilderConfig` with a stack-specific model that synchronises dataset, cache, retrieval, and ingestion defaults
- surface the new stack settings to the context builder and stack ingestion pipeline, including YAML defaults and property helpers
- update configuration tests to cover the new stack section and environment overrides

## Testing
- pytest tests/test_config.py tests/test_stack_context_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d746634e0c832e9abb4916286d7fb3