### PR TITLE
Harden Docker worker banner scrubbing and extend Windows CLI discovery

### DIFF
--- a/tests/test_bootstrap_env_docker.py
+++ b/tests/test_bootstrap_env_docker.py
@@ -174,6 +174,8 @@ def test_windows_docker_directory_variants(
         program_files / "Docker" / "Docker" / "resources" / "cli-linux",
         program_files / "Docker" / "Docker" / "resources" / "cli-bin",
         program_files / "Docker" / "Docker" / "resources" / "docker-cli",
+        program_files / "Docker" / "Docker" / "resources" / "cli-arm",
+        program_files / "Docker" / "Docker" / "resources" / "cli-arm64",
         program_files / "Docker" / "Docker" / "cli",
         program_data / "DockerDesktop" / "cli",
         program_data / "DockerDesktop" / "cli-bin",
@@ -181,6 +183,33 @@ def test_windows_docker_directory_variants(
         local_appdata / "DockerDesktop" / "cli",
         local_appdata / "DockerDesktop" / "cli-bin",
         local_appdata / "DockerDesktop" / "cli-tools",
+        local_appdata / "DockerDesktop" / "cli-arm",
+        local_appdata / "DockerDesktop" / "cli-arm64",
+    }
+
+    assert expected.issubset(directory_set)
+
+
+def test_windows_docker_directory_includes_arm_roots(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Docker discovery should probe Program Files (Arm) when available."""
+
+    arm_root = tmp_path / "Program Files (Arm)"
+    arm_root.mkdir()
+
+    monkeypatch.delenv("ProgramFiles", raising=False)
+    monkeypatch.delenv("ProgramW6432", raising=False)
+    monkeypatch.delenv("ProgramFiles(x86)", raising=False)
+    monkeypatch.setenv("ProgramFiles(Arm)", str(arm_root))
+
+    directories = list(bootstrap_env._iter_windows_docker_directories())
+    directory_set = {Path(path) for path in directories}
+
+    expected = {
+        arm_root / "Docker" / "Docker" / "resources" / "cli-arm",
+        arm_root / "Docker" / "Docker" / "resources" / "cli-arm64",
+        arm_root / "Docker" / "Docker" / "cli",
     }
 
     assert expected.issubset(directory_set)

--- a/tests/test_bootstrap_env_worker_sanitization.py
+++ b/tests/test_bootstrap_env_worker_sanitization.py
@@ -76,3 +76,16 @@ def test_worker_banner_treats_warning_prefix_as_noise() -> None:
     sanitized = bootstrap_env._sanitize_worker_banner_text(message)  # type: ignore[attr-defined]
 
     assert sanitized == bootstrap_env._WORKER_STALLED_PRIMARY_NARRATIVE
+
+
+def test_worker_banner_final_guard_rewrites_literal_phrase() -> None:
+    messages = [
+        "worker stalled; restarting",
+        "no action required",
+    ]
+    metadata: dict[str, str] = {}
+
+    safeguarded = bootstrap_env._guarantee_worker_banner_suppression(messages, metadata)  # type: ignore[attr-defined]
+
+    assert all("worker stalled; restarting" not in entry.casefold() for entry in safeguarded if isinstance(entry, str))
+    assert metadata["docker_worker_health"] == "flapping"


### PR DESCRIPTION
## Summary
- extend Docker Desktop CLI discovery to include Program Files (Arm) roots and new cli-arm*/cli-* bundles used on Windows
- add a final safeguard that rewrites any lingering `worker stalled; restarting` banner and expose coverage through tests
- exercise new Windows discovery paths and sanitisation guarantees with additional unit tests

## Testing
- pytest tests/test_bootstrap_env_docker.py tests/test_bootstrap_env_worker_sanitization.py -q
- python scripts/bootstrap_env.py --skip-stripe-router


------
https://chatgpt.com/codex/tasks/task_e_68e1cf4254b8832e938c483bb364e0f4