### PR TITLE
Harden Docker worker stall sanitisation

### DIFF
--- a/tests/test_bootstrap_env_worker_sanitization.py
+++ b/tests/test_bootstrap_env_worker_sanitization.py
@@ -430,3 +430,20 @@ def test_worker_banner_whitespace_separator_is_sanitized() -> None:
         if isinstance(entry, str)
     )
     assert metadata.get("docker_worker_health") == "flapping"
+
+
+def test_finalize_sequences_strip_carriage_return_variants() -> None:
+    """Final sanitisation should catch carriage-return variants of the banner."""
+
+    message = "WARNING: worker stalled;\r restarting component=\"vpnkit\""
+    metadata: dict[str, str] = {}
+
+    sanitized = bootstrap_env._finalize_worker_banner_sequences([message], metadata)  # type: ignore[attr-defined]
+
+    assert sanitized
+    assert all(
+        "worker stalled" not in entry.lower()
+        for entry in sanitized
+        if isinstance(entry, str)
+    )
+    assert metadata.get("docker_worker_health") == "flapping"


### PR DESCRIPTION
## Summary
- add a helper that normalises control characters so literal Docker "worker stalled; restarting" banners are still detected
- update the final sanitisation passes to use the helper across message, JSON, and metadata processing
- add a regression test covering carriage-return variants of the banner

## Testing
- pytest tests/test_bootstrap_env_worker_sanitization.py
- python scripts/bootstrap_env.py --skip-stripe-router

------
https://chatgpt.com/codex/tasks/task_e_68e2f8ea855883268014ff7b484f6f6d