### PR TITLE
Fix snapshot tracker imports for flat layout compatibility

### DIFF
--- a/self_improvement/snapshot_tracker.py
+++ b/self_improvement/snapshot_tracker.py
@@ -16,8 +16,16 @@ from typing import Any, Dict, Mapping, Sequence
 from .baseline_tracker import TRACKER as BASELINE_TRACKER
 from .metrics import collect_snapshot_metrics, compute_call_graph_complexity
 from .prompt_strategy_manager import PromptStrategyManager
-from ..sandbox_settings import SandboxSettings
-from ..audit_logger import log_event as audit_log_event
+
+try:  # pragma: no cover - prefer package-relative import when available
+    from ..sandbox_settings import SandboxSettings
+except ImportError:  # pragma: no cover - support flat execution layout
+    from sandbox_settings import SandboxSettings  # type: ignore
+
+try:  # pragma: no cover - prefer package-relative import when available
+    from ..audit_logger import log_event as audit_log_event
+except ImportError:  # pragma: no cover - support flat execution layout
+    from audit_logger import log_event as audit_log_event  # type: ignore
 try:  # pragma: no cover - optional dependency location
     from ..snapshot_history_db import (
         log_regression,


### PR DESCRIPTION
## Summary
- add flat-layout fallbacks when importing `SandboxSettings` and `audit_logger` inside the snapshot tracker

## Testing
- python -m compileall self_improvement/snapshot_tracker.py

------
https://chatgpt.com/codex/tasks/task_e_68dc6d663894832e9c280b163b3f1557