### PR TITLE
Improve dependency inference for halted imports

### DIFF
--- a/bot_registry.py
+++ b/bot_registry.py
@@ -436,6 +436,10 @@ _WINDOWS_ERROR_LOADING_RE = re.compile(
     r"Error loading ['\"](?P<module>[^'\"]+)['\"]",
     re.IGNORECASE,
 )
+_IMPORT_HALTED_RE = re.compile(
+    r"import of ['\"](?P<module>[^'\"]+)['\"] halted",
+    re.IGNORECASE,
+)
 
 # High level ImportError messages occasionally hide the underlying module
 # name which prevents ``_collect_missing_modules`` from surfacing actionable
@@ -632,6 +636,11 @@ def _collect_missing_modules(exc: BaseException) -> set[str]:
             partial_match = _PARTIAL_MODULE_RE.search(str(item))
             if partial_match:
                 missing.add(partial_match.group("module"))
+            halted_match = _IMPORT_HALTED_RE.search(message)
+            if halted_match:
+                missing.update(
+                    _normalise_module_aliases(halted_match.group("module"))
+                )
     return missing
 
 

--- a/tests/test_bot_registry_missing_modules.py
+++ b/tests/test_bot_registry_missing_modules.py
@@ -40,6 +40,16 @@ def test_collect_missing_modules_detects_circular_import_without_partial_hint():
     assert "menace_sandbox.task_validation_bot" in missing
 
 
+def test_collect_missing_modules_handles_import_halted_message():
+    err = ImportError("import of 'menace_sandbox.future_prediction_bots' halted; None")
+    missing = _collect_missing_modules(err)
+    assert missing == {
+        "future_prediction_bots",
+        "menace_sandbox",
+        "menace_sandbox.future_prediction_bots",
+    }
+
+
 def test_collect_missing_modules_honours_self_coding_unavailable_error():
     err = SelfCodingUnavailableError(
         "self-coding bootstrap failed",


### PR DESCRIPTION
## Summary
- teach the bot registry to recognise Windows-style "import of '<module>' halted" errors and treat them as missing dependencies
- expand the missing-module unit tests to cover the new error signature so we avoid future regressions

## Testing
- `pytest tests/test_bot_registry_missing_modules.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68e5d1e4838c83268534bfe7e8455495