### PR TITLE
Fix bootstrap script import path

### DIFF
--- a/menace/__init__.py
+++ b/menace/__init__.py
@@ -7,7 +7,19 @@ from dynamic_path_router import repo_root
 # Allow importing modules from repository root using ``menace`` prefix.
 __path__.append(str(repo_root()))
 
-from .numeric_backend import NUMERIC_BACKEND
+try:  # pragma: no cover - optional numeric backend
+    from .numeric_backend import NUMERIC_BACKEND
+except ImportError as exc:  # pragma: no cover - degrade gracefully in minimal envs
+    class _MissingNumericBackend:
+        """Placeholder that surfaces the optional numeric backend dependency."""
+
+        def __getattr__(self, name: str) -> None:
+            raise ImportError(
+                "Menace requires either PyTorch or NumPy for numeric operations; "
+                "install menace_sandbox[numeric] to enable NUMERIC_BACKEND"
+            ) from exc
+
+    NUMERIC_BACKEND = _MissingNumericBackend()  # type: ignore[assignment]
 
 # Default flag used by modules expecting it
 RAISE_ERRORS = False

--- a/menace/startup_checks.py
+++ b/menace/startup_checks.py
@@ -1,0 +1,10 @@
+"""Compatibility wrapper exposing :mod:`startup_checks` under ``menace``."""
+from __future__ import annotations
+
+from startup_checks import *  # noqa: F401,F403
+
+# Re-export ``__all__`` for ``from menace.startup_checks import *`` consumers.
+try:
+    from startup_checks import __all__ as __all__  # type: ignore
+except ImportError:  # pragma: no cover - defensive fallback
+    __all__ = []  # type: ignore[var-annotated]

--- a/scripts/bootstrap_env.py
+++ b/scripts/bootstrap_env.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 from menace.startup_checks import run_startup_checks
 from menace.environment_bootstrap import EnvironmentBootstrapper

--- a/startup_checks.py
+++ b/startup_checks.py
@@ -11,12 +11,40 @@ from pathlib import Path
 from typing import Iterable, Dict, Sequence
 import logging
 
-from .audit_trail import AuditTrail
+try:  # pragma: no cover - prefer package relative imports
+    from .audit_trail import AuditTrail
+except ImportError as exc:  # pragma: no cover - fallback for script execution
+    try:
+        from audit_trail import AuditTrail  # type: ignore
+    except ImportError as inner_exc:
+        class _MissingAuditTrail:  # pragma: no cover - informative stub
+            """Placeholder surfaced when optional crypto dependency is absent."""
+
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                raise ModuleNotFoundError(
+                    "cryptography is required for audit log verification; "
+                    "install menace_sandbox[security] to enable this feature"
+                ) from inner_exc
+
+        AuditTrail = _MissingAuditTrail  # type: ignore
 
 import tomllib
 
-from .dependency_verifier import verify_dependencies, verify_modules
-from .dynamic_path_router import resolve_path
+try:  # pragma: no cover - prefer package relative imports
+    from .dependency_verifier import verify_dependencies, verify_modules
+except ImportError as exc:  # pragma: no cover - fallback for script execution
+    try:
+        from dependency_verifier import verify_dependencies, verify_modules  # type: ignore
+    except ImportError:
+        raise exc
+
+try:  # pragma: no cover - prefer package relative imports
+    from .dynamic_path_router import resolve_path
+except ImportError as exc:  # pragma: no cover - fallback for script execution
+    try:
+        from dynamic_path_router import resolve_path  # type: ignore
+    except ImportError:
+        raise exc
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- ensure the bootstrap script adds the repository root to the module search path
- expose `startup_checks` through the `menace` package and make its imports resilient to optional dependencies
- gracefully handle missing numeric backend dependencies when importing `menace`

## Testing
- python -c "from menace.startup_checks import run_startup_checks; print(run_startup_checks.__name__)"


------
https://chatgpt.com/codex/tasks/task_e_68dcd733e028832e978bc757b9bf7ed6