### PR TITLE
Harden docker client recovery

### DIFF
--- a/tests/test_ensure_docker_client.py
+++ b/tests/test_ensure_docker_client.py
@@ -1,44 +1,116 @@
-import types
-import sandbox_runner.environment as env
+import ast
+from pathlib import Path
+
+
+class DummyLogger:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str]] = []
+
+    def info(self, msg, *args, **kwargs):
+        self.messages.append(("info", msg % args if args else msg))
+
+    def warning(self, msg, *args, **kwargs):
+        self.messages.append(("warning", msg % args if args else msg))
+
+    def error(self, msg, *args, **kwargs):
+        self.messages.append(("error", msg % args if args else msg))
+
+    def debug(self, msg, *args, **kwargs):
+        self.messages.append(("debug", msg % args if args else msg))
+
+
+class EnvProxy:
+    def __init__(self, namespace: dict[str, object]) -> None:
+        super().__setattr__("_ns", namespace)
+
+    def __getattr__(self, name: str):
+        try:
+            return self._ns[name]
+        except KeyError as exc:  # pragma: no cover - diagnostic aid
+            raise AttributeError(name) from exc
+
+    def __setattr__(self, name: str, value: object) -> None:
+        self._ns[name] = value
+
+
+def _load_env_subset() -> EnvProxy:
+    path = Path(__file__).resolve().parents[1] / "sandbox_runner" / "environment.py"
+    tree = ast.parse(path.read_text(encoding="utf8"))
+    ensure_node = None
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "ensure_docker_client":
+            ensure_node = node
+            break
+    if ensure_node is None:  # pragma: no cover - guard against refactor
+        raise AssertionError("ensure_docker_client not found")
+
+    subset = ast.Module(body=[ensure_node], type_ignores=[])
+    code = compile(subset, str(path), "exec")
+
+    logger = DummyLogger()
+    namespace: dict[str, object] = {
+        "docker": object(),
+        "DockerException": Exception,
+        "logger": logger,
+        "_fallback_logger": lambda: logger,
+        "_DOCKER_CLIENT": None,
+        "_DOCKER_PING_TIMEOUT": 1.0,
+        "_close_docker_client": lambda client: None,
+        "_create_docker_client": lambda: (None, None),
+        "_ping_docker": lambda client, timeout=None: (True, None),
+        "_suspend_cleanup_workers": lambda reason=None: None,
+    }
+    exec(code, namespace)
+    env = EnvProxy(namespace)
+    env.logger = logger
+    return env
 
 
 def test_reconnect_when_ping_fails(monkeypatch):
     class DummyErr(Exception):
         pass
 
-    class BadClient:
-        def ping(self):
-            raise DummyErr('boom')
+    env = _load_env_subset()
+    good = object()
+    env._DOCKER_CLIENT = object()
 
-    class GoodClient:
-        def __init__(self):
-            self.ping_called = 0
-        def ping(self):
-            self.ping_called += 1
-
-    good = GoodClient()
-
-    docker_mod = types.SimpleNamespace(from_env=lambda: good)
-    monkeypatch.setattr(env, 'docker', docker_mod)
-    monkeypatch.setattr(env, 'DockerException', DummyErr)
-    env._DOCKER_CLIENT = BadClient()
+    monkeypatch.setattr(
+        env,
+        "_ping_docker",
+        lambda client, timeout=None: (False, DummyErr("boom")),
+        raising=False,
+    )
+    monkeypatch.setattr(env, "_create_docker_client", lambda: (good, None), raising=False)
+    suspended: list[str | None] = []
+    monkeypatch.setattr(
+        env,
+        "_suspend_cleanup_workers",
+        lambda reason=None: suspended.append(reason),
+        raising=False,
+    )
 
     env.ensure_docker_client()
+
     assert env._DOCKER_CLIENT is good
-    assert good.ping_called == 1
+    assert not suspended
 
 
 def test_no_reconnect_when_ping_ok(monkeypatch):
-    class DummyClient:
-        def __init__(self):
-            self.ping_called = 0
-        def ping(self):
-            self.ping_called += 1
-
-    client = DummyClient()
+    env = _load_env_subset()
+    client = object()
     env._DOCKER_CLIENT = client
-    monkeypatch.setattr(env, 'docker', types.SimpleNamespace(from_env=lambda: None))
+
+    monkeypatch.setattr(
+        env,
+        "_ping_docker",
+        lambda client, timeout=None: (True, None),
+        raising=False,
+    )
+
+    called = []
+    monkeypatch.setattr(env, "_create_docker_client", lambda: called.append(True), raising=False)
 
     env.ensure_docker_client()
+
     assert env._DOCKER_CLIENT is client
-    assert client.ping_called == 1
+    assert not called


### PR DESCRIPTION
## Summary
- add bounded timeouts and safe ping helpers for docker client creation
- suspend cleanup workers when docker becomes unavailable and improve logging
- refresh docker client reconnection unit tests using an AST-loaded subset

## Testing
- python scripts/bootstrap_env.py --skip-stripe-router
- pytest tests/test_ensure_docker_client.py tests/test_schedule_cleanup_watchdog.py


------
https://chatgpt.com/codex/tasks/task_e_68df1cea5c20832e819e3ce8ae5fe94b