### PR TITLE
Normalize Docker worker stall banners separated by periods

### DIFF
--- a/scripts/bootstrap_env.py
+++ b/scripts/bootstrap_env.py
@@ -7997,6 +7997,7 @@ _WORKER_ASCII_RESTART_CONNECTORS: tuple[str, ...] = (
     ";",
     ":",
     ",",
+    ".",
     "-",
     "->",
     "=>",

--- a/tests/test_bootstrap_env_worker_sanitization.py
+++ b/tests/test_bootstrap_env_worker_sanitization.py
@@ -480,6 +480,23 @@ def test_worker_banner_whitespace_separator_is_sanitized() -> None:
     assert metadata.get("docker_worker_health") == "flapping"
 
 
+def test_worker_banner_period_separator_is_sanitized() -> None:
+    """A literal period separator should be treated as a stall banner delimiter."""
+
+    message = "WARNING: worker stalled. restarting component=\"vpnkit\" restartCount=2"
+    metadata: dict[str, str] = {}
+
+    safeguarded = bootstrap_env._guarantee_worker_banner_suppression([message], metadata)  # type: ignore[attr-defined]
+
+    assert safeguarded
+    assert all(
+        "worker stalled" not in entry.casefold()
+        for entry in safeguarded
+        if isinstance(entry, str)
+    )
+    assert metadata.get("docker_worker_health") == "flapping"
+
+
 def test_finalize_sequences_strip_carriage_return_variants() -> None:
     """Final sanitisation should catch carriage-return variants of the banner."""
 


### PR DESCRIPTION
## Summary
- treat literal period separators as Docker worker restart connectors so stall banners are rewritten
- cover the new scenario with a regression test around the worker banner sanitiser

## Testing
- pytest tests/test_bootstrap_env_worker_sanitization.py

------
https://chatgpt.com/codex/tasks/task_e_68e308f870a08326b6bf6df6c88bf0a9