### PR TITLE
Improve self-coding failure diagnostics on Windows

### DIFF
--- a/tests/test_bot_registry_missing_modules.py
+++ b/tests/test_bot_registry_missing_modules.py
@@ -161,6 +161,15 @@ def test_collect_missing_modules_detects_quick_fix_engine_install_hint():
     assert "quick_fix_engine" in missing
 
 
+def test_collect_missing_modules_handles_runtime_quick_fix_failure():
+    err = RuntimeError(
+        "context_builder_util helpers are required for quick_fix_engine"
+    )
+    missing = _collect_missing_modules(err)
+    assert "quick_fix_engine" in missing
+    assert "context_builder_util" in missing
+
+
 def test_transient_detection_uses_windows_path_hint():
     err = ModuleNotFoundError(
         "module import failed", name=None, path=r"C:\\bots\\future_lucrativity_bot.py"


### PR DESCRIPTION
## Summary
- expand self-coding dependency hint detection to catch quick-fix and context builder runtime failures that previously caused indefinite retries on Windows
- fall back to the dependency probe when import errors lack actionable metadata so the registry disables bots instead of looping
- add regression tests covering runtime quick-fix failures and the new dependency inference logic

## Testing
- PYTHONPATH=. pytest tests/test_bot_registry_missing_modules.py tests/test_bot_registry_self_coding.py


------
https://chatgpt.com/codex/tasks/task_e_68e5dcda89608326a386417250c5c723