### PR TITLE
Bootstrap standalone imports for error modules

### DIFF
--- a/error_logger.py
+++ b/error_logger.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+try:  # pragma: no cover - allow running module directly as a script
+    from import_compat import bootstrap as _bootstrap
+except Exception:  # pragma: no cover - compatibility helper unavailable
+    _bootstrap = None  # type: ignore
+else:  # pragma: no cover - executed only when script usage requires bootstrapping
+    _bootstrap(__name__, __file__)
+
 import logging
 import os
 import re

--- a/error_ontology.py
+++ b/error_ontology.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 
 """Centralised error taxonomy for Menace."""
 
+try:  # pragma: no cover - ensure script execution resolves package imports
+    from import_compat import bootstrap as _bootstrap
+except Exception:  # pragma: no cover - helper unavailable
+    _bootstrap = None  # type: ignore
+else:  # pragma: no cover - executed only when run as a script
+    _bootstrap(__name__, __file__)
+
 from enum import Enum
 from typing import Dict, Mapping, Type
 

--- a/sandbox_recovery_manager.py
+++ b/sandbox_recovery_manager.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 
 """Restart sandbox runs when unexpected failures occur."""
 
+try:  # pragma: no cover - lightweight bootstrap when run as a script
+    from import_compat import bootstrap as _bootstrap
+except Exception:  # pragma: no cover - import compatibility helper unavailable
+    _bootstrap = None  # type: ignore
+else:  # pragma: no cover - executed only for script usage
+    _bootstrap(__name__, __file__)
+
 from typing import Any, Callable, Dict, List
 import argparse
 import json


### PR DESCRIPTION
## Summary
- add lightweight bootstrap hooks so sandbox recovery components can be run as scripts
- use the shared import_compat helper to prime package context for error_logger, error_ontology, and sandbox_recovery_manager

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db2d89bb9c832e8ef1735a298b342e