### PR TITLE
Normalize Docker worker reset banners

### DIFF
--- a/tests/test_bootstrap_env_docker.py
+++ b/tests/test_bootstrap_env_docker.py
@@ -718,6 +718,24 @@ def test_enforce_worker_banner_sanitization_handles_dash_separator() -> None:
     assert metadata["docker_worker_health"] == "flapping"
 
 
+def test_enforce_worker_banner_sanitization_handles_resetting_variants() -> None:
+    """Resetting phrasing should be harmonised like restart diagnostics."""
+
+    metadata: dict[str, str] = {}
+    warnings = [
+        "WARNING worker stall detection triggered; resetting component=\"vpnkit\" "
+        "errCode=VPNKIT_VSOCK_TIMEOUT",
+    ]
+
+    harmonised = bootstrap_env._enforce_worker_banner_sanitization(warnings, metadata)
+
+    assert harmonised, "expected sanitized worker warning"
+    assert all("worker stalled" not in entry.lower() for entry in harmonised)
+    assert all("resetting" not in entry.lower() for entry in harmonised)
+    assert metadata["docker_worker_health"] == "flapping"
+    assert metadata.get("docker_worker_last_error_code") == "VPNKIT_VSOCK_TIMEOUT"
+
+
 def test_worker_banner_raw_metadata_is_redacted() -> None:
     """Raw banner metadata should be rewritten and fingerprinted."""
 


### PR DESCRIPTION
## Summary
- treat Docker Desktop "resetting" worker stall banners as restart variants so the bootstrap diagnostics normalise them into actionable guidance
- recognise reset markers in the worker stall detector and ensure the warning scrubber covers the new phrasing, adding regression coverage

## Testing
- pytest tests/test_bootstrap_env_docker.py -q
- python scripts/bootstrap_env.py --skip-stripe-router

------
https://chatgpt.com/codex/tasks/task_e_68e1077d9eb8832ea71f99b4e0a64d70