### PR TITLE
Improve bootstrap resilience for optional dependency gaps

### DIFF
--- a/metrics_exporter.py
+++ b/metrics_exporter.py
@@ -61,9 +61,9 @@ try:
     start_http_server = _start_http_server  # type: ignore
     _USING_STUB = False
 except Exception as exc:  # pragma: no cover - optional dependency missing
-    logger.warning(
-        "prometheus_client missing; using lightweight metrics server. "
-        "Advanced features disabled: %s",
+    logger.info(
+        "prometheus_client not installed; using lightweight metrics server. "
+        "Install the optional dependency to expose native Prometheus metrics (%s)",
         exc,
     )
     _USING_STUB = True

--- a/scripts/bootstrap_env.py
+++ b/scripts/bootstrap_env.py
@@ -39,6 +39,9 @@ def main(argv: list[str] | None = None) -> None:
     logging.basicConfig(level=logging.INFO)
     # Explicitly disable safe mode regardless of existing variables
     os.environ["MENACE_SAFE"] = "0"
+    # Menace sandbox environments often lack Hugging Face credentials; suppress
+    # the warning during bootstraps so local runs remain noise free.
+    os.environ.setdefault("MENACE_ALLOW_MISSING_HF_TOKEN", "1")
     # Ensure bootstrap runs without interactive prompts when stdin is a TTY.
     # CI environments as well as our automated tests execute this script in
     # non-interactive shells and would otherwise hang waiting for user input

--- a/tests/test_config_discovery.py
+++ b/tests/test_config_discovery.py
@@ -170,6 +170,26 @@ def test_missing_huggingface_token_increments_failure(tmp_path, monkeypatch):
     assert disc.failure_count == 1
 
 
+def test_missing_huggingface_token_can_be_suppressed(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    for key in [
+        "HUGGINGFACE_TOKEN",
+        "HUGGINGFACE_API_TOKEN",
+        "HF_TOKEN",
+        "HUGGINGFACEHUB_API_TOKEN",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("MENACE_ALLOW_MISSING_HF_TOKEN", "1")
+
+    disc = cd.ConfigDiscovery()
+    caplog.set_level("DEBUG")
+    disc.reload_tokens()
+
+    assert "warning suppressed" in caplog.text
+    assert "huggingface token not found" not in caplog.text
+    assert disc.failure_count == 0
+
+
 def test_stack_env_defaults_and_overrides(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     stack_dir = tmp_path / "stack_state"


### PR DESCRIPTION
## Summary
- add a suppressible Hugging Face token warning and enable it by default for bootstrap runs
- relax metrics exporter and bootstrap logging when optional services such as Prometheus or systemd are unavailable
- skip vector model downloads when huggingface-hub is absent and cover the new behaviours with tests

## Testing
- ⚠️ `pytest tests/test_config_discovery.py tests/test_environment_bootstrap.py` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_68de1a885634832ebf3e67a3cb29ce1a