### PR TITLE
Handle empty Windows lock files

### DIFF
--- a/lock_utils.py
+++ b/lock_utils.py
@@ -107,6 +107,10 @@ class _ContextFileLock(FileLock):
                         os.fchmod(fd, getattr(self._context, "mode", 0o644))
                 try:
                     if os.name == "nt":
+                        file_end = os.lseek(fd, 0, os.SEEK_END)
+                        if file_end == 0:
+                            os.write(fd, b"\0")
+                        os.lseek(fd, 0, os.SEEK_SET)
                         msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
                     else:
                         flock(fd, LOCK_EX | LOCK_NB)


### PR DESCRIPTION
## Summary
- ensure Windows lock acquisition writes a padding byte to empty files before invoking msvcrt.locking
- reset the file pointer to the start of the file once the padding byte is written
- add a regression test that simulates the Windows code path and verifies zero-length files no longer raise PermissionError

## Testing
- pytest tests/test_lock_files.py::test_windows_zero_length_file_lock -q

------
https://chatgpt.com/codex/tasks/task_e_68db96d35ecc832ea08b5ae7c004a34b