### PR TITLE
Handle chained missing module hints in self-coding registry

### DIFF
--- a/bot_registry.py
+++ b/bot_registry.py
@@ -548,6 +548,11 @@ def _collect_missing_modules(exc: BaseException) -> set[str]:
 
     missing: set[str] = set()
     for item in _iter_exception_chain(exc):
+        modules_attr = getattr(item, "missing_modules", None)
+        if modules_attr:
+            for module in modules_attr:
+                if isinstance(module, str) and module.strip():
+                    missing.add(module.strip())
         if isinstance(item, ModuleNotFoundError):
             name = _missing_module_name(item)
             if name:

--- a/tests/test_bot_registry_missing_modules.py
+++ b/tests/test_bot_registry_missing_modules.py
@@ -1,6 +1,7 @@
 """Regression tests for Windows-specific import error parsing in bot registry."""
 
 from menace_sandbox.bot_registry import (
+    SelfCodingUnavailableError,
     _collect_missing_modules,
     _is_probable_filesystem_path,
     _is_transient_internalization_error,
@@ -37,6 +38,24 @@ def test_collect_missing_modules_detects_circular_import_without_partial_hint():
     )
     missing = _collect_missing_modules(err)
     assert "menace_sandbox.task_validation_bot" in missing
+
+
+def test_collect_missing_modules_honours_self_coding_unavailable_error():
+    err = SelfCodingUnavailableError(
+        "self-coding bootstrap failed",
+        missing=(
+            "menace_sandbox.task_validation_bot",
+            "quick_fix_engine",
+            "  sklearn.feature_extraction.text  ",
+            None,
+        ),
+    )
+    missing = _collect_missing_modules(err)
+    assert missing == {
+        "menace_sandbox.task_validation_bot",
+        "quick_fix_engine",
+        "sklearn.feature_extraction.text",
+    }
 
 
 def test_circular_imports_not_treated_as_transient_errors():


### PR DESCRIPTION
## Summary
- ensure `_collect_missing_modules` inspects `missing_modules` on chained exceptions such as `SelfCodingUnavailableError`
- add regression coverage for harvesting `SelfCodingUnavailableError.missing_modules`

## Testing
- pytest tests/test_bot_registry_missing_modules.py

------
https://chatgpt.com/codex/tasks/task_e_68e5c1fc0cf08326a3a42a024a49730a