### PR TITLE
Add structured Docker worker health summary metadata

### DIFF
--- a/scripts/bootstrap_env.py
+++ b/scripts/bootstrap_env.py
@@ -4576,6 +4576,9 @@ def _post_process_docker_health(
     additional_metadata: dict[str, str] = {
         "docker_worker_health_severity": assessment.severity,
     }
+    summary = assessment.render()
+    if summary:
+        additional_metadata["docker_worker_health_summary"] = summary
     if assessment.reasons:
         additional_metadata["docker_worker_health_reasons"] = "; ".join(
             assessment.reasons
@@ -4596,7 +4599,8 @@ def _post_process_docker_health(
         virtualization_metadata.update(vw_metadata)
 
     if assessment.severity == "warning":
-        warnings.append(assessment.render())
+        if summary:
+            warnings.append(summary)
         if virtualization_warnings:
             warnings.extend(virtualization_warnings)
         if virtualization_errors:
@@ -4608,7 +4612,8 @@ def _post_process_docker_health(
             additional_metadata.update(virtualization_metadata)
         return warnings, errors, additional_metadata
 
-    errors.append(assessment.render())
+    if summary:
+        errors.append(summary)
 
     if virtualization_warnings:
         warnings.extend(virtualization_warnings)

--- a/tests/test_bootstrap_env_docker.py
+++ b/tests/test_bootstrap_env_docker.py
@@ -68,6 +68,10 @@ def test_post_process_virtualization_insights_for_warning(monkeypatch: pytest.Mo
     assert metadata["docker_worker_health_severity"] == "warning"
     assert "docker_worker_health_reasons" not in metadata
     assert metadata["wsl_default_version"] == "1"
+    summary = metadata["docker_worker_health_summary"]
+    assert summary
+    assert "worker stalled" not in summary.lower()
+    assert summary in warnings
 
 
 def test_post_process_virtualization_insights_for_error(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -102,6 +106,10 @@ def test_post_process_virtualization_insights_for_error(monkeypatch: pytest.Monk
     reasons = metadata["docker_worker_health_reasons"]
     assert "six worker restarts" in reasons
     assert metadata["wsl_integration"] == "disabled"
+    summary = metadata["docker_worker_health_summary"]
+    assert summary
+    assert "worker stalled" not in summary.lower()
+    assert summary in errors
 
 
 def test_worker_error_code_guidance_enriches_classification() -> None:


### PR DESCRIPTION
## Summary
- capture the rendered Docker worker health assessment as metadata and reuse it for warning/error logs
- ensure virtualization diagnostics still augment metadata without reintroducing the raw "worker stalled" banner
- extend Docker bootstrap tests to assert the new summary metadata for both warning and error scenarios

## Testing
- python scripts/bootstrap_env.py --skip-stripe-router
- pytest tests/test_bootstrap_env_docker.py

------
https://chatgpt.com/codex/tasks/task_e_68dfa72c1370832e981211e95f40192a