### PR TITLE
Handle optional dependency gaps in task validation bootstrap

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -26,6 +26,7 @@ sys.modules.setdefault(
         resolve_module_path=lambda m: Path(m.replace(".", "/") + ".py"),
         path_for_prompt=lambda p: Path(p).as_posix(),
         get_project_root=lambda: Path("."),
+        repo_root=lambda: Path("."),
     ),
 )
 


### PR DESCRIPTION
## Summary
- add a repo_root alias to the lightweight dynamic_path_router stub so menace imports keep working when the helper module is stubbed
- provide a minimal directed graph fallback in bot_registry so the registry can operate without networkx installed
- harden task_validation_bot bootstrap to use import_compat, gracefully disable self-coding when optional dependencies are missing, and register menace aliases for compatibility

## Testing
- pytest tests/test_task_validation_bot.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e48a87acbc83269c45956b34582847