### PR TITLE
Improve Docker worker warning sanitisation

### DIFF
--- a/tests/test_bootstrap_env.py
+++ b/tests/test_bootstrap_env.py
@@ -638,7 +638,10 @@ def test_normalise_docker_warning_masks_worker_restart_error_banner() -> None:
     assert metadata["docker_worker_last_error_original"] == (
         "Docker Desktop automatically restarted a background worker after it stalled"
     )
-    assert metadata["docker_worker_last_error_raw"] == "worker stalled; restarting"
+    assert metadata["docker_worker_last_error_raw"] == (
+        "Docker Desktop automatically restarted a background worker after it stalled"
+    )
+    assert metadata["docker_worker_last_error_banner"] == "worker stalled; restarting"
 
 
 def test_normalise_docker_warning_handles_has_stalled_phrase() -> None:


### PR DESCRIPTION
## Summary
- normalise Docker worker warning banners into structured metadata while preserving the original banner separately
- extend the worker warning aggregator and telemetry helpers to propagate the cleaned banner metadata
- update unit coverage to assert the sanitised warning payload and new metadata field

## Testing
- pytest tests/test_bootstrap_env.py -q
- pytest tests/test_bootstrap_env_docker.py -q
- python scripts/bootstrap_env.py --skip-stripe-router

------
https://chatgpt.com/codex/tasks/task_e_68df8726890c832e97c4558b2a4c5b70