### PR TITLE
Add explicit completion prompt to bootstrap script

### DIFF
--- a/scripts/bootstrap_env.py
+++ b/scripts/bootstrap_env.py
@@ -11637,6 +11637,10 @@ def _run_bootstrap(config: BootstrapConfig) -> None:
     )
     run_startup_checks(skip_stripe_router=config.skip_stripe_router, policy=policy)
     EnvironmentBootstrapper(policy=policy).bootstrap()
+    LOGGER.info("Environment bootstrap completed successfully")
+    if sys.stdout is not None and sys.stdout.isatty():
+        print("Bootstrap complete. You can close this window.")
+        sys.stdout.flush()
 
 
 def main(argv: list[str] | None = None) -> None:


### PR DESCRIPTION
## Summary
- print a friendly completion notice after the bootstrap process finishes when running in an interactive terminal

## Testing
- python -m compileall scripts/bootstrap_env.py

------
https://chatgpt.com/codex/tasks/task_e_68e322e564f883268633c88cc8e58ca8