### PR TITLE
Normalize Docker worker stall detection warnings

### DIFF
--- a/scripts/bootstrap_env.py
+++ b/scripts/bootstrap_env.py
@@ -1826,9 +1826,15 @@ def _normalise_worker_stalled_phrase(message: str) -> str:
     return _WORKER_STALLED_VARIATIONS_PATTERN.sub("worker stalled", normalized)
 
 
-_WORKER_STALL_CANONICALISERS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"\bworker[\s_-]+stall(?!ed)\b", re.IGNORECASE),
-    re.compile(r"\bworker[\s_-]+stalling\b", re.IGNORECASE),
+_WORKER_STALL_CANONICALISERS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\bworker[\s_-]+stall(?!ed)\b", re.IGNORECASE), "worker stalled"),
+    (re.compile(r"\bworker[\s_-]+stalling\b", re.IGNORECASE), "worker stalled"),
+)
+
+
+_WORKER_STALLED_DETECTION_PATTERN = re.compile(
+    r"(\bworker\s+stalled)(?:\s+(?:has|have|had|is|are|was|were)\s+(?:been\s+)?)?\s+(?:detected|detection)\b",
+    re.IGNORECASE,
 )
 
 
@@ -1858,8 +1864,10 @@ def _canonicalize_worker_stall_tokens(message: str) -> str:
         return message
 
     canonical = message
-    for pattern in _WORKER_STALL_CANONICALISERS:
-        canonical = pattern.sub("worker stalled", canonical)
+    for pattern, replacement in _WORKER_STALL_CANONICALISERS:
+        canonical = pattern.sub(replacement, canonical)
+
+    canonical = _WORKER_STALLED_DETECTION_PATTERN.sub(r"\1", canonical)
 
     return canonical
 

--- a/tests/test_bootstrap_env_docker.py
+++ b/tests/test_bootstrap_env_docker.py
@@ -498,3 +498,18 @@ def test_worker_context_extraction_ignores_backoff_tokens() -> None:
     assert cleaned
     assert metadata["docker_worker_backoff"] == "45s"
     assert "docker_worker_context" not in metadata
+
+
+def test_worker_stall_detected_variant_is_normalised() -> None:
+    """Windows stall detection banners should be collapsed into canonical phrasing."""
+
+    message = (
+        "WARNING: worker stall detected; restarting due to virtualization pressure"
+    )
+
+    cleaned, metadata = bootstrap_env._normalise_docker_warning(message)
+
+    assert cleaned
+    assert "worker stall detected" not in cleaned.lower()
+    assert "worker stalled; restarting" not in cleaned.lower()
+    assert metadata["docker_worker_health"] == "flapping"


### PR DESCRIPTION
## Summary
- expand Docker worker stall canonicalisation to collapse "worker stall detected" banners into the standard wording
- add regression coverage ensuring Windows stall detection messages are scrubbed from bootstrap diagnostics

## Testing
- pytest tests/test_bootstrap_env_docker.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e049eb1880832eb975ce56c3d1ff23