### PR TITLE
Add Stack retrieval integration test and config helpers

### DIFF
--- a/config.py
+++ b/config.py
@@ -589,6 +589,52 @@ class ContextBuilderConfig(_StrictBaseModel):
         self.stack = StackContextConfig.model_validate(combined_stack)
         return self
 
+    @property
+    def stack_top_k(self) -> int:
+        """Return the configured Stack retrieval depth.
+
+        Defaults to ``0`` when Stack integration is disabled or misconfigured.
+        """
+
+        if self.stack is not None:
+            try:
+                return int(self.stack.top_k)
+            except Exception:
+                pass
+        if self.stack_dataset is not None:
+            try:
+                return int(self.stack_dataset.retrieval.top_k)
+            except Exception:
+                pass
+        return 0
+
+    @property
+    def stack_weight(self) -> float:
+        """Return weighting multiplier applied to Stack results."""
+
+        if self.stack is not None:
+            try:
+                return float(self.stack.weight)
+            except Exception:
+                pass
+        if self.stack_dataset is not None:
+            try:
+                return float(self.stack_dataset.retrieval.weight)
+            except Exception:
+                pass
+        return 1.0
+
+    @property
+    def stack_penalty(self) -> float:
+        """Return penalty offset applied to Stack scores."""
+
+        if self.stack is not None:
+            try:
+                return float(self.stack.penalty)
+            except Exception:
+                pass
+        return 0.0
+
 
 class Config(_StrictBaseModel):
     """Top-level application configuration."""

--- a/docs/vector_service.md
+++ b/docs/vector_service.md
@@ -177,6 +177,23 @@ stored in a dedicated vector store constructed via `create_vector_store`.  Both
 the vector store and metadata database paths may be overridden to place them on
 larger disks.
 
+### Stack retrieval in prompts
+
+Once embedded, Stack snippets are surfaced by `ContextBuilder` alongside the
+traditional internal databases.  Queries are embedded via
+`SharedVectorService`, looked up against the Stack vector store and enriched
+with metadata from `stack_metadata.db`.  The resulting entries are governed by
+the same license deny-list, semantic risk checks and ROI penalties as internal
+results, ensuring unsafe or excluded strategies never leak into prompts.
+
+Stack hits participate in ranking with their own configurable weight and
+penalty offsets (`ContextBuilderConfig.stack_weight` / `stack_penalty`).  When a
+Stack snippet is selected it appears in the dedicated `"stack"` bucket within
+`build_context` results and is merged into the prompt example list.  Prompt
+metadata retains repository, path, language and license details so downstream
+consumers (such as `SelfCodingEngine`) can render attribution or apply
+additional filtering.
+
 ### Configuration
 
 The streamer consumes the following environment variables:

--- a/tests/integration/test_stack_retrieval.py
+++ b/tests/integration/test_stack_retrieval.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, List, Mapping
+
+import json
+
+import pytest
+
+from prompt_types import Prompt
+from vector_service.context_builder import ContextBuilder
+
+
+class DummyRetriever:
+    def __init__(self) -> None:
+        self.calls: List[tuple[str, Any]] = []
+
+    def search(self, query: str, **_: Any) -> List[Mapping[str, Any]]:
+        self.calls.append(("search", query))
+        return []
+
+    def embed_query(self, query: str) -> List[float]:
+        self.calls.append(("embed", query))
+        return [0.42, 0.17, 0.33]
+
+
+class DummyPatchRetriever:
+    def search(self, query: str, **_: Any) -> List[Mapping[str, Any]]:
+        return []
+
+
+class FakeStackRetriever:
+    def __init__(self) -> None:
+        self.calls: List[tuple[str, Any]] = []
+        self.top_k = 1
+        self.max_alert_severity = 1.0
+        self.max_alerts = 5
+        self.license_denylist: set[str] = set()
+        self.roi_tag_weights: Mapping[str, float] = {}
+
+    def embed_query(self, query: str) -> List[float]:
+        self.calls.append(("embed_query", query))
+        return [0.1, 0.2, 0.3]
+
+    def retrieve(
+        self,
+        embedding: Iterable[float],
+        *,
+        k: int | None = None,
+        languages: Iterable[str] | None = None,
+        max_lines: int | None = None,
+        **_: Any,
+    ) -> List[Mapping[str, Any]]:
+        self.calls.append(
+            (
+                "retrieve",
+                tuple(float(x) for x in embedding),
+                k,
+                tuple(languages or ()),
+                max_lines,
+            )
+        )
+        snippet = "Stack helper snippet text from external source"
+        metadata = {
+            "summary": snippet,
+            "desc": snippet,
+            "redacted": True,
+            "repo": "octo/demo",
+            "path": "src/app.py",
+            "language": "Python",
+            "license": "MIT",
+        }
+        return [
+            {
+                "identifier": "stack-123",
+                "score": 0.91,
+                "text": snippet,
+                "metadata": metadata,
+                "repo": metadata["repo"],
+                "path": metadata["path"],
+                "language": metadata["language"],
+                "license": metadata["license"],
+                "origin_db": "stack",
+            }
+        ]
+
+
+@pytest.fixture(autouse=True)
+def _no_embedding_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "vector_service.context_builder.ensure_embeddings_fresh", lambda *_: None
+    )
+
+
+def test_stack_hits_contribute_to_prompt() -> None:
+    stack = FakeStackRetriever()
+    builder = ContextBuilder(
+        retriever=DummyRetriever(),
+        patch_retriever=DummyPatchRetriever(),
+        stack_retriever=stack,
+        stack_config={
+            "enabled": True,
+            "top_k": 1,
+            "summary_tokens": 120,
+            "text_max_tokens": 320,
+            "ensure_before_search": False,
+        },
+        db_weights={"code": 1.0, "stack": 1.0},
+    )
+
+    bundles = builder._retrieve_stack_hits("Need stack example")
+    assert bundles and isinstance(bundles[0], Mapping)
+    bundle = bundles[0]
+    meta = bundle["metadata"]
+    assert "Stack helper snippet text" in bundle.get("text", "")
+    assert meta["repo"] == "octo/demo"
+    assert meta["path"] == "src/app.py"
+    assert meta["language"] == "Python"
+    assert meta["license"] == "MIT"
+    assert meta["redacted"] is True
+    assert bundle["score"] > 0
+    assert stack.calls and stack.calls[0][0] == "embed_query"
+
+    prompt = builder.build_prompt("Need stack example", top_k=1)
+    assert isinstance(prompt, Prompt)


### PR DESCRIPTION
## Summary
- expose helper properties on `ContextBuilderConfig` for Stack retrieval tuning
- allow the Stack retriever path to embed queries directly and document prompt usage
- add an integration test covering Stack bundles and prompt construction metadata

## Testing
- `pytest tests/integration/test_stack_retrieval.py`


------
https://chatgpt.com/codex/tasks/task_e_68d760dda930832ea6c67125ce2e98c0