### PR TITLE
Handle missing sandbox data outputs

### DIFF
--- a/adaptive_roi_predictor.py
+++ b/adaptive_roi_predictor.py
@@ -971,7 +971,7 @@ def load_training_data(
     tracker: ROITracker,
     evolution_path: str | Path = "evolution_history.db",
     roi_events_path: str | Path = "roi_events.db",
-    output_path: Path | str = resolve_path("sandbox_data/adaptive_roi.csv"),
+    output_path: Path | str | None = None,
     *,
     router: DBRouter | None = None,
 ) -> "pd.DataFrame":
@@ -1002,7 +1002,10 @@ def load_training_data(
 
     evolution_path = Path(evolution_path)
     roi_events_path = Path(roi_events_path)
-    output_path = Path(output_path)
+    if output_path is None:
+        output_path = Path("sandbox_data/adaptive_roi.csv")
+    else:
+        output_path = Path(output_path)
 
     try:
         evolution_path = resolve_path(evolution_path.as_posix())
@@ -1015,7 +1018,9 @@ def load_training_data(
     try:
         output_path = resolve_path(output_path.as_posix())
     except FileNotFoundError:
-        output_path = resolve_path(output_path.parent.as_posix()) / output_path.name
+        project_root = get_project_root()
+        output_path = (project_root / output_path).resolve()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
 
     router = router or DB_ROUTER
 

--- a/sandbox_data/README.md
+++ b/sandbox_data/README.md
@@ -1,0 +1,6 @@
+# Sandbox Data Directory
+
+This directory stores sandbox-related artifacts generated at runtime.  It is
+created during development so components that resolve paths under
+`sandbox_data/` do not fail when the repository is checked out without any
+pre-existing data files.


### PR DESCRIPTION
## Summary
- allow `load_training_data` to lazily resolve the adaptive ROI dataset path so imports do not fail when the CSV is absent
- create a placeholder `sandbox_data` directory so sandbox components that resolve shared paths can run without pre-existing artifacts

## Testing
- python -m menace_cli sandbox run -- --preset-count 1 --max-iterations 1 --runs 1 --discover-orphans --auto-include-isolated --log-level DEBUG --verbose *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_68db29326bcc832eb2e564fd15e0cb5c