### PR TITLE
Fix Pydantic v1 field validator shim to handle mode argument

### DIFF
--- a/config.py
+++ b/config.py
@@ -86,7 +86,17 @@ else:  # pragma: no cover - executed when running under pydantic v1
     def field_validator(*fields, **kwargs):  # type: ignore[override]
         """Compatibility shim for :func:`pydantic.field_validator` on v1."""
 
-        decorator = validator(*fields, allow_reuse=True, **kwargs)
+        mode = kwargs.pop("mode", None)
+        if mode is not None:
+            translated = {"before": True, "after": False, "plain": False}
+            if mode not in translated:
+                raise ValueError(
+                    f"Unsupported validation mode for pydantic<2: {mode!r}"
+                )
+            kwargs["pre"] = translated[mode]
+
+        kwargs.setdefault("allow_reuse", True)
+        decorator = validator(*fields, **kwargs)
 
         def wrapper(func):
             method = func.__func__ if isinstance(func, classmethod) else func


### PR DESCRIPTION
## Summary
- translate the pydantic v2 `mode` argument into the equivalent v1 `pre` flag in the compatibility shim
- default `allow_reuse` in the shim so validators mirror v2 behaviour when running on pydantic v1

## Testing
- python manual_bootstrap.py *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68d76c2ffcfc832ea0f010aecf52fe7f