### PR TITLE
Ensure module usage log file is created automatically

### DIFF
--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -599,7 +599,11 @@ def _env_path(name: str, default: str, *, create: bool = False) -> Path:
         raise
 
 # Persistent module usage tracking -------------------------------------------
-MODULE_USAGE_PATH = _env_path("SANDBOX_MODULE_USAGE_PATH", "sandbox_data/module_usage.json")
+MODULE_USAGE_PATH = _env_path(
+    "SANDBOX_MODULE_USAGE_PATH",
+    "sandbox_data/module_usage.json",
+    create=True,
+)
 _MODULE_USAGE_LOCK = FileLock(str(MODULE_USAGE_PATH) + ".lock")
 
 


### PR DESCRIPTION
## Summary
- ensure the sandbox environment automatically creates the module usage log file so startup no longer fails when it is missing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db8f0a6600832e925dbcad726556f0