### PR TITLE
Improve Docker warning sanitization and metadata in bootstrap script

### DIFF
--- a/tests/test_bootstrap_env.py
+++ b/tests/test_bootstrap_env.py
@@ -641,7 +641,11 @@ def test_normalise_docker_warning_masks_worker_restart_error_banner() -> None:
     assert metadata["docker_worker_last_error_raw"] == (
         "Docker Desktop automatically restarted a background worker after it stalled"
     )
-    assert metadata["docker_worker_last_error_banner"] == "worker stalled; restarting"
+    assert (
+        metadata["docker_worker_last_error_banner"]
+        == "Docker Desktop automatically restarted a background worker after it stalled"
+    )
+    assert metadata["docker_worker_last_error_banner_raw"] == "worker stalled; restarting"
 
 
 def test_normalise_docker_warning_extracts_last_error_code() -> None:


### PR DESCRIPTION
## Summary
- normalize Docker "worker stalled" warnings to surface descriptive guidance while keeping raw text separate
- extend worker restart aggregation to capture sanitized and raw banner telemetry for downstream diagnostics
- update unit tests to reflect the richer metadata structure

## Testing
- pytest tests/test_bootstrap_env.py tests/test_bootstrap_env_docker.py

------
https://chatgpt.com/codex/tasks/task_e_68df8b774588832eac136fb0f439835a