### PR TITLE
Decode HTML entities in Docker worker diagnostics

### DIFF
--- a/scripts/bootstrap_env.py
+++ b/scripts/bootstrap_env.py
@@ -11,6 +11,7 @@ import argparse
 import ast
 import base64
 import hashlib
+import html
 import json
 import logging
 import math
@@ -2860,7 +2861,8 @@ def _normalize_worker_banner_characters(message: str) -> str:
     # characters when the host locale is configured for East Asian languages.
     # The worker stall detectors rely on ASCII separators, so normalise these
     # variants to their half-width counterparts before applying the heuristics.
-    normalized = message.translate(_WORKER_BANNER_CHARACTER_TRANSLATION)
+    normalized = html.unescape(message)
+    normalized = normalized.translate(_WORKER_BANNER_CHARACTER_TRANSLATION)
     return normalized
 
 

--- a/tests/test_bootstrap_env_worker_sanitization.py
+++ b/tests/test_bootstrap_env_worker_sanitization.py
@@ -79,6 +79,14 @@ def test_worker_banner_treats_warning_prefix_as_noise() -> None:
     assert sanitized == bootstrap_env._WORKER_STALLED_PRIMARY_NARRATIVE
 
 
+def test_worker_banner_html_entity_semicolon_is_decoded() -> None:
+    message = "worker stalled&#59; restarting after host sleep"
+
+    sanitized = bootstrap_env._sanitize_worker_banner_text(message)  # type: ignore[attr-defined]
+
+    assert sanitized == bootstrap_env._WORKER_STALLED_PRIMARY_NARRATIVE
+
+
 def test_worker_banner_final_guard_rewrites_literal_phrase() -> None:
     messages = [
         "worker stalled; restarting",


### PR DESCRIPTION
## Summary
- decode Docker worker warning banners with HTML entities so the sanitisation pipeline removes the `worker stalled; restarting` text consistently on Docker for Windows
- add a regression test covering HTML-escaped semicolons in worker stall diagnostics

## Testing
- pytest tests/test_bootstrap_env_worker_sanitization.py -q
- python scripts/bootstrap_env.py --skip-stripe-router

------
https://chatgpt.com/codex/tasks/task_e_68e25bcd1ed08326b7aabad1c1a80a04