### PR TITLE
Allow ContextBuilder to accept database path overrides

### DIFF
--- a/context_builder_util.py
+++ b/context_builder_util.py
@@ -108,6 +108,9 @@ def create_context_builder(*args, **kwargs):  # type: ignore[override]
     unreadable: list[str] = []
     for attr, path in paths.items():
         candidate: Path | None = path
+        if not path.exists():
+            missing.append(path.name)
+            continue
         if callable(ensure_readable):
             try:
                 ensured = ensure_readable(path, path.name)


### PR DESCRIPTION
## Summary
- allow `ContextBuilder` to accept explicit database path overrides and retain them for downstream use
- tighten `create_context_builder` validation so missing database files are detected before instantiation

## Testing
- pytest tests/test_create_context_builder.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e621cf3b088326a71926d3d68e0492