### PR TITLE
Improve Docker worker context parsing for Docker Desktop warnings

### DIFF
--- a/tests/test_bootstrap_env.py
+++ b/tests/test_bootstrap_env.py
@@ -248,6 +248,20 @@ def test_normalise_docker_warning_extracts_subsystem_context() -> None:
     assert metadata["docker_worker_context"] == "background sync"
 
 
+def test_normalise_docker_warning_extracts_camel_case_context() -> None:
+    message = (
+        'warning: worker stalled; restarting componentName="vpnkitCore" '
+        'restartCount=3 lastError="worker stalled; restarting"'
+    )
+
+    cleaned, metadata = bootstrap_env._normalise_docker_warning(message)
+
+    assert "worker stalled" not in cleaned.lower()
+    assert metadata["docker_worker_context"] == "vpnkitCore"
+    assert metadata["docker_worker_restart_count"] == "3"
+    assert metadata["docker_worker_last_error_code"] == "stalled_restart"
+
+
 def test_worker_restart_telemetry_from_metadata_collates_samples() -> None:
     metadata = {
         "docker_worker_context": "desktop-linux",


### PR DESCRIPTION
## Summary
- expand worker context key detection to support camelCase metadata emitted by Docker Desktop on Windows
- adjust worker context weighting so subsystem telemetry outranks scope-only hints when present
- add a regression test covering camelCase worker warning payloads

## Testing
- `pytest tests/test_bootstrap_env.py -q`
- `pytest tests/test_bootstrap_env_docker.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68df81a8f768832ebea5755b1c26f28a