### PR TITLE
Fix stripe import checker path resolution

### DIFF
--- a/scripts/check_stripe_imports.py
+++ b/scripts/check_stripe_imports.py
@@ -27,8 +27,19 @@ import re
 import sys
 from pathlib import Path
 
-from dynamic_path_router import get_project_root, resolve_path
-from stripe_detection import HTTP_LIBRARIES, contains_payment_keyword
+try:  # pragma: no cover - prefer package relative imports
+    from menace_sandbox.dynamic_path_router import get_project_root, resolve_path
+    from menace_sandbox.stripe_detection import (
+        HTTP_LIBRARIES,
+        contains_payment_keyword,
+    )
+except ImportError:  # pragma: no cover - fallback for script execution
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    from dynamic_path_router import get_project_root, resolve_path  # type: ignore
+    from stripe_detection import (  # type: ignore
+        HTTP_LIBRARIES,
+        contains_payment_keyword,
+    )
 
 REPO_ROOT = get_project_root()
 


### PR DESCRIPTION
## Summary
- update the Stripe import guard to support both package and script executions
- extend the fallback import path so `dynamic_path_router` remains discoverable when running from the scripts directory

## Testing
- python scripts/check_stripe_imports.py --help


------
https://chatgpt.com/codex/tasks/task_e_68dce3522474832e9ed48226884b308a