### PR TITLE
Handle fragmented Docker worker stall diagnostics

### DIFF
--- a/tests/test_bootstrap_env_worker_sanitization.py
+++ b/tests/test_bootstrap_env_worker_sanitization.py
@@ -151,3 +151,22 @@ def test_worker_banner_nested_json_is_rewritten_by_guard() -> None:
     assert isinstance(safeguarded[0], str)
     assert "worker stalled; restarting" not in safeguarded[0].lower()
     assert metadata.get("docker_worker_context") == "vpnkit"
+
+
+def test_worker_banner_split_across_lines_is_stitched_and_rewritten() -> None:
+    messages = [
+        "WARNING: worker stalled;",
+        'restarting component="vpnkit" restartCount=2',
+        "lastError=\"worker stalled; restarting\"",
+    ]
+
+    metadata: dict[str, str] = {}
+
+    safeguarded = bootstrap_env._guarantee_worker_banner_suppression(messages, metadata)  # type: ignore[attr-defined]
+
+    assert all(
+        "worker stalled" not in entry.lower()
+        for entry in safeguarded
+        if isinstance(entry, str)
+    )
+    assert metadata.get("docker_worker_health") == "flapping"


### PR DESCRIPTION
## Summary
- stitch multi-line Docker worker stall banners before sanitisation so split messages are rewritten
- detect truncated worker stall fragments and guard against raw `worker stalled; restarting` output on Windows Docker
- extend worker warning sanitisation tests to cover split-line messages

## Testing
- pytest tests/test_bootstrap_env_worker_sanitization.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e256f3c3bc8326baae4a978f0242e4