### PR TITLE
Sanitize Docker worker stall diagnostics and add banner fingerprints

### DIFF
--- a/tests/test_bootstrap_env.py
+++ b/tests/test_bootstrap_env.py
@@ -874,8 +874,11 @@ def test_normalise_docker_warning_masks_worker_restart_error_banner() -> None:
     )
     assert (
         metadata["docker_worker_last_error_banner_preserved"]
-        == "worker stalled; restarting"
+        == bootstrap_env._WORKER_STALLED_PRIMARY_NARRATIVE
     )
+    signature = metadata.get("docker_worker_last_error_banner_signature")
+    assert signature is not None
+    assert signature.startswith(bootstrap_env._WORKER_STALLED_SIGNATURE_PREFIX)
 
 
 def test_normalise_docker_warning_extracts_last_error_code() -> None:
@@ -916,8 +919,12 @@ def test_normalise_docker_warning_handles_experienced_stall_variant() -> None:
     assert metadata["docker_worker_last_error_raw"].endswith(
         "background worker after it stalled"
     )
-    assert metadata["docker_worker_last_error_banner_preserved"].endswith(
-        "docker worker experienced a stall; restarting"
+    assert (
+        metadata["docker_worker_last_error_banner_preserved"]
+        == bootstrap_env._WORKER_STALLED_PRIMARY_NARRATIVE
+    )
+    assert metadata["docker_worker_last_error_banner_signature"].startswith(
+        bootstrap_env._WORKER_STALLED_SIGNATURE_PREFIX
     )
 
 


### PR DESCRIPTION
## Summary
- add deterministic fingerprinting for Docker worker stall banners and ensure sanitized guidance replaces the raw text across the bootstrap pipeline
- propagate the new banner signatures through worker warning aggregation/telemetry so diagnostics remain actionable without leaking the literal banner
- extend the bootstrap environment tests to assert the sanitized metadata and signature presence

## Testing
- pytest tests/test_bootstrap_env.py -k worker
- pytest tests/test_bootstrap_env_docker.py -k worker
- python scripts/bootstrap_env.py --skip-stripe-router


------
https://chatgpt.com/codex/tasks/task_e_68e0b4fd2608832e8c49a7422fc12d5a