### PR TITLE
Reduce default lock timeout to one minute

### DIFF
--- a/lock_utils.py
+++ b/lock_utils.py
@@ -15,7 +15,7 @@ try:  # pragma: no cover - platform specific
 except Exception:  # pragma: no cover - posix
     msvcrt = None  # type: ignore
 
-LOCK_TIMEOUT = float(os.getenv("LOCK_TIMEOUT", "3600"))
+LOCK_TIMEOUT = float(os.getenv("LOCK_TIMEOUT", "60"))
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- shorten the default LOCK_TIMEOUT fallback to 60 seconds so stale locks clear more quickly

## Testing
- pytest tests/test_lock_files.py

------
https://chatgpt.com/codex/tasks/task_e_68db8cc82714832e9896d2de8d305a85