### PR TITLE
Stop retrying circular import failures in self-coding registry

### DIFF
--- a/bot_registry.py
+++ b/bot_registry.py
@@ -394,12 +394,16 @@ def _is_transient_internalization_error(exc: Exception) -> bool:
     background scan instead of hard failing the import.
     """
 
+    message = str(exc)
+    if _CIRCULAR_HINT_RE.search(message):
+        return False
+
     if isinstance(exc, ModuleNotFoundError):
         module_name = _missing_module_name(exc)
         if module_name is None:
             return True
         return _resolved_module_exists(module_name)
-    if isinstance(exc, ImportError) and "partially initialized" in str(exc):
+    if isinstance(exc, ImportError) and "partially initialized" in message:
         return True
     return False
 

--- a/tests/test_bot_registry_missing_modules.py
+++ b/tests/test_bot_registry_missing_modules.py
@@ -1,6 +1,9 @@
 """Regression tests for Windows-specific import error parsing in bot registry."""
 
-from menace_sandbox.bot_registry import _collect_missing_modules
+from menace_sandbox.bot_registry import (
+    _collect_missing_modules,
+    _is_transient_internalization_error,
+)
 
 
 def test_collect_missing_modules_handles_dll_load_without_name():
@@ -33,3 +36,11 @@ def test_collect_missing_modules_detects_circular_import_without_partial_hint():
     )
     missing = _collect_missing_modules(err)
     assert "menace_sandbox.task_validation_bot" in missing
+
+
+def test_circular_imports_not_treated_as_transient_errors():
+    err = ImportError(
+        "cannot import name 'TaskValidationBot' from partially initialized module "
+        "'menace_sandbox.task_validation_bot' (most likely due to a circular import)"
+    )
+    assert _is_transient_internalization_error(err) is False


### PR DESCRIPTION
## Summary
- treat circular-import ImportErrors as non-transient so self-coding bots disable instead of endlessly retrying on Windows
- add regression coverage ensuring the registry recognises circular import errors

## Testing
- pytest tests/test_bot_registry_missing_modules.py

------
https://chatgpt.com/codex/tasks/task_e_68e4c1e40dc883268b7005930de66620