### PR TITLE
Sanitize Docker worker stall banners in bootstrap diagnostics

### DIFF
--- a/tests/test_bootstrap_env.py
+++ b/tests/test_bootstrap_env.py
@@ -846,7 +846,13 @@ def test_normalise_docker_warning_masks_worker_restart_error_banner() -> None:
         metadata["docker_worker_last_error_banner"]
         == "Docker Desktop automatically restarted a background worker after it stalled"
     )
-    assert metadata["docker_worker_last_error_banner_raw"] == "worker stalled; restarting"
+    assert metadata["docker_worker_last_error_banner_raw"] == (
+        "Docker Desktop automatically restarted a background worker after it stalled"
+    )
+    assert (
+        metadata["docker_worker_last_error_banner_preserved"]
+        == "worker stalled; restarting"
+    )
 
 
 def test_normalise_docker_warning_extracts_last_error_code() -> None:
@@ -885,6 +891,9 @@ def test_normalise_docker_warning_handles_experienced_stall_variant() -> None:
     )
     assert metadata["docker_worker_last_error_interpreted"] == "worker_stalled"
     assert metadata["docker_worker_last_error_banner_raw"].endswith(
+        "background worker after it stalled"
+    )
+    assert metadata["docker_worker_last_error_banner_preserved"].endswith(
         "docker worker experienced a stall; restarting"
     )
 

--- a/tests/test_bootstrap_env_docker.py
+++ b/tests/test_bootstrap_env_docker.py
@@ -1162,7 +1162,7 @@ def test_worker_error_fallback_sanitizes_worker_stalls(
     assert all(
         "worker stalled; restarting" not in str(value).lower()
         for key, value in metadata.items()
-        if "banner_raw" not in key
+        if "banner_raw" not in key and "banner_preserved" not in key
     )
 
 
@@ -1392,6 +1392,9 @@ def test_structured_notifications_with_text_field() -> None:
     assert metadata.get("docker_worker_last_error_code") == "VPNKIT_SYNC_TIMEOUT"
     assert "worker stalled" not in metadata.get("docker_worker_last_error", "").lower()
     assert "vpnkit background sync" in metadata.get(
+        "docker_worker_last_error_banner_preserved", ""
+    ).lower()
+    assert "worker stalled; restarting" not in metadata.get(
         "docker_worker_last_error_banner_raw", ""
     ).lower()
 


### PR DESCRIPTION
## Summary
- normalise docker worker stall metadata so the `docker_worker_last_error_banner_raw` field mirrors the cleaned narrative while preserving the original banner in a dedicated `docker_worker_last_error_banner_preserved` key for diagnostics
- extend the worker warning aggregator and telemetry models to track the preserved banner samples without leaking the raw stall string back into user-facing output
- update the bootstrap environment tests to cover the new metadata contract and ensure preserved banners remain available for advanced troubleshooting

## Testing
- `pytest tests/test_bootstrap_env.py -k "worker" -q`
- `pytest tests/test_bootstrap_env_docker.py -k "worker" -q`
- `python scripts/bootstrap_env.py --skip-stripe-router`


------
https://chatgpt.com/codex/tasks/task_e_68e09e87d240832e8566ed5e12db4ed9