### PR TITLE
Ensure self coding engine imports stripe via router

### DIFF
--- a/self_coding_engine.py
+++ b/self_coding_engine.py
@@ -228,10 +228,18 @@ try:  # pragma: no cover - required for payment integration checks
     _stripe_billing_router = load_internal("stripe_billing_router")
 except ModuleNotFoundError:  # pragma: no cover - optional
     stripe_billing_router = None  # type: ignore[assignment]
+    stripe = None  # type: ignore[assignment]
 except Exception:  # pragma: no cover - optional
     stripe_billing_router = None  # type: ignore[assignment]
+    stripe = None  # type: ignore[assignment]
 else:
     stripe_billing_router = _stripe_billing_router
+    try:  # pragma: no cover - prefer router-managed Stripe import
+        from stripe_billing_router import stripe as _stripe  # type: ignore
+    except Exception:  # pragma: no cover - degrade gracefully when unavailable
+        stripe = getattr(stripe_billing_router, "stripe", None)  # type: ignore[assignment]
+    else:
+        stripe = _stripe
 
 try:  # pragma: no cover - optional ROI tracking
     ROITracker = load_internal("roi_tracker").ROITracker


### PR DESCRIPTION
## Summary
- ensure the self-coding engine relies on stripe_billing_router to expose the stripe module, keeping policy checks satisfied

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcfc31bf08832eb42a0d64b38a0ccd