### PR TITLE
Fix ErrorParser import resolution in test harness

### DIFF
--- a/sandbox_runner/test_harness.py
+++ b/sandbox_runner/test_harness.py
@@ -25,7 +25,15 @@ from contextlib import contextmanager
 from dynamic_path_router import resolve_path, path_for_prompt
 
 
-from ..error_parser import ErrorParser
+if __package__ in {None, ""}:  # pragma: no cover - script execution fallback
+    _PROJECT_ROOT = Path(__file__).resolve().parents[1]
+    _PROJECT_ROOT_STR = str(_PROJECT_ROOT)
+    if _PROJECT_ROOT_STR not in sys.path:
+        sys.path.insert(0, _PROJECT_ROOT_STR)
+
+    from error_parser import ErrorParser  # type: ignore[import-not-found]
+else:  # pragma: no cover - package execution path
+    from ..error_parser import ErrorParser
 from sandbox_settings import SandboxSettings
 try:  # pragma: no cover - tolerate trimmed environments
     from . import environment as _environment


### PR DESCRIPTION
## Summary
- ensure the sandbox runner test harness resolves `ErrorParser` when executed as a script
- retain the package import path when the module is imported normally

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e36c4841808326b30214c3a85f3be7