### PR TITLE
Normalize Docker worker backoff ISO durations

### DIFF
--- a/tests/test_bootstrap_env.py
+++ b/tests/test_bootstrap_env.py
@@ -627,6 +627,20 @@ def test_normalise_docker_warning_handles_clock_style_backoff() -> None:
     assert "worker stalled" not in cleaned.lower()
 
 
+def test_normalise_docker_warning_handles_iso_duration_backoff() -> None:
+    message = (
+        "WARNING: worker stalled; restarting backoff=\"PT1H2M3.5S\" "
+        "lastError=\"io pressure\""
+    )
+
+    cleaned, metadata = bootstrap_env._normalise_docker_warning(message)
+
+    assert metadata["docker_worker_backoff"] == "1h 2m 3.5s"
+    assert metadata["docker_worker_last_error"] == "io pressure"
+    assert "1h 2m 3.5s" in cleaned
+    assert "worker stalled" not in cleaned.lower()
+
+
 def test_normalise_docker_warning_handles_multiplier_and_due_to_reason() -> None:
     message = (
         "WARN[0042] moby/buildkit: worker stalled; restarting (x3 over ~45s) due to network jitter"

--- a/tests/test_bootstrap_env_docker.py
+++ b/tests/test_bootstrap_env_docker.py
@@ -310,7 +310,7 @@ def test_worker_flapping_metadata_enrichment_handles_structured_payload() -> Non
     assert metadata["docker_worker_health"] == "flapping"
     assert metadata["docker_worker_context"] == "vpnkit"
     assert metadata["docker_worker_restart_count"] == "7"
-    assert metadata["docker_worker_backoff"].lower().startswith("pt45")
+    assert metadata["docker_worker_backoff"] == "45s"
     assert metadata["docker_worker_last_error"].lower().startswith("context deadline")
     assert metadata["docker_worker_last_restart"] == "2024-05-01T10:15:00Z"
 
@@ -330,6 +330,20 @@ def test_worker_warning_parenthetical_metadata_is_normalised() -> None:
     assert metadata["docker_worker_backoff"] == "5s"
     assert metadata["docker_worker_last_error"] == "EOF"
     assert metadata["docker_worker_last_error_raw"] == "EOF)"
+
+
+def test_normalize_warning_collection_parses_iso_backoff_metadata() -> None:
+    """ISO-8601 backoff tokens should be normalised to human readable durations."""
+
+    warnings = [
+        "WARNING: worker stalled; restarting backoff=\"PT45S\" restartCount=2"
+    ]
+
+    normalized, metadata = bootstrap_env._normalize_warning_collection(warnings)
+
+    assert normalized and "worker stalled" not in normalized[0].lower()
+    assert metadata["docker_worker_backoff"] == "45s"
+    assert metadata["docker_worker_restart_count"] == "2"
 
 
 def test_normalize_warnings_interprets_mapping_components() -> None:


### PR DESCRIPTION
## Summary
- add ISO-8601 duration parsing so Docker worker backoff metadata is rendered in human-friendly units
- extend Docker bootstrap warning normalisation to expose the new parsing utility and cover it with regression tests

## Testing
- pytest tests/test_bootstrap_env.py tests/test_bootstrap_env_docker.py -q
- python scripts/bootstrap_env.py --skip-stripe-router

------
https://chatgpt.com/codex/tasks/task_e_68e04bbaec6c832e84ebe0bfaba1f509