### PR TITLE
Fix circular import between synthesis and validation bots

### DIFF
--- a/information_synthesis_bot.py
+++ b/information_synthesis_bot.py
@@ -11,7 +11,7 @@ from .bot_registry import BotRegistry
 from .data_bot import DataBot
 
 from .coding_bot_interface import self_coding_managed
-from dataclasses import dataclass, asdict
+from dataclasses import asdict
 from typing import List, Iterable
 import os
 import logging
@@ -71,24 +71,7 @@ except Exception:  # pragma: no cover - optional dependency
     ValidationError = SimpleValidationError
 
 
-@dataclass
-class DataRequest:
-    """Request for additional data from Stage 2 bots."""
-
-    table: str
-    field: str
-    reason: str
-    priority: int = 1
-
-
-@dataclass
-class SynthesisTask:
-    """Actionable task for Stage 4 planning."""
-
-    description: str
-    urgency: int
-    complexity: int
-    category: str
+from .synthesis_models import DataRequest, SynthesisTask
 
 
 def send_to_task_manager(task: SynthesisTask) -> None:

--- a/model_automation_pipeline.py
+++ b/model_automation_pipeline.py
@@ -77,7 +77,8 @@ from vector_service.context_builder import ContextBuilder
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .research_aggregator_bot import ResearchAggregatorBot, ResearchItem
-    from .information_synthesis_bot import InformationSynthesisBot, SynthesisTask
+    from .information_synthesis_bot import InformationSynthesisBot
+    from .synthesis_models import SynthesisTask
 else:  # pragma: no cover - runtime fallback
     ResearchAggregatorBot = Any  # type: ignore
     ResearchItem = Any  # type: ignore
@@ -86,7 +87,7 @@ else:  # pragma: no cover - runtime fallback
 def _create_synthesis_task(**kwargs: Any) -> "SynthesisTask":
     """Construct :class:`SynthesisTask` without importing at module import time."""
 
-    from .information_synthesis_bot import SynthesisTask
+    from .synthesis_models import SynthesisTask
 
     return SynthesisTask(**kwargs)
 

--- a/synthesis_models.py
+++ b/synthesis_models.py
@@ -1,0 +1,28 @@
+"""Shared dataclasses for synthesis-related tasks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class DataRequest:
+    """Request for additional data from Stage 2 bots."""
+
+    table: str
+    field: str
+    reason: str
+    priority: int = 1
+
+
+@dataclass
+class SynthesisTask:
+    """Actionable task for Stage 4 planning."""
+
+    description: str
+    urgency: int
+    complexity: int
+    category: str
+
+
+__all__ = ["DataRequest", "SynthesisTask"]

--- a/task_validation_bot.py
+++ b/task_validation_bot.py
@@ -44,7 +44,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-from menace.information_synthesis_bot import SynthesisTask
+from menace.synthesis_models import SynthesisTask
 
 
 


### PR DESCRIPTION
## Summary
- move the shared DataRequest and SynthesisTask dataclasses into a lightweight synthesis_models module
- update information_synthesis_bot and task_validation_bot to import the shared models, preventing the circular dependency
- adjust model_automation_pipeline helpers to reference the new module for type hints and task creation

## Testing
- pytest tests/test_task_validation_bot.py -q *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68dc8cfc1438832e8e14dd0afb1403f3