### PR TITLE
Fix DataBot initialization order in prediction manager

### DIFF
--- a/prediction_manager_bot.py
+++ b/prediction_manager_bot.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from .bot_registry import BotRegistry
-
 from .coding_bot_interface import self_coding_managed
+from .data_bot import DataBot, MetricsDB
+
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -21,7 +22,6 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     pd = None  # type: ignore
 
-from .data_bot import DataBot, MetricsDB
 from .future_prediction_bots import (
     FutureLucrativityBot,
     FutureProfitabilityBot,


### PR DESCRIPTION
## Summary
- import DataBot before instantiating it in prediction_manager_bot to prevent NameError at import time

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcaaacc7d0832e9055a98d24d8b5f4