### PR TITLE
Normalize Docker "worker stalls" banner into actionable guidance

### DIFF
--- a/scripts/bootstrap_env.py
+++ b/scripts/bootstrap_env.py
@@ -1882,6 +1882,7 @@ def _normalise_worker_stalled_phrase(message: str) -> str:
 _WORKER_STALL_CANONICALISERS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"\bworker[\s_-]+stall(?!ed)\b", re.IGNORECASE), "worker stalled"),
     (re.compile(r"\bworker[\s_-]+stalling\b", re.IGNORECASE), "worker stalled"),
+    (re.compile(r"\bworker[\s_-]+stalls\b", re.IGNORECASE), "worker stalled"),
 )
 
 

--- a/tests/test_bootstrap_env_docker.py
+++ b/tests/test_bootstrap_env_docker.py
@@ -69,6 +69,22 @@ def test_parenthetical_plural_worker_banner_is_normalised() -> None:
     assert metadata["docker_worker_context"] == "vpnkit"
 
 
+def test_worker_stalls_variant_is_normalised() -> None:
+    """``worker stalls`` (present tense) banners should be harmonised."""
+
+    message = (
+        "WARNING: worker stalls; restarting component=\"vpnkit\" restartCount=5"
+    )
+
+    cleaned, metadata = bootstrap_env._normalise_docker_warning(message)
+
+    assert cleaned
+    assert "worker stalls" not in cleaned.lower()
+    assert metadata["docker_worker_health"] == "flapping"
+    assert metadata["docker_worker_restart_count"] == "5"
+    assert metadata["docker_worker_context"] == "vpnkit"
+
+
 def test_worker_has_stalled_phrase_is_sanitized() -> None:
     """Phrases like ``worker has stalled`` should be harmonised into guidance."""
 


### PR DESCRIPTION
## Summary
- canonicalize Docker Desktop warnings that emit "worker stalls" so they are rewritten into the existing worker-flapping guidance
- extend the Docker bootstrap test suite to cover the new warning variant and assert metadata enrichment

## Testing
- pytest tests/test_bootstrap_env_docker.py -k "worker" -q

------
https://chatgpt.com/codex/tasks/task_e_68e057bb9288832ea4db7560b67d2ce9