### PR TITLE
Fix Stack config validators for pydantic v1 compatibility

### DIFF
--- a/config.py
+++ b/config.py
@@ -342,7 +342,9 @@ class StackTokenConfig(_StrictBaseModel):
 
     @field_validator("env_vars")
     @classmethod
-    def _validate_env_vars(cls, value: List[str]) -> List[str]:
+    def _validate_env_vars(
+        cls, value: List[str], info: Any | None = None
+    ) -> List[str]:
         if not value:
             raise ValueError("env_vars must include at least one environment variable")
         return value
@@ -391,7 +393,9 @@ class StackIngestionConfig(_StrictBaseModel):
 
     @field_validator("languages")
     @classmethod
-    def _validate_languages(cls, value: List[str]) -> List[str]:
+    def _validate_languages(
+        cls, value: List[str], info: Any | None = None
+    ) -> List[str]:
         unknown = [lang for lang in value if lang not in STACK_LANGUAGE_ALLOWLIST]
         if unknown:
             allowed = ", ".join(sorted(STACK_LANGUAGE_ALLOWLIST))


### PR DESCRIPTION
## Summary
- allow Stack token and language validators to accept optional info arguments
- restore compatibility with the pydantic v1 validator shim used by the config loader

## Testing
- python -m menace_cli sandbox run -- --preset-count 1 --max-iterations 1 --runs 1 --discover-orphans --auto-include-isolated --log-level DEBUG --verbose *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_68db2672b94c832eb7f0c68c30b79b07