### PR TITLE
Fix script execution fallback for test harness

### DIFF
--- a/sandbox_runner/test_harness.py
+++ b/sandbox_runner/test_harness.py
@@ -33,7 +33,10 @@ if __package__ in {None, ""}:  # pragma: no cover - script execution fallback
 
     from error_parser import ErrorParser  # type: ignore[import-not-found]
 else:  # pragma: no cover - package execution path
-    from ..error_parser import ErrorParser
+    try:
+        from ..error_parser import ErrorParser
+    except ImportError:  # pragma: no cover - top-level package fallback
+        from error_parser import ErrorParser  # type: ignore[import-not-found]
 from sandbox_settings import SandboxSettings
 try:  # pragma: no cover - tolerate trimmed environments
     from . import environment as _environment


### PR DESCRIPTION
## Summary
- add a defensive import fallback in `sandbox_runner.test_harness` so running `run_autonomous.py` as a script no longer fails on `error_parser`

## Testing
- not run (dependency on SciPy prevents importing `run_autonomous.py` in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e377af28cc8326a09b32c24218f8c1