### PR TITLE
Disable sandbox cleanup automation during bootstrap

### DIFF
--- a/scripts/bootstrap_env.py
+++ b/scripts/bootstrap_env.py
@@ -559,6 +559,7 @@ def _prepare_environment(config: BootstrapConfig) -> Path | None:
     overrides: dict[str, str] = {
         "MENACE_SAFE": "0",
         "MENACE_SUPPRESS_PROMETHEUS_FALLBACK_NOTICE": "1",
+        "SANDBOX_DISABLE_CLEANUP": "1",
     }
     if config.skip_stripe_router:
         overrides["MENACE_SKIP_STRIPE_ROUTER"] = "1"


### PR DESCRIPTION
## Summary
- add an environment flag helper and gate the sandbox cleanup/watchdog routines when SANDBOX_DISABLE_CLEANUP is set, including informative one-time logging
- ensure the bootstrap environment script disables cleanup automation so Docker workers are not spawned during setup
- extend the watchdog unit tests to support the new flag and verify the short-circuit behaviour

## Testing
- pytest tests/test_schedule_cleanup_watchdog.py::test_cleanup_disabled_short_circuits


------
https://chatgpt.com/codex/tasks/task_e_68df2e8317f0832e8d8b6658efbbb134