### PR TITLE
Normalize Docker worker classification metadata

### DIFF
--- a/tests/test_bootstrap_env.py
+++ b/tests/test_bootstrap_env.py
@@ -945,6 +945,30 @@ def test_normalise_docker_warning_handles_experienced_stall_variant() -> None:
     )
 
 
+def test_finalize_worker_metadata_preserves_classification_tokens() -> None:
+    metadata = {
+        "docker_worker_last_error_interpreted": "WARNING: worker stalled; restarting",
+        "docker_worker_last_error_category": "stalled_restart",
+    }
+
+    bootstrap_env._finalize_worker_banner_metadata(metadata)
+
+    assert metadata["docker_worker_last_error_interpreted"] == "worker_stalled"
+    assert metadata["docker_worker_last_error_category"] == "worker_stalled"
+
+
+def test_finalize_worker_metadata_canonicalizes_restart_loop_label() -> None:
+    metadata = {
+        "docker_worker_last_error_interpreted": (
+            "Docker Desktop detected that a background worker entered a restart loop"
+        ),
+    }
+
+    bootstrap_env._finalize_worker_banner_metadata(metadata)
+
+    assert metadata["docker_worker_last_error_interpreted"] == "restart_loop"
+
+
 def test_normalise_docker_warning_extracts_context_from_has_stalled_variant() -> None:
     message = (
         "WARN[0002] [vpnkit] worker has stalled; restarting in ~30s due to disk latency"


### PR DESCRIPTION
## Summary
- canonicalize Docker worker classification metadata to normalized tokens when sanitizing Docker diagnostics
- add a classification-aware sanitizer and guard metadata rewrites so guidance never regresses to raw worker stall banners
- extend bootstrap environment tests with coverage for classification canonicalization and restart-loop guidance

## Testing
- python scripts/bootstrap_env.py --skip-stripe-router
- pytest tests/test_bootstrap_env.py -q
- pytest tests/test_bootstrap_env_docker.py -k worker -q


------
https://chatgpt.com/codex/tasks/task_e_68e2f6a4e9f08326ba0cbf65311543e8