### PR TITLE
Handle missing runtime resources during self-coding bootstrap

### DIFF
--- a/tests/test_bot_registry_missing_modules.py
+++ b/tests/test_bot_registry_missing_modules.py
@@ -3,6 +3,7 @@
 from menace_sandbox.bot_registry import (
     SelfCodingUnavailableError,
     _collect_missing_modules,
+    _collect_missing_resources,
     _is_probable_filesystem_path,
     _is_transient_internalization_error,
 )
@@ -173,3 +174,17 @@ def test_is_probable_filesystem_path_detects_unc_prefix():
 
 def test_is_probable_filesystem_path_rejects_module_names():
     assert _is_probable_filesystem_path("menace_sandbox.task_validation_bot") is False
+
+
+def test_collect_missing_resources_parses_context_builder_hint():
+    err = FileNotFoundError(
+        "Missing required context builder database(s): bots.db, errors.db"
+    )
+    missing = _collect_missing_resources(err)
+    assert {"bots.db", "errors.db"}.issubset(missing)
+
+
+def test_collect_missing_resources_uses_filename_attributes():
+    err = FileNotFoundError(2, "No such file", "C:/sandbox/data/code.db")
+    missing = _collect_missing_resources(err)
+    assert "code.db" in missing


### PR DESCRIPTION
## Summary
- extend `SelfCodingUnavailableError` and the bot registry to track missing runtime resources alongside missing modules
- treat filesystem/resource failures during coding bot internalisation as non-transient and surface them through registry state and events
- add regression tests that exercise the new resource detection paths and verify the disabled-state metadata

## Testing
- pytest tests/test_bot_registry_missing_modules.py tests/test_bot_registry_self_coding.py


------
https://chatgpt.com/codex/tasks/task_e_68e5d43145f08326b261b25b9067f9a8