### PR TITLE
Handle circular import bootstrap failures for coding bots

### DIFF
--- a/tests/test_bot_registry_missing_modules.py
+++ b/tests/test_bot_registry_missing_modules.py
@@ -17,3 +17,19 @@ def test_collect_missing_modules_handles_nested_dll_message():
     )
     missing = _collect_missing_modules(err)
     assert "helper_lib" in missing
+
+
+def test_collect_missing_modules_detects_circular_import():
+    err = ImportError(
+        "cannot import name 'TaskValidationBot' from partially initialized module 'menace_sandbox.task_validation_bot' (most likely due to a circular import)"
+    )
+    missing = _collect_missing_modules(err)
+    assert "menace_sandbox.task_validation_bot" in missing
+
+
+def test_collect_missing_modules_detects_circular_import_without_partial_hint():
+    err = ImportError(
+        "cannot import name 'TaskValidationBot' from 'menace_sandbox.task_validation_bot' (most likely due to a circular import)"
+    )
+    missing = _collect_missing_modules(err)
+    assert "menace_sandbox.task_validation_bot" in missing


### PR DESCRIPTION
## Summary
- detect circular import error messages when collecting missing self-coding modules and treat them as hard failures
- surface a dedicated circular-import reason when self-coding bootstrap aborts so the registry disables affected bots instead of retrying forever
- extend regression tests covering Windows import parsing to assert circular import messages are captured

## Testing
- pytest tests/test_bot_registry_missing_modules.py

------
https://chatgpt.com/codex/tasks/task_e_68e4b69a3a288326bee8509001e210ce