### PR TITLE
Enhance Docker worker warning handling in bootstrap diagnostics

### DIFF
--- a/tests/test_bootstrap_env.py
+++ b/tests/test_bootstrap_env.py
@@ -153,6 +153,16 @@ def test_extract_json_document_tolerates_prefixed_warnings() -> None:
     assert metadata.get("docker_worker_health") == "flapping"
 
 
+def test_normalise_docker_warning_handles_worker_stall_variants() -> None:
+    message = "WARNING[0012]: worker stalled; restarting (background-sync)"
+    cleaned, metadata = bootstrap_env._normalise_docker_warning(message)
+
+    assert "docker desktop reported" in cleaned.lower()
+    assert cleaned.lower().endswith("background-sync.")
+    assert metadata["docker_worker_health"] == "flapping"
+    assert metadata["docker_worker_context"] == "background-sync"
+
+
 def test_parse_docker_json_surfaces_non_json_output() -> None:
     completed = subprocess.CompletedProcess(
         ["docker", "info"],


### PR DESCRIPTION
## Summary
- normalize Docker warning prefixes that include numeric identifiers (e.g. `WARNING[0012]:`)
- extract context from worker restart warnings and enrich diagnostic metadata and messaging
- add regression coverage for worker stall warning variants in bootstrap diagnostics

## Testing
- `pytest tests/test_bootstrap_env.py -k warning -q`
- `python scripts/bootstrap_env.py --skip-stripe-router`


------
https://chatgpt.com/codex/tasks/task_e_68df40e695d8832e87e7f6597353a660