### PR TITLE
Handle ANSI encoded Docker warnings in bootstrap diagnostics

### DIFF
--- a/tests/test_bootstrap_env.py
+++ b/tests/test_bootstrap_env.py
@@ -218,6 +218,16 @@ def test_normalise_docker_warning_extracts_subsystem_context() -> None:
     assert metadata["docker_worker_context"] == "background sync"
 
 
+def test_normalise_docker_warning_strips_ansi_sequences() -> None:
+    message = "\x1b[33mWARN[0032] moby/buildkit: worker stalled; restarting\x1b[0m"
+
+    cleaned, metadata = bootstrap_env._normalise_docker_warning(message)
+
+    assert "docker desktop reported" in cleaned.lower()
+    assert metadata["docker_worker_health"] == "flapping"
+    assert metadata["docker_worker_context"] == "moby/buildkit"
+
+
 def test_normalise_docker_warning_enriches_restart_metadata() -> None:
     message = (
         "time=\"2024-05-05T00:01:02Z\" level=warning msg=\"worker stalled; restarting\" "


### PR DESCRIPTION
## Summary
- strip ANSI escape sequences and non-printable control characters from docker warnings before normalization
- ensure bootstrap_env treats cleaned warnings consistently with added unit coverage for ANSI encoded worker restart messages

## Testing
- pytest tests/test_bootstrap_env.py -q
- python scripts/bootstrap_env.py --skip-stripe-router

------
https://chatgpt.com/codex/tasks/task_e_68df4fd4e438832e81975616b3566957