### PR TITLE
Integrate stack dataset retrieval into context building

### DIFF
--- a/tests/test_cognition_layer_roi.py
+++ b/tests/test_cognition_layer_roi.py
@@ -21,7 +21,19 @@ from vector_metrics_db import VectorMetricsDB
 
 
 class DummyContextBuilder:
-    def build_context(self, prompt, *, top_k=5, include_vectors=False, session_id="", return_stats=False, return_metadata=False):
+    roi_tag_penalties: Dict[str, float] = {}
+
+    def build_context(
+        self,
+        prompt,
+        *,
+        top_k=5,
+        include_vectors=False,
+        session_id="",
+        return_stats=False,
+        return_metadata=False,
+        stack_preferences=None,
+    ):
         vectors = [
             ("db1", "v1", 0.5),
             ("db1", "v2", 0.3),


### PR DESCRIPTION
## Summary
- allow ContextBuilder to accept per-request stack preferences and restore configuration after each call
- redact StackRetriever results and expose stack retrieval options from create_context_builder
- propagate stack assist preferences in SelfCodingEngine and update related tests

## Testing
- pytest tests/test_cognition_layer_roi.py *(fails: transformers AutoModel missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d756ac7c48832e99e404b14d627411