### PR TITLE
Handle self-coding import failures as non-transient

### DIFF
--- a/tests/test_bot_registry_self_coding.py
+++ b/tests/test_bot_registry_self_coding.py
@@ -21,6 +21,20 @@ def _make_registry() -> bot_registry.BotRegistry:
     return bot_registry.BotRegistry(event_bus=None)
 
 
+def test_internal_self_coding_modules_not_transient():
+    exc = ModuleNotFoundError(
+        "No module named 'menace_sandbox.quick_fix_engine'",
+        name="menace_sandbox.quick_fix_engine",
+    )
+    assert not bot_registry._is_transient_internalization_error(exc)
+
+    exc_top_level = ModuleNotFoundError(
+        "No module named 'quick_fix_engine'",
+        name="quick_fix_engine",
+    )
+    assert not bot_registry._is_transient_internalization_error(exc_top_level)
+
+
 def test_register_bot_records_module_path_on_failure(monkeypatch, tmp_path):
     monkeypatch.setattr(
         bot_registry.BotRegistry,


### PR DESCRIPTION
## Summary
- classify missing self-coding runtime modules as non-transient import errors so the bot registry disables retries instead of looping on Windows
- add coverage that module-not-found failures for internal self-coding modules are treated as non-transient

## Testing
- pytest tests/test_bot_registry_self_coding.py::test_internal_self_coding_modules_not_transient -q
- pytest tests/test_bot_registry_self_coding.py -q
- pytest tests/test_bot_registry_internalization.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e587c8b77083268802c3c630f0d82b