### PR TITLE
Improve detection of unresolved import errors during bot internalization

### DIFF
--- a/tests/test_bot_registry_missing_modules.py
+++ b/tests/test_bot_registry_missing_modules.py
@@ -41,6 +41,18 @@ def test_collect_missing_modules_detects_circular_import_without_partial_hint():
     assert "menace_sandbox.task_validation_bot" in missing
 
 
+def test_collect_missing_modules_handles_cannot_import_without_hint():
+    err = ImportError(
+        "cannot import name 'TaskValidationBot' from 'menace_sandbox.task_validation_bot' (unknown location)"
+    )
+    missing = _collect_missing_modules(err)
+    assert missing >= {
+        "menace_sandbox.task_validation_bot",
+        "TaskValidationBot",
+        "menace_sandbox",
+    }
+
+
 def test_collect_missing_modules_handles_import_halted_message():
     err = ImportError("import of 'menace_sandbox.future_prediction_bots' halted; None")
     missing = _collect_missing_modules(err)
@@ -73,6 +85,13 @@ def test_circular_imports_not_treated_as_transient_errors():
     err = ImportError(
         "cannot import name 'TaskValidationBot' from partially initialized module "
         "'menace_sandbox.task_validation_bot' (most likely due to a circular import)"
+    )
+    assert _is_transient_internalization_error(err) is False
+
+
+def test_cannot_import_without_hint_not_transient():
+    err = ImportError(
+        "cannot import name 'FutureLucrativityBot' from 'menace_sandbox.future_prediction_bots' (unknown location)"
     )
     assert _is_transient_internalization_error(err) is False
 


### PR DESCRIPTION
## Summary
- enhance the bot registry's import diagnostics to recognise "cannot import name" failures and treat them as non-transient
- add unit coverage for previously unhandled Windows-style ImportError variants to avoid endless internalisation retries

## Testing
- `pytest tests/test_bot_registry_missing_modules.py`


------
https://chatgpt.com/codex/tasks/task_e_68e5dfcadca883268900fefd674c98a7