### PR TITLE
Improve Windows import error detection for self-coding bots

### DIFF
--- a/tests/test_bot_registry_missing_modules.py
+++ b/tests/test_bot_registry_missing_modules.py
@@ -1,0 +1,19 @@
+"""Regression tests for Windows-specific import error parsing in bot registry."""
+
+from menace_sandbox.bot_registry import _collect_missing_modules
+
+
+def test_collect_missing_modules_handles_dll_load_without_name():
+    err = ImportError(
+        "DLL load failed while importing win_ext: The specified module could not be found."
+    )
+    missing = _collect_missing_modules(err)
+    assert "win_ext" in missing
+
+
+def test_collect_missing_modules_handles_nested_dll_message():
+    err = ImportError(
+        "cannot import name 'Helper' from 'pkg' (DLL load failed while importing helper_lib: The specified module could not be found.)"
+    )
+    missing = _collect_missing_modules(err)
+    assert "helper_lib" in missing


### PR DESCRIPTION
## Summary
- normalize Windows DLL load failure messages so self-coding bots disable cleanly instead of looping on transient retries
- add regression tests covering the new import-error parsing logic

## Testing
- pytest tests/test_bot_registry_missing_modules.py


------
https://chatgpt.com/codex/tasks/task_e_68e4b22192288326bd3f56862022c3e4