### PR TITLE
Ensure self_improvement.metrics supports flat import layouts

### DIFF
--- a/self_improvement/metrics.py
+++ b/self_improvement/metrics.py
@@ -23,10 +23,25 @@ try:  # pragma: no cover - radon is an optional dependency
 except ImportError:  # pragma: no cover - fall back to AST-based metrics
     cc_visit = mi_visit = None
 
-from ..sandbox_settings import SandboxSettings
-from ..dynamic_path_router import resolve_path
-from ..logging_utils import setup_logging
-from ..module_graph_analyzer import build_import_graph
+try:  # pragma: no cover - prefer absolute imports when running from repo root
+    from sandbox_settings import SandboxSettings
+except ImportError:  # pragma: no cover - fallback for package-relative layout
+    from ..sandbox_settings import SandboxSettings
+
+try:  # pragma: no cover - prefer absolute imports when running from repo root
+    from dynamic_path_router import resolve_path
+except ImportError:  # pragma: no cover - fallback for package-relative layout
+    from ..dynamic_path_router import resolve_path
+
+try:  # pragma: no cover - prefer absolute imports when running from repo root
+    from logging_utils import setup_logging
+except ImportError:  # pragma: no cover - fallback for package-relative layout
+    from ..logging_utils import setup_logging
+
+try:  # pragma: no cover - prefer absolute imports when running from repo root
+    from module_graph_analyzer import build_import_graph
+except ImportError:  # pragma: no cover - fallback for package-relative layout
+    from ..module_graph_analyzer import build_import_graph
 
 logger = logging.getLogger(__name__)
 

--- a/tests/self_improvement/test_metrics_import_flat_layout.py
+++ b/tests/self_improvement/test_metrics_import_flat_layout.py
@@ -1,0 +1,29 @@
+"""Ensure ``self_improvement.metrics`` supports flat import layouts."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def test_metrics_import_flat_layout(monkeypatch):
+    """Import the metrics module with only the repo root on ``sys.path``."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+
+    # Ensure an import happens from the repository root rather than the package
+    # layout produced by ``menace_sandbox`` being present in ``sys.modules``.
+    monkeypatch.delitem(sys.modules, "menace_sandbox", raising=False)
+    monkeypatch.delitem(sys.modules, "self_improvement", raising=False)
+    monkeypatch.delitem(sys.modules, "self_improvement.metrics", raising=False)
+
+    # Restrict ``sys.path`` to only the repository root so absolute imports are
+    # exercised in environments that execute from the root directory.
+    monkeypatch.setattr(sys, "path", [str(repo_root)])
+
+    module = importlib.import_module("self_improvement.metrics")
+
+    assert module is not None
+    assert hasattr(module, "SandboxSettings")
+    assert hasattr(module, "resolve_path")


### PR DESCRIPTION
## Summary
- prefer absolute imports in `self_improvement.metrics` with fallbacks to the existing package-relative modules
- add a regression test ensuring the metrics module imports when only the repo root is present on `sys.path`

## Testing
- pytest tests/self_improvement/test_metrics_import_flat_layout.py *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68dc6b119da4832e907ba6697a659737