### PR TITLE
Fix TaskValidationBot bootstrap to avoid circular imports

### DIFF
--- a/task_validation_bot.py
+++ b/task_validation_bot.py
@@ -107,6 +107,14 @@ def _resolve_management() -> tuple[
         registry = registry_cls()
         data_bot = data_bot_cls(start_server=False)
         context_builder = ctx_util.create_context_builder()
+
+        def _validator_factory() -> "TaskValidationBot":
+            module = sys.modules.get(__name__)
+            if module is None or getattr(module, "TaskValidationBot", None) is None:
+                module = load_internal("task_validation_bot")
+            validator_cls = getattr(module, "TaskValidationBot")
+            return validator_cls([])
+
         engine = engine_mod.SelfCodingEngine(
             code_db_cls(),
             memory_cls(),
@@ -115,6 +123,7 @@ def _resolve_management() -> tuple[
         pipeline = pipeline_mod.ModelAutomationPipeline(
             context_builder=context_builder,
             bot_registry=registry,
+            validator_factory=_validator_factory,
         )
         manager = manager_mod.SelfCodingManager(
             engine,


### PR DESCRIPTION
## Summary
- add lazy validator bootstrap support to ModelAutomationPipeline so the validator is instantiated only when needed
- defer TaskValidationBot self-coding setup by providing a validator factory instead of immediately importing the bot class

## Testing
- pytest tests/test_model_automation_pipeline.py tests/test_task_validation_bot.py

------
https://chatgpt.com/codex/tasks/task_e_68e5b7126ae88326a64742b314ebceae