### PR TITLE
Normalize full-width Docker worker stall banners

### DIFF
--- a/tests/test_bootstrap_env_docker.py
+++ b/tests/test_bootstrap_env_docker.py
@@ -759,6 +759,21 @@ def test_enforce_worker_banner_sanitization_handles_question_separator() -> None
     assert harmonised, "expected sanitized worker warning"
     assert all("worker stalled" not in entry.lower() for entry in harmonised)
     assert metadata["docker_worker_health"] == "flapping"
+
+
+def test_enforce_worker_banner_sanitization_handles_fullwidth_punctuation() -> None:
+    """Full-width punctuation from localized Windows builds should be normalised."""
+
+    metadata: dict[str, str] = {}
+    warnings = [
+        "WARNING：worker stalled； restarting component=\"vpnkit\" errCode=VPNKIT_VSOCK_TIMEOUT",
+    ]
+
+    harmonised = bootstrap_env._enforce_worker_banner_sanitization(warnings, metadata)
+
+    assert harmonised, "expected sanitized worker warning"
+    assert all("worker stalled" not in entry.lower() for entry in harmonised)
+    assert metadata["docker_worker_health"] == "flapping"
     assert metadata["docker_worker_last_error_code"] == "VPNKIT_VSOCK_TIMEOUT"
 
 


### PR DESCRIPTION
## Summary
- normalise full-width and compatibility punctuation emitted by Windows-localised Docker diagnostics before worker stall analysis
- ensure worker stall banner rewriting operates on normalised characters so sanitisation never leaks "worker stalled; restarting" to users
- add regression coverage for full-width punctuation handling in Docker warning sanitisation

## Testing
- pytest tests/test_bootstrap_env_docker.py::test_enforce_worker_banner_sanitization_handles_fullwidth_punctuation
- python scripts/bootstrap_env.py --skip-stripe-router


------
https://chatgpt.com/codex/tasks/task_e_68e0b985e1f4832e8566ea76cd9b4f72