### PR TITLE
Improve cleanup heartbeats and watchdog resilience

### DIFF
--- a/tests/test_cleanup_scheduler.py
+++ b/tests/test_cleanup_scheduler.py
@@ -199,7 +199,7 @@ def test_cleanup_timeout_does_not_stall_watchdog(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr(env, "autopurge_if_needed", lambda: None)
     monkeypatch.setattr(env, "ensure_docker_client", lambda: None)
     monkeypatch.setattr(env, "ensure_cleanup_worker", lambda: None)
-    monkeypatch.setattr(env, "retry_failed_cleanup", lambda: (0, 0))
+    monkeypatch.setattr(env, "retry_failed_cleanup", lambda progress=None: (0, 0))
     monkeypatch.setattr(env, "_cleanup_idle_containers", lambda: (0, 0))
     monkeypatch.setattr(env, "_purge_stale_vms", lambda record_runtime=True: 0)
     monkeypatch.setattr(env, "_PRUNE_VOLUMES", False)

--- a/tests/test_cli_check_resources.py
+++ b/tests/test_cli_check_resources.py
@@ -44,7 +44,7 @@ def purge_leftovers():
     _STALE_VMS_REMOVED += 1
 
 
-def retry_failed_cleanup():
+def retry_failed_cleanup(progress=None):
     with open(os.environ['OUT_FILE'], 'a') as fh:
         fh.write('retry\\n')
 """

--- a/tests/test_cli_cleanup.py
+++ b/tests/test_cli_cleanup.py
@@ -41,7 +41,7 @@ def purge_leftovers():
     with open(os.environ['OUT_FILE'], 'a') as fh:
         fh.write('purge\\n')
 
-def retry_failed_cleanup():
+def retry_failed_cleanup(progress=None):
     with open(os.environ['OUT_FILE'], 'a') as fh:
         fh.write('retry\\n')
 """

--- a/tests/test_cli_system_cleanup.py
+++ b/tests/test_cli_system_cleanup.py
@@ -50,7 +50,7 @@ def purge_leftovers():
         shutil.rmtree(odir)
 
 
-def retry_failed_cleanup():
+def retry_failed_cleanup(progress=None):
     with open(os.environ['OUT_FILE'], 'a') as fh:
         fh.write('retry\\n')
 """

--- a/tests/test_container_pool_cleanup.py
+++ b/tests/test_container_pool_cleanup.py
@@ -166,7 +166,9 @@ def test_cleanup_worker_calls_retry(monkeypatch):
             await task
 
     monkeypatch.setattr(env, "_POOL_CLEANUP_INTERVAL", 0.01)
-    monkeypatch.setattr(env, "retry_failed_cleanup", lambda: called.append(True) or (0, 0))
+    monkeypatch.setattr(
+        env, "retry_failed_cleanup", lambda progress=None: called.append(True) or (0, 0)
+    )
     monkeypatch.setattr(env, "_cleanup_idle_containers", lambda: (0, 0))
     monkeypatch.setattr(env, "_purge_stale_vms", lambda record_runtime=True: 0)
 

--- a/unit_tests/test_environment_docker_ps_failure.py
+++ b/unit_tests/test_environment_docker_ps_failure.py
@@ -55,8 +55,8 @@ def test_docker_ps_failure_logged(monkeypatch):
     monkeypatch.setattr(env, "cancel_cleanup_check", lambda: None)
     monkeypatch.setattr(env, "_WARMUP_TASKS", {})
     monkeypatch.setattr(env, "_DOCKER_CLIENT", None)
-    monkeypatch.setattr(env, "_prune_volumes", lambda: 0)
-    monkeypatch.setattr(env, "_prune_networks", lambda: 0)
+    monkeypatch.setattr(env, "_prune_volumes", lambda progress=None: 0)
+    monkeypatch.setattr(env, "_prune_networks", lambda progress=None: 0)
     monkeypatch.setattr(env, "_release_pool_lock", lambda: None)
     monkeypatch.setattr(env, "_POOL_FILE_LOCK", types.SimpleNamespace(acquire=lambda: None))
 


### PR DESCRIPTION
## Summary
- emit progress callbacks throughout cleanup and reaper helpers so heartbeats update during long Docker operations
- record per-worker activity and runtime to let the watchdog use adaptive timeouts with an environment-configurable margin
- refresh cleanup-related tests to exercise the new progress hooks and updated scheduling logic

## Testing
- pytest tests/test_schedule_cleanup_watchdog.py -q

------
https://chatgpt.com/codex/tasks/task_e_68df0d946750832e9c1911ee747dda28