### PR TITLE
Improve Docker worker context extraction

### DIFF
--- a/tests/test_bootstrap_env.py
+++ b/tests/test_bootstrap_env.py
@@ -285,6 +285,19 @@ def test_normalise_docker_warning_handles_bracketed_inline_context() -> None:
     assert metadata["docker_worker_context"] == "vpnkit-core"
 
 
+def test_normalise_docker_warning_extracts_context_without_delimiter() -> None:
+    message = (
+        "vpnkit background sync worker stalled; restarting in 45s due to IO pressure"
+    )
+
+    cleaned, metadata = bootstrap_env._normalise_docker_warning(message)
+
+    assert "worker stalled" not in cleaned.lower()
+    assert metadata["docker_worker_context"] == "vpnkit background sync"
+    assert metadata["docker_worker_backoff"] == "45s"
+    assert metadata["docker_worker_last_error"] == "IO pressure"
+
+
 def test_worker_restart_telemetry_from_metadata_collates_samples() -> None:
     metadata = {
         "docker_worker_context": "desktop-linux",


### PR DESCRIPTION
## Summary
- extend the Docker warning parser to recognise context names that precede "worker stalled" without a delimiter
- harden context normalisation by stripping stopwords and discarding meaningless candidates so Windows diagnostics stay readable
- add regression coverage for the new warning variant to prevent reintroducing the "worker stalled; restarting" banner in summaries

## Testing
- python scripts/bootstrap_env.py --skip-stripe-router
- pytest tests/test_bootstrap_env.py -k docker --maxfail=1


------
https://chatgpt.com/codex/tasks/task_e_68df8db9953c832eb1cddd2c52ac99b9