### PR TITLE
Add reaper heartbeat updates and watchdog regression test

### DIFF
--- a/sandbox_runner/environment.py
+++ b/sandbox_runner/environment.py
@@ -4211,15 +4211,27 @@ async def _reaper_worker() -> None:
             _update_worker_heartbeat("reaper")
             try:
                 autopurge_if_needed()
+                _update_worker_heartbeat("reaper")
+                await asyncio.sleep(0)
                 reconcile_active_containers()
+                _update_worker_heartbeat("reaper")
+                await asyncio.sleep(0)
             finally:
                 _update_worker_heartbeat("reaper")
             start = time.monotonic()
             try:
                 removed = _reap_orphan_containers()
+                _update_worker_heartbeat("reaper")
+                await asyncio.sleep(0)
                 vm_removed = _purge_stale_vms(record_runtime=True)
+                _update_worker_heartbeat("reaper")
+                await asyncio.sleep(0)
                 vol_removed = _prune_volumes()
+                _update_worker_heartbeat("reaper")
+                await asyncio.sleep(0)
                 net_removed = _prune_networks()
+                _update_worker_heartbeat("reaper")
+                await asyncio.sleep(0)
                 total_removed += removed + vm_removed
                 if removed or vm_removed or vol_removed or net_removed:
                     logger.info(


### PR DESCRIPTION
## Summary
- update the reaper worker to emit interim heartbeats between synchronous maintenance helpers while keeping cleanup duration tracking intact
- preserve logging of resource cleanup totals and continue recording the elapsed cleanup pass duration
- add a watchdog regression test that simulates long-running reaper helpers and ensures heartbeats prevent spurious restarts

## Testing
- pytest tests/test_schedule_cleanup_watchdog.py::test_watchdog_accepts_reaper_midpass_heartbeats

------
https://chatgpt.com/codex/tasks/task_e_68df07549f20832e88aab1aaecd81888