### PR TITLE
Normalize worker stall Docker diagnostics

### DIFF
--- a/tests/test_bootstrap_env.py
+++ b/tests/test_bootstrap_env.py
@@ -298,6 +298,23 @@ def test_normalise_docker_warning_extracts_context_without_delimiter() -> None:
     assert metadata["docker_worker_last_error"] == "IO pressure"
 
 
+def test_normalise_docker_warning_handles_worker_stall_detected_variant() -> None:
+    """Variants such as ``worker stall detected`` should be normalised cleanly."""
+
+    message = (
+        "WARNING: worker stall detected; restarting component=\"vpnkit\" "
+        "restartCount=3"
+    )
+
+    cleaned, metadata = bootstrap_env._normalise_docker_warning(message)
+
+    assert cleaned
+    assert "worker stall detected" not in cleaned.lower()
+    assert metadata["docker_worker_health"] == "flapping"
+    assert metadata["docker_worker_context"] == "vpnkit"
+    assert metadata["docker_worker_restart_count"] == "3"
+
+
 def test_worker_restart_telemetry_from_metadata_collates_samples() -> None:
     metadata = {
         "docker_worker_context": "desktop-linux",


### PR DESCRIPTION
## Summary
- harmonize Docker worker "stall" banner variants so they are rewritten into actionable guidance
- add regression tests covering raw and structured "worker stall detected; restarting" payloads

## Testing
- pytest tests/test_bootstrap_env.py::test_normalise_docker_warning_handles_worker_stall_detected_variant
- pytest tests/test_bootstrap_env_docker.py::test_normalize_warnings_handles_worker_stall_detected_banner

------
https://chatgpt.com/codex/tasks/task_e_68dfa4fbf58c832e93339875f9bef003