### PR TITLE
Handle partial TaskValidationBot import errors on Windows

### DIFF
--- a/bot_registry.py
+++ b/bot_registry.py
@@ -520,7 +520,8 @@ _TRACEBACK_IGNORED_MODULES: frozenset[str] = frozenset(
     }
 )
 _CANNOT_IMPORT_RE = re.compile(
-    r"cannot import name ['\"](?P<symbol>[^'\"]+)['\"] from ['\"](?P<module>[^'\"]+)['\"]",
+    r"cannot import name ['\"](?P<symbol>[^'\"]+)['\"] from "
+    r"(?:partially init(?:ialized|ialised) module |module )?['\"](?P<module>[^'\"]+)['\"]",
     re.IGNORECASE,
 )
 _IMPORT_HALTED_RE = re.compile(

--- a/tests/test_bot_registry_missing_modules.py
+++ b/tests/test_bot_registry_missing_modules.py
@@ -122,6 +122,14 @@ def test_cannot_import_without_hint_not_transient():
     assert _is_transient_internalization_error(err) is False
 
 
+def test_partial_initialised_cannot_import_without_circular_hint_not_transient():
+    err = ImportError(
+        "cannot import name 'TaskValidationBot' from partially initialized module "
+        "'menace_sandbox.task_validation_bot' (unknown location)"
+    )
+    assert _is_transient_internalization_error(err) is False
+
+
 def test_collect_missing_modules_infers_from_windows_path():
     err = ImportError(
         "DLL load failed: The specified module could not be found.",


### PR DESCRIPTION
## Summary
- expand the "cannot import" regex so partial module import errors emit actionable missing-module hints
- add a regression test to ensure partially initialised TaskValidationBot imports are not retried indefinitely

## Testing
- pytest tests/test_bot_registry_missing_modules.py

------
https://chatgpt.com/codex/tasks/task_e_68e5f6bd047483268fa9522dd99e74ac