### PR TITLE
Improve Docker warning parsing for Windows worker stalls

### DIFF
--- a/tests/test_bootstrap_env.py
+++ b/tests/test_bootstrap_env.py
@@ -245,6 +245,22 @@ def test_normalise_docker_warning_detects_implied_backoff_interval() -> None:
     assert "30s" in cleaned
 
 
+def test_normalise_docker_warning_handles_bracketed_context_and_retry_tokens() -> None:
+    message = (
+        "WARN[0030] [background-sync] worker stalled; restarting; "
+        "retry_count=4 nextRetry=45s lastError=\"i/o timeout\""
+    )
+
+    cleaned, metadata = bootstrap_env._normalise_docker_warning(message)
+
+    assert "docker desktop reported" in cleaned.lower()
+    assert "worker stalled" not in cleaned.lower()
+    assert metadata["docker_worker_context"] == "background-sync"
+    assert metadata["docker_worker_restart_count"] == "4"
+    assert metadata["docker_worker_backoff"] == "45s"
+    assert metadata["docker_worker_last_error"] == "i/o timeout"
+
+
 def test_parse_wsl_distribution_table_handles_complex_rows() -> None:
     payload = (
         "  NAME                   STATE           VERSION\n"


### PR DESCRIPTION
## Summary
- expand Docker warning normalization to cover additional worker stall log formats, including bracketed contexts and extended metadata keys
- classify worker telemetry keys using semantic categories to capture restart, backoff, error, and last-seen details more reliably
- add regression coverage for bracketed BuildKit warnings to ensure "worker stalled" lines are rewritten into actionable guidance

## Testing
- pytest tests/test_bootstrap_env.py -k docker -q


------
https://chatgpt.com/codex/tasks/task_e_68df4d954cdc832ebf6e20efd09d7152