### PR TITLE
Handle QuickFixEngine ImportError hints during self-coding bootstrap

### DIFF
--- a/tests/test_bot_registry_missing_modules.py
+++ b/tests/test_bot_registry_missing_modules.py
@@ -127,6 +127,20 @@ def test_collect_missing_modules_handles_procedure_not_found():
     assert "quick_fix_engine" in missing
 
 
+def test_collect_missing_modules_detects_quick_fix_engine_hint():
+    err = ImportError("QuickFixEngine is required but could not be imported")
+    missing = _collect_missing_modules(err)
+    assert "quick_fix_engine" in missing
+
+
+def test_collect_missing_modules_detects_quick_fix_engine_install_hint():
+    err = ImportError(
+        "QuickFixEngine is required but could not be imported; pip install menace[quickfix]"
+    )
+    missing = _collect_missing_modules(err)
+    assert "quick_fix_engine" in missing
+
+
 def test_transient_detection_uses_windows_path_hint():
     err = ModuleNotFoundError(
         "module import failed", name=None, path=r"C:\\bots\\future_lucrativity_bot.py"


### PR DESCRIPTION
## Summary
- map QuickFixEngine ImportError messages to the quick_fix_engine module so the bot registry stops retrying endlessly when the extension is missing
- extend bot registry dependency tests to cover the new QuickFixEngine hints that appear on Windows command prompt environments

## Testing
- pytest tests/test_bot_registry_missing_modules.py

------
https://chatgpt.com/codex/tasks/task_e_68e5c3eb4dd48326ae3c5ea1929bd179