### PR TITLE
Add retry mechanism for coding bot internalization

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -78,6 +78,11 @@ sys.modules.setdefault(
     ),
 )
 
+threshold_stub = types.ModuleType("menace_sandbox.threshold_service")
+threshold_stub.threshold_service = types.SimpleNamespace(load=lambda *_a, **_k: None)
+sys.modules.setdefault("menace_sandbox.threshold_service", threshold_stub)
+sys.modules.setdefault("threshold_service", threshold_stub)
+
 import pytest
 from menace_sandbox.bot_registry import BotRegistry as SandboxBotRegistry
 from menace.bot_registry import BotRegistry as RootBotRegistry


### PR DESCRIPTION
## Summary
- add retry scheduling and helper utilities to `BotRegistry` so transient internalization errors are retried and pending state clears on success
- stub `threshold_service` for the lightweight test harness to avoid import failures in sandbox mode
- extend bot registry internalization tests with a retry scenario that simulates an initial module import failure

## Testing
- `PYTHONPATH=/workspace pytest tests/test_bot_registry_internalization.py`


------
https://chatgpt.com/codex/tasks/task_e_68dde9b45290832ebb10b6d2fb6a53bd