### PR TITLE
Fix worker stall banner preservation in bootstrap diagnostics

### DIFF
--- a/scripts/bootstrap_env.py
+++ b/scripts/bootstrap_env.py
@@ -4669,7 +4669,9 @@ def _normalise_worker_error_message(
     if preserved_signature:
         metadata["docker_worker_last_error_banner_signature"] = preserved_signature
 
-    preserved_banner_text = metadata.get("docker_worker_last_error_banner")
+    preserved_banner_text = preserved_banner or metadata.get(
+        "docker_worker_last_error_banner"
+    )
     if preserved_banner_text:
         metadata["docker_worker_last_error_banner_preserved"] = preserved_banner_text
         metadata["docker_worker_last_error_banner_preserved_samples"] = (


### PR DESCRIPTION
## Summary
- ensure Docker worker stall normalization preserves the original banner text when available
- keep diagnostic metadata aligned with Docker Desktop payloads so follow-up guidance retains vpnkit context

## Testing
- pytest tests/test_bootstrap_env_docker.py -k docker --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68e0b8ba0758832e86b380ea536502f6