### PR TITLE
Sanitize Docker worker context parsing

### DIFF
--- a/scripts/bootstrap_env.py
+++ b/scripts/bootstrap_env.py
@@ -2009,6 +2009,10 @@ _WORKER_CONTEXT_NOISE_TOKENS = {
     "attemptcounts",
     "wait",
     "waiting",
+    "code",
+    "codes",
+    "errcode",
+    "errorcode",
 }
 
 _WORKER_CONTEXT_NOISE_LEADING = {"next", "pending", "upcoming", "future"}
@@ -2942,7 +2946,8 @@ def _normalize_worker_context_candidate(candidate: str | None) -> str | None:
         return None
     if lowered_normalized.startswith("in ") and any(char.isdigit() for char in normalized):
         return None
-    if "code" in lowered_normalized and "=" in normalized:
+    separators = {"=", ":"}
+    if "code" in lowered_normalized and any(sep in normalized for sep in separators):
         return None
     if lowered_normalized.startswith("errcode"):
         return None

--- a/tests/test_bootstrap_env_docker.py
+++ b/tests/test_bootstrap_env_docker.py
@@ -591,6 +591,19 @@ def test_worker_context_extraction_ignores_backoff_tokens() -> None:
     assert "docker_worker_context" not in metadata
 
 
+def test_worker_context_extraction_ignores_errcode_colon_delimiter() -> None:
+    """Colon-delimited ``errCode`` metadata should not leak into the context."""
+
+    message = "WARNING: worker stalled; restarting errCode:WSL_VM_PAUSED"
+
+    cleaned, metadata = bootstrap_env._normalise_docker_warning(message)
+
+    assert cleaned
+    assert "Code:" not in cleaned
+    assert metadata["docker_worker_last_error_code"] == "WSL_VM_PAUSED"
+    assert "docker_worker_context" not in metadata
+
+
 def test_worker_stall_detected_variant_is_normalised() -> None:
     """Windows stall detection banners should be collapsed into canonical phrasing."""
 


### PR DESCRIPTION
## Summary
- treat colon-delimited errCode fields as metadata when normalising Docker worker stall warnings
- expand worker context noise heuristics so errCode tokens no longer surface as affected component names
- add regression coverage ensuring colon-delimited errCode payloads stay clean and preserve structured metadata

## Testing
- pytest tests/test_bootstrap_env_docker.py -q
- pytest tests/test_bootstrap_env.py -q
- python scripts/bootstrap_env.py --skip-stripe-router


------
https://chatgpt.com/codex/tasks/task_e_68e054baca58832e9e31c8c17998f4c3