### PR TITLE
Improve provenance resolution for Windows sandbox

### DIFF
--- a/tests/test_coding_bot_interface_provenance.py
+++ b/tests/test_coding_bot_interface_provenance.py
@@ -92,10 +92,17 @@ def test_signed_provenance_matches_abbreviated_commits(
     monkeypatch.setenv("PATCH_PROVENANCE_PUBKEY", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ")
 
     module = _reload_coding_bot_interface()
+    context = module._RepositoryContext(
+        patch_id=None,
+        commit=full_commit,
+        repo_root=None,
+        relative_path=None,
+        canonical_path=None,
+    )
     monkeypatch.setattr(
         module,
-        "_derive_repository_provenance",
-        lambda *_, **__: (None, full_commit),
+        "_resolve_repository_context",
+        lambda *_, **__: context,
     )
 
     decision = module._resolve_provenance_decision(
@@ -109,3 +116,55 @@ def test_signed_provenance_matches_abbreviated_commits(
     assert decision.mode == "signed"
     assert decision.patch_id == 915
     assert decision.commit == full_commit
+
+
+def test_signed_provenance_matches_windows_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Signed provenance should match by Windows-style paths when commits are missing."""
+
+    _clear_provenance_env(monkeypatch)
+
+    prov_payload = [
+        {
+            "patch_id": 321,
+            "commit": "abc123def456",
+            "files": [r"menace_sandbox\\task_validation_bot.py"],
+        }
+    ]
+    prov_file = tmp_path / "signed.json"
+    prov_file.write_text(json.dumps(prov_payload), encoding="utf-8")
+    monkeypatch.setenv("PATCH_PROVENANCE_FILE", os.fspath(prov_file))
+    monkeypatch.setenv(
+        "PATCH_PROVENANCE_PUBKEY", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ"
+    )
+    monkeypatch.setenv("MENACE_REQUIRE_SIGNED_PROVENANCE", "1")
+
+    module = _reload_coding_bot_interface()
+
+    repo_path = "menace_sandbox/task_validation_bot.py"
+    context = module._RepositoryContext(
+        patch_id=None,
+        commit=None,
+        repo_root=tmp_path,
+        relative_path=Path(repo_path),
+        canonical_path=repo_path,
+    )
+    monkeypatch.setattr(
+        module,
+        "_resolve_repository_context",
+        lambda *_, **__: context,
+    )
+
+    decision = module._resolve_provenance_decision(
+        "TaskValidationBot",
+        r"C:\\menace_sandbox\\menace_sandbox\\task_validation_bot.py",
+        [],
+        (None, None),
+    )
+
+    assert decision.available is True
+    assert decision.mode == "signed"
+    assert decision.patch_id == 321
+    assert decision.commit == "abc123def456"
+    assert decision.source == "signed:path"


### PR DESCRIPTION
## Summary
- enrich provenance resolution with repository context and path-aware signed metadata matching to avoid Windows import stalls
- add detection of Windows-style paths in signed provenance files to unblock strict signed-policy sandboxes
- extend provenance tests to cover repository context overrides and path-based resolution scenarios

## Testing
- pytest tests/test_coding_bot_interface_provenance.py

------
https://chatgpt.com/codex/tasks/task_e_68e5eb355e308326b47e2adf72214c5c