### PR TITLE
Gracefully handle optional DataBot dependencies

### DIFF
--- a/sandbox_settings.py
+++ b/sandbox_settings.py
@@ -7,7 +7,13 @@ import os
 from typing import Any
 from pathlib import Path
 
-import yaml
+try:
+    import yaml
+except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+    yaml = None  # type: ignore
+    _MISSING_YAML = exc
+else:
+    _MISSING_YAML = None
 try:
     from .dynamic_path_router import resolve_path
 except Exception:  # pragma: no cover
@@ -3393,6 +3399,11 @@ def load_sandbox_settings(path: str | None = None) -> SandboxSettings:
         path = resolve_path(path)
         with open(path, "r", encoding="utf-8") as fh:
             if path.suffix in (".yml", ".yaml"):
+                if yaml is None:
+                    missing = getattr(_MISSING_YAML, "name", "PyYAML") if _MISSING_YAML else "PyYAML"
+                    raise ModuleNotFoundError(
+                        f"{missing} is required to load YAML sandbox settings"
+                    ) from _MISSING_YAML
                 data = yaml.safe_load(fh) or {}
             elif path.suffix == ".json":
                 data = json.load(fh)


### PR DESCRIPTION
## Summary
- wrap menace_sandbox optional imports in a helper so TruthAdapter, ForesightTracker, UpgradeForecaster, and the LLM client expose informative stubs when dependencies are missing
- ensure sandbox_settings only requires PyYAML when loading YAML files, emitting a clear error when the optional dependency is absent

## Testing
- not run (dependencies unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_68dcb8aa3eb8832eb1e77d372060cccc