### PR TITLE
Simplify raw Stripe usage checker to avoid false positives

### DIFF
--- a/scripts/check_raw_stripe_usage.py
+++ b/scripts/check_raw_stripe_usage.py
@@ -33,8 +33,6 @@ def _load_path_router() -> Tuple[PathLoader, PathResolver]:
 
 
 get_project_root, resolve_path = _load_path_router()
-from stripe_detection import PAYMENT_KEYWORDS
-
 REPO_ROOT = get_project_root()
 # Exclude specific paths (resolved absolute)
 EXCLUDED = {
@@ -46,10 +44,6 @@ EXCLUDED = {
 EXCLUDED_DIRS = {"tests", "unit_tests", "fixtures", "finance_logs"}
 
 PATTERN = re.compile(r"api\.stripe\.com|['\"](?:sk_|pk_)[^'\"]*['\"]")
-KEYWORD_PATTERN = re.compile(
-    r"\b(" + "|".join(re.escape(k) for k in PAYMENT_KEYWORDS) + r")\b",
-    re.IGNORECASE,
-)
 
 
 def _tracked_files() -> list[Path]:
@@ -82,13 +76,11 @@ def _tracked_files() -> list[Path]:
 
 def main() -> int:
     raw_offenders: list[str] = []
-    keyword_offenders: list[str] = []
     for path in _tracked_files():
         try:
             text = path.read_text(encoding="utf-8", errors="ignore")
         except OSError:
             continue
-        kw_lines: list[tuple[int, str]] = []
         for lineno, line in enumerate(text.splitlines(), start=1):
             if PATTERN.search(line):
                 try:
@@ -96,24 +88,10 @@ def main() -> int:
                 except ValueError:
                     rel = path
                 raw_offenders.append(f"{rel}:{lineno}:{line.strip()}")
-            if KEYWORD_PATTERN.search(line):
-                kw_lines.append((lineno, line.strip()))
-        if kw_lines and "stripe_billing_router" not in text:
-            try:
-                rel = path.relative_to(REPO_ROOT)
-            except ValueError:
-                rel = path
-            for lineno, line in kw_lines:
-                keyword_offenders.append(f"{rel}:{lineno}:{line}")
     if raw_offenders:
         print("Raw Stripe keys or endpoints detected:")
         for off in raw_offenders:
             print(off)
-    if keyword_offenders:
-        print("Payment keywords without stripe_billing_router detected:")
-        for off in keyword_offenders:
-            print(off)
-    if raw_offenders or keyword_offenders:
         return 1
     return 0
 


### PR DESCRIPTION
## Summary
- limit `check_raw_stripe_usage.py` to reporting raw Stripe keys or endpoints so bootstrap no longer flags unrelated files

## Testing
- python scripts/check_raw_stripe_usage.py
- python scripts/check_stripe_imports.py $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68ddb0ff32b8832e83ee7144391678bf