### PR TITLE
Fix lazy self_improvement exports to avoid sandbox_runner circular import

### DIFF
--- a/self_improvement/__init__.py
+++ b/self_improvement/__init__.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 """Self-improvement engine public API."""
 
-import sys as _sys
-from types import ModuleType as _ModuleType
 from pathlib import Path as _Path
+import importlib as _importlib
+import sys as _sys
+import types as _types
+from typing import Any as _Any
 
 
 if __name__ == "self_improvement":  # pragma: no cover - runtime import aliasing
@@ -17,15 +19,110 @@ if __name__ == "self_improvement":  # pragma: no cover - runtime import aliasing
     __package__ = "menace_sandbox.self_improvement"
     parent = _sys.modules.get("menace_sandbox")
     if parent is None:
-        parent = _ModuleType("menace_sandbox")
+        parent = _types.ModuleType("menace_sandbox")
         parent.__path__ = [str(_Path(__file__).resolve().parent.parent)]
         _sys.modules["menace_sandbox"] = parent
     _sys.modules["menace_sandbox.self_improvement"] = _sys.modules[__name__]
 
 
-from .api import *  # noqa: F401,F403
-from .api import __all__  # noqa: F401
+def _load_api_module():
+    """Import :mod:`self_improvement.api` on demand."""
 
-# Backwards compatibility for the deprecated `state_snapshot` module
-from . import snapshot_tracker as state_snapshot  # noqa: F401
-_sys.modules[__name__ + ".state_snapshot"] = state_snapshot
+    module = _sys.modules.get(__name__ + ".api")
+    if module is None:
+        module = _importlib.import_module(".api", __name__)
+    return module
+
+
+_API_EXPORTS = (
+    "init_self_improvement",
+    "settings",
+    "_repo_path",
+    "_data_dir",
+    "_atomic_write",
+    "get_default_synergy_weights",
+    "integrate_orphans",
+    "post_round_orphan_scan",
+    "self_improvement_cycle",
+    "start_self_improvement_cycle",
+    "stop_self_improvement_cycle",
+    "generate_patch",
+    "apply_patch",
+    "update_alignment_baseline",
+    "router",
+    "STABLE_WORKFLOWS",
+    "SelfImprovementEngine",
+    "SynergyWeightLearner",
+    "DQNSynergyLearner",
+    "DoubleDQNSynergyLearner",
+    "SACSynergyLearner",
+    "TD3SynergyLearner",
+    "SynergyDashboard",
+    "ImprovementEngineRegistry",
+    "auto_x",
+    "benchmark_workflow_variants",
+    "load_synergy_history",
+    "synergy_stats",
+    "synergy_ma",
+    "Snapshot",
+    "capture_snapshot",
+    "delta",
+    "save_checkpoint",
+)
+
+__all__ = list(_API_EXPORTS)
+
+_STATE_SNAPSHOT_PROXY: "_LazySubmodule | None" = None
+
+
+def _ensure_api_exports(name: str):
+    module = _load_api_module()
+    attr = getattr(module, name)
+    globals()[name] = attr
+    return attr
+
+
+class _LazySubmodule(_types.ModuleType):
+    """Lightweight proxy that loads the target module on first attribute access."""
+
+    def __init__(self, name: str, loader):
+        super().__init__(name)
+        self.__dict__["_loader"] = loader
+
+    def _load(self):
+        module = self.__dict__.get("_module")
+        if module is None:
+            module = self.__dict__["_loader"]()
+            self.__dict__["_module"] = module
+            _sys.modules[self.__name__] = module
+        return module
+
+    def __getattr__(self, item: str):
+        module = self._load()
+        return getattr(module, item)
+
+
+def _load_state_snapshot_module():
+    module = _importlib.import_module(".snapshot_tracker", __name__)
+    globals()["state_snapshot"] = module
+    _sys.modules[__name__ + ".state_snapshot"] = module
+    return module
+
+
+def __getattr__(name: str) -> _Any:
+    if name in _API_EXPORTS:
+        return _ensure_api_exports(name)
+    if name == "state_snapshot":
+        return _load_state_snapshot_module()
+    raise AttributeError(name)
+
+
+def __dir__() -> list[str]:  # pragma: no cover - simple helper
+    return sorted(set(list(globals()) + list(_API_EXPORTS) + ["state_snapshot"]))
+
+
+if __name__ + ".state_snapshot" not in _sys.modules:
+    _STATE_SNAPSHOT_PROXY = _LazySubmodule(
+        __name__ + ".state_snapshot", _load_state_snapshot_module
+    )
+    _sys.modules[__name__ + ".state_snapshot"] = _STATE_SNAPSHOT_PROXY


### PR DESCRIPTION
## Summary
- delay importing self_improvement.api until its attributes are accessed to avoid eager sandbox_runner dependencies
- add a lazy state_snapshot proxy so legacy imports continue to work without triggering heavy modules

## Testing
- python - <<'PY'
from import_compat import load_internal

load_internal("self_improvement.baseline_tracker")
print("baseline tracker loaded")
PY


------
https://chatgpt.com/codex/tasks/task_e_68dcbfedcf30832e91809368f3868d64