### PR TITLE
Handle flat layout imports in bot registry

### DIFF
--- a/bot_registry.py
+++ b/bot_registry.py
@@ -44,9 +44,20 @@ except Exception:  # pragma: no cover - flat layout fallback
 import db_router
 from db_router import DBRouter, init_db_router
 
-from .sandbox_settings import SandboxSettings, normalize_workflow_tests
-from .threshold_service import threshold_service
-from .retry_utils import with_retry
+try:  # pragma: no cover - allow flat imports
+    from .sandbox_settings import SandboxSettings, normalize_workflow_tests
+except Exception:  # pragma: no cover - fallback for flat layout
+    from sandbox_settings import SandboxSettings, normalize_workflow_tests  # type: ignore
+
+try:  # pragma: no cover - allow flat imports
+    from .threshold_service import threshold_service
+except Exception:  # pragma: no cover - fallback for flat layout
+    from threshold_service import threshold_service  # type: ignore
+
+try:  # pragma: no cover - allow flat imports
+    from .retry_utils import with_retry
+except Exception:  # pragma: no cover - fallback for flat layout
+    from retry_utils import with_retry  # type: ignore
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
     from .self_coding_manager import SelfCodingManager

--- a/unified_event_bus.py
+++ b/unified_event_bus.py
@@ -34,8 +34,15 @@ else:
         def handle(self, event: object) -> None:
             ...
 
-from .resilience import CircuitBreaker, CircuitOpenError, retry_with_backoff
-from .logging_utils import set_correlation_id
+try:  # pragma: no cover - allow flat imports
+    from .resilience import CircuitBreaker, CircuitOpenError, retry_with_backoff
+except Exception:  # pragma: no cover - fallback for flat layout
+    from resilience import CircuitBreaker, CircuitOpenError, retry_with_backoff  # type: ignore
+
+try:  # pragma: no cover - allow flat imports
+    from .logging_utils import set_correlation_id
+except Exception:  # pragma: no cover - fallback for flat layout
+    from logging_utils import set_correlation_id  # type: ignore
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- add flat-layout fallbacks for sandbox configuration imports in `bot_registry`
- extend `unified_event_bus` to fall back to absolute imports when package context is missing

## Testing
- python - <<'PY'
import types, sys
sys.modules['networkx'] = types.ModuleType('networkx')
sys.modules['db_router'] = types.ModuleType('db_router')
setattr(sys.modules['db_router'], 'DBRouter', object)
setattr(sys.modules['db_router'], 'init_db_router', lambda *a, **k: None)
setattr(sys.modules['db_router'], 'GLOBAL_ROUTER', None)

sandbox_settings = types.ModuleType('sandbox_settings')
class _SandboxSettings:
    bot_thresholds = {}

def _normalize(values):
    return []
setattr(sandbox_settings, 'SandboxSettings', _SandboxSettings)
setattr(sandbox_settings, 'normalize_workflow_tests', _normalize)
sys.modules['sandbox_settings'] = sandbox_settings

threshold_service = types.ModuleType('threshold_service')
setattr(threshold_service, 'threshold_service', types.SimpleNamespace(load=lambda *a, **k: None))
sys.modules['threshold_service'] = threshold_service

retry_utils = types.ModuleType('retry_utils')
setattr(retry_utils, 'with_retry', lambda fn, *a, **k: fn())
sys.modules['retry_utils'] = retry_utils

import bot_registry
print('imported', bool(bot_registry))
PY

------
https://chatgpt.com/codex/tasks/task_e_68dde4a4c8a8832ebd6ea2adeaa9e6e8