### PR TITLE
Fix stack configuration validators for Pydantic v2 compatibility

### DIFF
--- a/config.py
+++ b/config.py
@@ -331,7 +331,9 @@ class StackTokenConfig(_StrictBaseModel):
 
     @field_validator("env_vars", mode="before")
     @classmethod
-    def _coerce_env_vars(cls, value: Any) -> List[str]:
+    def _coerce_env_vars(
+        cls, value: Any, info: Any | None = None
+    ) -> List[str]:
         if value is None:
             return []
         if isinstance(value, str):
@@ -382,7 +384,9 @@ class StackIngestionConfig(_StrictBaseModel):
 
     @field_validator("languages", mode="before")
     @classmethod
-    def _coerce_languages(cls, value: Any) -> List[str]:
+    def _coerce_languages(
+        cls, value: Any, info: Any | None = None
+    ) -> List[str]:
         return normalise_stack_languages(value)
 
     @field_validator("languages")


### PR DESCRIPTION
## Summary
- allow stack token and ingestion validators to accept the optional FieldValidationInfo parameter provided by Pydantic v2

## Testing
- python -m menace_cli sandbox run -- --preset-count 1 --max-iterations 1 --runs 1 --discover-orphans --auto-include-isolated --log-level DEBUG --verbose *(fails: missing sandbox_data directory)*

------
https://chatgpt.com/codex/tasks/task_e_68db25a250b0832e9f72b56671775959