### PR TITLE
Fix TaskValidationBot SynthesisTask import

### DIFF
--- a/task_validation_bot.py
+++ b/task_validation_bot.py
@@ -44,7 +44,10 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-from menace.synthesis_models import SynthesisTask
+try:
+    from .synthesis_models import SynthesisTask
+except ImportError:  # pragma: no cover - flat imports during bootstrap
+    from synthesis_models import SynthesisTask  # type: ignore
 
 
 


### PR DESCRIPTION
## Summary
- fix TaskValidationBot so it imports SynthesisTask from the sandbox package with a flat-layout fallback to avoid ModuleNotFoundError during bot internalisation

## Testing
- ⚠️ `python - <<'PY'
import importlib
import menace.task_validation_bot as tvb
print('Imported', tvb.TaskValidationBot.__name__)
module = importlib.import_module('task_validation_bot')
print('Imported fallback', module.TaskValidationBot.__name__)
PY` *(fails: ModuleNotFoundError: No module named 'networkx')*


------
https://chatgpt.com/codex/tasks/task_e_68e44cb858b0832696d2519663b88588