### PR TITLE
Improve Docker worker stall diagnostics messaging

### DIFF
--- a/scripts/bootstrap_env.py
+++ b/scripts/bootstrap_env.py
@@ -7261,7 +7261,11 @@ def _classify_worker_flapping(
             )
     else:
         headline = (
-            "Docker Desktop worker processes are repeatedly restarting and may not stabilize without intervention."
+            "Docker Desktop reported that worker processes are repeatedly restarting and may not stabilize without intervention."
+        )
+        details.insert(
+            0,
+            "Docker Desktop reported persistent background worker restarts that are not recovering automatically.",
         )
         if context.is_wsl:
             remediation.append(


### PR DESCRIPTION
## Summary
- ensure severe Docker worker stall guidance states that Docker Desktop reported the restarts
- add contextual detail emphasizing persistent, unrecovered worker restarts in the remediation narrative

## Testing
- pytest tests/test_bootstrap_env.py -k docker -q

------
https://chatgpt.com/codex/tasks/task_e_68e0a5907ce8832e87fdd7a06e6843fa