### PR TITLE
Add option to skip Stripe router verification during bootstrap

### DIFF
--- a/scripts/bootstrap_env.py
+++ b/scripts/bootstrap_env.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
-"""Bootstrap the Menace environment and verify dependencies."""
+"""Bootstrap the Menace environment and verify dependencies.
+
+Run ``python scripts/bootstrap_env.py`` to install required tooling and
+configuration.  Pass ``--skip-stripe-router`` to bypass the Stripe router
+startup verification when working offline or without Stripe credentials.
+"""
 from __future__ import annotations
 
+import argparse
 import logging
 import os
 import sys
@@ -15,11 +21,25 @@ from menace.startup_checks import run_startup_checks
 from menace.environment_bootstrap import EnvironmentBootstrapper
 
 
-def main() -> None:
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--skip-stripe-router",
+        action="store_true",
+        help=(
+            "Bypass the Stripe router startup verification. Useful when Stripe "
+            "credentials are unavailable during local bootstraps."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
     logging.basicConfig(level=logging.INFO)
     # Explicitly disable safe mode regardless of existing variables
     os.environ["MENACE_SAFE"] = "0"
-    run_startup_checks()
+    run_startup_checks(skip_stripe_router=args.skip_stripe_router)
     EnvironmentBootstrapper().bootstrap()
 
 

--- a/tests/test_startup_checks.py
+++ b/tests/test_startup_checks.py
@@ -214,6 +214,24 @@ def test_run_startup_checks_invokes_stripe_router(monkeypatch, tmp_path):
     assert called["val"]
 
 
+def test_run_startup_checks_skips_stripe_router(monkeypatch, tmp_path):
+    monkeypatch.setenv("MENACE_MODE", "test")
+    pyproj = tmp_path / "pyproject.toml"
+    _write_pyproject(pyproj, [])
+    called = {"val": False}
+
+    def fake_verify(*a, **k) -> None:
+        called["val"] = True
+
+    monkeypatch.setattr(sc, "verify_stripe_router", fake_verify)
+    monkeypatch.setattr(sc, "verify_project_dependencies", lambda p: [])
+    monkeypatch.setattr(sc, "verify_optional_dependencies", lambda: [])
+
+    sc.run_startup_checks(pyproject_path=str(pyproj), skip_stripe_router=True)
+
+    assert not called["val"]
+
+
 def test_verify_stripe_router_checks(monkeypatch):
     class FakeRegistry:
         def __init__(self, *a, **k):


### PR DESCRIPTION
## Summary
- add a --skip-stripe-router flag to bootstrap_env to bypass Stripe checks during local setup
- update startup_checks to allow skipping Stripe verification and document the new parameter
- extend startup check tests to cover the opt-out path

## Testing
- pytest tests/test_startup_checks.py

------
https://chatgpt.com/codex/tasks/task_e_68de112d624c832e983284d4ba307ed6