### PR TITLE
Escalate Docker worker stall warnings for sustained restarts

### DIFF
--- a/scripts/bootstrap_env.py
+++ b/scripts/bootstrap_env.py
@@ -7916,6 +7916,11 @@ def _classify_worker_flapping(
                 "excessive_restarts",
                 "Docker recorded at least six worker restarts during diagnostics",
             )
+        elif max_restart >= 4:
+            _register_reason(
+                "sustained_restarts",
+                "Docker recorded four or more worker restarts during diagnostics",
+            )
     elif telemetry.restart_samples:
         rendered = ", ".join(str(sample) for sample in telemetry.restart_samples)
         details.append(f"Docker reported restart counts during diagnostics: {rendered}.")


### PR DESCRIPTION
## Summary
- escalate Docker worker stall diagnostics to error severity once restart counts reach four
- keep existing severe restart handling for higher thresholds while preserving detailed remediation guidance

## Testing
- pytest tests/test_bootstrap_env_docker.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e1bb86ead0832e803f61fd33c81195