### PR TITLE
Handle cleanup subprocess timeouts and record reasons

### DIFF
--- a/tests/test_failed_cleanup.py
+++ b/tests/test_failed_cleanup.py
@@ -1,7 +1,24 @@
+import importlib
+import importlib.util
+from pathlib import Path
 import json
+import subprocess
+import sys
 import types
 import time
-import sandbox_runner.environment as env
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+spec = importlib.util.spec_from_file_location("dynamic_path_router", ROOT / "dynamic_path_router.py")
+dynamic_path_router = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(dynamic_path_router)  # type: ignore[union-attr]
+sys.modules["dynamic_path_router"] = dynamic_path_router
+
+env = importlib.import_module("menace_sandbox.sandbox_runner.environment")
+sys.modules["sandbox_runner.environment"] = env
 
 class DummyContainer:
     def __init__(self, cid="x"):
@@ -20,17 +37,47 @@ def test_failed_cleanup_record(monkeypatch, tmp_path):
     env._stop_and_remove(c)
     data = json.loads(file.read_text())
     assert list(data.keys()) == ["x"]
+    assert isinstance(data["x"], dict)
+    assert data["x"].get("reason") == ""
 
 
 def test_report_failed_cleanup(monkeypatch, tmp_path, caplog):
     file = tmp_path / "cleanup.json"
     now = time.time() - 120
-    file.write_text(json.dumps({"old": now, "new": time.time()}))
+    file.write_text(
+        json.dumps(
+            {
+                "old": {"ts": now, "reason": "stuck"},
+                "new": {"ts": time.time(), "reason": "fresh"},
+            }
+        )
+    )
     monkeypatch.setattr(env, "FAILED_CLEANUP_FILE", file)
     logs = {}
     monkeypatch.setattr(env, "_log_diagnostic", lambda issue, success: logs.setdefault("called", True))
     caplog.set_level("ERROR")
     res = env.report_failed_cleanup(threshold=60, alert=True)
     assert "old" in res and "new" not in res
+    assert res["old"]["reason"] == "stuck"
     assert logs.get("called")
     assert "failed cleanup items" in caplog.text
+
+
+def test_retry_records_timeout_reason(monkeypatch, tmp_path, caplog):
+    file = tmp_path / "cleanup.json"
+    entry = {"ts": time.time() - 120, "reason": ""}
+    file.write_text(json.dumps({"container:abc": entry}))
+    monkeypatch.setattr(env, "FAILED_CLEANUP_FILE", file)
+
+    def fake_run(cmd, *args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 1))
+
+    monkeypatch.setattr(env.subprocess, "run", fake_run)
+    caplog.set_level("WARNING")
+
+    successes, failures = env.retry_failed_cleanup()
+
+    assert successes == 0 and failures == 1
+    data = json.loads(file.read_text())
+    assert "timeout" in data["container:abc"]["reason"].lower()
+    assert "timed out" in caplog.text


### PR DESCRIPTION
## Summary
- add a configurable timeout for cleanup subprocesses and ensure reconciliation and pruning logic handles TimeoutExpired gracefully
- persist failure reasons for timed out cleanup resources so retry and reporting surfaces the context
- exercise the new timeout handling in the watchdog and failed cleanup unit tests

## Testing
- pytest tests/test_failed_cleanup.py tests/test_cleanup_scheduler.py

------
https://chatgpt.com/codex/tasks/task_e_68def01c17bc832ea899939ea4500be1