### PR TITLE
Improve docker cleanup heartbeat resilience

### DIFF
--- a/tests/test_purge_leftovers_reporting.py
+++ b/tests/test_purge_leftovers_reporting.py
@@ -1,6 +1,22 @@
 import json
+import sys
 import types
-import sandbox_runner.environment as env
+import importlib.util
+import importlib.machinery
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("sandbox_runner")
+pkg.__path__ = [str(ROOT / "sandbox_runner")]
+pkg.__spec__ = importlib.machinery.ModuleSpec("sandbox_runner", loader=None, is_package=True)
+sys.modules["sandbox_runner"] = pkg
+
+_ENV_PATH = ROOT / "sandbox_runner" / "environment.py"
+_SPEC = importlib.util.spec_from_file_location("sandbox_runner.environment", _ENV_PATH)
+env = importlib.util.module_from_spec(_SPEC)
+sys.modules["sandbox_runner.environment"] = env
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(env)
 
 class DummyLock:
     def __enter__(self):

--- a/tests/test_schedule_cleanup_watchdog.py
+++ b/tests/test_schedule_cleanup_watchdog.py
@@ -4,6 +4,7 @@ import threading
 import time
 import types
 from collections import Counter
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Callable
 
@@ -114,6 +115,11 @@ def env():
     ns = _load_environment_subset()
     logger = DummyLogger()
     ns["logger"] = logger
+    @contextmanager
+    def _noop_scope(callback):
+        yield
+
+    ns["_progress_scope"] = _noop_scope
     ns["_get_metrics_module"] = lambda: types.SimpleNamespace(
         cleanup_heartbeat_gauge=GaugeStub(), cleanup_duration_gauge=GaugeStub()
     )


### PR DESCRIPTION
## Summary
- add a heartbeat-aware subprocess wrapper and progress scope so docker cleanup commands keep watchdog timestamps up to date
- route cleanup workers and synchronous maintenance routines through the new helper to avoid false "worker stalled" warnings
- extend watchdog-related tests with the new progress scope stub and load the real environment module for purge leftovers coverage

## Testing
- python scripts/bootstrap_env.py --skip-stripe-router
- pytest tests/test_schedule_cleanup_watchdog.py -q
- pytest tests/test_purge_leftovers_reporting.py -q *(fails: ImportError: cannot import name 'repo_root' from '<unknown module name>')*


------
https://chatgpt.com/codex/tasks/task_e_68df1fd9876c832e8778a51d54fe2b2e