### PR TITLE
Handle missing EmbeddableDBMixin initializer

### DIFF
--- a/discrepancy_db.py
+++ b/discrepancy_db.py
@@ -109,13 +109,19 @@ class DiscrepancyDB(EmbeddableDBMixin):
             else Path(path).with_suffix(".index")
         )
         meta_path = Path(index_path).with_suffix(".json")
-        EmbeddableDBMixin.__init__(
-            self,
-            index_path=index_path,
-            metadata_path=meta_path,
-            embedding_version=embedding_version,
-            backend=vector_backend,
-        )
+        mixin_init = getattr(EmbeddableDBMixin, "__init__", None)
+        if mixin_init is not None and mixin_init is not object.__init__:
+            mixin_init(
+                self,
+                index_path=index_path,
+                metadata_path=meta_path,
+                embedding_version=embedding_version,
+                backend=vector_backend,
+            )
+        else:  # pragma: no cover - executed when embedding mixin unavailable
+            logger.debug(
+                "EmbeddableDBMixin has no usable __init__; skipping embedding setup"
+            )
 
     # ------------------------------------------------------------------
     def _embed_text(self, message: str, meta: Dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- guard the discrepancy database against environments where EmbeddableDBMixin lacks a custom initializer
- skip embedding setup gracefully when the mixin falls back to object and log the downgrade

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db27924270832e9b7907c770d0674b