### PR TITLE
Handle Docker worker stuck warnings

### DIFF
--- a/tests/test_bootstrap_env_docker.py
+++ b/tests/test_bootstrap_env_docker.py
@@ -770,6 +770,29 @@ def test_enforce_worker_banner_sanitization_handles_dash_separator() -> None:
     assert metadata["docker_worker_health"] == "flapping"
 
 
+def test_enforce_worker_banner_sanitization_handles_stuck_synonym() -> None:
+    """Stuck phrasing introduced by newer Docker builds should be normalised."""
+
+    metadata: dict[str, str] = {}
+    warnings = [
+        "WARN[0042] moby/buildkit: worker stuck; restarting component=\"vpnkit\" restartCount=2",
+    ]
+
+    harmonised = bootstrap_env._enforce_worker_banner_sanitization(warnings, metadata)
+
+    assert harmonised, "expected sanitized worker warning"
+    assert all("worker stuck; restarting" not in entry.lower() for entry in harmonised)
+    assert metadata["docker_worker_health"] == "flapping"
+
+
+def test_contains_worker_stall_signal_detects_stuck_banner() -> None:
+    """Heuristics should treat stuck workers as stall incidents."""
+
+    message = "WARNING: worker stuck; restarting component=\"vpnkit\""
+
+    assert bootstrap_env._contains_worker_stall_signal(message)
+
+
 def test_enforce_worker_banner_sanitization_handles_resetting_variants() -> None:
     """Resetting phrasing should be harmonised like restart diagnostics."""
 

--- a/tests/test_bootstrap_env_worker_sanitization.py
+++ b/tests/test_bootstrap_env_worker_sanitization.py
@@ -30,6 +30,7 @@ def test_nested_structures_are_scrubbed_of_worker_stall_banners() -> None:
             ],
             "tuple_data": (
                 "worker stalled; restarting soon",
+                "worker stuck; restarting",
                 "background worker stabilised",
             ),
         },


### PR DESCRIPTION
## Summary
- normalise new Docker Desktop worker "stuck" banners into the existing stall guidance pipeline
- share a reusable root pattern and keyword set so worker diagnostics stay consistent across sanitisation steps
- extend the docker bootstrap tests to cover the new synonym and nested metadata sanitisation

## Testing
- `pytest tests/test_bootstrap_env_docker.py -q`
- `pytest tests/test_bootstrap_env_worker_sanitization.py -q`
- `python scripts/bootstrap_env.py --skip-stripe-router`


------
https://chatgpt.com/codex/tasks/task_e_68e1c57a3db0832e9c3035f5eddf713a