### PR TITLE
Refine Docker worker restart headline

### DIFF
--- a/scripts/bootstrap_env.py
+++ b/scripts/bootstrap_env.py
@@ -7261,7 +7261,7 @@ def _classify_worker_flapping(
             )
     else:
         headline = (
-            "Docker Desktop reported that worker processes are repeatedly restarting and may not stabilize without intervention."
+            "Docker Desktop worker processes are repeatedly restarting and may not stabilize without intervention."
         )
         details.insert(
             0,


### PR DESCRIPTION
## Summary
- update the severe Docker Desktop worker restart headline to remove the extra "reported that" preface
- ensure structured Docker warnings surface the canonical "Docker Desktop worker processes are repeatedly restarting" phrasing

## Testing
- pytest tests/test_bootstrap_env_docker.py::test_structured_warning_prefers_status_message_over_status -q
- pytest tests/test_bootstrap_env_docker.py -q
- python scripts/bootstrap_env.py --skip-stripe-router


------
https://chatgpt.com/codex/tasks/task_e_68e0a7ee553c832e88912d91d10b158a