### PR TITLE
Fix bootstrap worker context regex initialisation

### DIFF
--- a/scripts/bootstrap_env.py
+++ b/scripts/bootstrap_env.py
@@ -1850,11 +1850,7 @@ _WORKER_CONTEXT_DURATION_PATTERN = re.compile(
     flags=re.IGNORECASE,
 )
 
-_WORKER_CONTEXT_KEY_PATTERN = (
-    r"(?P<key>(?:"
-    + "|".join(_WORKER_CONTEXT_BASE_KEYS)
-    + r")(?:(?:[._-][A-Za-z0-9]+)|(?:[A-Z][a-z0-9]+)|(?:\d+))*")
-)
+_WORKER_CONTEXT_KEY_PATTERN = rf"(?P<key>(?:{'|'.join(_WORKER_CONTEXT_BASE_KEYS)})(?:(?:[._-][A-Za-z0-9]+)|(?:[A-Z][a-z0-9]+)|(?:\d+))*)"
 
 _WORKER_CONTEXT_KV_PATTERN = re.compile(
     rf"{_WORKER_CONTEXT_KEY_PATTERN}\s*(?:=|:)\s*(?P<value>{_WORKER_VALUE_PATTERN})",


### PR DESCRIPTION
## Summary
- fix the worker metadata context regex construction so bootstrap_env.py parses correctly

## Testing
- python scripts/bootstrap_env.py --skip-stripe-router

------
https://chatgpt.com/codex/tasks/task_e_68e041a6f4b0832eb276e51442cd0ddc