### PR TITLE
Improve Docker worker stall remediation guidance

### DIFF
--- a/tests/test_bootstrap_env_worker_sanitization.py
+++ b/tests/test_bootstrap_env_worker_sanitization.py
@@ -187,6 +187,42 @@ def test_fullwidth_worker_banner_is_normalized() -> None:
     assert "docker desktop" in cleaned.lower()
 
 
+def test_worker_banner_errcode_cpu_pressure_guidance() -> None:
+    message = (
+        "WARNING: worker stalled; restarting component=\"vpnkit\" "
+        "errCode=VPNKIT_BACKGROUND_SYNC_CPU_PRESSURE restartCount=3"
+    )
+
+    cleaned, metadata = bootstrap_env._normalise_docker_warning(message)
+
+    lowered = cleaned.lower()
+    assert "worker stalled" not in lowered
+    assert "cpu pressure" in lowered
+    assert "vpnkit" in lowered
+
+    fingerprint_key = "docker_worker_last_error_guidance_vpnkit_background_sync_cpu_pressure"
+    assert fingerprint_key in metadata
+    assert "cpu" in metadata[fingerprint_key].lower()
+
+
+def test_worker_banner_errcode_vsock_signal_guidance() -> None:
+    message = (
+        "WARN[0032] moby/buildkit: worker stalled; restarting "
+        "component=\"vpnkit\" errCode=VPNKIT_VSOCK_SIGNAL_LOST"
+    )
+
+    cleaned, metadata = bootstrap_env._normalise_docker_warning(message)
+
+    lowered = cleaned.lower()
+    assert "worker stalled" not in lowered
+    assert "vsock" in lowered
+    assert "vpnkit" in lowered
+
+    fingerprint_key = "docker_worker_last_error_guidance_vpnkit_vsock_signal_lost"
+    assert fingerprint_key in metadata
+    assert "vsock" in metadata[fingerprint_key].lower()
+
+
 def test_format_worker_restart_reason_strips_prefixes() -> None:
     reason = "because of lingering IO pressure "
 


### PR DESCRIPTION
## Summary
- add Windows-specific Docker Desktop error code labels for new vpnkit CPU, memory, network and vsock failure diagnostics
- derive tailored remediation guidance for the new worker error codes so "worker stalled; restarting" warnings are rewritten with actionable steps
- extend the worker sanitization tests to cover the new Docker Desktop error-code variants to guard against regressions

## Testing
- pytest tests/test_bootstrap_env_worker_sanitization.py::test_worker_banner_errcode_cpu_pressure_guidance tests/test_bootstrap_env_worker_sanitization.py::test_worker_banner_errcode_vsock_signal_guidance
- scripts/bootstrap_env.py --skip-stripe-router

------
https://chatgpt.com/codex/tasks/task_e_68e2eaa1761883269ba03c07c517d71a