### PR TITLE
Normalize Windows PATH handling in bootstrap script

### DIFF
--- a/scripts/bootstrap_env.py
+++ b/scripts/bootstrap_env.py
@@ -347,7 +347,7 @@ def _gather_existing_path_entries() -> tuple[list[str], dict[str, str], bool]:
         parts: Iterable[str] = raw_path.split(";")
     else:
         parts = raw_path.split(separator)
-    entries = [entry for entry in parts if entry]
+    entries = [entry.strip() for entry in parts if entry and entry.strip()]
     normalizer = _windows_path_normalizer()
     seen: dict[str, str] = {}
     ordered: list[str] = []

--- a/tests/test_bootstrap_env_windows.py
+++ b/tests/test_bootstrap_env_windows.py
@@ -46,6 +46,26 @@ def test_gather_existing_path_entries_normalizes_duplicates(monkeypatch: pytest.
     assert scripts_entries[0].startswith('"') and scripts_entries[0].endswith('"')
 
 
+def test_gather_existing_path_entries_strips_incidental_whitespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(os, "pathsep", ";")
+    monkeypatch.setattr(bootstrap_env.os, "pathsep", ";")
+    raw_path = " ; ".join(
+        [
+            r"  C:\Tools  ",
+            r'   "C:\Program Files\Python\Scripts"   ',
+            "",  # ensure blanks are ignored
+        ]
+    )
+    monkeypatch.setenv("PATH", raw_path)
+
+    ordered, _, _ = bootstrap_env._gather_existing_path_entries()
+
+    assert all(entry == entry.strip() for entry in ordered)
+    assert ordered[0] == r"C:\Tools"
+
+
 def test_ensure_windows_compatibility_injects_scripts_directory(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- trim incidental whitespace from PATH entries before Windows normalization to avoid propagating malformed directories
- extend the Windows bootstrap tests to cover whitespace handling in PATH entries

## Testing
- pytest tests/test_bootstrap_env.py tests/test_bootstrap_env_windows.py
- python scripts/bootstrap_env.py --skip-stripe-router


------
https://chatgpt.com/codex/tasks/task_e_68de4d236df8832e8b8e4be4db6cc84b