### PR TITLE
Normalize Docker worker stall periods

### DIFF
--- a/scripts/bootstrap_env.py
+++ b/scripts/bootstrap_env.py
@@ -2646,7 +2646,7 @@ _WORKER_STALLED_BANNER_PATTERN = re.compile(
     )?
     stall(?:ed|ing)?                 # stall/stalled/stalling variations
     \s*
-    [;:,\u2013\u2014-]               # punctuation banner separator (;, :, -, –, —)
+    [;:,\.\u2013\u2014\u2026\u00b7\u2022-]+  # punctuation separators including ellipses/bullets
     \s*
     re[-\s]*start(?:ed|ing)?        # restart/restarting/re-starting variations
     """,

--- a/tests/test_bootstrap_env_docker.py
+++ b/tests/test_bootstrap_env_docker.py
@@ -683,6 +683,19 @@ def test_enforce_worker_banner_sanitization_handles_dash_separator() -> None:
     assert metadata["docker_worker_health"] == "flapping"
 
 
+def test_enforce_worker_banner_sanitization_handles_period_separator() -> None:
+    """Worker stall banners that use periods as separators should be rewritten."""
+
+    metadata: dict[str, str] = {}
+    warnings = ["WARNING: worker stalled. restarting component=\"vpnkit\" backoff=\"5s\""]
+
+    harmonised = bootstrap_env._enforce_worker_banner_sanitization(warnings, metadata)
+
+    assert harmonised, "expected sanitized worker warning"
+    assert all("worker stalled" not in entry.lower() for entry in harmonised)
+    assert metadata["docker_worker_health"] == "flapping"
+
+
 def test_errcode_field_feeds_worker_error_guidance() -> None:
     """errCode metadata should be interpreted as an actionable worker error code."""
 


### PR DESCRIPTION
## Summary
- extend the worker stall banner normalisation to treat period, ellipsis, and bullet separators as part of the restart banner
- add regression coverage ensuring period-separated Docker Desktop worker stall warnings are rewritten into guidance

## Testing
- pytest tests/test_bootstrap_env_docker.py::test_enforce_worker_banner_sanitization_handles_period_separator

------
https://chatgpt.com/codex/tasks/task_e_68e0a6ca3300832e9a7ef14168c06c86