### PR TITLE
Improve Docker worker banner normalization

### DIFF
--- a/tests/test_bootstrap_env_docker.py
+++ b/tests/test_bootstrap_env_docker.py
@@ -777,6 +777,21 @@ def test_enforce_worker_banner_sanitization_handles_fullwidth_punctuation() -> N
     assert metadata["docker_worker_last_error_code"] == "VPNKIT_VSOCK_TIMEOUT"
 
 
+def test_enforce_worker_banner_sanitization_strips_invisible_characters() -> None:
+    """Zero-width characters from Windows consoles should not leak raw banners."""
+
+    metadata: dict[str, str] = {}
+    warnings = [
+        "WARNING\u200b: worker\u202fstalled;\u2060 restarting component=\"vpnkit\" restartCount=2",
+    ]
+
+    harmonised = bootstrap_env._enforce_worker_banner_sanitization(warnings, metadata)
+
+    assert harmonised, "expected sanitized worker warning"
+    assert all("worker stalled" not in entry.lower() for entry in harmonised)
+    assert metadata["docker_worker_health"] == "flapping"
+
+
 def test_errcode_field_feeds_worker_error_guidance() -> None:
     """errCode metadata should be interpreted as an actionable worker error code."""
 


### PR DESCRIPTION
## Summary
- normalise zero-width and non-breaking punctuation in Docker Desktop worker banners before analysis
- rewrite worker stall guidance to preserve context while tracking raw banner diagnostics
- extend worker telemetry structures and add regression coverage for invisible characters in warnings

## Testing
- pytest tests/test_bootstrap_env.py tests/test_bootstrap_env_docker.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e0bb5db63c832ea16f8c09206ed944