### PR TITLE
Sanitize virtualization worker stall guidance

### DIFF
--- a/scripts/bootstrap_env.py
+++ b/scripts/bootstrap_env.py
@@ -8633,6 +8633,12 @@ def _post_process_docker_health(
 
     additional_metadata["docker_worker_health_severity"] = severity
     if summary:
+        sanitized_summary = _enforce_worker_banner_sanitization(
+            [summary],
+            additional_metadata,
+        )
+        if sanitized_summary:
+            summary = sanitized_summary[0]
         additional_metadata["docker_worker_health_summary"] = summary
     if virtualization_metadata:
         additional_metadata.update(virtualization_metadata)
@@ -8657,15 +8663,23 @@ def _post_process_docker_health(
         _append_unique(target, summary)
 
     if virtualization_warnings:
-        for message in virtualization_warnings:
+        sanitized_virtualization_warnings = _enforce_worker_banner_sanitization(
+            virtualization_warnings,
+            additional_metadata,
+        )
+        for message in sanitized_virtualization_warnings:
             _append_unique(warnings, message)
 
     if virtualization_errors:
+        sanitized_virtualization_errors = _enforce_worker_banner_sanitization(
+            virtualization_errors,
+            additional_metadata,
+        )
         if severity == "error":
-            for message in virtualization_errors:
+            for message in sanitized_virtualization_errors:
                 _append_unique(errors, message)
         else:
-            for message in virtualization_errors:
+            for message in sanitized_virtualization_errors:
                 _append_unique(
                     warnings,
                     f"Virtualization issue detected: {message}",


### PR DESCRIPTION
## Summary
- sanitize virtualization health summaries so worker stall banners are rewritten before surfacing to users
- normalize virtualization warning and error streams with the existing worker stall sanitizer to prevent "worker stalled; restarting" leakage on Windows hosts

## Testing
- pytest tests/test_bootstrap_env_docker.py --maxfail=1
- pytest tests/test_bootstrap_env_worker_sanitization.py --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68e1c3f4a404832e9f0e5ab8d05aa72f