### PR TITLE
Improve bootstrap resilience without optional Stripe deps

### DIFF
--- a/access_control.py
+++ b/access_control.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import logging
 
-from .roles import ROLE_PERMISSIONS, READ, WRITE, ADMIN
-from .models import BotRole
+try:  # pragma: no cover - support execution without package context
+    from .roles import ROLE_PERMISSIONS, READ, WRITE, ADMIN
+    from .models import BotRole
+except ImportError:  # pragma: no cover - fallback when imported as script
+    from roles import ROLE_PERMISSIONS, READ, WRITE, ADMIN  # type: ignore
+    from models import BotRole  # type: ignore
 
 logger = logging.getLogger(__name__)
 

--- a/bootstrap_policy.py
+++ b/bootstrap_policy.py
@@ -171,7 +171,7 @@ class DependencyPolicy:
         defaults: Sequence[str],
         *,
         skip_stripe: bool,
-        stripe_sensitive: Iterable[str],
+        router_sensitive: Iterable[str],
     ) -> tuple[str, ...]:
         """Return sandbox modules to probe during startup."""
 
@@ -182,12 +182,12 @@ class DependencyPolicy:
         )
         if not modules:
             return tuple()
-        stripe_sensitive_lower = {name.lower() for name in stripe_sensitive}
+        router_sensitive_lower = {name.lower() for name in router_sensitive}
         if skip_stripe:
             return tuple(
                 module
                 for module in modules
-                if module.lower() not in stripe_sensitive_lower
+                if module.lower() not in router_sensitive_lower
             )
         return tuple(modules)
 

--- a/models.py
+++ b/models.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .roles import ROLE_PERMISSIONS, READ
+try:  # pragma: no cover - support flat module execution
+    from .roles import ROLE_PERMISSIONS, READ
+except ImportError:  # pragma: no cover - fallback when package context missing
+    from roles import ROLE_PERMISSIONS, READ  # type: ignore
 
 
 @dataclass

--- a/rollback_manager.py
+++ b/rollback_manager.py
@@ -9,7 +9,14 @@ import json
 import base64
 import logging
 
-from .db_router import GLOBAL_ROUTER, init_db_router
+# ``rollback_manager`` needs to function whether it is imported as part of the
+# ``menace_sandbox`` package or executed from a plain source checkout.  Relative
+# imports break in the latter scenario (common during environment bootstrap on
+# Windows) so we provide explicit fallbacks to absolute imports.
+try:  # pragma: no cover - import path handling
+    from .db_router import GLOBAL_ROUTER, init_db_router
+except ImportError:  # pragma: no cover - script execution fallback
+    from db_router import GLOBAL_ROUTER, init_db_router  # type: ignore
 
 router = GLOBAL_ROUTER or init_db_router("rollback_manager")
 
@@ -18,10 +25,16 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     requests = None  # type: ignore
 
-from .audit_trail import AuditTrail
-from .access_control import READ, WRITE, check_permission
-from .unified_event_bus import UnifiedEventBus
-from .governance import evaluate_rules
+try:  # pragma: no cover - import path handling
+    from .audit_trail import AuditTrail
+    from .access_control import READ, WRITE, check_permission
+    from .unified_event_bus import UnifiedEventBus
+    from .governance import evaluate_rules
+except ImportError:  # pragma: no cover - script execution fallback
+    from audit_trail import AuditTrail  # type: ignore
+    from access_control import READ, WRITE, check_permission  # type: ignore
+    from unified_event_bus import UnifiedEventBus  # type: ignore
+    from governance import evaluate_rules  # type: ignore
 
 
 


### PR DESCRIPTION
## Summary
- guard Stripe bootstrap utilities against missing PyYAML, stripe, and other optional dependencies by providing graceful fallbacks and sandbox defaults
- harden audit/governance/rollback/access control modules so they can be imported outside of a package context or without heavy third-party libraries
- relax startup checks to skip bot registry validation when unavailable and rename the sandbox module filter argument for clarity

## Testing
- python scripts/bootstrap_env.py
- python scripts/bootstrap_env.py --skip-stripe-router

------
https://chatgpt.com/codex/tasks/task_e_68de2be71edc832e9c642c9e228cc8da